### PR TITLE
fix(compute): a 100ns wall-clock comparison in a required check blocked every open PR

### DIFF
--- a/crates/aprender-compute/src/brick/tests/model_trace/tile_profiling.rs
+++ b/crates/aprender-compute/src/brick/tests/model_trace/tile_profiling.rs
@@ -339,15 +339,32 @@ fn test_f375_toggle_safety_zero_cost() {
         "Disabled profiling should not record stats"
     );
 
-    // The absolute nanosecond bound here was `overhead_ns < 1000.0`. It failed
-    // this required check at 1043.1ns - 4% over - while 16 CI jobs shared one
-    // box. #2425 removed three wall-clock assertions from `workspace-test` for
-    // exactly this reason; this is a fourth it did not reach.
+    // NO wall-clock assertion. Two have now failed this REQUIRED check:
     //
-    // An absolute bound inside a REQUIRED check measures the runner, not the
-    // code. What this test is named for - "toggle safety, zero COST" - is a
-    // COMPARISON: disabled must be cheaper than enabled. Measure both in the same
-    // run and assert the ratio, so machine speed and contention cancel out.
+    //   * `overhead_ns < 1000.0` -- an absolute bound, failed at 1043.1ns (4%
+    //     over) with 16 CI jobs sharing one box.
+    //   * `overhead_ns < enabled_ns` -- a ratio, which was supposed to cancel
+    //     machine speed out. It failed at "disabled 156.0ns vs enabled 111.8ns"
+    //     and blocked every open PR. The ratio does not cancel WARMUP: the
+    //     disabled loop runs first, cold, and the enabled loop second, warm, so
+    //     at ~100ns/iteration the measurement order dominates the thing being
+    //     measured. Adding warmup passes would shrink the flake without
+    //     eliminating it -- at this magnitude the signal is smaller than the
+    //     scheduling noise on a shared runner.
+    //
+    // #2425 removed three wall-clock assertions from `workspace-test` for this
+    // reason; this is the fourth it did not reach. What "toggle safety, zero
+    // cost" actually claims is verified STRUCTURALLY above and below, and those
+    // assertions are deterministic:
+    //
+    //   * disabled records 0 tiles -- it really did no work
+    //   * enabled records exactly `iterations` tiles -- the comparison is not
+    //     vacuous, both paths were genuinely exercised
+    //
+    // A regression that made disabled profiling do real work would break the
+    // count assertion, which is the property worth gating on. Timings are
+    // REPORTED for humans and asserted by the benchmark suite, which owns
+    // performance claims and is not a merge gate.
     let mut enabled = BrickProfiler::new();
     enabled.enable_tile_profiling();
     let start_enabled = std::time::Instant::now();
@@ -357,19 +374,12 @@ fn test_f375_toggle_safety_zero_cost() {
     }
     let enabled_ns = start_enabled.elapsed().as_nanos() as f64 / iterations as f64;
 
-    // The enabled path must actually have recorded something, or "disabled is
-    // cheaper" would be trivially true with both paths doing nothing.
     assert_eq!(
         enabled.tile_stats(TileLevel::Micro).count,
         iterations as u64,
-        "enabled profiling must record every tile, else the comparison below is vacuous"
+        "enabled profiling must record every tile, else the disabled count above proves nothing"
     );
-    assert!(
-        overhead_ns < enabled_ns,
-        "disabled profiling must cost less than enabled: disabled {overhead_ns:.1}ns vs enabled {enabled_ns:.1}ns"
-    );
-    // Absolute figures are REPORTED, never asserted - they are a property of the
-    // machine that ran them.
+
     println!(
         "F375: disabled = {overhead_ns:.1}ns, enabled = {enabled_ns:.1}ns (ratio {:.2}x)",
         enabled_ns / overhead_ns.max(1.0)


### PR DESCRIPTION
`test_f375_toggle_safety_zero_cost` failed workspace-test with

    disabled profiling must cost less than enabled: disabled 156.0ns vs enabled 111.8ns

taking `gate` down with it. Nine PRs were open and none could merge.

That assertion was mine, added to replace an absolute bound (`overhead_ns <
1000.0`) that had failed the same required check at 1043.1ns -- 4% over -- while
16 CI jobs shared one box. The ratio was supposed to cancel machine speed out.
It does not cancel WARMUP: the disabled loop runs first, cold, and the enabled
loop second, warm, so at ~100ns/iteration the measurement ORDER dominates the
thing being measured. Adding warmup passes would shrink the flake without
eliminating it; at this magnitude the signal is smaller than the scheduling
noise on a shared runner.

#2425 removed three wall-clock assertions from workspace-test for exactly this
reason. This is the fourth it did not reach, and the second time I have tried to
keep a timing assertion in a required check by making it cleverer rather than
removing it.

The property the test is named for is verified STRUCTURALLY, and those
assertions are deterministic:

  * disabled records 0 tiles -- it really did no work
  * enabled records exactly `iterations` tiles -- so the disabled count is not
    vacuously zero because nothing ran

A regression that made disabled profiling do real work breaks the count
assertion, which is the property worth gating on. Timings are still printed for
humans; performance claims belong to the benchmark suite, which is not a merge
gate.

Verified:
  * 20/20 consecutive runs pass under concurrent load (the old form's whole
    problem was passing MOST of the time)
  * mutation: `profiler.enable_tile_profiling()` on the disabled profiler ->
    RED, "Disabled profiling should not record stats"; restored -> GREEN

My first attempt at that mutation edited the wrong one of 13 identical
`let mut profiler = BrickProfiler::new();` lines and proved nothing. A mutation
that fails to turn red needs its own diagnosis before the guard is blamed.

aprender-compute --lib: 3509 passed, 0 failed.

Refs #2425

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>