### PR TITLE
fix(profile): 58 test targets CI never ran, 110 failing, and a syscall the profiler could not name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,13 @@ jobs:
         run: bash scripts/check_guards_are_wired.sh
       - name: Wiring guard case table
         run: bash scripts/check_guards_are_wired.sh --self-test
+      # aprender-profile appeared in this file ZERO times while carrying 58
+      # integration test targets. Running them found 110 failures -- 109 from a
+      # single stale binary name left by the APR-MONO rename, dead since. Gated
+      # now so the crate cannot go dark again. --lib only: the integration
+      # targets shell out to the built binary and take minutes.
+      - name: aprender-profile lib tests (was gated by nothing)
+        run: cargo test -p aprender-profile --lib
       - name: Book rust examples compile
         run: bash scripts/check_book_examples_compile.sh
       # CB-510: a Cargo.toml `exclude` pattern can strip an include!() target

--- a/crates/aprender-profile/src/syscalls.rs
+++ b/crates/aprender-profile/src/syscalls.rs
@@ -135,6 +135,13 @@ static SYSCALL_TABLE_X86_64: &[(i64, &str)] = &[
     (217, "getdents64"),
     (218, "set_tid_address"),
     (228, "clock_gettime"),
+    // 229/230 were missing: the table jumped 228 -> 231, so clock_nanosleep
+    // rendered as an unnamed syscall. sprint20_realtime_anomaly_tests
+    // deliberately sleeps 50ms and asserts an anomaly is reported; the
+    // detector never saw the sleep, and the test only passed when unrelated
+    // microsecond jitter on `write` happened to exceed 3 sigma.
+    (229, "clock_getres"),
+    (230, "clock_nanosleep"),
     (231, "exit_group"),
     (257, "openat"),
     (262, "newfstatat"),
@@ -363,6 +370,73 @@ mod tests {
             let name = syscall_name(num);
             // clone3 (435) is below our range, so all should be unknown
             prop_assert_eq!(name, "unknown");
+        }
+    }
+}
+
+#[cfg(test)]
+mod table_completeness {
+    //! The x86_64 table jumped 228 -> 231, so `clock_nanosleep` (230) rendered
+    //! as an unnamed `syscall_230` and a deliberate 50ms sleep was invisible to
+    //! the profiler. Nothing caught it: removing the entries again left all 107
+    //! syscall tests green, because every existing test asserts a PROPERTY
+    //! (determinism, non-empty) rather than a specific mapping.
+    //!
+    //! A property test over `0..500` cannot catch a missing entry -- "unknown"
+    //! is a valid answer across most of that range. Only naming numbers can.
+
+    use super::*;
+
+    /// Syscalls this tracer must be able to name, numbers fixed by the x86_64
+    /// ABI. These are the ones a profiler actually meets.
+    const MUST_NAME: &[(i64, &str)] = &[
+        (0, "read"),
+        (1, "write"),
+        (60, "exit"),
+        (202, "futex"),
+        (228, "clock_gettime"),
+        (229, "clock_getres"),
+        (230, "clock_nanosleep"),
+        (231, "exit_group"),
+        (257, "openat"),
+    ];
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn every_common_syscall_resolves_to_its_abi_name() {
+        let missing: Vec<String> = MUST_NAME
+            .iter()
+            .filter(|(n, want)| syscall_name(*n) != *want)
+            .map(|(n, want)| format!("{n} should be {want}, got {}", syscall_name(*n)))
+            .collect();
+        assert!(missing.is_empty(), "syscall table is missing or wrong for: {missing:?}");
+    }
+
+    /// Non-vacuity. If `syscall_name` produced a name for anything asked of it,
+    /// the assertion above would pass while proving nothing.
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn an_unassigned_number_is_still_unknown() {
+        assert_eq!(
+            syscall_name(9_999),
+            "unknown",
+            "an unassigned syscall number resolved to a name, so the check above \
+             cannot distinguish a populated table from a permissive one"
+        );
+    }
+
+    /// The gap that produced the bug was contiguous. The clock family is where
+    /// the tracer's timing anomalies live, so assert it is whole.
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn the_clock_syscall_range_has_no_holes() {
+        for n in 228..=231 {
+            assert_ne!(
+                syscall_name(n),
+                "unknown",
+                "syscall {n} is unnamed; the 228-231 range is where clock_nanosleep \
+                 went missing and made a 50ms sleep invisible to the profiler"
+            );
         }
     }
 }

--- a/crates/aprender-profile/tests/sprint20_realtime_anomaly_tests.rs
+++ b/crates/aprender-profile/tests/sprint20_realtime_anomaly_tests.rs
@@ -11,43 +11,58 @@ use tempfile::TempDir;
 
 #[test]
 fn test_realtime_anomaly_detects_slow_syscall() {
-    // Test that --anomaly-realtime detects and reports slow syscalls in real-time
+    // The detector builds a PER-SYSCALL baseline and flags samples >3 sigma from
+    // it. The original fixture slept 50ms via nanosleep and asserted an anomaly
+    // -- but clock_nanosleep occurs exactly ONCE, so there is no baseline for it
+    // to deviate from, and it could never be flagged. The test passed only when
+    // unrelated microsecond jitter on `write` happened to exceed 3 sigma, which
+    // is why it was flaky and why its comment already read "increased for test
+    // stability".
+    //
+    // Fixed by giving the anomaly a baseline: many small writes establish one,
+    // then a single large write is the outlier. Same syscall, so the detector
+    // can actually see it.
+    //
+    // (Separately, clock_nanosleep was rendering as an unnamed `syscall_230` --
+    // the x86_64 table jumped 228 -> 231. Fixed in src/syscalls.rs.)
     let tmp_dir = TempDir::new().expect("test");
     let test_program = tmp_dir.path().join("realtime_anomaly_test");
 
-    // Create program with baseline fast syscalls + one anomalous slow syscall
     let source = r#"
 #include <unistd.h>
-#include <time.h>
+#include <stdlib.h>
 int main() {
-    // Establish baseline: 50 fast writes
-    for (int i = 0; i < 50; i++) {
+    // Baseline: 200 one-byte writes.
+    for (int i = 0; i < 200; i++) {
         write(1, "x", 1);
     }
-
-    // Simulate slow I/O (anomaly)
-    struct timespec ts = {0, 50000000};  // 50ms sleep (increased for test stability)
-    nanosleep(&ts, NULL);
-    write(1, "slow", 4);
-
+    // The anomaly: one write three orders of magnitude larger, same syscall so
+    // it lands in the same baseline.
+    char *big = malloc(4 * 1024 * 1024);
+    for (int i = 0; i < 4 * 1024 * 1024; i++) big[i] = 'y';
+    write(1, big, 4 * 1024 * 1024);
+    free(big);
     return 0;
 }
 "#;
     let source_file = tmp_dir.path().join("realtime_anomaly_test.c");
     fs::write(&source_file, source).expect("test");
 
-    std::process::Command::new("gcc")
+    let compile = std::process::Command::new("gcc")
         .arg(&source_file)
         .arg("-o")
         .arg(&test_program)
         .output()
         .expect("Failed to compile test program");
+    assert!(
+        compile.status.success(),
+        "fixture did not compile, so this test would assert about nothing: {}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
 
     let mut cmd = assert_cmd::cargo::cargo_bin_cmd!("aprender-profile");
     cmd.arg("--anomaly-realtime").arg("-T").arg("--").arg(&test_program);
-
-    // Should show real-time anomaly alert
-    cmd.assert().success().stderr(predicate::str::contains("⚠️  ANOMALY"));
+    cmd.assert().success().stderr(predicate::str::contains("\u{26a0}\u{fe0f}  ANOMALY"));
 }
 
 #[test]

--- a/crates/aprender-profile/tests/sprint22_isolation_forest_tests.rs
+++ b/crates/aprender-profile/tests/sprint22_isolation_forest_tests.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 #[test]
 fn test_ml_outliers_flag_accepted() {
     // Test that --ml-outliers flag is accepted
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--ml-outliers").arg("--").arg("echo").arg("test");
 
     // Should not error on flag parsing
@@ -30,7 +30,7 @@ fn test_ml_outliers_flag_accepted() {
 
 #[test]
 fn test_ml_outliers_with_statistics() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--ml-outliers").arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -73,7 +73,7 @@ int main() {
         .output()
         .expect("Failed to compile test program");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--ml-outliers").arg("--").arg(&test_program);
 
     // Should detect anomalies in output
@@ -86,7 +86,7 @@ int main() {
 
 #[test]
 fn test_explain_flag_provides_explainability() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--ml-outliers").arg("--explain").arg("--").arg("echo").arg("test");
 
     cmd.assert().success().stderr(
@@ -100,7 +100,7 @@ fn test_explain_flag_provides_explainability() {
 
 #[test]
 fn test_ml_outliers_json_export() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--format").arg("json").arg("--ml-outliers").arg("--").arg("echo").arg("test");
 
     cmd.assert().success().stdout(
@@ -114,7 +114,7 @@ fn test_ml_outliers_json_export() {
 
 #[test]
 fn test_ml_outliers_with_filtering() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--ml-outliers").arg("-e").arg("trace=file").arg("--").arg("ls").arg("-la");
 
     cmd.assert().success();
@@ -149,7 +149,7 @@ int main() {
         .output()
         .expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--ml-outliers").arg("--").arg(&test_program);
 
     // Should handle gracefully (no panic)
@@ -163,7 +163,7 @@ int main() {
 #[test]
 fn test_backward_compatibility_without_ml_outliers() {
     // Ensure existing functionality works without --ml-outliers flag
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -175,7 +175,7 @@ fn test_backward_compatibility_without_ml_outliers() {
 
 #[test]
 fn test_ml_outliers_with_timing() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("-T").arg("--ml-outliers").arg("--").arg("echo").arg("hello");
 
     cmd.assert().success();
@@ -187,7 +187,7 @@ fn test_ml_outliers_with_timing() {
 
 #[test]
 fn test_ml_outliers_compare_with_kmeans() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--ml-outliers")
         .arg("--ml-anomaly") // Also enable KMeans for comparison
@@ -205,7 +205,7 @@ fn test_ml_outliers_compare_with_kmeans() {
 
 #[test]
 fn test_ml_outliers_with_source_correlation() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--source").arg("--ml-outliers").arg("--").arg("echo").arg("test");
 
     // Should correlate anomalies with source locations
@@ -218,7 +218,7 @@ fn test_ml_outliers_with_source_correlation() {
 
 #[test]
 fn test_ml_outliers_threshold_configuration() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--ml-outliers")
         .arg("--ml-outlier-threshold")
@@ -236,7 +236,7 @@ fn test_ml_outliers_threshold_configuration() {
 
 #[test]
 fn test_ml_outliers_num_trees_configuration() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--ml-outliers")
         .arg("--ml-outlier-trees")

--- a/crates/aprender-profile/tests/sprint23_autoencoder_tests.rs
+++ b/crates/aprender-profile/tests/sprint23_autoencoder_tests.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 #[test]
 fn test_dl_anomaly_flag_accepted() {
     // Test that --dl-anomaly flag is accepted
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--dl-anomaly").arg("--").arg("echo").arg("test");
 
     // Should not error on flag parsing
@@ -30,7 +30,7 @@ fn test_dl_anomaly_flag_accepted() {
 
 #[test]
 fn test_dl_anomaly_with_statistics() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--dl-anomaly").arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -73,7 +73,7 @@ int main() {
         .output()
         .expect("Failed to compile test program");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--dl-anomaly").arg("--").arg(&test_program);
 
     // Should detect anomalies in output
@@ -89,7 +89,7 @@ int main() {
 
 #[test]
 fn test_dl_threshold_configuration() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--dl-anomaly")
         .arg("--dl-threshold")
@@ -107,7 +107,7 @@ fn test_dl_threshold_configuration() {
 
 #[test]
 fn test_dl_anomaly_json_export() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--format").arg("json").arg("--dl-anomaly").arg("--").arg("echo").arg("test");
 
     cmd.assert().success().stdout(
@@ -121,7 +121,7 @@ fn test_dl_anomaly_json_export() {
 
 #[test]
 fn test_dl_anomaly_with_filtering() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--dl-anomaly").arg("-e").arg("trace=file").arg("--").arg("ls").arg("-la");
 
     cmd.assert().success();
@@ -156,7 +156,7 @@ int main() {
         .output()
         .expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--dl-anomaly").arg("--").arg(&test_program);
 
     // Should handle gracefully (no panic)
@@ -170,7 +170,7 @@ int main() {
 #[test]
 fn test_backward_compatibility_without_dl_anomaly() {
     // Ensure existing functionality works without --dl-anomaly flag
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -182,7 +182,7 @@ fn test_backward_compatibility_without_dl_anomaly() {
 
 #[test]
 fn test_dl_anomaly_with_timing() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("-T").arg("--dl-anomaly").arg("--").arg("echo").arg("hello");
 
     cmd.assert().success();
@@ -194,7 +194,7 @@ fn test_dl_anomaly_with_timing() {
 
 #[test]
 fn test_dl_anomaly_with_other_ml() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--dl-anomaly")
         .arg("--ml-anomaly") // Also enable KMeans
@@ -213,7 +213,7 @@ fn test_dl_anomaly_with_other_ml() {
 
 #[test]
 fn test_dl_anomaly_with_explainability() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c").arg("--dl-anomaly").arg("--explain").arg("--").arg("echo").arg("test");
 
     // Should provide explanations
@@ -226,7 +226,7 @@ fn test_dl_anomaly_with_explainability() {
 
 #[test]
 fn test_dl_hidden_size_configuration() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--dl-anomaly")
         .arg("--dl-hidden-size")
@@ -244,7 +244,7 @@ fn test_dl_hidden_size_configuration() {
 
 #[test]
 fn test_dl_epochs_configuration() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("-c")
         .arg("--dl-anomaly")
         .arg("--dl-epochs")

--- a/crates/aprender-profile/tests/sprint24_transpiler_source_map_tests.rs
+++ b/crates/aprender-profile/tests/sprint24_transpiler_source_map_tests.rs
@@ -36,7 +36,7 @@ fn test_transpiler_map_flag_accepted() {
     fs::write(&source_map, map_content).expect("test");
 
     // Test that --transpiler-map flag is accepted
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     // Should not error on flag parsing
@@ -89,7 +89,7 @@ fn test_transpiler_map_basic_parsing() {
     fs::write(&source_map, map_content).expect("test");
 
     // Run with source map
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -107,7 +107,7 @@ fn test_transpiler_map_invalid_json() {
     // Create invalid JSON
     fs::write(&source_map, "{ this is not valid json }").expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().failure().stderr(predicate::str::contains("Invalid source map JSON"));
@@ -119,7 +119,7 @@ fn test_transpiler_map_invalid_json() {
 
 #[test]
 fn test_transpiler_map_missing_file() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg("/nonexistent/path/to/map.json")
         .arg("--")
@@ -152,7 +152,7 @@ fn test_transpiler_map_function_name_lookup() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -192,7 +192,7 @@ fn test_transpiler_map_line_number_lookup() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -228,7 +228,7 @@ fn test_transpiler_map_with_tracing() {
     fs::write(&source_map, map_content).expect("test");
 
     // Test that tracing still works with source map loaded
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("hello");
 
     cmd.assert().success().stdout(predicate::str::contains("write("));
@@ -253,7 +253,7 @@ fn test_transpiler_map_empty_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("true");
 
     cmd.assert().success();
@@ -288,7 +288,7 @@ fn test_transpiler_map_python_source() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -311,7 +311,7 @@ fn test_transpiler_map_missing_required_fields() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().failure().stderr(predicate::str::contains("Invalid source map"));
@@ -336,7 +336,7 @@ fn test_transpiler_map_unsupported_version() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().failure().stderr(predicate::str::contains("Unsupported source map version"));

--- a/crates/aprender-profile/tests/sprint25_function_name_correlation_tests.rs
+++ b/crates/aprender-profile/tests/sprint25_function_name_correlation_tests.rs
@@ -39,7 +39,7 @@ fn test_function_name_correlation_basic() {
     fs::write(&source_map, map_content).expect("test");
 
     // Run with --function-time and --transpiler-map
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -85,7 +85,7 @@ fn test_function_name_with_source_context() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     cmd.assert()
@@ -117,7 +117,7 @@ fn test_show_transpiler_context_flag() {
     fs::write(&source_map, map_content).expect("test");
 
     // Test that --show-transpiler-context is accepted
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -154,7 +154,7 @@ fn test_fallback_to_rust_names() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -197,7 +197,7 @@ fn test_function_correlation_with_source_flag() {
     fs::write(&source_map, map_content).expect("test");
 
     // Combine --transpiler-map + --function-time + --source
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -231,7 +231,7 @@ fn test_typescript_source_language() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -267,7 +267,7 @@ fn test_multiple_temp_variables() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     cmd.assert().success();
@@ -296,7 +296,7 @@ fn test_function_correlation_with_statistics() {
     fs::write(&source_map, map_content).expect("test");
 
     // Combine --transpiler-map + --function-time + -c
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -327,7 +327,7 @@ fn test_empty_function_map() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     // Should still work, just no function name translation
@@ -357,7 +357,7 @@ fn test_source_map_without_function_time() {
 
     // Source map loaded but --function-time NOT enabled
     // Should still succeed, just not use function mapping
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("echo").arg("test");
 
     cmd.assert().success();

--- a/crates/aprender-profile/tests/sprint26_decision_trace_tests.rs
+++ b/crates/aprender-profile/tests/sprint26_decision_trace_tests.rs
@@ -41,7 +41,7 @@ fn main() {
     assert!(compile_status.success(), "Failed to compile test program");
 
     // Run renacer with --trace-transpiler-decisions flag
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--trace-transpiler-decisions")
         .arg("-c") // Use statistics mode to suppress noise
@@ -91,7 +91,7 @@ fn main() {
         .expect("Failed to compile");
 
     // Run without --trace-transpiler-decisions flag
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd.arg("-c").arg("--").arg(&test_bin).output().expect("Failed to execute");
 
     assert!(output.status.success());
@@ -126,7 +126,7 @@ fn main() {
         .status()
         .expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--trace-transpiler-decisions")
         .arg("-c")
@@ -168,7 +168,7 @@ fn main() {
         .status()
         .expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--trace-transpiler-decisions")
         .arg("-c")

--- a/crates/aprender-profile/tests/sprint26_stack_trace_correlation_tests.rs
+++ b/crates/aprender-profile/tests/sprint26_stack_trace_correlation_tests.rs
@@ -33,7 +33,7 @@ fn test_rewrite_stacktrace_flag_accepted() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-stacktrace").arg("--").arg("true");
 
     // Should accept the flag without error
@@ -78,7 +78,7 @@ fn test_stack_trace_rewriting_with_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -119,7 +119,7 @@ fn test_display_python_context() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -163,7 +163,7 @@ fn test_temp_variable_rewriting() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -204,7 +204,7 @@ fn test_rewrite_stacktrace_with_function_time() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -245,7 +245,7 @@ fn test_rewrite_stacktrace_typescript() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -286,7 +286,7 @@ fn test_backward_compatibility_without_rewrite() {
     fs::write(&source_map, map_content).expect("test");
 
     // Use source map WITHOUT --rewrite-stacktrace
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("true");
 
     // Should still succeed
@@ -312,7 +312,7 @@ fn test_rewrite_stacktrace_empty_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-stacktrace").arg("--").arg("true");
 
     // Should succeed even with no mappings
@@ -341,7 +341,7 @@ fn test_rewrite_stacktrace_with_statistics() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")
@@ -407,7 +407,7 @@ fn test_multiple_line_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-stacktrace")

--- a/crates/aprender-profile/tests/sprint27_error_correlation_tests.rs
+++ b/crates/aprender-profile/tests/sprint27_error_correlation_tests.rs
@@ -32,7 +32,7 @@ fn test_rewrite_errors_flag_accepted() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-errors").arg("--").arg("true");
 
     // Should accept the flag without error
@@ -77,7 +77,7 @@ fn test_error_correlation_with_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")
@@ -118,7 +118,7 @@ fn test_rewrite_errors_with_context() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")
@@ -159,7 +159,7 @@ fn test_rewrite_errors_typescript() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")
@@ -200,7 +200,7 @@ fn test_backward_compatibility_without_rewrite_errors() {
     fs::write(&source_map, map_content).expect("test");
 
     // Use source map WITHOUT --rewrite-errors
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("true");
 
     // Should still succeed
@@ -226,7 +226,7 @@ fn test_rewrite_errors_empty_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-errors").arg("--").arg("true");
 
     // Should succeed even with no mappings
@@ -263,7 +263,7 @@ fn test_rewrite_errors_with_stacktrace() {
     fs::write(&source_map, map_content).expect("test");
 
     // Combine both flags
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")
@@ -295,7 +295,7 @@ fn test_rewrite_errors_with_statistics() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")
@@ -353,7 +353,7 @@ fn test_multiple_error_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-errors").arg("--").arg("true");
 
     cmd.assert().success();
@@ -380,7 +380,7 @@ fn test_rewrite_errors_with_function_time() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--rewrite-errors")

--- a/crates/aprender-profile/tests/sprint28_decy_integration_tests.rs
+++ b/crates/aprender-profile/tests/sprint28_decy_integration_tests.rs
@@ -35,7 +35,7 @@ fn test_c_source_language_accepted() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("true");
 
     cmd.assert().success();
@@ -63,7 +63,7 @@ fn test_c_source_with_function_time() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     cmd.assert()
@@ -101,7 +101,7 @@ fn test_c_source_with_line_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-stacktrace").arg("--").arg("true");
 
     cmd.assert()
@@ -139,7 +139,7 @@ fn test_c_source_with_context() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -182,7 +182,7 @@ fn test_c_source_with_rewrite_errors() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--rewrite-errors").arg("--").arg("true");
 
     cmd.assert().success();
@@ -209,7 +209,7 @@ fn test_c_source_with_statistics() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("-c").arg("--").arg("echo").arg("test");
 
     cmd.assert().success();
@@ -241,7 +241,7 @@ fn test_c_decy_temp_variables() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     cmd.assert().success();
@@ -277,7 +277,7 @@ fn test_c_source_all_flags() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map")
         .arg(&source_map)
         .arg("--function-time")
@@ -309,7 +309,7 @@ fn test_c_source_empty_mappings() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--").arg("true");
 
     cmd.assert().success();
@@ -344,7 +344,7 @@ fn test_c_header_file_source() {
     }"#;
     fs::write(&source_map, map_content).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     cmd.arg("--transpiler-map").arg(&source_map).arg("--function-time").arg("--").arg("true");
 
     cmd.assert().success().stdout(predicate::str::contains("types.h"));

--- a/crates/aprender-profile/tests/sprint31_ruchy_integration_tests.rs
+++ b/crates/aprender-profile/tests/sprint31_ruchy_integration_tests.rs
@@ -37,7 +37,7 @@ echo "[RESULT] type_inference: inferred i32" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -71,7 +71,7 @@ echo "[RESULT] optimization: inlined" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -105,7 +105,7 @@ echo "[RESULT] type_check: type is valid" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -153,7 +153,7 @@ echo "[RESULT] pattern_compile: compiled" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -189,7 +189,7 @@ echo "[RESULT] trait_solve: bound satisfied" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -216,7 +216,7 @@ fn test_backward_compatibility_otlp_without_decisions() {
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint").arg("http://localhost:4317").arg("--").arg(&test_program);
 
     // Should work fine - OTLP without decisions
@@ -246,7 +246,7 @@ echo "[RESULT] const_eval: evaluated to 42" >&2
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--trace-transpiler-decisions").arg("--").arg(&test_program);
 
     // Should work fine - decisions without OTLP
@@ -280,7 +280,7 @@ echo "Done"
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -315,7 +315,7 @@ echo "Result"
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")
@@ -350,7 +350,7 @@ echo "Output"
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--otlp-service-name")
@@ -386,7 +386,7 @@ echo "Output"
             .expect("Failed to set permissions");
     }
 
-    let mut cmd = Command::cargo_bin("renacer").expect("Failed to find renacer binary");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("Failed to find renacer binary");
     cmd.arg("--otlp-endpoint")
         .arg("http://localhost:4317")
         .arg("--trace-transpiler-decisions")

--- a/crates/aprender-profile/tests/sprint33_span_context_propagation_tests.rs
+++ b/crates/aprender-profile/tests/sprint33_span_context_propagation_tests.rs
@@ -11,7 +11,7 @@ use assert_cmd::Command;
 /// Test 1: --trace-parent CLI flag is accepted
 #[test]
 fn test_trace_parent_cli_flag_accepted() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -30,7 +30,7 @@ fn test_trace_parent_cli_flag_accepted() {
 /// Test 2: Valid traceparent format is parsed correctly
 #[test]
 fn test_trace_parent_valid_format() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -56,7 +56,7 @@ fn test_trace_parent_valid_format() {
 /// Test 3: Invalid traceparent format falls back to new root trace
 #[test]
 fn test_trace_parent_invalid_format_fallback() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -83,7 +83,7 @@ fn test_trace_parent_invalid_format_fallback() {
 /// Test 4: All-zero trace-id is rejected
 #[test]
 fn test_trace_parent_all_zero_trace_id() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -110,7 +110,7 @@ fn test_trace_parent_all_zero_trace_id() {
 /// Test 5: All-zero parent-id is rejected
 #[test]
 fn test_trace_parent_all_zero_parent_id() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -137,7 +137,7 @@ fn test_trace_parent_all_zero_parent_id() {
 /// Test 6: Invalid version is rejected
 #[test]
 fn test_trace_parent_invalid_version() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -164,7 +164,7 @@ fn test_trace_parent_invalid_version() {
 /// Test 7: Backward compatibility - works without trace context
 #[test]
 fn test_backward_compatibility_no_trace_context() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -185,7 +185,7 @@ fn test_backward_compatibility_no_trace_context() {
 /// Test 8: trace-parent requires otlp-endpoint
 #[test]
 fn test_trace_parent_requires_otlp() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--trace-parent")
         .arg("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
@@ -206,7 +206,7 @@ fn test_trace_parent_requires_otlp() {
 /// Test 9: Sampled flag (01) is detected
 #[test]
 fn test_trace_parent_sampled_flag_set() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -229,7 +229,7 @@ fn test_trace_parent_sampled_flag_set() {
 /// Test 10: Not sampled flag (00) is detected
 #[test]
 fn test_trace_parent_not_sampled_flag() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -252,7 +252,7 @@ fn test_trace_parent_not_sampled_flag() {
 /// Test 11: Combine with statistics mode
 #[test]
 fn test_trace_parent_with_statistics() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -276,7 +276,7 @@ fn test_trace_parent_with_statistics() {
 /// Test 12: Combine with source correlation
 #[test]
 fn test_trace_parent_with_source() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -300,7 +300,7 @@ fn test_trace_parent_with_source() {
 /// Test 13: Combine with timing mode
 #[test]
 fn test_trace_parent_with_timing() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -324,7 +324,7 @@ fn test_trace_parent_with_timing() {
 /// Test 14: Combine with filtering
 #[test]
 fn test_trace_parent_with_filtering() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -349,7 +349,7 @@ fn test_trace_parent_with_filtering() {
 /// Test 15: Combine with compute tracing (Sprint 32)
 #[test]
 fn test_trace_parent_with_compute_tracing() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -375,7 +375,7 @@ fn test_trace_parent_with_compute_tracing() {
 /// Test 16: Combine with transpiler decision tracing (Sprint 31)
 #[test]
 fn test_trace_parent_with_decision_tracing() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")
@@ -399,7 +399,7 @@ fn test_trace_parent_with_decision_tracing() {
 /// Test 17: Full observability stack (all Sprint 30-33 features)
 #[test]
 fn test_trace_parent_full_observability_stack() {
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg("http://localhost:4317")

--- a/crates/aprender-profile/tests/sprint34_integration_tests.rs
+++ b/crates/aprender-profile/tests/sprint34_integration_tests.rs
@@ -34,7 +34,7 @@ fn test_compute_jaeger_export() {
     setup_jaeger();
 
     // Run Renacer with compute tracing
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -81,7 +81,7 @@ fn test_compute_adaptive_sampling() {
     clear_jaeger_data().expect("Failed to clear Jaeger");
 
     // Run with default adaptive sampling (100μs)
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -139,7 +139,7 @@ fn test_compute_trace_all_flag() {
     clear_jaeger_data().expect("Failed to clear Jaeger");
 
     // Run with --trace-compute-all (no sampling)
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -187,7 +187,7 @@ fn test_compute_span_attributes() {
     clear_jaeger_data().expect("Failed to clear Jaeger");
 
     // Run with compute tracing
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -237,7 +237,7 @@ fn test_compute_parent_child_relationship() {
     clear_jaeger_data().expect("Failed to clear Jaeger");
 
     // Run with compute tracing
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -293,7 +293,7 @@ fn test_compute_multiple_blocks() {
     clear_jaeger_data().expect("Failed to clear Jaeger");
 
     // Run with compute tracing on a program that should generate multiple compute blocks
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -340,7 +340,7 @@ fn test_distributed_trace_context_propagation() {
     let traceparent = format!("00-{}-{}-01", trace_id, parent_span_id);
 
     // Run Renacer with injected trace context
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -399,7 +399,7 @@ fn test_distributed_env_var_extraction() {
     let traceparent = format!("00-{}-{}-00", trace_id, parent_span_id);
 
     // Run Renacer (should auto-detect TRACEPARENT)
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .env("TRACEPARENT", &traceparent)
         .arg("--otlp-endpoint")
@@ -437,7 +437,7 @@ fn test_w3c_traceparent_validation() {
     setup_jaeger();
 
     // Test invalid traceparent format (should be rejected)
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -473,7 +473,7 @@ fn test_distributed_trace_flags() {
     let parent_span_id = "fedcba0987654321";
     let traceparent = format!("00-{}-{}-01", trace_id, parent_span_id);
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -510,7 +510,7 @@ fn test_distributed_service_name() {
     let traceparent = format!("00-{}-{}-01", trace_id, parent_span_id);
 
     // Run with trace context
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -552,7 +552,7 @@ fn test_full_observability_stack() {
     let traceparent = format!("00-{}-{}-01", trace_id, parent_span_id);
 
     // Run with ALL features: distributed + compute + stats
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -608,7 +608,7 @@ fn test_full_stack_span_hierarchy() {
     let traceparent = format!("00-{}-{}-01", trace_id, parent_span_id);
 
     // Run with all features
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)
@@ -683,7 +683,7 @@ fn test_full_stack_performance_overhead() {
 
     // Run WITHOUT tracing (baseline)
     let start = std::time::Instant::now();
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--")
         .arg("./tests/fixtures/simple_program")
@@ -695,7 +695,7 @@ fn test_full_stack_performance_overhead() {
 
     // Run WITH full tracing
     let start = std::time::Instant::now();
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd
         .arg("--otlp-endpoint")
         .arg(OTLP_ENDPOINT)

--- a/crates/aprender-profile/tests/sprint49_decision_export_tests.rs
+++ b/crates/aprender-profile/tests/sprint49_decision_export_tests.rs
@@ -212,7 +212,7 @@ fn test_cli_stats_command() {
 
     std::fs::write(&msgpack_path, rmp_serde::to_vec(&traces).expect("test")).expect("test");
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd.arg("stats").arg(&msgpack_path).output().expect("Failed to execute");
 
     assert!(output.status.success(), "stats command should succeed");
@@ -229,7 +229,7 @@ fn test_cli_export_command_help() {
     // AC: renacer export --help shows usage
     use assert_cmd::Command;
 
-    let mut cmd = Command::cargo_bin("renacer").expect("test");
+    let mut cmd = Command::cargo_bin("aprender-profile").expect("test");
     let output = cmd.arg("export").arg("--help").output().expect("Failed to execute");
 
     assert!(output.status.success());


### PR DESCRIPTION
Test triage of a binary surface area, per the standing instruction: **bubble the tests up, fix what can be fixed, delete what cannot.**

`aprender-profile` appears in `ci.yml` **zero times** and carries **58 integration test targets**. They all compile. Running them:

| | targets | passed | failed | ignored |
|---|---|---|---|---|
| before | 61 | 1966 | **110** | 48 |
| after | 61 | **2079** | **0** | 48 |

## Two root causes

### 109 failures, one cause

```
`CARGO_BIN_EXE_renacer` is unset
```

`[lib] name = "renacer"` but the **binary target** is `aprender-profile`, so that env var never existed. **126 `cargo_bin("renacer")` call sites across 12 files**, dead since the APR-MONO rename. Identical defect to the cgp one in #2496, different crate. Binary name taken from `cargo metadata`, not assumed.

### 1 failure, hiding a real defect in the profiler

`test_realtime_anomaly_detects_slow_syscall` compiles a program that sleeps 50 ms and asserts an anomaly is reported. It wasn't. Two findings:

**a. `clock_nanosleep` (x86_64 syscall 230) had no name.** The table jumped `(228, clock_gettime)` → `(231, exit_group)`, so the tracer printed `syscall_230` and the 50 ms sleep was invisible as a named syscall. Added 229 `clock_getres` and 230 `clock_nanosleep`.

**b. The test could never have passed for the right reason.** The detector builds a **per-syscall baseline** and flags >3σ from it — and `clock_nanosleep` occurs exactly *once*, so there is no baseline to deviate from. The green runs were unrelated microsecond jitter on `write` (8–19 μs against a 10 μs baseline) happening to exceed 3σ. Its own comment already read *"increased for test stability"* — which is what tuning a test that asserts the wrong thing looks like.

Rewritten so the anomaly **has** a baseline: 200 one-byte writes, then one 4 MiB write. Same syscall, so the detector can see it. Stable across three consecutive runs. It now also asserts the fixture compiled — a `gcc` failure would otherwise make the test assert about nothing.

## The falsifier, because nothing guarded this

Removing the two syscall entries again left **all 107 syscall tests green**. Every existing test asserts a *property* — determinism, non-empty — and a property test over `0..500` cannot catch a missing entry, since `"unknown"` is a valid answer across most of that range. **Only naming numbers can.**

`mod table_completeness` names nine ABI-fixed syscalls, asserts the 228–231 clock range has no holes, and carries a non-vacuity arm: `9_999` must still be `"unknown"`, or a permissive lookup would satisfy the rest.

**Mutation**: restore the gap → the two name assertions go RED, the non-vacuity arm stays green.

## Gated

`cargo test -p aprender-profile --lib` wired into `guard-runner-labels` (in `gate.needs`) so the crate cannot go dark again. `--lib` only: the integration targets shell out to the built binary and take minutes.

## Two measurements I got wrong and corrected

- I first read *"21 targets ran, 58 files exist"* as **37 files never running**. Wrong — cargo stops at the first failing target. `cargo metadata` confirms all 58 exist; `--no-fail-fast` gave the real 61/110.
- I tested a stale binary once and had to resolve the path from `cargo --message-format=json` — the worktree `target/debug/` is not where builds land here.