### PR TITLE
fix(publish): 5.4 MB of build scratch was shipping to crates.io, unseen by the guard meant to stop it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,19 @@ jobs:
       # itself either. Text-only, no build.
       - name: README claims must match measurement
         run: bash scripts/check_readme_claims.sh
+
+      # Three guards that existed and could not block a merge. The publish-safety
+      # one is the gate credited with keeping a 28 MB test.apr out of a published
+      # package, and it was `make`-only -- invoked by whoever remembered to type
+      # it. Its size check also looked at 2 of 72 publishable crates and never
+      # measured a size, so the 5.4 MB of .pmat-baseline.json it now catches had
+      # been shipping to crates.io unseen.
+      - name: Publish safety (binary/oversize files in published packages)
+        run: bash scripts/check_publish_safety.sh
+      - name: Every include!() file is tracked by git (CB-510)
+        run: bash scripts/check_include_files.sh
+      - name: Book rust examples compile
+        run: bash scripts/check_book_examples_compile.sh
       # Poka-yoke: APR-MONO made every sibling a path alias under crates/, but
       # `trueno = "0.16"` still BUILDS - cargo resolves the crates.io copy
       # alongside the in-tree one, so the tree compiles two mutually

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 keywords = ["machine-learning", "inference", "model-serving", "gguf", "transformer"]
 categories = ["science", "web-programming::http-server"]
 exclude = [
+    ".pmat-baseline.json",
     "artifacts/", "models/", "docs/", "/tests/", "benches/", "book/",
     "target/", ".pmat/", ".pmat-work/", ".vscode/", ".idea/",
     "*.profraw", "*.profdata", "proptest-regressions/",

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 keywords = ["machine-learning", "neural-networks", "autograd", "lora", "quantization"]
 categories = ["science", "mathematics"]
 exclude = [
+    ".pmat-baseline.json",
     "book/",
     "docs/",
     "examples/",

--- a/scripts/check_publish_safety.sh
+++ b/scripts/check_publish_safety.sh
@@ -16,6 +16,8 @@
 
 set -uo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 errors=0
 checked=0
 
@@ -99,23 +101,58 @@ else
     echo "OK"
 fi
 
-# Check 6: No large binary files (>1MB) in publishable packages
+# Check 6: No large or binary files in publishable packages
+#
+# This check had two holes, and the defect it is credited with catching (a 28 MB
+# test.apr) would slip through both today:
+#
+#   1. It iterated `for pkg in aprender apr-cli` -- 2 of the 72 publishable
+#      crates. The 0.63.0 CB-510 recurrence was in aprender-serve, which is not
+#      one of them. A 2 MB blob planted in aprender-core passed cleanly.
+#   2. Its name and comment say ">1MB" and it never measured a size. It grepped
+#      an extension list, so a 100 MB .txt passed and a 1 KB .bin failed. The
+#      threshold in the title did not exist in the code.
+#
+# Now: every publishable crate, and an actual byte threshold alongside the
+# extension list.
 echo -n "  Package size check... "
 checked=$((checked + 1))
 large_files=""
-for pkg in aprender apr-cli; do
-    # Check for binary/model files that shouldn't be in packages
-    binaries=$(cargo package -p "$pkg" --list --allow-dirty 2>/dev/null \
-        | grep -E '\.(apr|gguf|safetensors|bin|pt|onnx|wav|mp3|db|db-shm|db-wal)$' || true)
-    if [ -n "$binaries" ]; then
-        large_files="${large_files}${pkg}: ${binaries}\n"
-    fi
+MAX_PACKAGED_BYTES=1048576
+
+pub_pkgs=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+    | python3 "${REPO_ROOT:-.}/scripts/lib/publishable_crates.py" | cut -f1)
+
+for pkg in $pub_pkgs; do
+    listing=$(cargo package -p "$pkg" --list --allow-dirty 2>/dev/null < /dev/null) || continue
+    [ -n "$listing" ] || continue
+    pkg_dir=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+        | python3 "${REPO_ROOT:-.}/scripts/lib/publishable_crates.py" \
+        | awk -F'\t' -v p="$pkg" '$1==p{print $2}')
+    [ -n "$pkg_dir" ] || continue
+
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        # SIZE, not extension. The old rule failed on an extension list and
+        # never measured anything, which is both too strict and too loose: it
+        # would reject a 77-byte golden .apr fixture while passing a 3.6 MB
+        # .pmat-baseline.json. Every real instance of this defect -- the 28 MB
+        # test.apr, and the 5.4 MB of baseline JSON found when this check was
+        # first pointed at all 72 crates -- is a SIZE problem.
+        if [ -f "$pkg_dir/$f" ]; then
+            sz=$(stat -c%s "$pkg_dir/$f" 2>/dev/null || echo 0)
+            if [ "$sz" -gt "$MAX_PACKAGED_BYTES" ]; then
+                large_files="${large_files}${pkg}: ${f} (${sz} bytes > ${MAX_PACKAGED_BYTES})\n"
+            fi
+        fi
+    done <<< "$listing"
 done
+
 if [ -n "$large_files" ]; then
     echo "FAIL"
-    echo "FAIL: Binary/model files found in packages:"
+    echo "FAIL: large or binary files found in published packages:"
     echo -e "$large_files"
-    echo "Fix: add to Cargo.toml [package] exclude or .gitignore"
+    echo "Fix: add to Cargo.toml [package] exclude (root-anchored) or .gitignore"
     errors=$((errors + 1))
 else
     echo "OK"

--- a/scripts/lib/publishable_crates.py
+++ b/scripts/lib/publishable_crates.py
@@ -1,0 +1,14 @@
+"""Print "<package name>\t<crate dir>" for every publishable workspace crate.
+
+Reads `cargo metadata --no-deps --format-version 1` on stdin. A separate file
+because bashrs parses inline python inside a shell script as shell.
+"""
+import json
+import os
+import sys
+
+meta = json.load(sys.stdin)
+for pkg in meta["packages"]:
+    if pkg.get("publish") == []:
+        continue
+    print(pkg["name"] + "\t" + os.path.dirname(pkg["manifest_path"]))


### PR DESCRIPTION
`check_publish_safety.sh` is the gate credited with keeping a 28 MB `test.apr`
out of a published package. It was invoked from the Makefile only -- by whoever
remembered to type `make` -- and its Check 6 had two holes that between them
would let that same 28 MB file through today.

  1. `for pkg in aprender apr-cli` -- 2 of the 72 publishable crates. The 0.63.0
     CB-510 recurrence was in aprender-serve, which is not one of them. A 2 MB
     blob planted in aprender-core passed cleanly, verified by mutation.
  2. The check is named "No large binary files (>1MB)" and never measured a
     size. It grepped an extension list, so a 100 MB `.txt` passed and a 77-byte
     golden `.apr` fixture failed. The threshold in the title did not exist in
     the code.

Pointed at all 72 crates with a real byte threshold, it immediately found build
scratch in two published packages:

    aprender-serve: .pmat-baseline.json  3,622,472 bytes
    aprender-train: .pmat-baseline.json  1,836,859 bytes

5.4 MB of pmat baseline JSON, downloaded by every consumer of those crates.
Neither file is gitignored, so nothing else would have caught it either. Both are
now in `[package] exclude`; verified absent from `cargo package --list`.

The rule is now SIZE, not extension. Every real instance of this defect -- the
28 MB test.apr, and these two -- is a size problem, while the extension list was
simultaneously too strict (it rejected 77-byte fixtures in apr-format,
aprender-tsp, aprender-verify-ml and aprender-present-lib, all legitimate) and
too loose (no size bound at all).

Also wires three guards that could not block a merge:
  * check_publish_safety.sh    (185 LOC, Makefile-only)
  * check_include_files.sh     (CB-510 sibling; mutation-verified -- an untracked
                                include!() target turns it RED)
  * check_book_examples_compile.sh (103 rust blocks)

All three pass at HEAD, so wiring them does not turn main red. `check_msrv.sh`
is deliberately left out: it runs a full MSRV build (~56 s here) and belongs in a
nightly, not the per-PR guard block.

Mutation-verified: 2 MB blob in aprender-core -> RED naming the file; removed ->
GREEN.

Refs #2481

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>