### PR TITLE
fix(test): prop_greedy_is_argmax reddened at random on tied logits

### DIFF
--- a/crates/aprender-contracts/src/kernels/sampling.rs
+++ b/crates/aprender-contracts/src/kernels/sampling.rs
@@ -315,11 +315,33 @@ mod tests {
     proptest! {
         #[test]
         fn prop_greedy_is_argmax(logits in proptest::collection::vec(-10.0f32..10.0, 1..16)) {
+            // TIES. The old form compared this index against
+            //     logits.iter().enumerate().max_by(..).unwrap().0
+            // which returns the LAST maximum, while `greedy_scalar` keeps the
+            // FIRST (`if v > best_val`, strictly greater). On a tie the two
+            // disagree by construction, so the property failed at random —
+            // whenever proptest happened to generate duplicate maxima. Observed
+            // in CI on `[9.086451, 9.086451]` after 127 successes, red on a PR
+            // that touches nothing near sampling.
+            //
+            // Index equality was never the real property, and a required check
+            // that reds at random is worse than one that cannot red at all: it
+            // trains everyone to re-run until green. Assert what actually has
+            // to hold, and pin the tie-break rule explicitly rather than
+            // inheriting whatever `max_by` happens to do.
             let result = greedy_scalar(&logits);
-            let argmax = logits.iter().enumerate()
-                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-                .unwrap().0;
-            prop_assert_eq!(result, argmax);
+
+            // 1. greedy returns AN index holding the maximum value.
+            let best = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            prop_assert_eq!(logits[result], best);
+
+            // 2. and specifically the FIRST such index. Sampling must be
+            //    deterministic for a fixed input, so the tie-break is part of
+            //    the contract, not an implementation detail. This is STRICTLY
+            //    STRONGER than the old assertion, which could not even be
+            //    stated on ties.
+            let first_max = logits.iter().position(|&v| v == best).unwrap();
+            prop_assert_eq!(result, first_max);
         }
 
         #[test]


### PR DESCRIPTION
`workspace-test` failed on **#2540** — a PR that removes a CLI route and touches nothing near sampling:

```
prop_greedy_is_argmax panicked at kernels/sampling.rs:315
  left: 0, right: 1
  minimal failing input: logits = [9.086451, 9.086451]
  successes: 127
```

## Cause — the property was over-specified, and only wrong on ties

```rust
let argmax = logits.iter().enumerate()
    .max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap().0;
prop_assert_eq!(result, argmax);
```

`Iterator::max_by` returns the **last** maximum. `greedy_scalar` keeps the **first** (`if v > best_val`, strictly greater). On a tie they disagree **by construction** — so the test failed whenever proptest happened to draw duplicate maxima. It took 127 successes to hit one here.

Nondeterministic, seed-dependent, and able to red **any** PR.

`greedy_scalar` is not the problem: first-wins is the conventional argmax tie-break, and it is deterministic — which sampling requires.

## Fix — assert what must hold, and pin the tie-break

```rust
let best = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
prop_assert_eq!(logits[result], best);        // greedy returns A maximum

let first_max = logits.iter().position(|&v| v == best).unwrap();
prop_assert_eq!(result, first_max);           // and specifically the FIRST
```

This is **strictly stronger** than what it replaces. It pins the tie-break as part of the contract rather than inheriting whatever `max_by` happens to do, and it can be stated on ties at all — which the old form could not.

## Verified on the exact failing input

```
greedy_scalar        = 0
OLD max_by().0       = 1   ->  old assert FAILS
NEW value match      = true
NEW first_max        = 0   ->  new assert PASSES

cargo test -p aprender-contracts --lib   1435 passed, 0 failed
cargo fmt --check                        rc=0
```

Not "the tests pass now" — the old assertion is shown failing and the new one passing on the input CI actually produced.

## Why this matters beyond one PR

Same class as the SIGPIPE false-red in `check_beats_gated` (#2542): **a required check that goes red at random is worse than one that cannot go red at all.** It trains everyone to re-run until green, and a genuine failure then rides through on the retry that happens to pass.

Two such flakes surfaced in a single day, both in required checks. Worth watching for a third.