### PR TITLE
fix(guards): the meta-guard passed on a COMMENT, so the MSRV floor ran nowhere

### DIFF
--- a/.github/workflows/toolchain-ceiling.yml
+++ b/.github/workflows/toolchain-ceiling.yml
@@ -35,6 +35,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # THE FLOOR. This file's own header has said since aprender#2370 that
+  # "scripts/check_msrv.sh guards the FLOOR" -- but that script ran in NO
+  # workflow. Its only two mentions in the whole repo were comments: this one,
+  # and Makefile:132. So the ceiling was gated, the floor was not, and the
+  # sentence asserting otherwise was the only thing standing in for the gate.
+  #
+  # Found by check_guards_are_wired.sh once its predicate was changed from
+  # "the name appears somewhere in .github/workflows/" (which a comment
+  # satisfies) to "a non-comment line INVOKES it". The meta-guard was itself
+  # the thing that could not see this.
+  #
+  # It belongs here rather than on every PR: it compiles the whole workspace on
+  # the declared MSRV toolchain (~1 min warm, longer cold), and MSRV drift is a
+  # dependency-graph event, not a per-commit one. Same cadence as the ceiling it
+  # is the counterpart to.
+  msrv-floor:
+    runs-on: [self-hosted, X64, Linux, clean-room]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Workspace builds on its DECLARED MSRV
+        run: bash scripts/check_msrv.sh
+
   clippy-current-stable:
     # clean-room pool, same as coverage-nightly: this is a full-workspace clippy
     # run on a toolchain that is NOT the pinned one, so it cold-builds.

--- a/scripts/check_guards_are_wired.sh
+++ b/scripts/check_guards_are_wired.sh
@@ -44,7 +44,28 @@ unwired_in() {
     for g in "$root"/scripts/check_*.sh; do
         [ -f "$g" ] || continue
         base=$(basename "$g")
-        if ! grep -rqF -- "$base" "$root"/.github/workflows/ 2>/dev/null; then
+        # EXECUTION, not mention. `grep -rqF -- "$base"` matched the script's
+        # NAME anywhere in the workflows tree -- including inside a `#` comment.
+        # So a guard could be documented and never run, and this meta-guard,
+        # whose entire purpose is to catch exactly that, reported it as wired.
+        #
+        # Require a non-comment line that INVOKES it: `bash scripts/x.sh`,
+        # `sh scripts/x.sh`, `./scripts/x.sh`, or a bare `scripts/x.sh` as a
+        # command.
+        #
+        # `sed 's/#.*$//'` strips from the FIRST `#`, not just whole-line
+        # comments. My first version filtered only lines matching `^\s*#`, and
+        # a TRAILING comment defeated it: `run: echo skipped # bash
+        # scripts/check_msrv.sh` still matched and reported the guard as wired.
+        # That is the same mention-vs-execution defect this function exists to
+        # fix, one level down, and it was caught by mutation-testing the fix
+        # rather than by reading it. Erring strict is correct here: a `#` inside
+        # a quoted YAML string would make a wired guard look unwired, which is a
+        # loud false alarm rather than a silent miss.
+        if ! grep -rh --include='*.yml' --include='*.yaml' -- "$base" \
+                "$root"/.github/workflows/ 2>/dev/null \
+             | sed 's/#.*$//' \
+             | grep -qE "(^|[[:space:];&|(])((ba)?sh[[:space:]]+|\\./)?[^[:space:]]*${base}([[:space:]]|$|['\"])" ; then
             printf '%s\n' "$base"
         fi
     done | LC_ALL=C sort


### PR DESCRIPTION
check_guards_are_wired.sh exists to catch a guard that is written but never run.
Its predicate was:

    grep -rqF -- "$base" "$root"/.github/workflows/

a fixed-string search for the script's NAME anywhere in the workflows tree --
which a `#` comment satisfies. So the one guard whose entire job is detecting
mention-without-execution was itself detecting mention.

WHAT IT WAS HIDING

check_msrv.sh. It is a real, working guard that passes today (rc=0, "workspace
builds on its declared MSRV 1.91"), and it ran in NO workflow. Its only two
mentions in the entire repo are comments:

    Makefile:132                        "Mirror of `check_msrv.sh`, ..."
    .github/workflows/toolchain-ceiling.yml:3
        "The CEILING gate (aprender#2370). `scripts/check_msrv.sh` guards the FLOOR"

The ceiling was gated. The floor was not. The sentence asserting the floor was
guarded was the only thing standing in for the gate -- and the meta-guard read
that sentence and called it wiring.

Its own header records why it matters: rust-version had silently drifted to 1.89
while pmcp/wasmtime required 1.91 and rust-toolchain.toml pinned 1.93, and
NOTHING verified the claim.

THE FIX

Predicate now requires a non-comment line that INVOKES the script
(`bash x.sh` / `sh x.sh` / `./x.sh` / bare `x.sh` as a command), and
check_msrv.sh is wired as a `msrv-floor` job in toolchain-ceiling.yml -- next to
the ceiling it is the counterpart to, on the same nightly cadence, because it
compiles the whole workspace on the MSRV toolchain (~1 min warm) and MSRV drift
is a dependency-graph event, not a per-commit one.

MY FIRST FIX HAD THE SAME DEFECT ONE LEVEL DOWN

It filtered `^[[:space:]]*#`, i.e. whole-line comments only. A TRAILING comment
defeated it: `run: echo skipped # bash scripts/check_msrv.sh` still matched and
still reported the guard as wired. Mutation-testing the fix caught it; reading
the fix would not have. Now `sed 's/#.*$//'` strips from the first `#`.

MUTATION-VERIFIED IN BOTH DIRECTIONS, against reality rather than a fixture:

    wired (as committed)                 -> rc=0, "43 scanned, 1 named by no workflow, PASS"
    unwire check_msrv.sh                 -> rc=1, "NEW: check_msrv.sh"
    restore                              -> rc=0
    OLD name-presence predicate, unwired -> rc=0   <- the defect, reproduced
    --self-test                          -> rc=0

The baseline is NOT auto-updated: `--update` is explicit, and the one
grandfathered entry (check_book_examples_executable.sh) stays ratcheted.

Refs #2370

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
