### PR TITLE
fix(serve): delete two lib tests that assert nothing and take 19 minutes; scale four more

### DIFF
--- a/crates/aprender-serve/src/gguf/tests/parity014d_memory_phi2.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity014d_memory_phi2.rs
@@ -194,10 +194,26 @@ fn test_parity014e_batch_benchmark_design() {
 fn test_parity015a_gpu_batch_matmul_actual() {
     use crate::gpu::HybridScheduler;
 
-    // Create test matrices matching phi-2 FFN dimensions
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
+    // SCALED DOWN from phi-2 FFN dimensions (batch 32, hidden 2560, intermediate
+    // 10240). This test asserts a SHAPE property of the batched matmul, and a shape
+    // property does not need production-sized tensors. At phi-2 size the matmul is
+    // 32*2560*10240 = 839M MACs; `HybridScheduler::new()` succeeds without a GPU
+    // (`GpuCompute::auto()` falls back to CPU), so on a CPU-only runner this ran
+    // through `cpu_matmul` and cost minutes of workspace-test wall clock — times
+    // three under nextest's `retries = 2`. These dimensions do the same work
+    // 1600x smaller.
+    //
+    // The dimensions are chosen so m*k*n stays ABOVE `HybridScheduler`'s
+    // `gpu_threshold` (64*64*64 = 262_144): 8*128*512 = 524_288, so the
+    // GPU-vs-CPU dispatch decision this test exercises (and prints) is UNCHANGED
+    // on a GPU-equipped host.
+    //
+    // The GFLOPS reporting was removed rather than rescaled: at this size the
+    // number is meaningless, and a printed rate invites someone to cite it.
+    // Benchmarks belong in `benches/`, not in `--lib` tests.
+    let batch_size = 8;
+    let hidden_dim = 128;
+    let intermediate_dim = 512;
 
     // Create batched input: [batch_size, hidden_dim]
     let input: Vec<f32> = (0..batch_size * hidden_dim)
@@ -220,9 +236,7 @@ fn test_parity015a_gpu_batch_matmul_actual() {
         println!("  GPU available: {}", scheduler.has_gpu());
 
         // Perform actual matmul
-        let start = std::time::Instant::now();
         let result = scheduler.matmul(&input, &weight, batch_size, hidden_dim, intermediate_dim);
-        let elapsed = start.elapsed();
 
         match result {
             Ok(output) => {
@@ -232,14 +246,16 @@ fn test_parity015a_gpu_batch_matmul_actual() {
                     "PARITY-015a: Output should be [batch_size, intermediate_dim]"
                 );
 
-                let ops = 2.0 * batch_size as f64 * hidden_dim as f64 * intermediate_dim as f64;
-                let gflops = ops / elapsed.as_secs_f64() / 1e9;
-                println!("  Time: {:?}", elapsed);
-                println!("  GFLOPS: {:.2}", gflops);
                 println!("  Status: VERIFIED - GPU batch matmul works");
             },
             Err(e) => {
-                println!("  Error: {} (expected if no GPU)", e);
+                // This arm used to swallow the error and PASS, which made the
+                // assertion above unreachable for any defect surfacing as `Err`.
+                // The "expected if no GPU" it used to claim was also false: with no
+                // GPU, `HybridScheduler::matmul` takes the `cpu_matmul` path, which
+                // returns `Ok` unconditionally. The input here is small and valid,
+                // so an `Err` is a real defect, not a capability gap.
+                panic!("PARITY-015a: matmul failed on valid input: {}", e);
             },
         }
     } else {

--- a/crates/aprender-serve/src/gguf/tests/parity015d_batch_throughput.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity015d_batch_throughput.rs
@@ -1,82 +1,16 @@
 
-/// Test PARITY-015d: End-to-end batch forward timing
-///
-/// Measures actual timing of batch forward pass components.
-#[test]
-fn test_parity015d_batch_forward_timing() {
-    use crate::gpu::HybridScheduler;
-
-    /// Timing breakdown for batch forward pass
-    struct ForwardTiming {
-        component: &'static str,
-        time_us: u64,
-        ops: u64,
-    }
-
-    impl ForwardTiming {
-        fn throughput_mops(&self) -> f64 {
-            if self.time_us > 0 {
-                self.ops as f64 / self.time_us as f64
-            } else {
-                0.0
-            }
-        }
-    }
-
-    // Simulate timing for phi-2 batch forward
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
-    let num_layers = 32;
-
-    // Create test data
-    let input: Vec<f32> = vec![0.1; batch_size * hidden_dim];
-    let weight: Vec<f32> = vec![0.01; hidden_dim * intermediate_dim];
-
-    let mut timings = Vec::new();
-
-    // Time actual GPU matmul if available
-    if let Ok(mut scheduler) = HybridScheduler::new() {
-        let start = std::time::Instant::now();
-        let _ = scheduler.matmul(&input, &weight, batch_size, hidden_dim, intermediate_dim);
-        let elapsed = start.elapsed();
-
-        let ops = 2 * batch_size * hidden_dim * intermediate_dim;
-        timings.push(ForwardTiming {
-            component: "FFN Up (GPU/CPU)",
-            time_us: elapsed.as_micros() as u64,
-            ops: ops as u64,
-        });
-    }
-
-    println!("\nPARITY-015d: Batch Forward Timing Analysis");
-    println!("  Batch size: {}", batch_size);
-    println!("  Model: phi-2 ({} layers)", num_layers);
-
-    for timing in &timings {
-        println!(
-            "  {}: {}µs ({:.1} MOPS)",
-            timing.component,
-            timing.time_us,
-            timing.throughput_mops()
-        );
-    }
-
-    // Estimate full forward pass time
-    let ffn_time_us = timings.first().map_or(10000, |t| t.time_us);
-    let estimated_layer_us = ffn_time_us * 2; // up + down projections
-    let estimated_total_us = estimated_layer_us * num_layers as u64;
-    let estimated_total_ms = estimated_total_us as f64 / 1000.0;
-
-    let tokens_per_batch = batch_size;
-    let tps = tokens_per_batch as f64 / (estimated_total_ms / 1000.0);
-
-    println!("  Estimated per-layer: {}µs", estimated_layer_us);
-    println!("  Estimated total: {:.1}ms", estimated_total_ms);
-    println!("  Estimated TPS: {:.0} tok/s", tps);
-
-    println!("  Status: VERIFIED - Timing analysis complete");
-}
+// PARITY-015d: `test_parity015d_batch_forward_timing` was DELETED.
+//
+// It was a benchmark wearing a `#[test]` attribute: it ran a [32 x 2560] @
+// [2560 x 10240] matmul, discarded the result with `let _ =`, printed a MOPS
+// figure extrapolated to 32 layers, and asserted NOTHING — it could not fail
+// even if `matmul` returned `Err`. `HybridScheduler::new()` succeeds without a
+// GPU (`GpuCompute::auto()` falls back to CPU), so on a CPU-only runner this
+// went through `cpu_matmul` and cost minutes of workspace-test wall clock,
+// times three under nextest's `retries = 2`.
+//
+// Zero assertions means zero coverage lost. Do NOT reintroduce it as a `#[test]`;
+// a throughput measurement belongs in `benches/` (see `benches/inference.rs`).
 
 /// Test PARITY-015e: Integration verification
 ///
@@ -333,12 +267,29 @@ fn test_parity016b_dequant_weight_cache_integration() {
 #[test]
 fn test_parity016c_batch_ffn_with_scheduler() {
     use crate::gpu::HybridScheduler;
-    use std::time::Instant;
 
     // Actually run batch FFN through HybridScheduler
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
+    //
+    // SCALED DOWN from phi-2 dimensions (batch 32, hidden 2560, intermediate 10240).
+    // This test asserts a SHAPE property of the batched up projection, and a shape
+    // property does not need production-sized tensors. At phi-2 size the matmul is
+    // 32*2560*10240 = 839M MACs; `HybridScheduler::new()` succeeds without a GPU
+    // (`GpuCompute::auto()` falls back to CPU), so on a CPU-only runner this ran
+    // through `cpu_matmul` and cost minutes of workspace-test wall clock — times
+    // three under nextest's `retries = 2`. These dimensions do the same work
+    // 1600x smaller.
+    //
+    // The dimensions are chosen so m*k*n stays ABOVE `HybridScheduler`'s
+    // `gpu_threshold` (64*64*64 = 262_144): 8*128*512 = 524_288, so the
+    // GPU-vs-CPU dispatch decision this test exercises (and prints) is UNCHANGED
+    // on a GPU-equipped host.
+    //
+    // The GFLOPS reporting was removed rather than rescaled: at this size the
+    // number is meaningless, and a printed rate invites someone to cite it.
+    // Benchmarks belong in `benches/`, not in `--lib` tests.
+    let batch_size = 8;
+    let hidden_dim = 128;
+    let intermediate_dim = 512;
 
     // Create input batch
     let input: Vec<f32> = (0..batch_size * hidden_dim)
@@ -360,41 +311,44 @@ fn test_parity016c_batch_ffn_with_scheduler() {
         println!("  Should use GPU: {}", should_use_gpu);
         println!("  GPU available: {}", scheduler.has_gpu());
 
-        // Time the matmul
-        let start = Instant::now();
         let result = scheduler.matmul(&input, &up_weight, batch_size, hidden_dim, intermediate_dim);
-        let elapsed = start.elapsed();
 
-        if let Ok(output) = result {
-            assert_eq!(
-                output.len(),
-                batch_size * intermediate_dim,
-                "PARITY-016c: Output should be [batch, intermediate]"
-            );
+        match result {
+            Ok(output) => {
+                assert_eq!(
+                    output.len(),
+                    batch_size * intermediate_dim,
+                    "PARITY-016c: Output should be [batch, intermediate]"
+                );
 
-            let gflops = (2.0 * batch_size as f64 * hidden_dim as f64 * intermediate_dim as f64)
-                / (elapsed.as_secs_f64() * 1e9);
+                println!("  Output shape: [{}x{}]", batch_size, intermediate_dim);
 
-            println!("  Output shape: [{}x{}]", batch_size, intermediate_dim);
-            println!("  Time: {:?}", elapsed);
-            println!("  GFLOPS: {:.2}", gflops);
+                // Apply GELU activation (element-wise)
+                let activated: Vec<f32> = output
+                    .iter()
+                    .map(|&x| {
+                        // Approximate GELU
+                        let x64 = x as f64;
+                        (x64
+                            * 0.5
+                            * (1.0 + (x64 * 0.7978845608 * (1.0 + 0.044715 * x64 * x64)).tanh()))
+                            as f32
+                    })
+                    .collect();
 
-            // Apply GELU activation (element-wise)
-            let activated: Vec<f32> = output
-                .iter()
-                .map(|&x| {
-                    // Approximate GELU
-                    let x64 = x as f64;
-                    (x64 * 0.5 * (1.0 + (x64 * 0.7978845608 * (1.0 + 0.044715 * x64 * x64)).tanh()))
-                        as f32
-                })
-                .collect();
-
-            // For full FFN, would do down projection here
-            println!("  GELU applied: {} elements", activated.len());
-            println!("  Status: VERIFIED - Batch FFN works");
-        } else {
-            println!("  Status: SKIP - Matmul failed (may be CPU fallback)");
+                // For full FFN, would do down projection here
+                println!("  GELU applied: {} elements", activated.len());
+                println!("  Status: VERIFIED - Batch FFN works");
+            },
+            Err(e) => {
+                // This arm used to `println!("SKIP")` and PASS, which made the
+                // assertion above unreachable for any defect surfacing as `Err`. The
+                // "may be CPU fallback" it used to claim was also false: the CPU
+                // fallback path is `cpu_matmul`, which returns `Ok` unconditionally.
+                // The input here is small and valid, so an `Err` is a real defect,
+                // not a capability gap.
+                panic!("PARITY-016c: matmul failed on valid input: {}", e);
+            },
         }
     } else {
         println!("  Status: SKIP - GPU not available");

--- a/crates/aprender-serve/src/gguf/tests/parity016d_batch.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity016d_batch.rs
@@ -158,7 +158,6 @@ fn test_parity016e_performance_projection() {
 #[test]
 fn test_parity017a_gpu_batch_ffn_implementation() {
     use crate::gpu::HybridScheduler;
-    use std::time::Instant;
 
     // Implement the actual gpu_batch_ffn function
     // This processes [batch, hidden] -> [batch, hidden] through FFN with GPU
@@ -201,10 +200,26 @@ fn test_parity017a_gpu_batch_ffn_implementation() {
         Ok(output)
     }
 
-    // Test with phi-2 dimensions
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
+    // SCALED DOWN from phi-2 dimensions (batch 32, hidden 2560, intermediate 10240).
+    // This test asserts a SHAPE property of the up -> GELU -> down chain, and a
+    // shape property does not need production-sized tensors. At phi-2 size each
+    // projection is 32*2560*10240 = 839M MACs; `HybridScheduler::new()` succeeds
+    // without a GPU (`GpuCompute::auto()` falls back to CPU), so on a CPU-only
+    // runner both projections ran through `cpu_matmul` and this test alone cost
+    // minutes of workspace-test wall clock — times three under nextest's
+    // `retries = 2`. These dimensions do the same work 1600x smaller.
+    //
+    // The dimensions are chosen so m*k*n stays ABOVE `HybridScheduler`'s
+    // `gpu_threshold` (64*64*64 = 262_144): up and down are both
+    // 8*128*512 = 524_288, so the GPU-vs-CPU dispatch decision this test
+    // exercises is UNCHANGED on a GPU-equipped host.
+    //
+    // The throughput/GFLOPS reporting was removed rather than rescaled: at this
+    // size the number is meaningless, and a printed rate invites someone to cite
+    // it. Benchmarks belong in `benches/`, not in `--lib` tests.
+    let batch_size = 8;
+    let hidden_dim = 128;
+    let intermediate_dim = 512;
 
     // Create test data
     let input: Vec<f32> = (0..batch_size * hidden_dim)
@@ -223,7 +238,6 @@ fn test_parity017a_gpu_batch_ffn_implementation() {
     println!("  Down: [{}x{}]", intermediate_dim, hidden_dim);
 
     if let Ok(mut scheduler) = HybridScheduler::new() {
-        let start = Instant::now();
         let result = gpu_batch_ffn(
             &input,
             &up_weight,
@@ -233,7 +247,6 @@ fn test_parity017a_gpu_batch_ffn_implementation() {
             intermediate_dim,
             &mut scheduler,
         );
-        let elapsed = start.elapsed();
 
         match result {
             Ok(output) => {
@@ -243,19 +256,20 @@ fn test_parity017a_gpu_batch_ffn_implementation() {
                     "PARITY-017a: Output should be [batch, hidden]"
                 );
 
-                // Calculate FLOPS for full FFN (up + down)
-                let flops =
-                    2.0 * batch_size as f64 * hidden_dim as f64 * intermediate_dim as f64 * 2.0;
-                let gflops = flops / (elapsed.as_secs_f64() * 1e9);
-
                 println!("  Output: [{}x{}]", batch_size, hidden_dim);
-                println!("  Time: {:?}", elapsed);
-                println!("  GFLOPS: {:.2}", gflops);
                 println!("  Status: VERIFIED - GPU batch FFN works");
             },
             Err(e) => {
-                println!("  Error: {}", e);
-                println!("  Status: SKIP - GPU path failed");
+                // This arm used to `println!("SKIP - GPU path failed")` and PASS,
+                // which made the assertion above unreachable for any defect that
+                // surfaces as an `Err` — the test excluded no outcome on a
+                // GPU-equipped host. Verified by mutation: truncating
+                // `HybridScheduler::matmul`'s output by one element makes the down
+                // projection return `InvalidShape`, and the test reported `ok` at
+                // BOTH the scaled and the original [32x2560] dimensions. The input
+                // here is small and valid, so an `Err` is a real defect, not a
+                // capability gap.
+                panic!("PARITY-017a: gpu_batch_ffn failed on valid input: {}", e);
             },
         }
     } else {

--- a/crates/aprender-serve/src/gguf/tests/parity017c_batch_integration.rs
+++ b/crates/aprender-serve/src/gguf/tests/parity017c_batch_integration.rs
@@ -173,132 +173,20 @@ fn test_parity017d_dequant_cache_struct() {
     println!("  Status: VERIFIED - Cache structure works");
 }
 
-#[test]
-fn test_parity017e_end_to_end_batch_throughput() {
-    use crate::gpu::HybridScheduler;
-    use std::time::Instant;
-
-    // Measure actual end-to-end batch throughput with GPU FFN
-
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
-    let num_layers = 4; // Test with subset for speed
-
-    println!("\nPARITY-017e: End-to-End Batch Throughput");
-    println!("  Batch: {}", batch_size);
-    println!("  Hidden: {}", hidden_dim);
-    println!("  Intermediate: {}", intermediate_dim);
-    println!("  Layers: {}", num_layers);
-
-    // Create test weights for multiple layers
-    let up_weights: Vec<Vec<f32>> = (0..num_layers)
-        .map(|_| {
-            (0..hidden_dim * intermediate_dim)
-                .map(|i| (i as f32 * 0.0001).cos() * 0.01)
-                .collect()
-        })
-        .collect();
-    let down_weights: Vec<Vec<f32>> = (0..num_layers)
-        .map(|_| {
-            (0..intermediate_dim * hidden_dim)
-                .map(|i| (i as f32 * 0.0001).sin() * 0.01)
-                .collect()
-        })
-        .collect();
-
-    // Initial hidden states
-    let mut hidden: Vec<f32> = (0..batch_size * hidden_dim)
-        .map(|i| (i as f32 * 0.001).sin() * 0.1)
-        .collect();
-
-    if let Ok(mut scheduler) = HybridScheduler::new() {
-        let start = Instant::now();
-
-        // Process through all layers
-        for layer_idx in 0..num_layers {
-            // FFN: up projection
-            let intermediate = scheduler
-                .matmul(
-                    &hidden,
-                    &up_weights[layer_idx],
-                    batch_size,
-                    hidden_dim,
-                    intermediate_dim,
-                )
-                .expect("Up projection failed");
-
-            // GELU activation
-            let activated: Vec<f32> = intermediate
-                .iter()
-                .map(|&x| {
-                    let x64 = x as f64;
-                    (x64 * 0.5 * (1.0 + (x64 * 0.7978845608 * (1.0 + 0.044715 * x64 * x64)).tanh()))
-                        as f32
-                })
-                .collect();
-
-            // FFN: down projection
-            let ffn_out = scheduler
-                .matmul(
-                    &activated,
-                    &down_weights[layer_idx],
-                    batch_size,
-                    intermediate_dim,
-                    hidden_dim,
-                )
-                .expect("Down projection failed");
-
-            // Residual (simplified - just replace for now)
-            hidden = ffn_out;
-        }
-
-        let elapsed = start.elapsed();
-
-        // Calculate throughput
-        let tokens_processed = batch_size;
-        let tps = tokens_processed as f64 / elapsed.as_secs_f64();
-
-        // Scale to full model (32 layers)
-        let scaled_time_ms = elapsed.as_secs_f64() * (32.0 / num_layers as f64) * 1000.0;
-        let scaled_tps = tokens_processed as f64 / (scaled_time_ms / 1000.0);
-
-        println!("\n  Results ({} layers):", num_layers);
-        println!("    Time: {:?}", elapsed);
-        println!("    Throughput: {:.0} tok/s", tps);
-
-        println!("\n  Projected (32 layers):");
-        println!("    Time: {:.1}ms", scaled_time_ms);
-        println!("    Throughput: {:.0} tok/s", scaled_tps);
-
-        // Compare to baseline
-        let baseline_tps = 5.09;
-        let speedup = scaled_tps / baseline_tps;
-        println!("\n  Comparison:");
-        println!("    Baseline (single req): {:.2} tok/s", baseline_tps);
-        println!("    Batch GPU FFN: {:.0} tok/s", scaled_tps);
-        println!("    Speedup: {:.1}x", speedup);
-
-        // Note: Throughput varies significantly due to:
-        // 1. This test isolates FFN only (not full transformer)
-        // 2. GPU resource contention when running with other tests
-        // 3. Scaling from 4 to 32 layers is approximate
-        //
-        // The key insight is that GPU batch FFN WORKS:
-        // - test_parity017a verifies FFN correctness (~10 GFLOPS)
-        // - test_parity017c shows integration design
-        // - This test measures actual throughput under varying conditions
-        //
-        // Actual performance improvement requires:
-        // - Full transformer integration (not isolated FFN)
-        // - Dequantized weight caching
-        // - Running in isolation (not parallel with 2100+ other tests)
-
-        println!("  Status: MEASURED - {:.1}x relative to baseline", speedup);
-        println!("    Note: Run in isolation for accurate benchmark");
-    } else {
-        println!("  Status: SKIP - GPU not available");
-    }
-}
+// PARITY-017e: `test_parity017e_end_to_end_batch_throughput` was DELETED.
+//
+// It was a benchmark wearing a `#[test]` attribute: it allocated 4 layers of
+// [2560 x 10240] f32 FFN weights (~840 MB), pushed a batch of 32 through
+// up/GELU/down for every layer, then printed a tok/s number and asserted
+// NOTHING. `HybridScheduler::new()` succeeds without a GPU (`GpuCompute::auto()`
+// falls back to CPU), so the "GPU not available" arm never ran on a CPU-only
+// runner and the whole thing went through `cpu_matmul` — >19 min of workspace-test
+// wall clock, times three under nextest's `retries = 2`.
+//
+// Zero assertions means zero coverage lost. Do NOT reintroduce it as a `#[test]`;
+// a throughput measurement belongs in `benches/` (see `benches/inference.rs`),
+// where it is not on the critical path of every PR. The FFN shape/dispatch
+// properties it nominally exercised are still covered by test_parity017a and
+// test_parity018b.
 
 // ============================================================================

--- a/crates/aprender-serve/src/gguf/tests/tests_14.rs
+++ b/crates/aprender-serve/src/gguf/tests/tests_14.rs
@@ -164,7 +164,6 @@ fn test_parity018a_dequantized_weight_cache_production() {
 #[serial_test::serial]
 fn test_parity018b_batch_ffn_gpu_method() {
     use crate::gpu::HybridScheduler;
-    use std::time::Instant;
 
     // Test batch_ffn_gpu as a standalone method
     // This will be integrated into OwnedQuantizedModelCachedSync
@@ -230,9 +229,26 @@ fn test_parity018b_batch_ffn_gpu_method() {
         output
     }
 
-    let batch_size = 32;
-    let hidden_dim = 2560;
-    let intermediate_dim = 10240;
+    // SCALED DOWN from phi-2 dimensions (batch 32, hidden 2560, intermediate 10240).
+    // This test asserts a SHAPE property of the up -> bias -> GELU -> down chain,
+    // and a shape property does not need production-sized tensors. At phi-2 size
+    // each projection is 32*2560*10240 = 839M MACs; `HybridScheduler::new()`
+    // succeeds without a GPU (`GpuCompute::auto()` falls back to CPU), so on a
+    // CPU-only runner both projections ran through `cpu_matmul` and this test
+    // alone cost minutes of workspace-test wall clock — times three under
+    // nextest's `retries = 2`. These dimensions do the same work 1600x smaller.
+    //
+    // The dimensions are chosen so m*k*n stays ABOVE `HybridScheduler`'s
+    // `gpu_threshold` (64*64*64 = 262_144): up and down are both
+    // 8*128*512 = 524_288, so the GPU-vs-CPU dispatch decision this test
+    // exercises is UNCHANGED on a GPU-equipped host.
+    //
+    // The throughput/GFLOPS reporting was removed rather than rescaled: at this
+    // size the number is meaningless, and a printed rate invites someone to cite
+    // it. Benchmarks belong in `benches/`, not in `--lib` tests.
+    let batch_size = 8;
+    let hidden_dim = 128;
+    let intermediate_dim = 512;
 
     // Create test data
     let hidden_states: Vec<f32> = (0..batch_size * hidden_dim)
@@ -248,7 +264,6 @@ fn test_parity018b_batch_ffn_gpu_method() {
     println!("\nPARITY-018b: batch_ffn_gpu Method");
 
     if let Ok(mut scheduler) = HybridScheduler::new() {
-        let start = Instant::now();
         let output = batch_ffn_gpu(
             &hidden_states,
             &up_weight,
@@ -260,7 +275,6 @@ fn test_parity018b_batch_ffn_gpu_method() {
             intermediate_dim,
             &mut scheduler,
         );
-        let elapsed = start.elapsed();
 
         assert_eq!(
             output.len(),
@@ -268,13 +282,8 @@ fn test_parity018b_batch_ffn_gpu_method() {
             "PARITY-018b: Output should be [batch, hidden]"
         );
 
-        let flops = 2.0 * batch_size as f64 * hidden_dim as f64 * intermediate_dim as f64 * 2.0;
-        let gflops = flops / (elapsed.as_secs_f64() * 1e9);
-
         println!("  Input: [{}x{}]", batch_size, hidden_dim);
         println!("  Output: [{}x{}]", batch_size, hidden_dim);
-        println!("  Time: {:?}", elapsed);
-        println!("  GFLOPS: {:.2}", gflops);
         println!("  Status: VERIFIED - batch_ffn_gpu works");
     } else {
         println!("  Status: SKIP - GPU not available");


### PR DESCRIPTION
These were the top cause of `workspace-test` timing out at its 75-minute step limit — which blocks **every PR in the repo**. They were invisible until #2517 fixed nextest's suppressed SLOW reporting; before that the job died anonymously.

From CI job `95324516796`. "Max threshold" is the highest `SLOW [> Ns]` line seen, so real durations are higher — and several appeared as `TRY 2 SLOW`, i.e. **being retried** (`retries = 2`), tripling the cost:

| max threshold | test | asserts |
|---|---|---|
| **>1140s (19 min)** | `test_parity017e_end_to_end_batch_throughput` | **0** |
| >300s | `test_parity017a_gpu_batch_ffn_implementation` | 1 |
| >300s | `test_parity018b_batch_ffn_gpu_method` | 1 |
| >120s | `test_parity015d_batch_forward_timing` | **0** |

`017e` allocated batch 32 × hidden 2560 × intermediate 10240 × 4 layers of f32 — **gigabytes** — measured wall-clock with `Instant`, printed a throughput number, and asserted nothing. On a CPU-only runner the "GPU" path falls back to CPU. **A 19-minute test that cannot fail** is the purest form of the assertions-must-exclude-an-outcome defect.

## Deleted (0 asserts), with tombstones pointing throughput work at `benches/`

Coverage lost, stated precisely rather than as "none":

- **`015d`: nothing.** It did `let _ = scheduler.matmul(...)` — result discarded. It could not fail even if matmul returned `Err`.
- **`017e`: not literally nothing.** Zero asserts but two `.expect()` calls, so it *did* check `Err`-freedom for a 4-layer FFN at phi-2 sizes. That same `Err`-freedom is still covered by 017a/018b on the same code path; what's genuinely gone is `Err`-freedom **at phi-2 tensor sizes specifically**, plus the 4-sequential-layer loop. A fair trade, but not zero.

## Scaled (assertion kept)

`017a`, `018b`, plus `015a` and `016c` found by enumerating the family programmatically. batch 32→8, hidden 2560→128, intermediate 10240→512 — **1600× less arithmetic**. Dimensions chosen so `m*k*n = 524,288` stays above `HybridScheduler`'s `gpu_threshold` (262,144), so **the GPU-vs-CPU dispatch decision is unchanged** (verified: `Should use GPU: true` still prints). Meaningless `Instant`/GFLOPS prints removed; no timing assertions present or added.

## A real defect found while mutation-testing — worth more than the speedup

Mutating `HybridScheduler::matmul` to drop one output element left `017a` **green**. Its `Err` arm printed `"SKIP - GPU path failed"` and **passed**. Same hole in `015a` and `016c`:

```diff
-  println!("  Error: {} (expected if no GPU)", e);
-  println!("  Status: SKIP - Matmul failed (may be CPU fallback)");
-  println!("  Status: SKIP - GPU path failed");
```

Three tests **passing when the operation they test failed** — and the reassurance was *false*: `cpu_matmul` returns `Ok` unconditionally, so "may be CPU fallback" could never explain an `Err`.

Proven **pre-existing rather than caused by the scaling**, by re-running the identical mutation at the original `[32×2560]` dimensions — also `test result: ok`. Those arms are now `panic!`, after which **all 8 combinations** (4 tests × GPU and CPU-forced paths) go RED, rc=101.

## Measurements

CPU-only path forced with `VK_ICD_FILENAMES=/nonexistent` and **proven engaged** (`GPU available: false`, GFLOPS 9.99 → 0.25) rather than assumed:

| test | before | after |
|---|---|---|
| 017e | 55.3s | deleted |
| 015d | 6.5s | deleted |
| 017a | 13.9s | 0.03s |
| 018b | 13.9s | 0.03s |
| 015a | 7.0s | 0.02s |
| 016c | 7.0s | 0.02s |
| **total** | **103.6s** | **0.10s** |

Absolute seconds here run ~20× below CI's for both 017a and 017e — a consistent ratio, being runner concurrency contention across 15,721 tests. **Treat the ~1000× reduction as the reliable figure, not the absolute times.**

## Verification

| | |
|---|---|
| `cargo test -p aprender-serve --lib` | rc=0, **15,660 passed, 0 failed**, 59 ignored |
| test count | 15721 → 15719, exactly the two deletions |
| `cargo fmt --check` | rc=0 |
| `cargo clippy --all-targets` | rc=101 — **pre-existing**, proven by materialising `origin/main`'s version of these 5 files via `git show` and getting the identical rc and same 4 errors in files never touched here. No lint config changed. |

<sub>CI cannot currently verify this: the fleet is down again (#2528, reopened — `rustup` deleted a second time). Everything above is local.</sub>

Refs #2503, #2517