### PR TITLE
fix(guard): check_beats_gated reported a FALSE "UNGATED BEAT" at random

### DIFF
--- a/scripts/check_beats_gated.sh
+++ b/scripts/check_beats_gated.sh
@@ -49,7 +49,21 @@ while IFS= read -r f; do
     [ -n "$f" ] || continue
     n_integration=$((n_integration + 1))
     name=$(basename "$f" .rs)
-    if ! printf '%s\n' "$REFERENCED" | grep -qx "$name"; then
+    # NOT `printf ... | grep -qx`. `grep -q` exits at the FIRST match, closing
+    # the pipe; printf then dies of SIGPIPE (141). This script runs under
+    # `set -o pipefail` (line 29), so the PIPELINE inherits printf's 141 even
+    # though grep MATCHED — `!` inverts that into a false "UNGATED BEAT".
+    #
+    # It is a race (does printf finish writing before grep exits?), so it
+    # reproduces intermittently: this guard passed locally and failed in CI on
+    # the same tree, emitting
+    #     scripts/check_beats_gated.sh: line 52: printf: write error: Broken pipe
+    # A required check that goes red at random is worse than one that cannot go
+    # red at all — it trains everyone to re-run until green.
+    #
+    # Verified: `set -o pipefail; printf "$BIG" | grep -qx "1"` returns 141 on
+    # 5/5 attempts. A here-string has no pipe and therefore no SIGPIPE.
+    if ! grep -qx "$name" <<<"$REFERENCED"; then
         echo "✗ UNGATED BEAT: $f"
         echo "    No workflow runs it. It is an integration test TARGET, so"
         echo "    \`cargo test --lib\` does NOT reach it  -  it executes only if a"
@@ -95,7 +109,8 @@ while IFS= read -r f; do
     segs=$(grep -hE -- "--test[[:space:]]+${name}([^A-Za-z0-9_]|$)" "$WORKFLOWS"/*.yml 2>/dev/null \
            | sed 's/&&/\n/g' \
            | grep -E -- "--test[[:space:]]+${name}([^A-Za-z0-9_]|$)")
-    if [ -n "$segs" ] && ! printf '%s\n' "$segs" | grep -qE -- '--ignored|--include-ignored'; then
+    # Same SIGPIPE-under-pipefail hazard as line 52 — here-string, no pipe.
+    if [ -n "$segs" ] && ! grep -qE -- '--ignored|--include-ignored' <<<"$segs"; then
         echo "✗ VACUOUSLY GATED BEAT: $f"
         echo "    A workflow names it, so rule 1 is satisfied - but the beat is"
         echo "    \`#[ignore]\`d and NO invocation passes \`--ignored\`, so the run"


### PR DESCRIPTION
`guard-runner-labels` — a **required** check — fails nondeterministically for every PR. It hit #2541 with:

```
✗ UNGATED BEAT: crates/aprender-core/tests/beat_sklearn_iris.rs
scripts/check_beats_gated.sh: line 52: printf: write error: Broken pipe
```

The beat **is** gated. `cargo test -p aprender-core --test beat_sklearn_iris` is on ci.yml's integration line on `main` and on that branch, #2541 doesn't touch `ci.yml`, and the same script passes locally on the identical tree.

## Cause

```bash
if ! printf '%s\n' "$REFERENCED" | grep -qx "$name"; then
```

`grep -q` exits at the **first match** and closes the pipe. `printf` then dies of SIGPIPE (141). The script runs under `set -uo pipefail` (line 29), so the **pipeline** inherits printf's 141 even though grep *matched* — and `!` inverts that into a false "UNGATED BEAT".

It's a race — does `printf` finish writing before `grep` exits? — which is exactly why it passed locally and failed in CI on the same commit. Reproduced deterministically with a large input:

```
$ set -o pipefail; printf "%s\n" "$(seq 1 200000)" | grep -qx "1"
pipeline_status=141      # 5/5 attempts, grep MATCHED every time
```

## Fix

Here-strings — no pipe, so no SIGPIPE, so `pipefail` has nothing to inherit.

Applied to **both** occurrences, not just the one that fired: line 52 (`grep -qx "$name"`) and line 98 (`grep -qE -- '--ignored|...'`), which had the identical shape and the identical latent race. Fixing only the observed instance would leave the second to surface later as another mystery red.

## Why this matters beyond one PR

`guard-runner-labels` is required by `gate`, so this can block any PR at random. **A required check that goes red randomly is worse than one that cannot go red at all** — it trains everyone to re-run until green, which is precisely how a *real* ungated beat would then slip through unnoticed.

That is the anti-theater failure mode this very script exists to police, turned on the script itself.

## Verified

| case | result |
|---|---|
| clean tree | `rc=0` — "all 24 beats execute (21 integration wired via --test, 3 lib via --lib)" |
| **mutation**: remove iris from ci.yml | `rc=1` — `✗ UNGATED BEAT: ...beat_sklearn_iris.rs` |
| restored | `rc=0` |

So the guard still catches a genuinely ungated beat — it just no longer invents one.

`bashrs`: 0 errors.