### PR TITLE
fix(ci): nextest had no per-test timeout — the key name was wrong, so a hang killed the job anonymously and evicted the merge queue

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,15 +1,41 @@
 # cargo-nextest CI profile
-# Deployed from paiml/infra — do not edit manually.
+# Deployed from paiml/infra — CHANGED HERE deliberately; fold back upstream.
 # Spec: docs/specifications/unified-ci-pipeline.md
-
+#
+# `slow-warning` was not a nextest key. nextest does not reject an unknown key,
+# it prints `ignoring unknown configuration key: profile.ci.slow-warning` and
+# carries on -- so this profile had NO per-test timeout at all, and the warning
+# sat unread in every workspace-test log. Consequence, merge_group job
+# 95162862834 for #2502:
+#
+#     12:50:58  Starting 80806 tests across 69 binaries
+#     13:36:07  ##[error]The operation was canceled.
+#
+# 45 minutes inside nextest, killed by the JOB's `timeout-minutes: 85`, naming
+# no test; the queue entry was evicted 31 seconds later. `check_nextest_config_keys.sh`
+# now fails on any key nextest ignores.
 [profile.ci]
 retries = 2
 fail-fast = true
-slow-warning = "60s"
-status-level = "fail"
+# Measured on an idle 48-core box, 80806 tests, 353s wall: slowest single test
+# is 202.7s (aprender-orchestrate bug_hunter::test_bh_mod_001_hunt_all_modes),
+# only 2 tests exceed 120s and NONE exceeds 300s. terminate-after = 20 periods
+# = 1200s is ~6x the slowest real test, so it cannot kill a legitimately slow
+# one, while a genuine hang dies at 20 minutes WITH A NAME instead of taking
+# the whole 85-minute job down anonymously.
+slow-timeout = { period = "60s", terminate-after = 20 }
+# Must be "slow", not "fail". nextest's status levels are ordered
+#   none < fail < retry < slow < pass < all
+# so "fail" is BELOW "slow" and suppresses the SLOW lines entirely. Measured on
+# a probe crate: status-level="fail" emits 0 SLOW lines, "slow" emits 3. Setting
+# the timeout above without this would fix the kill and keep hiding the warning
+# that precedes it.
+status-level = "slow"
 
 [profile.ci.junit]
-path = "target/nextest/ci/junit.xml"
+# Relative to the store dir (target/nextest/<profile>/), NOT to the workspace
+# root -- the old value produced target/nextest/ci/target/nextest/ci/junit.xml.
+path = "junit.xml"
 store-success-output = false
 store-failure-output = true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,9 +439,26 @@ jobs:
       # warning was in every workspace-test log and nobody read it, so it is a
       # hard failure now. Runs nextest's real parser on a 3-line crate.
       - name: nextest must ignore no key in .config/nextest.toml
-        run: bash scripts/check_nextest_config_keys.sh
+        # Runs INSIDE the image: cargo-nextest is installed there, not on the
+        # host runner (the first version of this step failed with "SKIP:
+        # cargo-nextest not installed" -> exit 1, which is the guard failing
+        # closed in the wrong place). The probe crate has ZERO dependencies, so
+        # CARGO_NET_OFFLINE=1 is safe and no registry mount is needed.
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            -e CARGO_NET_OFFLINE=1 \
+            "$IMAGE" \
+            bash scripts/check_nextest_config_keys.sh
       - name: "nextest-key guard must still turn RED (case table)"
-        run: bash scripts/check_nextest_config_keys.sh --self-test
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            -e CARGO_NET_OFFLINE=1 \
+            "$IMAGE" \
+            bash scripts/check_nextest_config_keys.sh --self-test
       # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
       # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
       # `set -uo pipefail` deliberately (it must run every beat and tally the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
     runs-on: [self-hosted, X64, Linux, clean-room]
-    timeout-minutes: 85  # bumped to match 75min step + 10min overhead
+    # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
+    # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
+    # timeout always fired first -- producing a bare "The operation was canceled"
+    # that names no step. Job 95162862834 died exactly on the 85-minute mark this
+    # way. The step timeout must be the one that can fire, because it points at
+    # the step; the job timeout is the backstop behind it.
+    timeout-minutes: 100
     env:
       IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
@@ -426,6 +432,16 @@ jobs:
       # correct everywhere else). Run the table; do not re-read the regex.
       - name: "`apr`-pinning guard must still turn RED (case table + surfaces)"
         run: bash scripts/check_apr_bin_pinned.sh --self-test
+      # Poka-yoke: nextest IGNORES an unknown config key with a warning instead
+      # of failing. `slow-warning = "60s"` is not a nextest key, so profile.ci
+      # had no per-test timeout and a hung run died at the job's 85-minute
+      # timeout naming nothing -- evicting #2502 from the merge queue. The
+      # warning was in every workspace-test log and nobody read it, so it is a
+      # hard failure now. Runs nextest's real parser on a 3-line crate.
+      - name: nextest must ignore no key in .config/nextest.toml
+        run: bash scripts/check_nextest_config_keys.sh
+      - name: "nextest-key guard must still turn RED (case table)"
+        run: bash scripts/check_nextest_config_keys.sh --self-test
       # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
       # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
       # `set -uo pipefail` deliberately (it must run every beat and tally the

--- a/scripts/check_nextest_config_keys.sh
+++ b/scripts/check_nextest_config_keys.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# check_nextest_config_keys.sh — nextest must not IGNORE any key in
+# .config/nextest.toml.
+#
+# WHY THIS EXISTS
+# ---------------
+# `.config/nextest.toml` carried
+#
+#     [profile.ci]
+#     slow-warning = "60s"
+#
+# There is no `slow-warning` key in nextest. The real one is `slow-timeout`.
+# nextest does not fail on an unknown key — it prints a warning and carries on:
+#
+#     warning: in config file .config/nextest.toml, ignoring unknown
+#              configuration key: profile.ci.slow-warning
+#
+# So `profile.ci` had NO slow-timeout at all. Consequence, measured on the
+# merge_group run for #2502 (job 95162862834):
+#
+#     12:50:58  Starting 80806 tests across 69 binaries
+#     13:36:07  ##[error]The operation was canceled.
+#
+# 45 minutes inside nextest, killed by the JOB's `timeout-minutes: 85`, naming
+# no test. The queue entry was evicted 31 seconds later. `main` did not move.
+# Without a per-test timeout there is nothing to name the culprit, and the whole
+# job dies anonymously instead.
+#
+# The warning was on line 353 of that job's log, and of every workspace-test log
+# before it. A diagnostic nobody reads is not a diagnostic — so this makes it a
+# hard failure.
+#
+# HOW
+# ---
+# nextest only validates config when it runs, so this runs it: a throwaway
+# three-line crate, with the REPO's config passed via `--config-file`. Costs one
+# trivial rustc invocation, not a workspace build, and exercises the real parser
+# rather than a regex of our own guessing at nextest's schema.
+#
+#   bash scripts/check_nextest_config_keys.sh              # check
+#   bash scripts/check_nextest_config_keys.sh --self-test  # case table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="${REPO_ROOT}/.config/nextest.toml"
+
+if ! command -v cargo-nextest >/dev/null 2>&1 && ! cargo nextest --version >/dev/null 2>&1; then
+    printf 'SKIP: cargo-nextest not installed; install with `cargo install cargo-nextest --locked`.\n' >&2
+    [ "${CI:-}" = "true" ] && exit 1
+    exit 0
+fi
+
+# Run nextest on a throwaway crate with the given config; echo any ignored-key
+# warnings. Nothing else about the run matters.
+ignored_keys_for() {
+    local cfg="$1" dir
+    dir="$(mktemp -d)" || return 1
+    case "$dir" in
+        /tmp/*|/var/folders/*) : ;;
+        *) printf 'BADTMP %s\n' "${dir:-<empty>}"; return 1 ;;
+    esac
+    mkdir -p "$dir/src"
+    # Line by line rather than a heredoc: bashrs parses an embedded heredoc as
+    # shell, so TOML `name = "x"` gets reported as SC1007.
+    {
+        printf '[package]\n'
+        printf 'name = "nextest-config-probe"\n'
+        printf 'version = "0.0.0"\n'
+        printf 'edition = "2021"\n'
+    } > "$dir/Cargo.toml"
+    printf 'pub fn probe() -> u8 { 1 }\n' > "$dir/src/lib.rs"
+
+    ( cd "$dir" && cargo nextest run --config-file "$cfg" --profile ci 2>&1 ) \
+        | grep -F 'ignoring unknown configuration key' \
+        | sed -e 's/.*ignoring unknown configuration key: //' -e 's/[[:space:]]*$//'
+
+    rm -rf "${dir:?refusing to rm an empty path}"
+}
+
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    SD="$(mktemp -d)" || exit 1
+    trap 'rm -rf "${SD:?}"' EXIT
+
+    # Row 1: the exact historical defect must be REPORTED.
+    printf '[profile.ci]\nslow-warning = "60s"\n' > "$SD/bad.toml"
+    got="$(ignored_keys_for "$SD/bad.toml")"
+    if [ "$got" = "profile.ci.slow-warning" ]; then
+        printf 'ok    row 1 the dead key that cost #2502 is reported\n'
+    else
+        printf 'FAIL  row 1 got [%s], expected profile.ci.slow-warning\n' "$got"; fails=1
+    fi
+
+    # Row 2 is the control. Without it row 1 passes even if this reported every
+    # key it saw -- and then the real config could never go green.
+    printf '[profile.ci]\nslow-timeout = { period = "60s", terminate-after = 10 }\n' > "$SD/good.toml"
+    got="$(ignored_keys_for "$SD/good.toml")"
+    if [ -z "$got" ]; then
+        printf 'ok    row 2 the CORRECT key is not reported\n'
+    else
+        printf 'FAIL  row 2 reported [%s] for a valid config\n' "$got"; fails=1
+    fi
+
+    [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
+    printf '\nSELF-TEST PASSED (2/2)\n'
+    exit 0
+fi
+
+printf '=== nextest must ignore no key in .config/nextest.toml (check_nextest_config_keys.sh) ===\n'
+
+if [ ! -f "$CONFIG" ]; then
+    printf 'FAIL: %s does not exist. This guard is scanning nothing.\n' "$CONFIG"
+    exit 1
+fi
+
+# Vacuity: a config nextest cannot parse at all, or an empty one, would report
+# zero ignored keys and look like a pass.
+if ! grep -q '^\[profile\.ci\]' "$CONFIG"; then
+    printf 'FAIL (vacuity): %s has no [profile.ci] section.\n' "$CONFIG"
+    printf 'CI runs `--profile ci`; if that section is gone the scan proves nothing.\n'
+    exit 1
+fi
+
+FOUND="$(ignored_keys_for "$CONFIG")"
+
+if [ -n "$FOUND" ]; then
+    printf '\nFAIL: nextest is IGNORING these keys:\n\n'
+    printf '%s\n' "$FOUND" | sed 's|^|  |'
+    printf '\nA key nextest ignores is a setting that does not exist. Check the\n'
+    printf 'spelling against `cargo nextest show-config` / the nextest docs --\n'
+    printf '`slow-warning` was one of these, and it cost a merge-queue eviction.\n'
+    exit 1
+fi
+
+printf 'PASS: every key is understood.\n'
+exit 0


### PR DESCRIPTION
`main` has not moved all day. This is why.

## The defect

```toml
[profile.ci]
slow-warning = "60s"
```

**There is no `slow-warning` key in nextest.** The real one is `slow-timeout`. nextest does not reject an unknown key — it prints a warning and carries on:

```
warning: in config file .config/nextest.toml, ignoring unknown
         configuration key: profile.ci.slow-warning
```

So `profile.ci` had **no per-test timeout at all**. From merge_group job `95162862834` for #2502:

```
12:31:55  build starts
12:50:58  Starting 80806 tests across 69 binaries
13:36:07  ##[error]The operation was canceled.
```

45 minutes inside nextest, killed by the **job's** `timeout-minutes: 85`, naming no test. **#2502 was evicted from the merge queue 31 seconds later.**

That warning was **line 353 of that job's log** — and of every workspace-test log before it.

## The compounding half

`status-level = "fail"` is *below* `slow` in nextest's ordering (`none < fail < retry < slow < pass < all`), so the SLOW lines that would have named the culprit were suppressed too. Measured on a probe crate:

| status-level | SLOW lines |
|---|---|
| `fail` (current) | **0** |
| `slow` | 3 |

Fixing the timeout without this would have kept hiding the warning that precedes the kill.

## terminate-after is measured, not guessed

Full workspace run on an idle 48-core box — 80,806 tests, **353s wall**:

| test | duration |
|---|---|
| `aprender-orchestrate bug_hunter::test_bh_mod_001_hunt_all_modes` | **202.7s** |
| `aprender-orchestrate bug_hunter::test_bh_mod_001_hunt_returns_result` | 157.3s |
| `aprender-orchestrate bug_hunter::test_bh_mod_046_apply_spec_quality_gate_no_pmat` | 118.0s |
| `aprender-train transformer_trainer::falsify_lora_tests::…rslora_stable_high_rank` | 67.5s |

over 60s: **6** · over 120s: **2** · over 300s: **0**

`terminate-after = 20` periods = 1200s is **~6× the slowest real test**, so it cannot kill a legitimately slow one — while a genuine hang dies at 20 minutes *with a name* instead of taking the whole job down anonymously.

(The `bug_hunter` tests are separately being made fast; this bound does not depend on that landing.)

## Also fixed

- **`timeout-minutes: 85` → 100.** The step sets 75, but "Set up runner" measured **20 minutes**, so 20 + 75 = 95 > 85 and the job timeout always fired first — producing a bare "The operation was canceled" naming no step. The step timeout must be the one that *can* fire, because it points at the step.
- **junit path was doubled.** `path` is relative to the store dir, not the workspace root, so `target/nextest/ci/junit.xml` produced `target/nextest/ci/target/nextest/ci/junit.xml`. Now `junit.xml`, verified landing at `target/nextest/ci/junit.xml`.

## Guarded

A warning nobody reads is not a diagnostic, so it is a hard failure now. `check_nextest_config_keys.sh` runs nextest's **real parser** against a three-line throwaway crate with this repo's config — no regex of my own guessing at nextest's schema — and fails on any ignored key. Its case table carries a control row so it cannot pass by reporting every key it sees.

**Mutation**: restoring `slow-warning` turns it RED; restoring `slow-timeout` turns it green. Verified both directions.

Wired into `guard-runner-labels`, which is in `gate.needs`. `bashrs lint`: 0 errors.

Refs #2502