### PR TITLE
fix(ci): workspace-test must use the same sccache cap, or it evicts the shared cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
       # paiml/infra commit f4fccf9 (PR #66, "use exec script not symlink").
       # 2026-05-12: re-enabled — image verified to ship `/usr/local/bin/rustc-sccache`
       # (sccache 0.14.0), shared cache at `/home/noah/data/sccache` (warm, ~11GB).
+      # 2026-08-20: that "warm, ~11GB" was NOT health — it was the cache pinned
+      # at sccache's DEFAULT 10 GiB cap. /var/log/ci-metrics/sccache-*.json has
+      # recorded cache_size and max_cache_size on every job all along (18,292
+      # files); nothing ever compared them. All of the newest 4000 samples read
+      # cache_size within ~2 KB of max_cache_size, i.e. an LRU evicting on every
+      # write. paiml-mcp-agent-toolkit-coverage was running 1240 compile requests
+      # for 5 hits and 811 misses. Cap raised to 50G in paiml/infra#230 and
+      # paiml/.github#50; the workspace-test job below passes the SAME value,
+      # because a server capped lower EVICTS the shared cache back down to its
+      # own cap — a mixed cap is strictly worse than a uniform small one.
       enable_sccache: true
       use_nextest: true
       # NOTE: coverage_min (the opt-in coverage ratchet from the build-system audit)
@@ -270,6 +280,7 @@ jobs:
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
             -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
@@ -288,6 +299,7 @@ jobs:
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
             -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
@@ -327,6 +339,7 @@ jobs:
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
             -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \


### PR DESCRIPTION
The fleet's shared sccache at /home/noah/data/sccache has been running at
sccache's DEFAULT 10 GiB cap because nothing set SCCACHE_CACHE_SIZE anywhere.

The evidence was already in this file and was read as good news. The comment
above enable_sccache says the shared cache is "warm, ~11GB". That was not
warmth, it was the ceiling. Every CI job writes sccache --show-stats to
/var/log/ci-metrics/, 18,292 files by 2026-08-20, each carrying top-level
cache_size and max_cache_size, and nothing had ever compared the two. All of
the newest 4000 samples read cache_size within ~2 KB of a max_cache_size of
exactly 10,737,418,240 B — an LRU evicting on every single write.

Large jobs eat the cost while small frequent ones look healthy:

    rmedia-lint                        1156 reqs   732 hits     3 miss
    paiml-mcp-agent-toolkit-coverage   1240 reqs     5 hits   811 miss

That hurts this repo more than most: the per-run target dir (#1693)
deliberately removed cross-run cargo incremental warmth, so sccache is the ONLY
cross-run cache left and every thrashed run is genuinely cold. It is a
plausible contributor to the workspace-test CANCELLED-at-timeout pattern, where
the same job took 54 min warm and 100+ min cold before being killed.

This PR is the third of three surfaces, and the set is not optional. Several
independent sccache servers share one directory; a server configured at 10 GiB
evicts that directory back down to 10 GiB no matter what any other server
wrote. A mixed cap is strictly worse than a uniform small one:

  - paiml/infra#230   Dockerfile ENV (the default) + nightly saturation detector
  - paiml/.github#50  sovereign-ci.yml, all four job env blocks
  - this PR           the three docker run sites in workspace-test

50G rather than higher because / is 3.6T at 85% used with ~531G free and the
pre-job disk guard prunes at >=85%. paiml/infra#230 adds the detector that
makes the next saturation announce itself instead of going unread for months.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
