### PR TITLE
fix(make): recipes ran without pipefail, so the release gate could not fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,24 @@
 
 # Use bash for shell commands
 SHELL := /bin/bash
+# Recipes ran as `bash -c` with NO pipefail, so any `cmd | tail`/`| grep` reported
+# the LAST command's status and a failing producer was laundered to success. That
+# is the defect class this repo keeps rediscovering (see the Verification
+# Discipline section of CLAUDE.md: "Never read $? through a pipe").
+#
+# Measured on this Makefile before the change: 577 recipe lines, 14 with a pipe.
+# The worst was the release gate itself, `contracts:` -> `pv lint contracts/ 2>&1
+# | tail -5`, which could never fail the build no matter what pv reported.
+#
+# DELIBERATELY `-o pipefail` ONLY, not `-eu -o pipefail`. Measured exposure of the
+# other two flags on this file: 248 recipe lines use `;` chains (-e would abort
+# them mid-recipe) and 74 reference `$$VAR` (-u would error on any unset one).
+# Changing three variables at once across 577 lines is how a "small" fix becomes
+# an outage. pipefail is provably orthogonal to both -- verified with fixtures:
+# a `;` chain and an unset var both still exit 0 under pipefail alone -- so it
+# closes the laundering class and touches nothing else. Add -e/-u later, one at
+# a time, each with its own blast-radius measurement.
+.SHELLFLAGS := -o pipefail -c
 
 # Disable built-in rules for performance
 .SUFFIXES:


### PR DESCRIPTION
`SHELL := /bin/bash` was set; `.SHELLFLAGS` was not. Recipes therefore ran as
`bash -c` with no pipefail, so any `cmd | tail` / `| grep` reported the LAST
command's status and a failing producer was laundered into success.

The worst instance is the release gate itself, Makefile `contracts:`:

    @pv lint contracts/ 2>&1 | tail -5

That line could never fail the build no matter what pv reported. Measured on an
isolated fixture of exactly that recipe:

    failing pv, NO pipefail : rc=0    <- laundered, the defect
    failing pv, pipefail    : rc=2    <- fixed
    passing pv, pipefail    : rc=0    <- non-vacuity: no false failure

(An earlier attempt ran the whole `contracts:` target and produced inverted
numbers, because that target also runs `cargo test -p aprender-contracts --lib`
through a second pipe; the per-line fixture above is what actually isolates the
variable. Recording that because the misleading run is instructive.)

This is the Makefile instance of the class CLAUDE.md already documents:
"Never read $? through a pipe. It is the LAST command's status." It shipped
twice before in CI (#2336 qwen-story-daily captured tee's status; #2360 the
publish POST-PUBLISH VERIFICATION did the same).

DELIBERATELY `-o pipefail` ONLY, not `-eu -o pipefail`

Blast radius measured on this Makefile before choosing, rather than discovered
after:

    577 recipe lines total
     14 contain a pipe          <- pipefail exposure
    248 contain `;` chains      <- what -e would abort mid-recipe
     74 reference $$VAR         <- what -u would error on

Changing three variables at once across 577 lines is how a one-line fix becomes
an outage. pipefail is provably orthogonal to the other two: with pipefail alone,
a fixture using a `;` chain after a failing command still exits 0, and a fixture
echoing an unset variable still exits 0. So this closes the laundering class and
touches neither of the other populations. -e and -u remain worth adding, later,
one at a time, each with its own measurement.

Blast radius of THIS change is exactly those 14 lines. Any that now fail are the
find, not the breakage — they were reporting success while their producer failed.

Refs #2336, #2360

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
