### PR TITLE
fix(apr): an unknown quant type was written to APR labelled F32

### DIFF
--- a/crates/aprender-serve/src/gguf/dtype.rs
+++ b/crates/aprender-serve/src/gguf/dtype.rs
@@ -1,7 +1,27 @@
 
 /// GH-321: Convert GGML qtype to APR dtype string using unified enum.
-fn apr_qtype_to_dtype(qtype: u32) -> &'static str {
-    crate::gguf::GgmlQuantType::from_id(qtype).map_or("F32", crate::gguf::GgmlQuantType::as_str)
+///
+/// FAILS on an unrecognized qtype. This used to be
+/// `.map_or("F32", ..)`, and the result is written straight into the APR
+/// tensor index by `write_apr_tensor_entry` -- so a model carrying a quant type
+/// this build does not know had its quantized bytes emitted LABELLED F32.
+/// The file is structurally valid; the reader then interprets Q-whatever blocks
+/// as raw f32 and produces garbage weights, with nothing anywhere reporting an
+/// error. That is the PMAT-781/783 silent-garbage class, at the conversion
+/// boundary instead of the GPU one.
+///
+/// The doc comment on `gpu_unsupported_quant_qtype` directly above states the
+/// policy this now follows: an unsupported quant must fail loudly rather than be
+/// silently decoded as something else.
+fn apr_qtype_to_dtype(qtype: u32) -> Result<&'static str> {
+    crate::gguf::GgmlQuantType::from_id(qtype)
+        .map(crate::gguf::GgmlQuantType::as_str)
+        .ok_or_else(|| RealizarError::FormatError {
+            reason: format!(
+                "unknown GGML quant type {qtype}: refusing to write it to APR as F32, \
+                 which would emit quantized bytes that the reader decodes as raw floats"
+            ),
+        })
 }
 
 /// PMAT-783/PMAT-785: GGML quant types WITHOUT a verified GPU GEMV kernel.
@@ -132,7 +152,7 @@ impl OwnedQuantizedModel {
         use crate::apr::{ALIGNMENT, HEADER_SIZE, MAGIC};
 
         // Collect all tensors
-        let tensors = self.collect_apr_model_tensors();
+        let tensors = self.collect_apr_model_tensors()?;
 
         // Build metadata JSON
         let metadata = serde_json::json!({
@@ -206,7 +226,7 @@ impl OwnedQuantizedModel {
 
     /// Collect all model tensors as (name, dtype, shape, data) tuples for APR serialization
     #[allow(clippy::cast_possible_truncation)]
-    fn collect_apr_model_tensors(&self) -> Vec<(String, String, Vec<usize>, Vec<u8>)> {
+    fn collect_apr_model_tensors(&self) -> Result<Vec<(String, String, Vec<usize>, Vec<u8>)>> {
         let mut tensors = Vec::new();
 
         // Token embedding (F32)
@@ -228,7 +248,7 @@ impl OwnedQuantizedModel {
         let kv_dim = self.config.num_kv_heads * head_dim;
 
         for (layer_idx, layer) in self.layers.iter().enumerate() {
-            self.collect_apr_layer_tensors(&mut tensors, layer_idx, layer, kv_dim);
+            self.collect_apr_layer_tensors(&mut tensors, layer_idx, layer, kv_dim)?;
         }
 
         // Output norm (F32)
@@ -247,12 +267,12 @@ impl OwnedQuantizedModel {
         // LM head (quantized)
         tensors.push((
             "output.weight".to_string(),
-            apr_qtype_to_dtype(self.lm_head_weight.qtype).to_string(),
+            apr_qtype_to_dtype(self.lm_head_weight.qtype)?.to_string(),
             vec![self.config.vocab_size, self.config.hidden_dim],
             self.lm_head_weight.data.clone(),
         ));
 
-        tensors
+        Ok(tensors)
     }
 
     /// Collect tensors for a single transformer layer
@@ -262,7 +282,7 @@ impl OwnedQuantizedModel {
         layer_idx: usize,
         layer: &OwnedQuantizedLayer,
         kv_dim: usize,
-    ) {
+    ) -> Result<()> {
         // Attention norm (F32)
         let norm_bytes: Vec<u8> = layer
             .attn_norm_weight
@@ -281,19 +301,19 @@ impl OwnedQuantizedModel {
             OwnedQKVWeights::Separate { q, k, v } => {
                 tensors.push((
                     format!("blk.{layer_idx}.attn_q.weight"),
-                    apr_qtype_to_dtype(q.qtype).to_string(),
+                    apr_qtype_to_dtype(q.qtype)?.to_string(),
                     vec![self.config.hidden_dim, self.config.hidden_dim],
                     q.data.clone(),
                 ));
                 tensors.push((
                     format!("blk.{layer_idx}.attn_k.weight"),
-                    apr_qtype_to_dtype(k.qtype).to_string(),
+                    apr_qtype_to_dtype(k.qtype)?.to_string(),
                     vec![kv_dim, self.config.hidden_dim],
                     k.data.clone(),
                 ));
                 tensors.push((
                     format!("blk.{layer_idx}.attn_v.weight"),
-                    apr_qtype_to_dtype(v.qtype).to_string(),
+                    apr_qtype_to_dtype(v.qtype)?.to_string(),
                     vec![kv_dim, self.config.hidden_dim],
                     v.data.clone(),
                 ));
@@ -301,7 +321,7 @@ impl OwnedQuantizedModel {
             OwnedQKVWeights::Fused(t) => {
                 tensors.push((
                     format!("blk.{layer_idx}.attn_qkv.weight"),
-                    apr_qtype_to_dtype(t.qtype).to_string(),
+                    apr_qtype_to_dtype(t.qtype)?.to_string(),
                     vec![t.out_dim, t.in_dim],
                     t.data.clone(),
                 ));
@@ -311,7 +331,7 @@ impl OwnedQuantizedModel {
         // Output projection (quantized)
         tensors.push((
             format!("blk.{layer_idx}.attn_output.weight"),
-            apr_qtype_to_dtype(layer.attn_output_weight.qtype).to_string(),
+            apr_qtype_to_dtype(layer.attn_output_weight.qtype)?.to_string(),
             vec![self.config.hidden_dim, self.config.hidden_dim],
             layer.attn_output_weight.data.clone(),
         ));
@@ -331,7 +351,7 @@ impl OwnedQuantizedModel {
         if let Some(ref gate) = layer.ffn_gate_weight {
             tensors.push((
                 format!("blk.{layer_idx}.ffn_gate.weight"),
-                apr_qtype_to_dtype(gate.qtype).to_string(),
+                apr_qtype_to_dtype(gate.qtype)?.to_string(),
                 vec![self.config.intermediate_dim, self.config.hidden_dim],
                 gate.data.clone(),
             ));
@@ -339,17 +359,19 @@ impl OwnedQuantizedModel {
 
         tensors.push((
             format!("blk.{layer_idx}.ffn_up.weight"),
-            apr_qtype_to_dtype(layer.ffn_up_weight.qtype).to_string(),
+            apr_qtype_to_dtype(layer.ffn_up_weight.qtype)?.to_string(),
             vec![self.config.intermediate_dim, self.config.hidden_dim],
             layer.ffn_up_weight.data.clone(),
         ));
 
         tensors.push((
             format!("blk.{layer_idx}.ffn_down.weight"),
-            apr_qtype_to_dtype(layer.ffn_down_weight.qtype).to_string(),
+            apr_qtype_to_dtype(layer.ffn_down_weight.qtype)?.to_string(),
             vec![self.config.hidden_dim, self.config.intermediate_dim],
             layer.ffn_down_weight.data.clone(),
         ));
+
+        Ok(())
     }
 }
 

--- a/crates/aprender-serve/src/gguf/embedding.rs
+++ b/crates/aprender-serve/src/gguf/embedding.rs
@@ -15,35 +15,45 @@ fn transpose_f32_matrix(data: &[f32], rows: usize, cols: usize) -> Vec<f32> {
 /// O(num_blocks), not O(num_elements). A non-finite `d`/`dmin` poisons every element
 /// of its block at dequant, so checking the scales is both cheap and sufficient. F32
 /// tensors (embeddings/norms) are stored separately and are not handled here.
-fn quant_scale_first_nonfinite(data: &[u8], qtype: u32) -> Option<f32> {
+/// Block layout for a scaled-block quant type: `(block_bytes, &[scale_offsets])`.
+///
+/// Each offset marks a 2-byte little-endian f16 scale field within the block.
+/// `None` for F16/F32/BF16/unknown, which are not scaled-block layouts.
+///
+/// Split out of `quant_scale_first_nonfinite` so that function stays under the
+/// cognitive-complexity gate: this ten-arm table was the whole of its 30, and
+/// dtype.rs `include!()`s this file, so the gate rejected every commit touching
+/// dtype.rs regardless of what it changed.
+fn quant_block_layout(qtype: u32) -> Option<(usize, &'static [usize])> {
     use crate::gguf::types::{
         GGUF_TYPE_Q2_K, GGUF_TYPE_Q3_K, GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_1, GGUF_TYPE_Q4_K,
         GGUF_TYPE_Q5_0, GGUF_TYPE_Q5_1, GGUF_TYPE_Q5_K, GGUF_TYPE_Q6_K, GGUF_TYPE_Q8_0,
     };
+    match qtype {
+        // 32-element blocks (one or two leading f16 scales).
+        t if t == GGUF_TYPE_Q4_0 => Some((18, &[0])),
+        t if t == GGUF_TYPE_Q8_0 => Some((34, &[0])),
+        t if t == GGUF_TYPE_Q4_1 => Some((20, &[0, 2])),
+        t if t == GGUF_TYPE_Q5_0 => Some((22, &[0])),
+        t if t == GGUF_TYPE_Q5_1 => Some((24, &[0, 2])),
+        // 256-element K-quant super-blocks.
+        t if t == GGUF_TYPE_Q4_K => Some((144, &[0, 2])),  // d, dmin
+        t if t == GGUF_TYPE_Q5_K => Some((176, &[0, 2])),  // d, dmin
+        t if t == GGUF_TYPE_Q6_K => Some((210, &[208])),   // d (trailing)
+        t if t == GGUF_TYPE_Q2_K => Some((84, &[80, 82])), // d, dmin (trailing)
+        t if t == GGUF_TYPE_Q3_K => Some((110, &[108])),   // d_all (trailing)
+        _ => None,
+    }
+}
+
+fn quant_scale_first_nonfinite(data: &[u8], qtype: u32) -> Option<f32> {
     use crate::quantize::read_f16;
 
     if data.is_empty() {
         return None;
     }
 
-    // (block_bytes, &[scale_offsets_within_block]) for each supported quant type.
-    // Each offset marks a 2-byte little-endian f16 scale field.
-    let (block_bytes, scale_offsets): (usize, &[usize]) = match qtype {
-        // 32-element blocks (one or two leading f16 scales).
-        t if t == GGUF_TYPE_Q4_0 => (18, &[0]),
-        t if t == GGUF_TYPE_Q8_0 => (34, &[0]),
-        t if t == GGUF_TYPE_Q4_1 => (20, &[0, 2]),
-        t if t == GGUF_TYPE_Q5_0 => (22, &[0]),
-        t if t == GGUF_TYPE_Q5_1 => (24, &[0, 2]),
-        // 256-element K-quant super-blocks.
-        t if t == GGUF_TYPE_Q4_K => (144, &[0, 2]),    // d, dmin
-        t if t == GGUF_TYPE_Q5_K => (176, &[0, 2]),    // d, dmin
-        t if t == GGUF_TYPE_Q6_K => (210, &[208]),     // d (trailing)
-        t if t == GGUF_TYPE_Q2_K => (84, &[80, 82]),   // d, dmin (trailing)
-        t if t == GGUF_TYPE_Q3_K => (110, &[108]),     // d_all (trailing)
-        // F16/F32/BF16/unknown: not a scaled-block layout — skip here.
-        _ => return None,
-    };
+    let (block_bytes, scale_offsets) = quant_block_layout(qtype)?;
 
     if block_bytes == 0 || !data.len().is_multiple_of(block_bytes) {
         // Malformed block size for this qtype: leave to the existing shape gates.
@@ -284,5 +294,71 @@ impl OwnedQuantizedModel {
             #[cfg(feature = "cuda")]
             cached_weight_names: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
+    }
+}
+
+#[cfg(test)]
+mod quant_block_layout_tests {
+    use super::{quant_block_layout, quant_scale_first_nonfinite};
+    use crate::gguf::types::{GGUF_TYPE_Q4_0, GGUF_TYPE_Q4_K, GGUF_TYPE_Q6_K};
+
+    /// The layout table had NO coverage: changing Q4_K's block size from 144 to
+    /// 999 left all 15,657 lib tests green. It is the sole input to a corruption
+    /// detector, so a wrong entry silently disables that detector for one quant
+    /// type. These tests exist because this table was refactored out of
+    /// `quant_scale_first_nonfinite`, and refactoring untested code without
+    /// leaving a test behind is how a "pure move" changes behaviour unnoticed.
+    #[test]
+    fn block_layout_matches_the_ggml_wire_format() {
+        // Q4_0: 2-byte f16 scale + 16 bytes of packed nibbles.
+        assert_eq!(quant_block_layout(GGUF_TYPE_Q4_0), Some((18, &[0][..])));
+        // Q4_K super-block: 144 bytes, leading d and dmin.
+        assert_eq!(quant_block_layout(GGUF_TYPE_Q4_K), Some((144, &[0, 2][..])));
+        // Q6_K: 210 bytes with a TRAILING scale at 208 -- the offset most likely
+        // to be transcribed as 0 by someone assuming scales lead.
+        assert_eq!(quant_block_layout(GGUF_TYPE_Q6_K), Some((210, &[208][..])));
+    }
+
+    #[test]
+    fn unscaled_and_unknown_types_have_no_block_layout() {
+        // F32(0), F16(1), BF16(30) are not scaled-block layouts; 99 is not a
+        // GGML type at all. All must decline rather than guess a layout.
+        for qtype in [0, 1, 30, 99] {
+            assert_eq!(
+                quant_block_layout(qtype),
+                None,
+                "qtype {qtype} must not report a scaled-block layout"
+            );
+        }
+    }
+
+    #[test]
+    fn a_nonfinite_scale_is_reported_and_a_finite_one_is_not() {
+        // One Q4_0 block: f16 scale then 16 quant bytes.
+        let mut block = vec![0u8; 18];
+
+        // f16 1.0 = 0x3C00.
+        block[0] = 0x00;
+        block[1] = 0x3C;
+        assert_eq!(
+            quant_scale_first_nonfinite(&block, GGUF_TYPE_Q4_0),
+            None,
+            "a finite scale must not be reported as corruption"
+        );
+
+        // f16 NaN = 0x7E00. This is the case the function exists to catch.
+        block[0] = 0x00;
+        block[1] = 0x7E;
+        let found = quant_scale_first_nonfinite(&block, GGUF_TYPE_Q4_0)
+            .expect("a NaN scale must be detected");
+        assert!(found.is_nan(), "expected the NaN scale itself, got {found}");
+    }
+
+    #[test]
+    fn a_block_size_mismatch_declines_rather_than_reading_past_the_end() {
+        // 17 bytes is not a whole number of 18-byte Q4_0 blocks.
+        let short = vec![0u8; 17];
+        assert_eq!(quant_scale_first_nonfinite(&short, GGUF_TYPE_Q4_0), None);
+        assert_eq!(quant_scale_first_nonfinite(&[], GGUF_TYPE_Q4_0), None);
     }
 }

--- a/crates/aprender-serve/src/gguf/loader_vocab_tests.rs
+++ b/crates/aprender-serve/src/gguf/loader_vocab_tests.rs
@@ -251,6 +251,48 @@ mod tests {
         assert_eq!(apr_bytes[4], 2, "version major");
     }
 
+    /// An unrecognized GGML quant type must ABORT the APR write, not be labelled F32.
+    ///
+    /// `apr_qtype_to_dtype` used `.map_or("F32", ..)`, and its result is written
+    /// straight into the APR tensor index. A model carrying a quant type this
+    /// build does not know therefore had its quantized bytes emitted LABELLED
+    /// F32 — a structurally valid file whose reader decodes Q-blocks as raw
+    /// floats and produces garbage weights, silently. Same class as the GPU
+    /// `unwrap_or(Q4K)` that `gpu_unsupported_quant_qtype` exists to prevent;
+    /// the conversion path simply had no equivalent gate.
+    ///
+    /// Asserts on `to_apr_bytes()` rather than on the helper, so it proves the
+    /// failure PROPAGATES rather than merely that the helper can return Err.
+    #[test]
+    fn unknown_qtype_aborts_apr_write_instead_of_labelling_it_f32() {
+        let (mut model, _) = build_model_via_gguf_roundtrip();
+
+        // Control: the untouched model converts cleanly, so a later failure is
+        // attributable to the qtype and not to the fixture.
+        model
+            .to_apr_bytes()
+            .expect("control: unmodified model must convert");
+
+        // 99 is not in GgmlQuantType::from_id's table.
+        model.lm_head_weight.qtype = 99;
+
+        // `.map(|b| b.len())` so a regression reports "wrote N bytes" instead of
+        // dumping the whole APR file into the failure message.
+        let err = model
+            .to_apr_bytes()
+            .map(|b| format!("wrote {} bytes instead of failing", b.len()))
+            .expect_err("an unknown quant type must abort the APR write");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("99"),
+            "the error must name the offending quant type: {msg}"
+        );
+        assert!(
+            !msg.is_empty() && msg.to_lowercase().contains("quant"),
+            "the error must say what went wrong: {msg}"
+        );
+    }
+
     #[test]
     fn test_to_apr_bytes_tensor_count_nonzero() {
         let (model, _) = build_model_via_gguf_roundtrip();

--- a/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
+++ b/crates/aprender-serve/src/gguf/tests/loader_tests_apr.rs
@@ -302,12 +302,30 @@ fn test_to_apr_bytes_various_qtypes() {
         };
 
         let result = model.to_apr_bytes();
-        assert!(
-            result.is_ok(),
-            "to_apr_bytes should succeed for qtype {}: {:?}",
-            qtype,
-            result.err()
-        );
+        // qtype 99 is not a GGML quant type. This used to assert `is_ok()` for
+        // EVERY value in the list including 99 -- pinning the defect in place:
+        // `apr_qtype_to_dtype` mapped an unknown qtype to "F32" and the writer
+        // emitted quantized bytes under that label, so the file was structurally
+        // valid and its weights were garbage. The test asserting is_ok() on an
+        // invalid input is what made that permanent.
+        if crate::gguf::GgmlQuantType::from_id(qtype).is_some() {
+            assert!(
+                result.is_ok(),
+                "to_apr_bytes should succeed for known qtype {}: {:?}",
+                qtype,
+                result.err()
+            );
+        } else {
+            let err = result
+                .map(|b| format!("wrote {} bytes", b.len()))
+                .expect_err(&format!(
+                    "to_apr_bytes must REFUSE unknown qtype {qtype} rather than label it F32"
+                ));
+            assert!(
+                err.to_string().contains(&qtype.to_string()),
+                "the error must name the offending qtype: {err}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
`apr_qtype_to_dtype` mapped an unrecognized GGML quant type to the string "F32":

    GgmlQuantType::from_id(qtype).map_or("F32", GgmlQuantType::as_str)

That string is written straight into the APR tensor index by
`write_apr_tensor_entry` during `to_apr_bytes()`. Converting a model carrying a
quant type this build does not know therefore emitted its QUANTIZED bytes under
an F32 label. The file is structurally valid -- correct magic, header, offsets --
and its reader decodes Q-format blocks as raw f32, producing garbage weights with
nothing reporting an error.

This is the PMAT-781/783 silent-garbage class at the conversion boundary. The doc
comment immediately above the offending line states the policy for the GPU path:
an unsupported quant must fail loudly rather than be silently decoded as
something else, which is why `gpu_unsupported_quant_qtype` exists. Conversion had
no equivalent gate. `infer/mod.rs:39` performs the same lookup and maps the
unknown case to "Unknown" -- two functions, one job, opposite answers.

`apr_qtype_to_dtype` now returns `Result` and `to_apr_bytes()` propagates.

Why it survived: `test_to_apr_bytes_various_qtypes` iterated a qtype list
INCLUDING 99 -- deliberately not a GGML type -- and asserted `is_ok()` for all of
them. The test named for exercising the qtype mapping pinned its worst behaviour
in place. Exactly the class the 0.63.0 hansei identified and that
check_assertions_exclude.sh ratchets down. It now requires success for known
types and REFUSAL for unknown ones.

Two things this commit had to fix to be committable at all, both pre-existing:

* `embedding.rs::quant_scale_first_nonfinite` sat at cognitive 30 vs a threshold
  of 25, and dtype.rs `include!()`s that file -- so the gate rejected every
  commit touching dtype.rs regardless of content. Its ten-arm layout table is
  extracted to `quant_block_layout`; 30 -> 17.

* That table had NO test coverage. Changing Q4_K's block size from 144 to 999
  left all 15,657 lib tests green. It is the sole input to a corruption
  detector, so a wrong entry silently disables that detector for one quant type.
  Refactoring untested code without leaving a test behind is how a "pure move"
  changes behaviour unnoticed, so it now has four: the wire-format table
  (including Q6_K's TRAILING scale offset, the one most likely to be transcribed
  as 0), unscaled/unknown types declining, NaN-scale detection with a finite
  control, and short/empty input declining rather than reading past the end.

Mutation-verified, each RED then restored GREEN:
  * restore `.map_or("F32", ..)`      -> "wrote 34113 bytes instead of failing"
  * Q4_K block size 144 -> 999        -> caught (was invisible before)
  * Q6_K scale offset 208 -> 0        -> caught (was invisible before)

The falsifier asserts on `to_apr_bytes()` rather than the helper, so it proves
the failure PROPAGATES, and runs a control conversion on the unmodified model
first so a failure is attributable to the qtype and not the fixture.

aprender-serve --lib: 15661 passed, 0 failed. Zero clippy lints.

Refs #2481

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>