### PR TITLE
fix(contracts): five falsification conditions named a cargo test target that does not exist (closes #2504)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,6 +444,21 @@ jobs:
       # compile its own test suite. Text-only check, no build.
       - name: No exclude pattern may swallow a src/ directory
         run: bash scripts/check_exclude_anchored.sh
+      # Poka-yoke: a contract may not name an enforcement command that cannot
+      # run. #2504: apr-cli-commands-v1.yaml declared five falsification
+      # conditions enforced by `cargo test --test apr_cli_commands ...`; there
+      # is no such target, so all five exited 101. The underlying tests are real
+      # and DO run (line 327, inside workspace-test) — what was fiction is the
+      # contract's account of HOW, which destroys the discrimination between
+      # "stale pointer" and "missing gate" that a contract exists to provide.
+      # Nothing caught it because these strings sit under a `falsification:`
+      # key the typed Contract struct does not have, so serde drops them and
+      # `pv validate` never sees them. Self-test first (Verification Discipline
+      # #7). Needs `cargo metadata` only — no build.
+      - name: Enforcement guard's own case table must pass before it judges
+        run: bash scripts/check_contract_enforcement.sh --self-test
+      - name: No contract may name an enforcement command that cannot run
+        run: bash scripts/check_contract_enforcement.sh
       # Poka-yoke: capturing `cmd 2>&1` into one variable and then parsing it as
       # JSON puts the command's diagnostics in front of its data. On 2026-08-11
       # the nightly story reported `no format_parity gate found in --json output

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ tier3:
 	@echo "Checking no contract cites a test that does not exist (aprender#2465)..."
 	@bash scripts/check_contract_test_binding.sh --self-test
 	@bash scripts/check_contract_test_binding.sh
+	@echo "Checking no contract names an enforcement command that cannot run (aprender#2504)..."
+	@bash scripts/check_contract_enforcement.sh --self-test
+	@bash scripts/check_contract_enforcement.sh
 	@if [ -d tests/golden ]; then \
 		if . scripts/apr_bin.sh 2>/dev/null; then \
 			echo "Running probar golden regression with profiling... ($$APR)"; \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1771** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1772** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **105** CLI commands | `apr --help` |
 | Book CLI chapters | **105** chapters | `ls book/src/cli/*.md` (parity with CLI) |
 | Book lib chapters | **69** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1771 provable YAML contracts
+├── contracts/                      # 1772 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1771 contracts across inference, training, quantization, attention, FFN,
+1772 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/apr-cli-commands-v1.yaml
+++ b/contracts/apr-cli-commands-v1.yaml
@@ -21,7 +21,7 @@ metadata:
 kind: CLICommandContract
 name: apr-cli-commands
 version: "1.1.0"
-scope: "all apr CLI subcommands (77 commands — original 57 + `mcp` added 2026-04-17 via PR #864 + `registry` added 2026-04-20 via CRUX-A-01 + `ollama-chat-lint` added 2026-04-21 via CRUX-C-04 SHIP-001 retrofit + `dry-sampling-lint` added 2026-04-21 via CRUX-C-23 SHIP-001 retrofit + `awq-lint` added 2026-04-21 via CRUX-B-08 SHIP-001 retrofit + `oom-lint` added 2026-04-21 via CRUX-F-13 SHIP-001 + `tool-use-lint` added 2026-04-21 via CRUX-C-11 SHIP-001 retrofit + `gbnf-lint` added 2026-04-21 via CRUX-C-10 SHIP-001 retrofit + `typical-p-lint` added 2026-04-21 via CRUX-C-22 SHIP-001 retrofit + `grad-norm` added 2026-04-21 via CRUX-F-09 + `registry-quota-lint` added 2026-04-21 via CRUX-A-22 SHIP-001 retrofit + `fp8-lint` added 2026-04-22 via CRUX-B-11 SHIP-001 retrofit + `imatrix-lint` added 2026-04-22 via CRUX-B-07 SHIP-001 retrofit + `nf4-lint` added 2026-04-22 via CRUX-B-10 SHIP-001 retrofit + `gptq-lint` added 2026-04-22 via CRUX-B-09 SHIP-001 retrofit + `embeddings-lint` added 2026-04-23 via CRUX-C-13 SHIP-001 retrofit + `unified-search-lint` added 2026-04-23 via CRUX-A-23 SHIP-001 retrofit + `rm-gc-lint` added 2026-04-23 via CRUX-A-25 SHIP-001 retrofit + `shared-cache-lint` added 2026-04-23 via CRUX-A-21 SHIP-001 retrofit + `ppl` added 2026-04-23 via CRUX-E-02 SHIP-001 retrofit)"
+scope: "all apr CLI subcommands (105 commands; count is derived from the `commands:` list below and checked against `apr --help` by FALSIFY-CLI-005 — do not hand-maintain a number here)"
 binary: "apr"
 install: "cargo install aprender"
 
@@ -702,27 +702,27 @@ falsification:
   - name: FALSIFY-CLI-001
     description: "Command listed in contract but missing from `apr --help`"
     check: "Every command.name in this YAML must appear in `apr --help` output"
-    enforcement: "cargo test --test apr_cli_commands test_all_contract_commands_exist"
+    enforcement: "cargo test -p apr-cli --test cli_commands test_all_contract_commands_exist"
 
   - name: FALSIFY-CLI-002
     description: "Command in `apr --help` but missing from contract"
     check: "Every command in `apr --help` must have an entry in this YAML"
-    enforcement: "cargo test --test apr_cli_commands test_no_unregistered_commands"
+    enforcement: "cargo test -p apr-cli --test cli_commands test_no_unregistered_commands"
 
   - name: FALSIFY-CLI-003
     description: "Command --help exits with non-zero code"
     check: "Every command must exit 0 on --help"
-    enforcement: "cargo test --test apr_cli_commands test_all_commands_help"
+    enforcement: "cargo test -p apr-cli --test cli_commands test_all_commands_respond_to_help"
 
   - name: FALSIFY-CLI-004
     description: "Command panics on --help"
     check: "No command may panic when invoked with --help"
-    enforcement: "cargo test --test apr_cli_commands test_all_commands_help"
+    enforcement: "cargo test -p apr-cli --test cli_commands test_all_commands_respond_to_help"
 
   - name: FALSIFY-CLI-005
     description: "Command count drifts from contract"
     check: "The number of commands in `apr --help` must equal the count in this YAML"
-    enforcement: "cargo test --test apr_cli_commands test_command_count_matches"
+    enforcement: "cargo test -p apr-cli --test cli_commands test_command_count_matches"
 
   - name: FALSIFY-CLI-THRESHOLD-NAN-001
     description: >

--- a/contracts/apr-contract-enforcement-v1.yaml
+++ b/contracts/apr-contract-enforcement-v1.yaml
@@ -1,0 +1,162 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-contract-enforcement-v1
+#
+# A contract may not name an enforcement command that cannot run.
+#
+# ORIGIN (#2504, SURF-14 / R11)
+# contracts/apr-cli-commands-v1.yaml declared, five times:
+#
+#     enforcement: "cargo test --test apr_cli_commands <fn>"
+#
+# There is no `apr_cli_commands` test target — the target is `cli_commands`
+# (crates/apr-cli/tests/cli_commands.rs). All five exited 101 with
+# `error: no test target named apr_cli_commands`. Two were wrong twice over,
+# naming `test_all_commands_help` where the function is
+# `test_all_commands_respond_to_help` (cli_commands.rs:201).
+#
+# The underlying tests are REAL and DO run — `cli_commands` is invoked at
+# ci.yml:327 inside `workspace-test`, which is inside `gate.needs`. Nothing was
+# unguarded. What was fiction is the contract's ACCOUNT of how it is enforced.
+#
+# WHY THAT IS A CONTRACT DEFECT AND NOT A TYPO
+# A contract exists to let a reader discriminate. Someone auditing whether
+# FALSIFY-CLI-003 is live runs the command the contract hands them, gets an
+# error, and cannot tell "the pointer is stale" from "the gate is missing".
+# The contract has destroyed exactly the signal it was written to provide.
+# This is R1 one level up: a claim verified against nothing.
+#
+# WHY NOTHING CAUGHT IT
+# These strings live under a top-level `falsification:` list. The typed
+# `Contract` struct has no such field — it has `falsification_tests`
+# (crates/aprender-contracts/src/schema/types.rs:33). serde drops the unknown
+# key silently, so `pv validate` never sees them, and the sibling guard
+# check_contract_test_binding.sh (#2465) reads `falsification_tests[].test`,
+# a different field entirely. The block is inert YAML that reads as governance.
+#
+# PROOF LADDER (crates/aprender-contracts/src/proof_status.rs):
+#   * L1 — YAML + obligations (this file).
+#   * L2 — falsification tests cover obligations. >>> ACHIEVED <<<: the guard
+#          ships an 8-case must-flag/must-not-flag table plus a vacuity arm, and
+#          BOTH guard-logic mutations were verified RED (neutered resolver;
+#          disabled vacuity floor). The guard was also confirmed RED on
+#          unmodified main against the 5 real defects before the fix landed.
+#   * L3 — Kani BMC. NOT APPLICABLE and deliberately not declared: the subject
+#          is a filesystem + `cargo metadata` resolution over unbounded strings,
+#          not a bounded arithmetic kernel. Declaring an un-backed Kani harness
+#          to inflate the level would be theater. This contract honestly
+#          reports L2.
+# ─────────────────────────────────────────────────────────────────────────────
+name: apr-contract-enforcement
+version: "1.0.0"
+scope: >
+  Every `enforcement:` scalar under contracts/ that names a `cargo test`
+  invocation. Out of scope: enforcement strings naming CI job names, runtime
+  assertions, or build-time checks (182 of the 195 strings in the tree today) —
+  those have no single mechanical resolver and are a named follow-up, not a
+  silent omission.
+status: active
+
+metadata:
+  kind: pattern     # cross-cutting CI-lane guard over contract metadata, not a
+                    # math kernel. Set EXPLICITLY so `pv validate`'s `kernel`
+                    # default never silently applies (spec §5.3).
+  version: "1.0.0"
+  created: '2026-08-15'
+  last_modified: '2026-08-15'
+  author: PAIML Engineering
+  description: >
+    A contract that misreports how it is enforced provides no discrimination
+    between a stale pointer and a missing gate. This pins every cargo-shaped
+    enforcement string to a target and test function that actually exist,
+    resolved against `cargo metadata` rather than against a guess.
+
+contract: |
+  For every `enforcement:` scalar E in contracts/**/*.yaml such that E names a
+  `cargo test` invocation:
+
+    (1) if E names `--test T`, then T is a test target of some workspace
+        package, as reported by `cargo metadata --no-deps`;
+    (2) if E also names `-p P` (or `--package P`), then the package owning T
+        is exactly P;
+    (3) if E carries a trailing bare token F (a `cargo test` filter), then the
+        source file of T contains a definition `fn F(`.
+
+  Rule (3) is an exact function-name match, deliberately stricter than cargo's
+  own substring filtering. Accepting prefixes would let `test_all` "resolve"
+  against `test_all_commands_respond_to_help` — the precise near-miss shape
+  that produced #2504.
+
+equations:
+  - name: ENF-EQ-001
+    statement: "resolves(E) ⟺ target_exists(E) ∧ package_matches(E) ∧ fn_exists(E)"
+    description: >
+      Resolution is the conjunction of the three rules. Total over all
+      cargo-shaped enforcement strings: every E is either resolved or reported,
+      never skipped.
+
+proof_obligations:
+  - id: ENF-OB-001
+    statement: "No enforcement string names a --test target absent from cargo metadata."
+    discharged_by: falsification_tests[0]
+  - id: ENF-OB-002
+    statement: "No enforcement string names a test fn absent from its target's source."
+    discharged_by: falsification_tests[1]
+  - id: ENF-OB-003
+    statement: "No enforcement string names a -p package that does not own its target."
+    discharged_by: falsification_tests[2]
+  - id: ENF-OB-004
+    statement: >
+      The guard refuses to pass when it resolves zero enforcement strings — a
+      regex that stopped matching must never be indistinguishable from a clean
+      tree (#2476, #2485).
+    discharged_by: falsification_tests[3]
+
+falsification_tests:
+  - name: enforcement_target_must_exist
+    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
+    description: >
+      Fixture case bad_target.yaml names `--test ghost_target`. MUST be flagged.
+    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
+  - name: enforcement_fn_must_exist
+    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
+    description: >
+      Fixture cases bad_fn.yaml (`test_ghost_fn`) and bad_prefix.yaml
+      (`test_real`, a prefix of a real fn) MUST both be flagged.
+    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
+  - name: enforcement_package_must_own_target
+    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
+    description: >
+      Fixture case bad_pkg.yaml names `-p other` for a target owned by `fx`.
+      MUST be flagged.
+    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
+  - name: enforcement_guard_refuses_to_pass_vacuously
+    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
+    description: >
+      An empty contract directory MUST fail, never read as clean.
+    mutation: "Disable the MIN_CMDS floor — VERIFIED RED."
+
+non_goals:
+  - "Checking that the named test PASSES. That is workspace-test's job; this proves the command RESOLVES."
+  - "Resolving non-cargo enforcement strings (CI job names, runtime assertions, build-time checks)."
+  - "Teaching the typed schema about the `falsification:` key. That is the better long-term home for this check and is named as follow-up in #2504; it is a schema change with its own blast radius."
+
+binding_registry:
+  guard: scripts/check_contract_enforcement.sh
+  ci_job: guard-runner-labels          # inside gate.needs (.github/workflows/ci.yml)
+  make_target: tier3
+  issue: "https://github.com/paiml/aprender/issues/2504"
+
+verification_summary: >
+  L2. Guard confirmed RED on unmodified main against the 5 real defects
+  (13 cargo enforcement strings checked, 5 failing), and GREEN after the fix
+  (13/13 resolve). The corrected command was independently confirmed to run:
+  `cargo test -p apr-cli --test cli_commands test_all_commands_respond_to_help
+  --no-run` exits 0, where the original exited 101. Self-test: 8 resolution
+  cases + 1 vacuity arm; both guard-logic mutations verified RED.
+
+formal_verification_roadmap: >
+  L3/Kani not applicable — the subject is filesystem and cargo-metadata
+  resolution over unbounded strings, not a bounded kernel. The real next rung is
+  moving the check into `pv` once the typed schema admits the `falsification:`
+  key, at which point the resolver becomes a total function over a typed model
+  rather than a text scan, and gains a property-test surface.

--- a/contracts/apr-contract-enforcement-v1.yaml
+++ b/contracts/apr-contract-enforcement-v1.yaml
@@ -64,6 +64,13 @@ metadata:
   created: '2026-08-15'
   last_modified: '2026-08-15'
   author: PAIML Engineering
+  references:
+    - 'scripts/check_contract_enforcement.sh — the resolver (implementation)'
+    - 'contracts/apr-cli-commands-v1.yaml — the contract whose five conditions were unrunnable (#2504)'
+    - 'crates/apr-cli/tests/cli_commands.rs — the real test target the five strings should have named'
+    - 'crates/aprender-contracts/src/schema/types.rs:33 — `falsification_tests`; the absent `falsification` field is why serde dropped these strings'
+    - 'scripts/check_contract_test_binding.sh — sibling guard (#2465) covering falsification_tests[].test, a different field'
+    - 'https://github.com/paiml/aprender/issues/2504 — SURF-14 / R11'
   description: >
     A contract that misreports how it is enforced provides no discrimination
     between a stale pointer and a missing gate. This pins every cargo-shaped
@@ -112,28 +119,26 @@ proof_obligations:
     discharged_by: falsification_tests[3]
 
 falsification_tests:
-  - name: enforcement_target_must_exist
-    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
-    description: >
-      Fixture case bad_target.yaml names `--test ghost_target`. MUST be flagged.
-    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
-  - name: enforcement_fn_must_exist
-    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
-    description: >
-      Fixture cases bad_fn.yaml (`test_ghost_fn`) and bad_prefix.yaml
-      (`test_real`, a prefix of a real fn) MUST both be flagged.
-    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
-  - name: enforcement_package_must_own_target
-    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
-    description: >
-      Fixture case bad_pkg.yaml names `-p other` for a target owned by `fx`.
-      MUST be flagged.
-    mutation: "Neuter resolve_one() to `return 0` — VERIFIED RED."
-  - name: enforcement_guard_refuses_to_pass_vacuously
-    test_harness: "bash scripts/check_contract_enforcement.sh --self-test"
-    description: >
-      An empty contract directory MUST fail, never read as clean.
-    mutation: "Disable the MIN_CMDS floor — VERIFIED RED."
+  - id: enforcement_target_must_exist
+    obligation: ENF-OB-001
+    test_harness: 'bash scripts/check_contract_enforcement.sh --self-test'
+    prediction: 'Fixture case bad_target.yaml names `--test ghost_target`, absent from cargo metadata; the resolver flags it and the self-test reports bad_target.'
+    if_fails: 'The --test token is not being extracted, or the cargo metadata target table is empty; check target_table() output before suspecting the regex.'
+  - id: enforcement_fn_must_exist
+    obligation: ENF-OB-002
+    test_harness: 'bash scripts/check_contract_enforcement.sh --self-test'
+    prediction: 'bad_fn.yaml (`test_ghost_fn`) and bad_prefix.yaml (`test_real`, a strict prefix of a real fn) are BOTH flagged; the prefix case must not resolve.'
+    if_fails: 'The fn match has loosened to a substring, which is exactly how `test_all` would silently "resolve" against test_all_commands_respond_to_help — the #2504 near-miss.'
+  - id: enforcement_package_must_own_target
+    obligation: ENF-OB-003
+    test_harness: 'bash scripts/check_contract_enforcement.sh --self-test'
+    prediction: 'bad_pkg.yaml names `-p other` for a target owned by package `fx`; the ownership comparison flags it.'
+    if_fails: 'The -p token is unparsed or compared against the wrong column of the target table.'
+  - id: enforcement_guard_refuses_to_pass_vacuously
+    obligation: ENF-OB-004
+    test_harness: 'bash scripts/check_contract_enforcement.sh --self-test'
+    prediction: 'An empty contract directory yields zero cargo enforcement strings and the guard EXITS NON-ZERO rather than reporting a clean tree.'
+    if_fails: 'The MIN_CMDS floor is disarmed; a regex that stopped matching would now be indistinguishable from a clean tree (#2476, #2485).'
 
 non_goals:
   - "Checking that the named test PASSES. That is workspace-test's job; this proves the command RESOLVES."
@@ -146,13 +151,23 @@ binding_registry:
   make_target: tier3
   issue: "https://github.com/paiml/aprender/issues/2504"
 
-verification_summary: >
-  L2. Guard confirmed RED on unmodified main against the 5 real defects
-  (13 cargo enforcement strings checked, 5 failing), and GREEN after the fix
-  (13/13 resolve). The corrected command was independently confirmed to run:
-  `cargo test -p apr-cli --test cli_commands test_all_commands_respond_to_help
-  --no-run` exits 0, where the original exited 101. Self-test: 8 resolution
-  cases + 1 vacuity arm; both guard-logic mutations verified RED.
+# VERIFICATION NARRATIVE (prose lives in a comment; the field below is typed)
+#   Guard confirmed RED on unmodified main against the 5 real defects
+#   (13 cargo enforcement strings checked, 5 failing), and GREEN after the fix
+#   (13/13 resolve). The corrected command was independently confirmed to run:
+#   `cargo test -p apr-cli --test cli_commands test_all_commands_respond_to_help
+#   --no-run` exits 0, where the original exited 101. Self-test: 8 resolution
+#   cases + 1 vacuity arm; both guard-logic mutations verified RED.
+#
+#   L3/Kani is counted as NOT APPLICABLE, not as un-proved: the subject is
+#   filesystem + `cargo metadata` resolution over unbounded strings, not a
+#   bounded arithmetic kernel. Declaring an un-backed Kani harness to inflate
+#   the level would be theater.
+verification_summary:
+  total_obligations: 4
+  l2_property_tested: 4
+  l3_kani_proved: 0
+  l4_not_applicable: 4
 
 formal_verification_roadmap: >
   L3/Kani not applicable — the subject is filesystem and cargo-metadata

--- a/scripts/check_contract_enforcement.sh
+++ b/scripts/check_contract_enforcement.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# check_contract_enforcement.sh — a contract may not name an enforcement command
+# that cannot run.
+#
+# WHY THIS EXISTS (#2504, SURF-14 / R11)
+# --------------------------------------
+# contracts/apr-cli-commands-v1.yaml carried five falsification conditions, each
+# declaring how it is enforced:
+#
+#     enforcement: "cargo test --test apr_cli_commands test_all_contract_commands_exist"
+#
+# There is no `apr_cli_commands` test target. The file is
+# crates/apr-cli/tests/cli_commands.rs and the target is `cli_commands`, so all
+# five commands exit 101 with `error: no test target named apr_cli_commands`.
+# Two were wrong twice over, also naming `test_all_commands_help` where the
+# function is `test_all_commands_respond_to_help`.
+#
+# The tests themselves are real and DO run (ci.yml:327, inside workspace-test,
+# inside gate.needs). What was fiction is the contract's account of HOW. A
+# reader auditing whether FALSIFY-CLI-003 is live runs the command the contract
+# hands them, gets an error, and cannot distinguish "the pointer is stale" from
+# "the gate is missing" — which is precisely the discrimination a contract
+# exists to provide.
+#
+# WHY NOTHING CAUGHT IT
+# ---------------------
+# The strings live under a top-level `falsification:` list. `Contract` has no
+# such field — it has `falsification_tests` (schema/types.rs:33). serde drops
+# the unknown key silently, so `pv validate` never sees these strings, and
+# check_contract_test_binding.sh (#2465) reads `falsification_tests[].test`,
+# a different field. The block is inert YAML that reads as governance.
+#
+# That is why this guard scans YAML text rather than the typed model: the field
+# it must police is one the typed model does not admit. Teaching the schema
+# about `falsification:` is the better long-term home and is filed as follow-up;
+# it is a schema change with its own blast radius, not a prerequisite for
+# closing the hole.
+#
+# WHAT IT CHECKS
+# --------------
+# Every `enforcement:` scalar in contracts/ that names a `cargo test`
+# invocation must resolve, against `cargo metadata` — not against a guess:
+#
+#   1. `--test <target>` names a test target that exists in the workspace.
+#   2. `-p <pkg>`, when present, owns that target.
+#   3. A trailing bare token is a `cargo test` filter and must appear as
+#      `fn <token>` in that target's source file.
+#
+# Rule 3 is deliberately a substring-free exact `fn` match. `cargo test FOO`
+# filters on a SUBSTRING of `module::path::fn`, so a filter can legitimately be
+# a prefix — but every filter in this tree today names a whole function, and
+# accepting prefixes would let `test_all` silently "resolve" against
+# `test_all_commands_respond_to_help`, which is the exact class of near-miss
+# that produced #2504. Loosen this only with a case in the self-test table.
+#
+# VACUITY GUARD
+# -------------
+# A regex that stops matching is indistinguishable from a clean tree, and that
+# failure mode has shipped here twice (#2476, #2485). This refuses to pass
+# unless it found at least MIN_CMDS cargo enforcement strings, and it prints the
+# count it resolved. Its universe is built by `find` over contracts/, and the
+# defect — a wrong string — cannot remove a file from that universe.
+#
+# SELF-TEST
+# ---------
+#   bash scripts/check_contract_enforcement.sh --self-test
+# drives the real resolver over a hermetic fixture with an eight-case
+# must-flag / must-not-flag table, then mutates the resolver's own inputs to
+# prove each arm turns RED. Verification Discipline #7: re-run the table, never
+# re-read the pattern.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+CONTRACT_DIR="${CONTRACT_DIR:-$REPO_ROOT/contracts}"
+MIN_CMDS="${MIN_CMDS:-8}"
+
+GUARD_TMP=""
+cleanup() {
+    if [ -z "$GUARD_TMP" ]; then
+        return 0
+    fi
+    if [ "$GUARD_TMP" = "/" ]; then
+        return 0
+    fi
+    rm -rf "$GUARD_TMP"
+}
+trap cleanup EXIT
+
+die() {
+    printf '%s\n' "$*" >&2
+    exit 1
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "check_contract_enforcement: missing required tool: $1"
+}
+
+# ---------------------------------------------------------------------------
+# Emit "pkg<TAB>target<TAB>src_path" for every test target in the workspace.
+# Sourced from cargo metadata so the guard cannot disagree with cargo about
+# what exists — the disagreement is the whole defect.
+# ---------------------------------------------------------------------------
+target_table() {
+    local manifest="$1" out="$2"
+    ( cd "$(dirname "$manifest")" && cargo metadata --no-deps --format-version 1 2>/dev/null ) \
+        | jq -r '.packages[] as $p
+                 | $p.targets[]
+                 | select(.kind | index("test"))
+                 | "\($p.name)\t\(.name)\t\(.src_path)"' \
+        > "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Emit "file:line<TAB>command" for every enforcement scalar naming cargo test.
+# ---------------------------------------------------------------------------
+enforcement_commands() {
+    local dir="$1"
+    grep -rn --include='*.yaml' -E '^[[:space:]]*enforcement:[[:space:]]*.*cargo[[:space:]]+test' "$dir" 2>/dev/null \
+        | sed -E 's/^([^:]+:[0-9]+):[[:space:]]*enforcement:[[:space:]]*/\1\t/' \
+        | sed -E 's/\t"(.*)"[[:space:]]*$/\t\1/' \
+        | sed -E "s/\t'(.*)'[[:space:]]*\$/\t\1/"
+}
+
+# ---------------------------------------------------------------------------
+# Resolve one command. Prints a diagnostic and returns 1 on failure.
+# ---------------------------------------------------------------------------
+resolve_one() {
+    local loc="$1" cmd="$2" table="$3"
+    local target pkg filter row src owner
+
+    target=$(printf '%s\n' "$cmd" | grep -oE '\-\-test[[:space:]]+[A-Za-z0-9_]+' | awk '{print $2}' | head -1)
+    if [ -z "$target" ]; then
+        # A cargo test invocation with no --test target (e.g. `cargo test --lib`).
+        # Nothing to resolve; counted, not judged.
+        return 0
+    fi
+
+    row=$(awk -F'\t' -v t="$target" '$2 == t {print; exit}' "$table")
+    if [ -z "$row" ]; then
+        printf '%s\n' "  $loc" >&2
+        printf '%s\n' "      names --test $target, which is not a test target in this workspace" >&2
+        printf '%s\n' "      command: $cmd" >&2
+        return 1
+    fi
+    owner=$(printf '%s' "$row" | cut -f1)
+    src=$(printf '%s' "$row" | cut -f3)
+
+    pkg=$(printf '%s\n' "$cmd" | grep -oE '(-p|--package)[[:space:]]+[A-Za-z0-9_-]+' | awk '{print $2}' | head -1)
+    if [ -n "$pkg" ] && [ "$pkg" != "$owner" ]; then
+        printf '%s\n' "  $loc" >&2
+        printf '%s\n' "      names -p $pkg, but target $target belongs to $owner" >&2
+        return 1
+    fi
+
+    # The test filter: the last bare token, excluding cargo's own words.
+    filter=$(printf '%s\n' "$cmd" \
+        | tr ' ' '\n' \
+        | grep -vE '^(cargo|test|--test|-p|--package|--all-features|--release|--|--lib|--no-fail-fast)$' \
+        | grep -vE '^-' \
+        | grep -vE "^(${target}|${pkg:-__none__})$" \
+        | tail -1)
+    if [ -z "$filter" ]; then
+        return 0
+    fi
+    if ! grep -qE "fn[[:space:]]+${filter}[[:space:]]*\(" "$src" 2>/dev/null; then
+        printf '%s\n' "  $loc" >&2
+        printf '%s\n' "      names test fn '$filter', which does not exist in $src" >&2
+        return 1
+    fi
+    return 0
+}
+
+scan() {
+    local dir="$1" manifest="$2"
+    local table="$GUARD_TMP/targets.tsv"
+    target_table "$manifest" "$table"
+    [ -s "$table" ] || die "VACUOUS: cargo metadata yielded no test targets - the resolver has no universe."
+
+    local checked=0 bad=0 loc cmd
+    while IFS=$'\t' read -r loc cmd; do
+        [ -n "$cmd" ] || continue
+        checked=$((checked + 1))
+        resolve_one "$loc" "$cmd" "$table" || bad=$((bad + 1))
+    done < <(enforcement_commands "$dir")
+
+    printf '%s %s\n' "$checked" "$bad" > "$GUARD_TMP/stats"
+}
+
+# ---------------------------------------------------------------------------
+self_test() {
+    need jq
+    GUARD_TMP="$(mktemp -d)"
+    local fx="$GUARD_TMP/fx" fail=0
+    mkdir -p "$fx/tests" "$fx/c"
+
+    printf '%s\n' \
+        '[package]' 'name = "fx"' 'version = "0.0.0"' 'edition = "2021"' \
+        '[[test]]' 'name = "real_target"' 'path = "tests/real_target.rs"' > "$fx/Cargo.toml"
+    printf '%s\n' \
+        '#[test]' 'fn test_real_fn() {}' \
+        '#[test]' 'fn test_real_fn_longer() {}' > "$fx/tests/real_target.rs"
+
+    # MUST NOT FLAG
+    printf 'enforcement: "cargo test --test real_target test_real_fn"\n'        > "$fx/c/ok_full.yaml"
+    printf 'enforcement: "cargo test -p fx --test real_target test_real_fn"\n'  > "$fx/c/ok_pkg.yaml"
+    printf 'enforcement: "cargo test --test real_target"\n'                     > "$fx/c/ok_nofilter.yaml"
+    printf 'enforcement: "cargo test --lib"\n'                                  > "$fx/c/ok_notarget.yaml"
+    # MUST FLAG
+    printf 'enforcement: "cargo test --test ghost_target test_real_fn"\n'       > "$fx/c/bad_target.yaml"
+    printf 'enforcement: "cargo test --test real_target test_ghost_fn"\n'       > "$fx/c/bad_fn.yaml"
+    printf 'enforcement: "cargo test -p other --test real_target test_real_fn"\n' > "$fx/c/bad_pkg.yaml"
+    # Prefix must NOT resolve (the #2504 near-miss shape)
+    printf 'enforcement: "cargo test --test real_target test_real"\n'           > "$fx/c/bad_prefix.yaml"
+
+    local out
+    out="$(MIN_CMDS=1 scan_capture "$fx/c" "$fx/Cargo.toml" 2>&1)"
+
+    local must_flag="bad_target bad_fn bad_pkg bad_prefix"
+    local must_not="ok_full ok_pkg ok_nofilter ok_notarget"
+    local c
+    for c in $must_flag; do
+        case "$out" in
+            *"$c.yaml"*) ;;
+            *) printf 'SELF-TEST FAIL: %s should have been flagged, was not\n' "$c" >&2; fail=1 ;;
+        esac
+    done
+    for c in $must_not; do
+        case "$out" in
+            *"$c.yaml"*) printf 'SELF-TEST FAIL: %s was flagged, should not have been\n' "$c" >&2; fail=1 ;;
+            *) ;;
+        esac
+    done
+
+    # Vacuity arm: an empty contract dir must FAIL, never read as clean.
+    mkdir -p "$fx/empty"
+    if CONTRACT_DIR="$fx/empty" MIN_CMDS=1 bash "$SCRIPT_PATH" --manifest "$fx/Cargo.toml" >/dev/null 2>&1; then
+        printf 'SELF-TEST FAIL: empty contract dir should FAIL (vacuity), it passed\n' >&2
+        fail=1
+    fi
+
+    [ "$fail" -eq 0 ] || die "check_contract_enforcement: SELF-TEST FAILED"
+    printf 'check_contract_enforcement: SELF-TEST PASSED (8 resolution cases + 1 vacuity arm)\n'
+}
+
+scan_capture() {
+    GUARD_TMP="${GUARD_TMP:-$(mktemp -d)}"
+    scan "$1" "$2"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    local manifest="$REPO_ROOT/Cargo.toml"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --self-test) self_test; exit 0 ;;
+            --manifest) manifest="$2"; shift 2 ;;
+            *) die "check_contract_enforcement: unknown argument: $1" ;;
+        esac
+    done
+
+    need jq
+    need cargo
+    GUARD_TMP="$(mktemp -d)"
+    [ -d "$CONTRACT_DIR" ] || die "check_contract_enforcement: no contract dir at $CONTRACT_DIR"
+
+    scan "$CONTRACT_DIR" "$manifest"
+    local checked bad
+    read -r checked bad < "$GUARD_TMP/stats"
+
+    if [ "$checked" -lt "$MIN_CMDS" ]; then
+        die "VACUOUS: found only $checked cargo enforcement string(s) (floor: $MIN_CMDS). The scan collapsed; this is a broken guard, not a clean tree."
+    fi
+    if [ "$bad" -gt 0 ]; then
+        printf '\nFAIL: %s of %s cargo enforcement string(s) name something that cannot run.\n' "$bad" "$checked" >&2
+        printf 'A contract that misreports how it is enforced provides no discrimination\n' >&2
+        printf 'between "the pointer is stale" and "the gate is missing".\n' >&2
+        exit 1
+    fi
+    printf 'OK: %s cargo enforcement strings in %s; every target and test fn resolves\n' \
+        "$checked" "${CONTRACT_DIR#"$REPO_ROOT"/}"
+}
+
+main "$@"


### PR DESCRIPTION
contracts/apr-cli-commands-v1.yaml declared, five times:

    enforcement: "cargo test --test apr_cli_commands <fn>"

There is no `apr_cli_commands` test target. The target is `cli_commands`
(crates/apr-cli/tests/cli_commands.rs), so every one of those five commands
exits 101 with `error: no test target named apr_cli_commands`. Two were wrong
twice over, naming `test_all_commands_help` where the function is
`test_all_commands_respond_to_help` (cli_commands.rs:201).

The underlying tests are REAL and DO run: `cli_commands` is invoked at
ci.yml:327 inside `workspace-test`, which is inside `gate.needs`. Nothing was
unguarded. What was fiction is the contract's ACCOUNT of how it is enforced --
and that is not cosmetic. A reader auditing whether FALSIFY-CLI-003 is live runs
the command the contract hands them, gets an error, and cannot distinguish "the
pointer is stale" from "the gate is missing". The contract destroyed exactly the
discrimination it exists to provide. R1 one level up: a claim verified against
nothing.

WHY NOTHING CAUGHT IT

These strings live under a top-level `falsification:` list. The typed `Contract`
struct has no such field -- it has `falsification_tests`
(crates/aprender-contracts/src/schema/types.rs:33). serde drops the unknown key
silently, so `pv validate` never sees them, and the sibling guard
check_contract_test_binding.sh (#2465) reads `falsification_tests[].test`, a
different field. The whole block is inert YAML that reads as governance.

That is also why the new guard scans YAML text rather than the typed model: the
field it must police is one the typed model does not admit. Teaching the schema
about `falsification:` is the better long-term home and is named as follow-up in
the contract's roadmap -- it is a schema change with its own blast radius, not a
prerequisite for closing the hole.

WHAT LANDS

  scripts/check_contract_enforcement.sh   resolves every cargo-shaped
    `enforcement:` string against `cargo metadata` -- not against a guess:
      1. `--test T` names a real workspace test target
      2. `-p P`, when present, owns T
      3. a trailing bare filter token exists as `fn F(` in T's source

    Rule 3 is an exact match, deliberately stricter than cargo's substring
    filtering: accepting prefixes would let `test_all` "resolve" against
    `test_all_commands_respond_to_help`, the precise near-miss that produced
    this bug.

  contracts/apr-contract-enforcement-v1.yaml   metadata.kind: pattern, set
    explicitly so pv's `kernel` default never silently applies. Honestly reports
    L2 and states why L3/Kani does not apply rather than declaring an un-backed
    harness.

  Five conditions corrected, and the `scope:` prose -- which still read
  "77 commands" against a 105-entry registry -- now points at the list instead
  of carrying a hand-maintained number.

FULL SWEEP

All 1771 contracts, not just the reported file. 195 `enforcement:` strings
exist; 13 name a cargo invocation. Of those 13: 5 broken (all in
apr-cli-commands-v1.yaml), 7 `monorepo_invariants` resolve, 1 `cli_commands`
resolves. Every target AND every named test function was checked. No baseline
ratchet is needed -- the tree reaches zero in this PR. The other 182 strings name
CI jobs, runtime assertions or build-time checks; they have no single mechanical
resolver and are declared out of scope in the contract rather than silently
skipped.

EVIDENCE

  guard on unmodified main   exit 1, naming exactly the 5, "5 of 13"
  guard after the fix        exit 0, "13 cargo enforcement strings; every
                             target and test fn resolves"
  the corrected command      `cargo test -p apr-cli --test cli_commands
                             test_all_commands_respond_to_help --no-run`
                             exits 0, where the original exited 101
  cargo test -p apr-cli --test cli_commands    10 passed, 0 failed
  bashrs lint                0 errors

Self-test: 8 resolution cases (bad target / bad fn / bad package / bad PREFIX,
and four that must NOT flag) plus a vacuity arm. Vacuity matters here: a regex
that stops matching is indistinguishable from a clean tree, and that failure mode
has already shipped twice (#2476, #2485), so the guard refuses to pass on zero
and prints the count it resolved.

Both guard-logic mutations verified RED, each with the correct message:
  neuter resolve_one() to `return 0`  -> all four must-flag cases fail
  disable the MIN_CMDS floor          -> the vacuity arm fails

Wired into `guard-runner-labels` (inside gate.needs) and `make tier3`, self-test
first in both. Needs `cargo metadata` only -- no build.

Closes #2504.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)