### PR TITLE
fix(book): the CLI-example gate pinned apr and then ran a different one

### DIFF
--- a/scripts/check_book_examples_executable.sh
+++ b/scripts/check_book_examples_executable.sh
@@ -31,13 +31,13 @@ total=0
 # /mnt/nvme-raid0/targets/aprender/release/apr. Both are the #2357 defect, and
 # this gate is a bad place for it: it executes the book's own examples and
 # reports whether they work. Against a stale binary it certifies that examples
-# run correctly on code nobody is shipping — an example using a flag added this
+# run correctly on code nobody is shipping -- an example using a flag added this
 # week FAILS, and an example using a flag deleted this week PASSES. The /mnt
 # fallback is worse than stale: nothing writes that path any more.
 #
 # `. scripts/apr_bin.sh` asks cargo for the target dir and asserts the binary's
 # embedded git SHA matches HEAD. It returns non-zero when there is no
-# freshly-built binary, which for this gate is a SKIP, not a failure — the
+# freshly-built binary, which for this gate is a SKIP, not a failure -- the
 # examples are still scanned and rust blocks still reported.
 APR_BIN=""
 # The pinned binary must be REACHED, not merely resolved. Every example below
@@ -104,7 +104,7 @@ while IFS= read -r record; do
     code=$(printf '%s\n' "$record" | python3 -c "import json,sys;print(json.load(sys.stdin)['code'])")
     model=$(printf '%s\n' "$record" | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('model',''))")
 
-    # Rust blocks are not executed here — that's the compile checker's job.
+    # Rust blocks are not executed here -- that's the compile checker's job.
     if [ "$lang" = "rust" ]; then
         skip=$((skip + 1))
         echo "[SKIP] $path :: $cost rust (compile gate handles this)"
@@ -122,10 +122,10 @@ while IFS= read -r record; do
                 pass=$((pass + 1))
                 echo "[PASS] $path :: trivial"
             else
-                # Special-case `apr <subcmd> --help` and `apr --version` —
+                # Special-case `apr <subcmd> --help` and `apr --version` --
                 # those are guaranteed by clap to exit 0 if the binary works.
                 fail=$((fail + 1))
-                echo "[FAIL] $path :: trivial — $(printf '%s' "$code" | head -c 80)"
+                echo "[FAIL] $path :: trivial -- $(printf '%s' "$code" | head -c 80)"
             fi
             ;;
         model-required)
@@ -176,7 +176,7 @@ while IFS= read -r record; do
                 echo "[PASS] $path :: model-required"
             else
                 fail=$((fail + 1))
-                echo "[FAIL] $path :: model-required — $(printf '%s' "$run_code" | head -c 80)"
+                echo "[FAIL] $path :: model-required -- $(printf '%s' "$run_code" | head -c 80)"
             fi
             ;;
         gpu)
@@ -205,7 +205,7 @@ while IFS= read -r record; do
                 echo "[PASS] $path :: gpu"
             else
                 fail=$((fail + 1))
-                echo "[FAIL] $path :: gpu — $(printf '%s' "$code" | head -c 80)"
+                echo "[FAIL] $path :: gpu -- $(printf '%s' "$code" | head -c 80)"
             fi
             ;;
         destructive)
@@ -252,12 +252,12 @@ fi
 # mattered was zero and the verdict was green.
 if [ "$total" -gt 0 ] && [ "$pass" -eq 0 ]; then
     if [ -z "$APR_BIN" ]; then
-        echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: NOT RUN — no apr binary built from HEAD," \
+        echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: NOT RUN -- no apr binary built from HEAD," \
              "so all $skip example(s) skipped and nothing was verified."
         echo "  Build one first:  cargo build --release -p apr-cli --bin apr"
         exit 1
     fi
-    echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: FAIL — apr is available at $APR_BIN but" \
+    echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: FAIL -- apr is available at $APR_BIN but" \
          "0 of $total example(s) executed. The gate measured nothing."
     exit 1
 fi

--- a/scripts/check_book_examples_executable.sh
+++ b/scripts/check_book_examples_executable.sh
@@ -40,8 +40,20 @@ total=0
 # freshly-built binary, which for this gate is a SKIP, not a failure — the
 # examples are still scanned and rust blocks still reported.
 APR_BIN=""
+# The pinned binary must be REACHED, not merely resolved. Every example below
+# runs through `bash -c "$code"`, and the code says `apr ...` -- which PATH
+# resolves, not $APR_BIN. On this box a bare `apr` was /home/noah/.local/bin/apr
+# = 0.60.0, so the gate that certifies the book's CLI examples was exercising a
+# binary from a different release than the tree it was gating. Putting the pinned
+# binary FIRST on PATH covers `apr` in any position, including pipelines and
+# subshells, which substituting a leading token does not.
+APR_PATH_PREFIX=""
 if . scripts/apr_bin.sh 2>/dev/null; then
     APR_BIN="$APR"
+    APR_PATH_PREFIX="$(dirname "$APR_BIN")"
+    PATH="${APR_PATH_PREFIX}:${PATH}"
+    export PATH
+    echo "[INFO] apr pinned to $APR_BIN (prepended to PATH)"
 else
     echo "[INFO] no apr binary built from HEAD; all CLI examples will SKIP"
     echo "[INFO]   build one with: cargo build --release -p apr-cli --bin apr"
@@ -230,6 +242,23 @@ echo ""
 echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: total=$total pass=$pass skip=$skip fail=$fail"
 if [ "$fail" -gt 0 ]; then
     echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: FAIL"
+    exit 1
+fi
+
+# A run that executed NOTHING is not a pass. With no apr binary built from HEAD
+# every CLI example skips, and this gate printed
+#   total=244 pass=0 skip=244 fail=0 ... PASS
+# which is the whole "gate that cannot fail" class in one line: the number that
+# mattered was zero and the verdict was green.
+if [ "$total" -gt 0 ] && [ "$pass" -eq 0 ]; then
+    if [ -z "$APR_BIN" ]; then
+        echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: NOT RUN — no apr binary built from HEAD," \
+             "so all $skip example(s) skipped and nothing was verified."
+        echo "  Build one first:  cargo build --release -p apr-cli --bin apr"
+        exit 1
+    fi
+    echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: FAIL — apr is available at $APR_BIN but" \
+         "0 of $total example(s) executed. The gate measured nothing."
     exit 1
 fi
 echo "FALSIFY-BOOK-EXAMPLE-EXECUTES-001: PASS"


### PR DESCRIPTION
`check_book_examples_executable.sh` (FALSIFY-BOOK-EXAMPLE-EXECUTES-001) sources
`scripts/apr_bin.sh`, which asks cargo for the target dir and asserts the
binary's embedded SHA matches HEAD. That is the repo's binary-pinning protocol
and it works. The gate then never used the result.

`$APR_BIN` gated only the SKIP branch. Every example that DID run went through
`timeout N bash -c "$code"`, and the code says `apr ...` — resolved by PATH.
Measured on this box: a bare `apr` is 0.60.0 while the tree is 0.63.0, so the
gate certifying the book's CLI examples was exercising a binary from three
minor releases back. That is the exact failure this repo has hit four times
(#2357/#2358/#2360/#2361) and the reason apr_bin.sh exists.

Fix: prepend the pinned binary's directory to PATH. That covers `apr` in any
position — pipelines, subshells, `$(...)` — which substituting a leading token
does not. Verified: `bash -c 'apr --version'` reports 0.60.0 before and the
pinned binary after.

Second defect, worse, in the verdict itself. With no apr built from HEAD every
CLI example skips, and the gate printed:

    total=244 pass=0 skip=244 fail=0
    FALSIFY-BOOK-EXAMPLE-EXECUTES-001: PASS

Zero executed, verdict green. It now refuses:
  * no apr binary  -> "NOT RUN — nothing was verified", exit 1, with the build
    command to fix it
  * apr present but 0 of 244 executed -> FAIL, "the gate measured nothing"

NOT wired into CI in this commit, deliberately. It needs a job that builds apr
first, and when apr IS available this gate reports 5 real failures in book text.
Wiring it before those are fixed turns main red. The order is: fix the 5, add a
build step, then wire. This commit makes the gate honest so that sequence is
possible at all — until now it could not have reported anything.

Refs #2481

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>