### PR TITLE
fix(release): the publish cascade could not SEE the three facades it must ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,9 @@ jobs:
       # aprender#2558: nothing detected two crates declaring the same `[[bin]]
       # name`. FOUR things claimed `pv` -- the crates.io pipe viewer, /usr/bin/pv,
       # aprender-contracts-cli and the provable-contracts-cli facade -- all
-      # writing ~/.cargo/bin/pv, with `cargo install` overwriting silently. The
+      # writing ~/.cargo/bin/pv. MEASURED: `cargo install` FAILS CLOSED on that
+      # collision (exit 101, first binary survives); it does NOT overwrite, so
+      # the hazard is a BLOCKED install rather than a silent clobber. The
       # facade gave up the name; this stops the next one being noticed by
       # accident. Scans BOTH workspaces: crates/facades is `exclude`d from the
       # root, so a root-only scan is inert by construction. `apr` is a
@@ -703,6 +705,29 @@ jobs:
         run: bash scripts/check_duplicate_bin_names.sh --self-test
       - name: No two crates may claim one bin name
         run: bash scripts/check_duplicate_bin_names.sh
+      # aprender#2559: the release cascade could not SEE the facades. TIERS[] in
+      # scripts/cascade-publish.sh was exactly the 70 publishable crates of the
+      # ROOT workspace -- a perfect match, no drift -- so nothing indicated the
+      # three publishable crates in the second, `exclude`d workspace were
+      # missing. FINAL VERIFICATION iterated the same TIERS[], so their absence
+      # printed as "ALL crates at 0.63.0". This step also checks the ORDER: a
+      # facade resolves its upstream from the REGISTRY, so publishing it first
+      # yields a crate that cannot compile for anyone -- while inside this tree
+      # it resolves through `path` and looks perfectly fine. Case table first.
+      - name: Cascade-coverage case table
+        run: bash scripts/check_cascade_covers_all_crates.sh --self-test
+      - name: The release cascade must cover and order every publishable crate
+        run: bash scripts/check_cascade_covers_all_crates.sh
+      # The bump half of the same defect. `cargo set-version --workspace` cannot
+      # reach an `exclude`d workspace and does not warn, so three files in
+      # crates/facades/ have to ride in every bump commit. scripts/bump-version.sh
+      # does that; these two rows keep its case table live and assert the tree is
+      # version-consistent right now (which check_facade_compat.sh R3/R5 also
+      # backstop from the compat side).
+      - name: Version-bump case table (reaches the excluded workspace)
+        run: bash scripts/bump-version.sh --self-test
+      - name: Every workspace is at a consistent version
+        run: bash scripts/bump-version.sh --check
       # The meta-guard. Four guards were found unwired by accident while looking
       # for something else; without this the fifth is found the same way.
       - name: Every check_*.sh is named by a workflow

--- a/Makefile
+++ b/Makefile
@@ -966,7 +966,11 @@ publish: ## Publish crate(s) to crates.io — strips [patch], publishes, then ve
 	fi
 	@CRATE=$(CRATE); \
 	if [ -z "$$CRATE" ]; then \
-		echo "Usage: make publish CRATE=aprender   (or apr-cli, entrenar-lora)"; \
+		echo "Usage: make publish CRATE=aprender   (or apr-cli, provable-contracts, ...)"; \
+		echo "       any crate listed by: python3 scripts/lib/cascade_universe.py ."; \
+		echo "       -- INCLUDING the crates/facades/ workspace, which is excluded"; \
+		echo "          from the root and which this target could not reach at all"; \
+		echo "          before aprender#2559."; \
 		echo "Restoring config..."; \
 		if [ -f .cargo/config.toml.publish-backup ]; then \
 			cp .cargo/config.toml.publish-backup .cargo/config.toml; \
@@ -975,7 +979,29 @@ publish: ## Publish crate(s) to crates.io — strips [patch], publishes, then ve
 		exit 1; \
 	fi; \
 	echo "Publishing $$CRATE..."; \
-	cargo publish -p $$CRATE --allow-dirty --locked; \
+	SEL="-p $$CRATE"; \
+	MANIFEST=$$(python3 scripts/lib/cascade_universe.py . | awk -F'\t' -v c="$$CRATE" '$$1==c{print $$3}'); \
+	WSROOT=$$(python3 scripts/lib/cascade_universe.py . | awk -F'\t' -v c="$$CRATE" '$$1==c{print $$4}'); \
+	if [ -z "$$MANIFEST" ]; then \
+		echo "FAIL: $$CRATE is not a publishable crate in ANY workspace here."; \
+		echo "      (scripts/lib/cascade_universe.py enumerates all of them)"; \
+		if [ -f .cargo/config.toml.publish-backup ]; then \
+			cp .cargo/config.toml.publish-backup .cargo/config.toml; \
+			rm -f .cargo/config.toml.publish-backup; \
+		fi; \
+		exit 1; \
+	fi; \
+	if [ "$$WSROOT" != "$$(pwd)" ]; then \
+		echo "  ($$CRATE lives in the excluded workspace $$WSROOT; selecting by --manifest-path,"; \
+		echo "   because \`cargo publish -p $$CRATE\` from here is rc=101 'did not match any packages')"; \
+		SEL="--manifest-path $$MANIFEST"; \
+	fi; \
+	DRY=""; \
+	if [ -n "$$PUBLISH_DRY_RUN" ]; then \
+		echo "  (PUBLISH_DRY_RUN set: packaging and resolving, but NOT uploading)"; \
+		DRY="--dry-run --no-verify"; \
+	fi; \
+	cargo publish $$SEL $$DRY --allow-dirty --locked; \
 	STATUS=$$?; \
 	echo "Restoring .cargo/config.toml..."; \
 	if [ -f .cargo/config.toml.publish-backup ]; then \
@@ -985,6 +1011,10 @@ publish: ## Publish crate(s) to crates.io — strips [patch], publishes, then ve
 	if [ $$STATUS -ne 0 ]; then \
 		echo "FAIL: cargo publish failed"; \
 		exit $$STATUS; \
+	fi; \
+	if [ -n "$$PUBLISH_DRY_RUN" ]; then \
+		echo "DRY RUN OK: $$CRATE resolved and packaged; nothing was uploaded."; \
+		exit 0; \
 	fi; \
 	echo ""; \
 	echo "=== POST-PUBLISH VERIFICATION (PMAT-517) ==="; \

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh — bump the release version across EVERY workspace, including
+# the one `cargo set-version --workspace` cannot reach.
+#
+# WHY THIS EXISTS (aprender#2559)
+# -------------------------------
+# The release bump was `cargo set-version --workspace <v>` plus a written-down
+# reminder that three more files have to ride in the same commit. `--workspace`
+# means "every member of THIS workspace"; `crates/facades/` is `exclude`d from
+# the root, so cargo does not see it and does not warn about it. The three files
+# it cannot touch are:
+#
+#   crates/facades/provable-contracts/Cargo.toml         upstream version pin
+#   crates/facades/provable-contracts-macros/Cargo.toml  upstream version pin
+#   crates/facades/Cargo.lock                            resolved versions
+#
+# Omitting them does not fail quietly — it fails LOUDLY and in the worst place:
+# the bump commit reds its own CI, because check_facade_compat.sh rows R3 and R5
+# compare those exact files against the workspace version. A reminder in prose is
+# not a mechanism; this script is, and the existing R3/R5 rows stay as the
+# backstop that catches a hand-edited bump that skipped it.
+#
+# WHAT IS DELIBERATELY *NOT* BUMPED
+# ---------------------------------
+# `crates/facades/Cargo.toml`'s own `[workspace.package] version` (0.4.0). The
+# facade crate NAMES version independently of the aprender version line, and
+# that independence is deliberate and documented (aprender#2546): 0.3.1 -> 0.4.0
+# signals "something changed" without claiming a 0.63.0 history these names do
+# not have. This script asserts that value is unchanged after it runs, so a
+# future edit cannot quietly couple the two lines.
+#
+# What DOES track the aprender version is the facades' `upstream = { version =
+# "..." }` requirement — the version of `aprender-contracts*` a PUBLISHED facade
+# resolves from the registry. Two different version lines in the same directory,
+# which is exactly why this is scripted rather than remembered.
+#
+#   bash scripts/bump-version.sh 0.64.0
+#   bash scripts/bump-version.sh --check          # are all workspaces consistent NOW?
+#   bash scripts/bump-version.sh --self-test      # case table
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The facade manifests whose `upstream` pin tracks the aprender version. Derived,
+# not listed: a fourth facade added later is picked up without editing this file,
+# and the signpost facade (no `upstream` line at all) is skipped by the same rule
+# that makes it publishable at any point in the cascade.
+facade_pinned_manifests() {  # root
+    local f
+    for f in "$1"/crates/facades/*/Cargo.toml; do
+        [ -f "$f" ] || continue
+        grep -q '^upstream *=.*version *= *"' "$f" && printf '%s\n' "$f"
+    done
+    return 0
+}
+
+facade_pin() {  # manifest
+    sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "$1" | head -1
+}
+
+# The facades' own package version — the one that must NOT move.
+facade_own_version() {  # root
+    sed -n 's/^version *= *"\([^"]*\)".*/\1/p' "$1/crates/facades/Cargo.toml" | head -1
+}
+
+root_version() {  # root
+    grep -E '^version = "' "$1/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/'
+}
+
+# Rewrite every `upstream = { ..., version = "X", ... }` pin to $2. Anchored at
+# line start and scoped to the version field so it cannot touch the `path`, the
+# `package` rename, or any other key on the line.
+set_facade_pins() {  # root new_version
+    local f n=0
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        sed -i -E "s|^(upstream *=.*version *= *\")[^\"]*(\".*)$|\1$2\2|" "$f"
+        n=$((n + 1))
+    done < <(facade_pinned_manifests "$1")
+    printf '%s\n' "$n"
+}
+
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    TD="$(mktemp -d)" || exit 1
+    case "$TD" in /tmp/*|/var/folders/*) : ;; *) printf 'bad tmp\n'; exit 1 ;; esac
+    trap 'rm -rf "${TD:?}"' EXIT
+
+    mkdir -p "$TD/crates/facades/reexport" "$TD/crates/facades/signpost"
+    printf '[workspace]\n[workspace.package]\nversion = "0.4.0"\n' \
+        > "$TD/crates/facades/Cargo.toml"
+    printf '[dependencies]\nupstream = { path = "../../up", version = "0.63.0", package = "up" }\n' \
+        > "$TD/crates/facades/reexport/Cargo.toml"
+    printf '[package]\nname = "signpost"\n# NO [dependencies].\n' \
+        > "$TD/crates/facades/signpost/Cargo.toml"
+
+    # Row 1: the pinned facade is rewritten.
+    n="$(set_facade_pins "$TD" 0.64.0)"
+    if [ "$(facade_pin "$TD/crates/facades/reexport/Cargo.toml")" = "0.64.0" ]; then
+        printf 'ok    row 1 a re-export facade pin is bumped\n'
+    else
+        printf 'FAIL  row 1 pin not bumped\n'; fails=1
+    fi
+
+    # Row 2: exactly one manifest was eligible. Without this, row 1 passes even
+    # if the rewrite sprayed every file in the tree.
+    if [ "$n" = "1" ]; then
+        printf 'ok    row 2 exactly the 1 pinned manifest was rewritten (signpost skipped)\n'
+    else
+        printf 'FAIL  row 2 rewrote %s manifest(s), expected 1\n' "$n"; fails=1
+    fi
+
+    # Row 3: THE INDEPENDENCE. The facades' own version must be untouched. This
+    # is the row that stops a future "simplification" from coupling the two
+    # version lines (#2546).
+    if [ "$(facade_own_version "$TD")" = "0.4.0" ]; then
+        printf 'ok    row 3 crates/facades/Cargo.toml version = 0.4.0 is UNTOUCHED\n'
+    else
+        printf 'FAIL  row 3 the facades own version moved to %s -- #2546 says it must not\n' \
+            "$(facade_own_version "$TD")"; fails=1
+    fi
+
+    # Row 4: the signpost facade, which has no upstream at all, is left alone
+    # rather than acquiring a pin.
+    if ! grep -q 'upstream' "$TD/crates/facades/signpost/Cargo.toml"; then
+        printf 'ok    row 4 the signpost facade did not acquire an upstream pin\n'
+    else
+        printf 'FAIL  row 4 an upstream pin appeared in the signpost facade\n'; fails=1
+    fi
+
+    # Row 5: the rewrite preserves the rest of the dependency line. A pin that
+    # bumps the version but eats `path` or `package` breaks the build in a way
+    # the version check would still call correct.
+    if grep -q 'path = "../../up"' "$TD/crates/facades/reexport/Cargo.toml" \
+       && grep -q 'package = "up"' "$TD/crates/facades/reexport/Cargo.toml"; then
+        printf 'ok    row 5 path and package survive the rewrite\n'
+    else
+        printf 'FAIL  row 5 the rewrite damaged the dependency line:\n'
+        sed 's/^/        /' "$TD/crates/facades/reexport/Cargo.toml"; fails=1
+    fi
+
+    # Row 6: idempotence. A bump re-run must be a no-op, not a corruption.
+    before="$(cat "$TD/crates/facades/reexport/Cargo.toml")"
+    set_facade_pins "$TD" 0.64.0 >/dev/null
+    if [ "$before" = "$(cat "$TD/crates/facades/reexport/Cargo.toml")" ]; then
+        printf 'ok    row 6 re-running the same bump is a no-op\n'
+    else
+        printf 'FAIL  row 6 re-running the bump changed the file again\n'; fails=1
+    fi
+
+    [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
+    printf '\nSELF-TEST PASSED (6/6)\n'
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--check" ]; then
+    WS="$(root_version "$REPO_ROOT")"
+    printf '=== version consistency across workspaces ===\n'
+    printf 'root workspace:            %s\n' "$WS"
+    printf 'crates/facades own version: %s  (INDEPENDENT by design, #2546)\n' \
+        "$(facade_own_version "$REPO_ROOT")"
+    rc=0
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        got="$(facade_pin "$f")"
+        if [ "$got" = "$WS" ]; then
+            printf 'ok    %s upstream pin %s\n' "${f#"$REPO_ROOT"/}" "$got"
+        else
+            printf 'FAIL  %s upstream pin %s, workspace is %s\n' \
+                "${f#"$REPO_ROOT"/}" "$got" "$WS"
+            rc=1
+        fi
+    done < <(facade_pinned_manifests "$REPO_ROOT")
+    if ( cd "$REPO_ROOT/crates/facades" && cargo metadata --format-version 1 --locked ) >/dev/null 2>&1; then
+        printf 'ok    crates/facades/Cargo.lock matches its manifests (--locked)\n'
+    else
+        printf 'FAIL  crates/facades/Cargo.lock is stale\n'; rc=1
+    fi
+    exit "$rc"
+fi
+
+NEW="${1:-}"
+if ! printf '%s' "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    printf 'Usage: %s <x.y.z> | --check | --self-test\n' "$0" >&2
+    exit 2
+fi
+
+OLD_FACADE_OWN="$(facade_own_version "$REPO_ROOT")"
+printf '=== bumping to %s ===\n' "$NEW"
+
+printf -- '--- root workspace (cargo set-version --workspace) ---\n'
+if ! ( cd "$REPO_ROOT" && cargo set-version --workspace "$NEW" ); then
+    printf 'FAIL  cargo set-version failed (is cargo-edit installed?)\n' >&2
+    exit 1
+fi
+
+# THE PART --workspace CANNOT REACH.
+printf -- '--- crates/facades (excluded from the root workspace) ---\n'
+N="$(set_facade_pins "$REPO_ROOT" "$NEW")"
+printf 'rewrote %s facade upstream pin(s)\n' "$N"
+# Vacuity: zero rewrites means the pattern stopped matching, not that there is
+# nothing to do. Silently bumping nothing is the exact failure being fixed.
+if [ "${N:-0}" -lt 1 ]; then
+    printf 'FAIL (vacuity): no facade upstream pin matched. The REWRITE is broken,\n' >&2
+    printf '      not the tree -- crates/facades still needs bumping by hand.\n' >&2
+    exit 1
+fi
+
+# Regenerate the second lockfile. `cargo metadata` resolves and writes it; no
+# build, about a second. check_lockfile_current.sh resolves the ROOT workspace
+# only and cannot see this file.
+if ! ( cd "$REPO_ROOT/crates/facades" && cargo metadata --format-version 1 ) >/dev/null; then
+    printf 'FAIL  could not regenerate crates/facades/Cargo.lock\n' >&2
+    exit 1
+fi
+printf 'regenerated crates/facades/Cargo.lock\n'
+
+# THE INDEPENDENCE ASSERTION. `cargo set-version --workspace` run from inside
+# crates/facades would move this, and so would a plausible "fix" to the rewrite
+# above. #2546 says it must not move.
+NOW_FACADE_OWN="$(facade_own_version "$REPO_ROOT")"
+if [ "$NOW_FACADE_OWN" != "$OLD_FACADE_OWN" ]; then
+    printf 'FAIL  crates/facades/Cargo.toml version moved %s -> %s. The facade crate\n' \
+        "$OLD_FACADE_OWN" "$NOW_FACADE_OWN" >&2
+    printf '      NAMES version independently of the aprender line (#2546) -- these\n' >&2
+    printf '      names have no %s history. Revert that file.\n' "$NEW" >&2
+    exit 1
+fi
+printf 'crates/facades/Cargo.toml version left at %s (independent, #2546)\n' "$NOW_FACADE_OWN"
+
+printf -- '\n--- files that MUST ride in the bump commit ---\n'
+( cd "$REPO_ROOT" && git status --porcelain -- crates/facades ) | sed 's/^/  /'
+
+printf -- '\n--- verifying ---\n'
+exec bash "$REPO_ROOT/scripts/bump-version.sh" --check

--- a/scripts/cascade-drain.sh
+++ b/scripts/cascade-drain.sh
@@ -56,10 +56,38 @@ fi
 # returns empty for EVERY crate and the drain reports 0/N forever.
 UA="aprender-release/${TARGET} (noah.gift@gmail.com)"
 
-CRATES=$(grep -oE 'TIERS\[[0-9]+\]="[^"]*"' scripts/cascade-publish.sh \
-         | sed 's/.*="//;s/"//' | tr ' ' '\n' | sort -u)
-TOTAL=$(printf '%s\n' "$CRATES" | grep -c .)
-[ "$TOTAL" -gt 0 ] || { echo "ERROR: no crates parsed from TIERS[]" >&2; exit 2; }
+# THE UNIVERSE IS READ FROM CARGO, NOT FROM THE CASCADE'S OWN TABLE.
+#
+# This used to be `grep -oE 'TIERS\[...' scripts/cascade-publish.sh`, which made
+# the drain's idea of "the release" a copy of the cascade's. A crate absent from
+# TIERS[] was therefore absent from TOTAL as well, so it was never published,
+# never counted, and never missed: the drain printed DRAIN COMPLETE n/n while
+# the three crates/facades crates sat unshipped (aprender#2559). Two checks
+# sharing one blind list is one check.
+#
+# Reading from `cargo metadata` across every workspace inverts that: if the
+# cascade under-covers, TOTAL exceeds what any pass can publish and the drain
+# says STUCK — loudly, instead of silently agreeing.
+#
+# Each row also carries its OWN expected version. The facades version
+# independently of the aprender line (0.4.0 vs 0.63.0, aprender#2546); a single
+# $TARGET would mark them permanently behind, and the drain would exit 2 STUCK
+# on an append-only registry — the most dangerous thing this script can report.
+UNIVERSE=$(python3 scripts/lib/cascade_universe.py "$REPO_ROOT") || {
+    echo "ERROR: cascade_universe.py failed; refusing to drain against an unknown universe" >&2
+    exit 2
+}
+# name<TAB>expected-version. Root-workspace crates are pinned to $TARGET so that
+# an explicit --target still overrides what cargo read from the manifests;
+# crates from any other workspace keep their own version.
+WANT=$(printf '%s\n' "$UNIVERSE" | REPO_ROOT="$REPO_ROOT" TARGET="$TARGET" awk -F'\t' '
+    { print $1 "\t" ($4 == ENVIRON["REPO_ROOT"] ? ENVIRON["TARGET"] : $2) }' | sort -u)
+TOTAL=$(printf '%s\n' "$WANT" | grep -c .)
+[ "$TOTAL" -gt 0 ] || { echo "ERROR: no crates in the publish universe" >&2; exit 2; }
+# Vacuity: a shrunken universe would let the drain report DRAIN COMPLETE over
+# almost nothing. 70 is the root workspace alone; anything less is a broken
+# enumeration, not a smaller repo.
+[ "$TOTAL" -ge 70 ] || { echo "ERROR vacuity: universe holds $TOTAL crates, expected 70 or more" >&2; exit 2; }
 
 # Count how many tiered crates are live on crates.io at $TARGET.
 #
@@ -79,9 +107,13 @@ TOTAL=$(printf '%s\n' "$CRATES" | grep -c .)
 # UA/TARGET pass via the environment rather than being spliced into the
 # single-quoted body: the old '"$UA"' splicing was unparseable (bashrs SC1078)
 # and broke on any character needing quoting.
+# Each line of $WANT is "<crate>\t<expected version>", so the worker compares
+# against the version THAT crate is supposed to reach rather than one global
+# target. Passing the pair through xargs keeps the single-quoted body free of
+# splicing (the SC1078 hazard the UA/TARGET env vars already document).
 count_pub() {
-    printf '%s\n' "$CRATES" | DRAIN_UA="$UA" DRAIN_TARGET="$TARGET" xargs -P 8 -I{} bash -c '
-        crate="$1"
+    printf '%s\n' "$WANT" | DRAIN_UA="$UA" xargs -P 8 -I{} bash -c '
+        IFS="$(printf "\t")" read -r crate DRAIN_TARGET <<< "$1"
         n=${#crate}
         if   [ "$n" -eq 1 ]; then p="1/${crate}"
         elif [ "$n" -eq 2 ]; then p="2/${crate}"

--- a/scripts/cascade-publish.sh
+++ b/scripts/cascade-publish.sh
@@ -28,6 +28,8 @@
 
 set +e  # don't exit on individual crate failures — track each and report at end
 
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
 # Tier definitions per SPEC-HF-PUBLISH-001 § crates.io release cascade.
 declare -A TIERS
 TIERS[1]="apr-format aprender-contracts-macros aprender-quant aprender-gemm-codegen aprender-sparse aprender-solve aprender-rand aprender-fft aprender-image aprender-tensor aprender-cupti"
@@ -43,10 +45,71 @@ TIERS[10]="apr-cli"
 TIERS[11]="aprender"
 TIERS[12]="aprender-tsp aprender-monte-carlo aprender-shell"
 TIERS[13]="aprender-test-derive aprender-test-lib aprender-test-js-gen aprender-test-cli aprender-test-showcase aprender-zram-core aprender-zram-adaptive aprender-zram-generator aprender-zram-cli aprender-zram aprender-present-test-macros aprender-present-test aprender-present-lib aprender-present-cli aprender-db aprender-rag aprender-viz aprender-registry aprender-distribute aprender-simulate aprender-verify aprender-verify-ml aprender-train-shell aprender-train-inspect aprender-train-bench aprender-train-wasm aprender-contracts-cli aprender-rag-cli"
+# TIER 14 — the crates.io compatibility facades (aprender#2559).
+#
+# THESE WERE NOT HERE, AND THE CASCADE STILL REPORTED SUCCESS. Tiers 1-13 are
+# EXACTLY the 70 publishable crates of the root workspace — MEASURED, zero drift
+# in either direction — so the table looked complete. `crates/facades/` is a
+# second workspace, `exclude`d from the root, and FINAL VERIFICATION below
+# iterates TIERS[]: three publishable crates were absent from the loop, so their
+# absence read as "✅ ALL crates at $TARGET". See scripts/lib/cascade_universe.py.
+#
+# LAST TIER ON PURPOSE, AND THE ORDER IS ENFORCED, NOT ASSUMED. A re-export
+# facade resolves `aprender-contracts*` FROM THE REGISTRY, not through its path
+# dep, so publishing a facade before its upstream yields a crate that cannot
+# compile for anyone. Being last makes the order LIKELY; `facade_upstream_ready`
+# below makes it TRUE — it refuses to upload a facade until the exact upstream
+# version that facade requires is live on the sparse index.
+TIERS[14]="provable-contracts provable-contracts-macros provable-contracts-cli"
 
 TARGET_VERSION=$(grep -E '^version = "' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 [ -z "$TARGET_VERSION" ] && { echo "ERROR: could not detect target version from Cargo.toml"; exit 1; }
 echo "Target version: $TARGET_VERSION"
+
+# --------------------------------------------------------------------------
+# THE UNIVERSE — read from cargo, across EVERY workspace, never hand-written.
+#
+# Two facts about each crate that a bare name cannot carry, and that this
+# cascade got wrong for the facades in both directions:
+#
+#   MANIFEST[c]  `cargo publish -p provable-contracts` is not merely wrong from
+#                the repo root, it is IMPOSSIBLE — MEASURED, rc=101, "package ID
+#                specification `provable-contracts` did not match any packages".
+#                An excluded crate must be published by --manifest-path.
+#
+#   EXPECT[c]    the facades version INDEPENDENTLY of the aprender version line
+#                (0.4.0 vs 0.63.0) and that is deliberate (aprender#2546 — these
+#                names have no 0.63.0 history). Comparing them against one
+#                $TARGET_VERSION would mark them permanently behind and make
+#                FINAL VERIFICATION unreachable — a false failure on an
+#                append-only registry.
+# --------------------------------------------------------------------------
+declare -A MANIFEST
+declare -A EXPECT
+declare -A ROOTWS
+UNIVERSE_N=0
+while IFS=$'\t' read -r _u_name _u_ver _u_manifest _u_ws; do
+  [ -n "$_u_name" ] || continue
+  EXPECT[$_u_name]="$_u_ver"
+  MANIFEST[$_u_name]="$_u_manifest"
+  ROOTWS[$_u_name]="$_u_ws"
+  UNIVERSE_N=$((UNIVERSE_N + 1))
+done < <(python3 "$REPO_ROOT/scripts/lib/cascade_universe.py" "$REPO_ROOT")
+# Vacuity: an enumeration that saw nothing would publish nothing and verify
+# nothing, and every row below would read as a clean pass. Make it RED.
+if [ "$UNIVERSE_N" -lt 70 ]; then
+  echo "ERROR (vacuity): cascade_universe.py enumerated $UNIVERSE_N crate(s), expected 70+."
+  echo "The ENUMERATION is broken. Refusing to publish against an unknown universe."
+  exit 1
+fi
+echo "Universe: $UNIVERSE_N publishable crate(s) across all workspaces"
+
+# What version this crate is expected to reach. Falls back to the workspace
+# version for anything cargo did not enumerate, so an unknown name still gets a
+# defined answer rather than an empty string that matches nothing.
+expected_version() {
+  echo "${EXPECT[$1]:-$TARGET_VERSION}"
+}
 
 MODE="${1:-publish}"
 ONLY_TIER="${2:-}"
@@ -62,16 +125,79 @@ check_version() {
     | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('crate',{}).get('max_version','none'))" 2>/dev/null
 }
 
-publish_crate() {
-  local crate=$1
-  local cur=$(check_version "$crate")
-  if [ "$cur" = "$TARGET_VERSION" ]; then
-    echo "  ✓ $crate (already $TARGET_VERSION)"
+# Is EXACTLY this version of this crate live? `check_version` answers
+# max_version, which cannot express "0.64.0 is up" once 0.65.0 exists, and the
+# publish-ORDER precondition below needs the exact question. Uses the sparse
+# index (a static CDN, what cargo itself resolves against) rather than the JSON
+# API, which rate-limited the v0.61.0 cascade into reporting 0/70.
+version_live() {
+  local crate=$1 want=$2 n p
+  n=${#crate}
+  if   [ "$n" -eq 1 ]; then p="1/${crate}"
+  elif [ "$n" -eq 2 ]; then p="2/${crate}"
+  elif [ "$n" -eq 3 ]; then p="3/${crate:0:1}/${crate}"
+  else p="${crate:0:2}/${crate:2:2}/${crate}"
+  fi
+  curl -s --retry 3 --retry-delay 2 \
+    -H "User-Agent: aprender-cascade-publish (release automation)" \
+    "https://index.crates.io/${p}" 2>/dev/null \
+    | grep -qF "\"vers\":\"${want}\""
+}
+
+# PUBLISH ORDER AS A PRECONDITION, NOT AS A COMMENT.
+#
+# `scripts/check_facade_compat.sh` already ends with a `note` saying the order
+# is a hard constraint. A note is not a mechanism: nothing stopped tier 14 being
+# uploaded first, and nothing would have noticed. Inside THIS tree `upstream`
+# resolves through its `path` and every build is green; a consumer installing
+# from crates.io resolves it from the REGISTRY. Only the second is what
+# `cargo install provable-contracts` does, and a facade published ahead of its
+# upstream is a crate that cannot compile for anyone.
+#
+# The requirement is READ FROM THE FACADE'S OWN MANIFEST rather than assumed to
+# equal $TARGET_VERSION, so it stays true if the pin ever legitimately differs.
+# A crate with no `upstream =` line (the lib-only signpost facade, which has no
+# dependencies at all) is ready by construction — that independence is stated in
+# its manifest and is what makes it publishable at any point in the cascade.
+facade_upstream_ready() {
+  local crate=$1 manifest=${MANIFEST[$1]:-} up_name up_ver
+  [ -n "$manifest" ] || return 0
+  up_name=$(sed -n 's/^upstream *=.*package *= *"\([^"]*\)".*/\1/p' "$manifest" 2>/dev/null | head -1)
+  up_ver=$(sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "$manifest" 2>/dev/null | head -1)
+  # No upstream requirement -> nothing to order against.
+  [ -n "$up_name" ] && [ -n "$up_ver" ] || return 0
+  if version_live "$up_name" "$up_ver"; then
     return 0
   fi
-  echo -n "  → $crate ($cur → $TARGET_VERSION): "
+  echo "ORDER-WAIT (needs $up_name $up_ver on crates.io first)"
+  return 1
+}
+
+publish_crate() {
+  local crate=$1
+  local want=$(expected_version "$crate")
+  local cur=$(check_version "$crate")
+  if [ "$cur" = "$want" ]; then
+    echo "  ✓ $crate (already $want)"
+    return 0
+  fi
+  echo -n "  → $crate ($cur → $want): "
+  # ORDER PRECONDITION. Deliberately a DEFER, not a FATAL: the drain re-runs the
+  # cascade, so a facade whose upstream lands in pass N becomes publishable in
+  # pass N+1 — the same mechanism every other dependency layer uses. Failing
+  # hard here would abort a release that is still making forward progress.
+  if ! facade_upstream_ready "$crate"; then
+    return 1
+  fi
+  # An excluded crate has no package ID in the root workspace; `-p` cannot name
+  # it at all (rc=101, "did not match any packages"). Select by manifest path
+  # for anything cargo enumerated from a workspace other than the root one.
+  local sel=(-p "$crate")
+  if [ -n "${MANIFEST[$crate]:-}" ] && [ "${ROOTWS[$crate]:-}" != "$REPO_ROOT" ]; then
+    sel=(--manifest-path "${MANIFEST[$crate]}")
+  fi
   local out
-  out=$(cargo publish -p "$crate" --allow-dirty --locked 2>&1 | tail -6)
+  out=$(cargo publish "${sel[@]}" --allow-dirty --locked 2>&1 | tail -6)
   if echo "$out" | grep -q "Published $crate"; then
     echo "✓ PUBLISHED"
     sleep 10  # let crates.io index settle before dependents try to fetch
@@ -111,20 +237,53 @@ if [ -f .cargo/config.toml ]; then
 fi
 trap 'if [ -f .cargo/config.toml.cascade-backup ]; then cp .cargo/config.toml.cascade-backup .cargo/config.toml && rm -f .cargo/config.toml.cascade-backup; fi' EXIT
 
+# --order-check: run ONLY the publish-order precondition, against the live
+# registry, and publish nothing. Two reasons this mode exists rather than the
+# order being checked implicitly at publish time:
+#
+#   1. PRE-FLIGHT. It answers "is it safe to run tier 14 right now" before any
+#      upload, which is the question an operator actually has.
+#   2. IT MAKES THE PRECONDITION TESTABLE. A branch that only ever runs in the
+#      middle of a real cascade cannot be exercised, so it cannot be shown to
+#      turn RED — and an ordering rule that has only ever been green is
+#      indistinguishable from one that never ran. This mode drives the SAME
+#      `facade_upstream_ready` the publish path calls; there is no second copy.
+if [ "$MODE" = "--order-check" ]; then
+  echo ""
+  echo "=== PUBLISH ORDER PRECONDITION (not publishing) ==="
+  order_rc=0
+  for crate in ${TIERS[14]}; do
+    echo -n "  $crate: "
+    if facade_upstream_ready "$crate"; then
+      echo "READY"
+    else
+      order_rc=1
+    fi
+  done
+  if [ $order_rc -eq 0 ]; then
+    echo "  ✅ every facade has its upstream live at the version it requires"
+  else
+    echo "  ⛔ publish the upstream crates FIRST — a facade published ahead of its"
+    echo "     upstream resolves the upstream from the REGISTRY and cannot compile."
+  fi
+  exit $order_rc
+fi
+
 if [ "$MODE" = "--check" ]; then
   echo ""
   echo "=== STATUS REPORT (not publishing) ==="
   any_behind=0
   for tier in $(echo "${!TIERS[@]}" | tr ' ' '\n' | sort -n); do
     for crate in ${TIERS[$tier]}; do
+      want=$(expected_version "$crate")
       cur=$(check_version "$crate")
-      if [ "$cur" != "$TARGET_VERSION" ]; then
-        echo "  T$tier  $crate: $cur"
+      if [ "$cur" != "$want" ]; then
+        echo "  T$tier  $crate: $cur (want $want)"
         any_behind=1
       fi
     done
   done
-  [ $any_behind -eq 0 ] && echo "  ✅ ALL at $TARGET_VERSION"
+  [ $any_behind -eq 0 ] && echo "  ✅ ALL $UNIVERSE_N crates at their target version"
   exit 0
 fi
 
@@ -157,19 +316,26 @@ fi
 
 echo ""
 echo "=== FINAL VERIFICATION ==="
+# Iterates the UNIVERSE, not TIERS[]. Verifying the same list you published is
+# circular: a crate missing from TIERS[] was skipped by the publish loop AND by
+# the verify loop, so it could not be reported. That is precisely how the three
+# facades went unshipped under a green "✅ ALL crates at $TARGET" — the check
+# and the omission shared one list. scripts/check_cascade_covers_all_crates.sh
+# closes the other half by failing CI when TIERS[] and the universe disagree.
 ALL_OK=1
-for tier in $(echo "${!TIERS[@]}" | tr ' ' '\n' | sort -n); do
-  for crate in ${TIERS[$tier]}; do
-    cur=$(check_version "$crate")
-    if [ "$cur" != "$TARGET_VERSION" ]; then
-      echo "  ✗ $crate at $cur (expected $TARGET_VERSION)"
-      ALL_OK=0
-    fi
-  done
+VERIFIED=0
+for crate in $(printf '%s\n' "${!EXPECT[@]}" | sort); do
+  want=$(expected_version "$crate")
+  cur=$(check_version "$crate")
+  VERIFIED=$((VERIFIED + 1))
+  if [ "$cur" != "$want" ]; then
+    echo "  ✗ $crate at $cur (expected $want)"
+    ALL_OK=0
+  fi
 done
 
 if [ $ALL_OK -eq 1 ]; then
-  echo "  ✅ ALL crates at $TARGET_VERSION"
+  echo "  ✅ ALL $VERIFIED crates at their target version (root $TARGET_VERSION)"
   echo ""
   echo "Run: cargo install aprender --force && apr --version"
   exit 0

--- a/scripts/check_cascade_covers_all_crates.sh
+++ b/scripts/check_cascade_covers_all_crates.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# check_cascade_covers_all_crates.sh — the release cascade must be able to SEE
+# every crate it is supposed to ship, and must ship the facades AFTER the crates
+# they resolve from the registry.
+#
+# WHY THIS EXISTS (aprender#2559)
+# -------------------------------
+# `scripts/cascade-publish.sh` hand-maintains TIERS[]. On c22fe88ef that table
+# held exactly the 70 publishable crates of the ROOT workspace — MEASURED, an
+# exact match with no drift in either direction:
+#
+#     $ comm -13 <TIERS[] names> <root publishable>   ->  (empty)
+#     $ comm -23 <TIERS[] names> <root publishable>   ->  (empty)
+#
+# So every signal available said the table was complete. It was complete with
+# respect to the wrong universe. `crates/facades/` is a SECOND workspace,
+# `exclude`d from the root, holding three publishable crates carried forward
+# from the APR-MONO rename — `provable-contracts` (10.8K downloads),
+# `provable-contracts-macros` (46.6K) and `provable-contracts-cli`. None of the
+# three appeared anywhere in the cascade, the drain, or the publish-safety
+# scan, because all three built their universe from the root workspace and the
+# root workspace does not contain them.
+#
+# Then the FINAL VERIFICATION loop iterated TIERS[] as well. A crate missing
+# from the table was skipped by the publish loop AND by the loop that checks
+# the publish loop, so its absence printed as
+#
+#     ✅ ALL crates at 0.63.0
+#
+# That is the shape this repository keeps paying for: the loop cannot iterate
+# what it cannot see, so absence reads as success. It is not fixed by adding
+# three names — it is fixed by deriving the universe from cargo across every
+# workspace (scripts/lib/cascade_universe.py) and then FAILING when the
+# hand-written ordering table and that universe disagree.
+#
+# ADDING A CRATE IS NOT THE FIX, EITHER
+# -------------------------------------
+# Names go stale in both directions. A crate deleted from the repo but left in
+# TIERS[] never publishes and never can, so the cascade defers it every pass
+# and the drain reports EXHAUSTED — a release that reads as broken while
+# nothing is wrong. Both directions are checked.
+#
+# WHAT IS CHECKED
+# ---------------
+#   R1 COVERAGE   every publishable crate in every workspace appears in TIERS[]
+#   R2 NO GHOSTS  every name in TIERS[] is a publishable crate that exists
+#   R3 ORDER      a facade that resolves an upstream FROM THE REGISTRY sits in a
+#                 strictly LATER tier than that upstream. Publishing a facade
+#                 first yields a crate that cannot compile for anyone — inside
+#                 this tree `upstream` resolves through its `path` and every
+#                 build is green, which is exactly what hides it.
+#
+# R3 is the STATIC half of the ordering constraint. The DYNAMIC half lives in
+# cascade-publish.sh's `facade_upstream_ready`, which refuses to upload a facade
+# until the exact upstream version it requires is live on the sparse index. Two
+# halves because the tier table can be right while a `--tier 14` invocation
+# still runs first, and the registry check can be right while the table quietly
+# rots. Neither subsumes the other.
+#
+#   bash scripts/check_cascade_covers_all_crates.sh              # check
+#   bash scripts/check_cascade_covers_all_crates.sh --self-test  # case table
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNIVERSE_PY="${REPO_ROOT}/scripts/lib/cascade_universe.py"
+
+# Print "<tier>\t<crate>" for every crate named in a cascade script's TIERS[].
+tier_rows() {
+    grep -oE 'TIERS\[[0-9]+\]="[^"]*"' "$1" \
+        | sed -E 's/^TIERS\[([0-9]+)\]="(.*)"$/\1 \2/' \
+        | while read -r tier names; do
+              for n in $names; do printf '%s\t%s\n' "$tier" "$n"; done
+          done
+}
+
+# Print "<facade>\t<upstream>" for every facade manifest carrying an `upstream`
+# dependency with a version requirement — i.e. every facade that resolves its
+# upstream FROM THE REGISTRY when published. A facade with no such line (the
+# lib-only signpost) imposes no ordering and is correctly absent here.
+facade_edges() {
+    local dir
+    for dir in "$1"/crates/facades/*/; do
+        [ -f "${dir}Cargo.toml" ] || continue
+        local up
+        up=$(sed -n 's/^upstream *=.*package *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1)
+        [ -n "$up" ] || continue
+        sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1 \
+            | grep -q . || continue
+        printf '%s\t%s\n' "$(basename "$dir")" "$up"
+    done
+}
+
+# The three rules, over an already-materialised universe file and cascade file.
+# Factored out so the self-test can drive them against fixtures rather than
+# against the live repo — a case table that can only run on the real tree can
+# only ever be green, which is the fail mode this whole file is about.
+run_rules() {  # universe_names_file cascade_file repo_for_edges
+    local uni="$1" casc="$2" root="$3" rc=0 rows missing ghosts
+    rows="$(tier_rows "$casc")"
+
+    # Vacuity: a cascade whose table did not parse would report zero ghosts and
+    # every crate missing, or with an empty universe, nothing missing at all.
+    if [ -z "$rows" ]; then
+        printf 'FAIL  R0 no TIERS[] rows parsed from %s — the READER is broken\n' "$casc"
+        return 1
+    fi
+    if [ ! -s "$uni" ]; then
+        printf 'FAIL  R0 the crate universe is empty — the ENUMERATION is broken\n'
+        return 1
+    fi
+
+    missing="$(comm -23 <(sort -u "$uni") <(printf '%s\n' "$rows" | cut -f2 | sort -u))"
+    if [ -n "$missing" ]; then
+        printf 'FAIL  R1 publishable crate(s) absent from TIERS[] — the cascade cannot\n'
+        printf '      ship what it cannot iterate, and FINAL VERIFICATION iterates the\n'
+        printf '      same table, so this prints as success:\n'
+        printf '%s\n' "$missing" | sed 's/^/        /'
+        rc=1
+    else
+        printf 'ok    R1 every publishable crate appears in TIERS[]\n'
+    fi
+
+    ghosts="$(comm -13 <(sort -u "$uni") <(printf '%s\n' "$rows" | cut -f2 | sort -u))"
+    if [ -n "$ghosts" ]; then
+        printf 'FAIL  R2 TIERS[] names crate(s) that are not publishable here. They\n'
+        printf '      DEFER on every pass, so the drain reports EXHAUSTED and a healthy\n'
+        printf '      release reads as broken:\n'
+        printf '%s\n' "$ghosts" | sed 's/^/        /'
+        rc=1
+    else
+        printf 'ok    R2 every name in TIERS[] is a publishable crate\n'
+    fi
+
+    local edges
+    edges="$(facade_edges "$root")"
+    if [ -z "$edges" ]; then
+        printf 'ok    R3 no facade declares a registry-resolved upstream (nothing to order)\n'
+        return "$rc"
+    fi
+    while IFS=$'\t' read -r facade upstream; do
+        [ -n "$facade" ] || continue
+        local ft ut
+        ft="$(printf '%s\n' "$rows" | awk -F'\t' -v c="$facade"   '$2==c{print $1; exit}')"
+        ut="$(printf '%s\n' "$rows" | awk -F'\t' -v c="$upstream" '$2==c{print $1; exit}')"
+        if [ -z "$ft" ] || [ -z "$ut" ]; then
+            printf 'FAIL  R3 %s -> %s: one of them is not tiered (facade=%s upstream=%s)\n' \
+                "$facade" "$upstream" "${ft:-none}" "${ut:-none}"
+            rc=1
+        elif [ "$ft" -gt "$ut" ]; then
+            printf 'ok    R3 %s (T%s) publishes after its upstream %s (T%s)\n' \
+                "$facade" "$ft" "$upstream" "$ut"
+        else
+            printf 'FAIL  R3 %s is in T%s but its upstream %s is in T%s. A facade\n' \
+                "$facade" "$ft" "$upstream" "$ut"
+            printf '      resolves its upstream FROM THE REGISTRY; published first it is a\n'
+            printf '      crate that cannot compile for anyone. Inside this tree it resolves\n'
+            printf '      through `path` and looks fine, which is what hides it.\n'
+            rc=1
+        fi
+    done <<< "$edges"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    TD="$(mktemp -d)" || exit 1
+    case "$TD" in /tmp/*|/var/folders/*) : ;; *) printf 'bad tmp\n'; exit 1 ;; esac
+    trap 'rm -rf "${TD:?}"' EXIT
+
+    # A miniature repo: two upstreams, one facade that pins one of them, one
+    # signpost facade with no upstream at all.
+    mkdir -p "$TD/repo/crates/facades/face" "$TD/repo/crates/facades/signpost"
+    printf 'upstream = { path = "../../up", version = "1.2.3", package = "up" }\n' \
+        > "$TD/repo/crates/facades/face/Cargo.toml"
+    printf '[package]\nname = "signpost"\n' \
+        > "$TD/repo/crates/facades/signpost/Cargo.toml"
+    printf 'up\nother\nface\nsignpost\n' | sort -u > "$TD/uni_good"
+
+    mkcasc() { printf '%s\n' "$@" > "$TD/casc"; }
+
+    row() {  # name expect_rc universe needle
+        local name="$1" want="$2" uni="$3" needle="$4" out rc
+        out="$(run_rules "$TD/$uni" "$TD/casc" "$TD/repo" 2>&1)"; rc=$?
+        if [ "$rc" != "$want" ]; then
+            printf 'FAIL  %s: exit %s, expected %s\n%s\n' "$name" "$rc" "$want" "$out"
+            fails=1; return
+        fi
+        if [ -n "$needle" ] && ! grep -q -- "$needle" <<< "$out"; then
+            printf 'FAIL  %s: exit %s as expected but did not name %s\n%s\n' \
+                "$name" "$rc" "$needle" "$out"
+            fails=1; return
+        fi
+        printf 'ok    %s\n' "$name"
+    }
+
+    # Row 1 is the CONTROL. Without a passing case every row below is satisfied
+    # by a checker that fails unconditionally.
+    mkcasc 'TIERS[1]="up other"' 'TIERS[2]="face signpost"'
+    row 'row 1 a complete, correctly ordered table passes' 0 uni_good ''
+
+    # Row 2 is the DEFECT, reproduced: a publishable crate the table cannot see.
+    # This is the mutation that must turn RED — on c22fe88ef it was the live
+    # state of the repo and nothing anywhere reported it.
+    mkcasc 'TIERS[1]="up other"' 'TIERS[2]="signpost"'
+    row 'row 2 a publishable crate missing from TIERS[] is REJECTED' 1 uni_good 'FAIL  R1'
+
+    # Row 3: the reverse drift. A name with nothing behind it defers forever.
+    mkcasc 'TIERS[1]="up other ghostcrate"' 'TIERS[2]="face signpost"'
+    row 'row 3 a TIERS[] name that is not publishable is REJECTED' 1 uni_good 'FAIL  R2'
+
+    # Row 4: the ORDER constraint. Same names, same coverage, wrong sequence —
+    # so this row cannot pass by accident on coverage alone.
+    mkcasc 'TIERS[1]="face signpost"' 'TIERS[2]="up other"'
+    row 'row 4 a facade tiered BEFORE its upstream is REJECTED' 1 uni_good 'FAIL  R3'
+
+    # Row 5: equal tiers are also rejected. Within one tier the cascade walks a
+    # shell word list, so "same tier" is an ordering by luck, not by rule — the
+    # class of defect where a verdict is decided by something nobody declared.
+    mkcasc 'TIERS[1]="up other face signpost"'
+    row 'row 5 a facade in the SAME tier as its upstream is REJECTED' 1 uni_good 'FAIL  R3'
+
+    # Row 6: vacuity in each direction. A checker that reads nothing must be RED,
+    # never a clean pass over nothing.
+    : > "$TD/uni_empty"
+    mkcasc 'TIERS[1]="up other"' 'TIERS[2]="face signpost"'
+    row 'row 6a an empty universe is REJECTED, not a clean pass' 1 uni_empty 'FAIL  R0'
+    mkcasc 'nothing here parses as a tier'
+    row 'row 6b an unparsable cascade table is REJECTED' 1 uni_good 'FAIL  R0'
+
+    [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
+    printf '\nSELF-TEST PASSED (7/7)\n'
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+printf '=== the release cascade must see every publishable crate ===\n\n'
+
+UNI="$(mktemp)"
+trap 'rm -f "${UNI:?}"' EXIT
+if ! python3 "$UNIVERSE_PY" --names "$REPO_ROOT" > "$UNI"; then
+    printf 'FAIL  the crate universe could not be enumerated; nothing was checked.\n'
+    exit 1
+fi
+printf '%s publishable crate(s) across all workspaces\n\n' "$(grep -c . "$UNI")"
+
+if run_rules "$UNI" "${REPO_ROOT}/scripts/cascade-publish.sh" "$REPO_ROOT"; then
+    printf '\nPASS  the cascade covers and correctly orders every publishable crate\n'
+    exit 0
+fi
+printf '\nFAIL  see rows above\n'
+exit 1

--- a/scripts/check_publish_safety.sh
+++ b/scripts/check_publish_safety.sh
@@ -113,23 +113,37 @@ fi
 #      an extension list, so a 100 MB .txt passed and a 1 KB .bin failed. The
 #      threshold in the title did not exist in the code.
 #
-# Now: every publishable crate, and an actual byte threshold alongside the
-# extension list.
+# It then acquired a THIRD hole, of exactly the same species as the first
+# (aprender#2559): "every publishable crate" meant one `cargo metadata` on the
+# ROOT workspace, and `crates/facades/` is a second workspace `exclude`d from
+# the root. Its three crates are published to crates.io and were never size- or
+# hygiene-scanned -- and could not be, because `cargo package -p
+# provable-contracts` from the repo root is rc=101, "did not match any
+# packages". The `|| continue` below turned that into a silent skip.
+#
+# Now: scripts/lib/cascade_universe.py -- every publishable crate in every
+# workspace, each with the manifest path needed to reach it -- an actual byte
+# threshold, and a count that must be accounted for rather than skipped.
 echo -n "  Package size check... "
 checked=$((checked + 1))
 large_files=""
+skipped_pkgs=""
+scanned_pkgs=0
 MAX_PACKAGED_BYTES=1048576
 
-pub_pkgs=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
-    | python3 "${REPO_ROOT:-.}/scripts/lib/publishable_crates.py" | cut -f1)
+universe=$(python3 "${REPO_ROOT:-.}/scripts/lib/cascade_universe.py" "${REPO_ROOT:-.}")
 
-for pkg in $pub_pkgs; do
-    listing=$(cargo package -p "$pkg" --list --allow-dirty 2>/dev/null < /dev/null) || continue
-    [ -n "$listing" ] || continue
-    pkg_dir=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
-        | python3 "${REPO_ROOT:-.}/scripts/lib/publishable_crates.py" \
-        | awk -F'\t' -v p="$pkg" '$1==p{print $2}')
-    [ -n "$pkg_dir" ] || continue
+while IFS=$'\t' read -r pkg _ver manifest _ws; do
+    [ -n "$pkg" ] || continue
+    # --manifest-path, not -p: `-p` cannot name a crate outside this workspace.
+    listing=$(cargo package --manifest-path "$manifest" --list --allow-dirty 2>/dev/null < /dev/null) \
+        || { skipped_pkgs="${skipped_pkgs} ${pkg}"; continue; }
+    if [ -z "$listing" ]; then
+        skipped_pkgs="${skipped_pkgs} ${pkg}"
+        continue
+    fi
+    pkg_dir=$(dirname "$manifest")
+    scanned_pkgs=$((scanned_pkgs + 1))
 
     while IFS= read -r f; do
         [ -n "$f" ] || continue
@@ -146,7 +160,7 @@ for pkg in $pub_pkgs; do
             fi
         fi
     done <<< "$listing"
-done
+done <<< "$universe"
 
 if [ -n "$large_files" ]; then
     echo "FAIL"
@@ -154,8 +168,17 @@ if [ -n "$large_files" ]; then
     echo -e "$large_files"
     echo "Fix: add to Cargo.toml [package] exclude (root-anchored) or .gitignore"
     errors=$((errors + 1))
+elif [ "$scanned_pkgs" -lt 70 ]; then
+    # Vacuity, in the direction this check has now failed twice: a scan that
+    # covered almost nothing reports no large files and reads as a clean pass.
+    # An unscannable crate is a RESULT, not a skip.
+    echo "FAIL"
+    echo "FAIL: only $scanned_pkgs package(s) were actually scanned, expected 70+."
+    echo "Unscannable:${skipped_pkgs:- (none named)}"
+    echo "The ENUMERATION is broken, not the packages."
+    errors=$((errors + 1))
 else
-    echo "OK"
+    echo "OK ($scanned_pkgs packages)"
 fi
 
 # Check 7: No hardcoded /home/ paths in non-test production source

--- a/scripts/check_publishable_deps_publishable.sh
+++ b/scripts/check_publishable_deps_publishable.sh
@@ -34,11 +34,40 @@
 set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Scans EVERY workspace given, as ONE graph (aprender#2559).
+#
+# This used to be a single `cargo metadata` on the repo root. `crates/facades/`
+# is a second workspace, `exclude`d from the root, so its three publishable
+# crates were outside the universe and this guard could say nothing about them
+# -- the same "universe built from the wrong side" defect that let the release
+# cascade report success while never shipping them.
+#
+# Merging the documents rather than running the scan twice is the point. Run
+# separately, the facade workspace is VACUOUSLY green: `provable-contracts`
+# depends on `aprender-contracts`, which is not a MEMBER of the facade
+# workspace, so it never appears in that document's `unpub` set no matter what
+# its publish flag says. The cross-workspace edge is exactly the edge that
+# matters -- a `publish = false` on `aprender-contracts` would make the facade
+# unpublishable, and only a merged graph can see it.
 scan() {
-    ( cd "$1" && cargo metadata --no-deps --format-version 1 2>/dev/null ) | python3 -c '
+    local d
+    for d in "$@"; do
+        ( cd "$d" && cargo metadata --no-deps --format-version 1 2>/dev/null )
+    done | python3 -c '
 import json,sys
-md=json.load(sys.stdin)
-members={p["name"]:p for p in md["packages"]}
+# One JSON document per workspace, concatenated on stdin.
+dec=json.JSONDecoder()
+buf=sys.stdin.read()
+members={}
+i=0
+while True:
+    while i < len(buf) and buf[i].isspace():
+        i += 1
+    if i >= len(buf):
+        break
+    md,i = dec.raw_decode(buf,i)
+    for p in md["packages"]:
+        members[p["name"]]=p
 # publish == [] means `publish = false`. publish == None means publishable.
 unpub={n for n,p in members.items() if p.get("publish")==[]}
 bad=[]
@@ -107,13 +136,46 @@ if [ "${1:-}" = "--self-test" ]; then
         printf 'FAIL  row 3 flagged a pair that never reaches crates.io\n'; fails=1
     fi
 
+    # Rows 4 and 5 are aprender#2559: the edge that CROSSES a workspace
+    # boundary. `w4` is the "root", `w4x` an EXCLUDED second workspace whose
+    # crate depends on an unpublishable crate in the first. This is the exact
+    # shape of crates/facades -> aprender-contracts.
+    W="$TD/w4"; mkdir -p "$W"
+    printf '[workspace]\nmembers = ["libx"]\nresolver = "2"\n' > "$W/Cargo.toml"
+    mk w4/libx libx yes ""
+    WX="$TD/w4x"; mkdir -p "$WX"
+    printf '[workspace]\nmembers = ["face"]\nresolver = "2"\n' > "$WX/Cargo.toml"
+    mkdir -p "$WX/face/src"; : > "$WX/face/src/lib.rs"
+    printf '[package]\nname = "face"\nversion = "0.0.0"\nedition = "2021"\n\n[dependencies]\nlibx = { path = "../../w4/libx", version = "0.0.0" }\n' \
+        > "$WX/face/Cargo.toml"
+
+    # Row 4 is the CONTROL FOR THE SCOPE, and it is the row that matters: scanning
+    # only the "root" workspace reports NOTHING, because `face` is not in it. A
+    # guard that passes here is not lenient, it is BLIND -- and that is precisely
+    # what shipped.
+    if [ -z "$(scan "$W" | tail -n +2)" ]; then
+        printf 'ok    row 4 the root workspace alone CANNOT see the cross-workspace edge\n'
+    else
+        printf 'FAIL  row 4 expected the single-workspace scan to be blind here\n'; fails=1
+    fi
+
+    # Row 5: with both workspaces merged, the same edge IS reported.
+    if scan "$W" "$WX" | tail -n +2 | grep -q "^face	libx$"; then
+        printf 'ok    row 5 scanning BOTH workspaces reports face -> libx\n'
+    else
+        printf 'FAIL  row 5 merged scan missed the cross-workspace edge; got [%s]\n' \
+            "$(scan "$W" "$WX" | tail -n +2)"; fails=1
+    fi
+
     [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
-    printf '\nSELF-TEST PASSED (3/3)\n'
+    printf '\nSELF-TEST PASSED (5/5)\n'
     exit 0
 fi
 
 printf '=== a publishable crate may not depend on an unpublishable one ===\n'
-OUT="$(scan "$REPO_ROOT")"
+# BOTH workspaces. crates/facades is `exclude`d from the root, so naming it here
+# is the only way it enters the universe -- cargo will never volunteer it.
+OUT="$(scan "$REPO_ROOT" "$REPO_ROOT/crates/facades")"
 TOTAL="$(printf '%s' "$OUT" | head -1)"
 VIOL="$(printf '%s' "$OUT" | tail -n +2 | grep . || true)"
 

--- a/scripts/lib/cascade_universe.py
+++ b/scripts/lib/cascade_universe.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""The set of crates a release cascade must ship — read from EVERY workspace.
+
+WHY THIS FILE EXISTS (aprender#2559)
+------------------------------------
+`scripts/cascade-publish.sh` hand-maintains a TIERS[] table, and
+`scripts/cascade-drain.sh` recovered its universe by grepping that same table.
+MEASURED on c22fe88ef: TIERS[] listed exactly the 70 publishable crates of the
+ROOT workspace — a perfect match, zero drift, and therefore no signal that
+anything was missing.
+
+    $ comm -13 <TIERS> <root publishable>   -> empty
+    $ comm -23 <TIERS> <root publishable>   -> empty
+
+But `crates/facades/` is a SECOND workspace, `exclude`d from the root, holding
+three publishable crates (`provable-contracts`, `-macros`, `-cli`). None of
+them appeared anywhere in the cascade, and the cascade's FINAL VERIFICATION
+loop iterates TIERS[] — so it printed "ALL crates at $TARGET" while three
+crates with 57K downloads between them had never been uploaded. Absence read
+as success. That is the "guard's universe built from the wrong side" defect:
+the loop cannot iterate what it cannot see, and a universe derived from one
+workspace is complete *with respect to itself*.
+
+The remedy is to stop deriving the universe from a hand-written list or from a
+single `cargo metadata`, and to derive it from EVERY workspace this repository
+publishes out of. Every consumer — the cascade, the drain, the coverage guard,
+the publish-safety scan — reads it from here, so they cannot disagree about
+what "the release" contains.
+
+TWO PROPERTIES THE CONSUMERS NEED AND CANNOT GET FROM A BARE NAME
+----------------------------------------------------------------
+1. MANIFEST PATH. `cargo publish -p provable-contracts` from the repo root is
+   not merely wrong, it is impossible — MEASURED:
+
+       $ cargo publish -p provable-contracts --dry-run --no-verify
+       error: package ID specification `provable-contracts` did not match any packages
+       rc=101
+
+   so adding the name to TIERS[] without also carrying its manifest path would
+   have produced a cascade that fails on every pass. Excluded crates must be
+   published with `--manifest-path`.
+
+2. VERSION. The facades version INDEPENDENTLY of the aprender version line
+   (0.4.0 vs 0.63.0) and that independence is deliberate and documented
+   (aprender#2546): these crate names have no 0.63.0 history. A cascade that
+   compares every crate against one `$TARGET_VERSION` would judge the facades
+   permanently behind, never reach N/N, and report a false failure on an
+   append-only registry — the single most dangerous thing the drain can say.
+   So the expected version travels WITH the crate, from its own workspace.
+
+Output is TSV, one row per publishable crate, sorted by name:
+
+    <name>\t<version>\t<absolute manifest path>\t<workspace root>
+
+Usage:
+    cascade_universe.py <repo-root>            # all workspaces
+    cascade_universe.py --names <repo-root>    # names only, one per line
+
+A crate carrying `publish = false` is not in the universe: it is never
+uploaded, so the cascade must not wait for it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Every workspace this repository publishes out of, as a path relative to the
+# repo root. `crates/facades` is `exclude`d from the root workspace on purpose
+# (two primary packages sharing one lib name collide on the uplifted rlib —
+# rust-lang/cargo#6313), which is exactly why it has to be named HERE: cargo
+# will never volunteer it.
+#
+# Adding a workspace to this list is the whole maintenance burden. If a third
+# excluded workspace ever appears, scripts/check_cascade_covers_all_crates.sh
+# fails until it is listed and tiered.
+WORKSPACES = (
+    ".",
+    "crates/facades",
+)
+
+# A universe smaller than this means the enumeration broke, not that the repo
+# shrank. A vacuous universe would let every consumer report a clean pass over
+# nothing, which is the failure mode this file exists to remove.
+MIN_CRATES = 70
+
+
+def metadata(repo_root, ws):
+    manifest = os.path.join(repo_root, ws, "Cargo.toml")
+    out = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1",
+         "--manifest-path", manifest],
+        capture_output=True, check=False,
+    )
+    if out.returncode != 0 or not out.stdout.strip():
+        sys.stderr.write(
+            f"cascade_universe: cargo metadata failed for {manifest}\n"
+            f"{out.stderr.decode('utf-8', 'replace')}\n"
+        )
+        return None
+    return json.loads(out.stdout)
+
+
+def rows(repo_root):
+    seen = {}
+    for ws in WORKSPACES:
+        doc = metadata(repo_root, ws)
+        if doc is None:
+            return None
+        ws_root = os.path.normpath(os.path.join(os.path.abspath(repo_root), ws))
+        for pkg in doc["packages"]:
+            if pkg.get("publish") == []:  # `publish = false`
+                continue
+            # A name appearing in two workspaces would make "which version is
+            # the release" ambiguous. Say so rather than picking one.
+            if pkg["name"] in seen and seen[pkg["name"]][1] != pkg["manifest_path"]:
+                sys.stderr.write(
+                    f"cascade_universe: `{pkg['name']}` is publishable from two "
+                    f"workspaces:\n  {seen[pkg['name']][1]}\n  {pkg['manifest_path']}\n"
+                )
+                return None
+            seen[pkg["name"]] = (pkg["version"], pkg["manifest_path"], ws_root)
+    return sorted((n, v, m, w) for n, (v, m, w) in seen.items())
+
+
+def main(argv):
+    names_only = "--names" in argv[1:]
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    repo_root = args[0] if args else "."
+
+    got = rows(repo_root)
+    if got is None:
+        return 2
+    if len(got) < MIN_CRATES:
+        sys.stderr.write(
+            f"cascade_universe: enumerated only {len(got)} publishable crate(s), "
+            f"expected at least {MIN_CRATES}. The ENUMERATION is broken, not the repo.\n"
+        )
+        return 2
+
+    for name, version, manifest, ws_root in got:
+        if names_only:
+            print(name)
+        else:
+            print(f"{name}\t{version}\t{manifest}\t{ws_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/facade_facts.py
+++ b/scripts/lib/facade_facts.py
@@ -30,9 +30,14 @@ what cargo will actually build or publish.
                   instead of reporting a clean run over nothing.
   R7 NO BINARIES  no facade declares a `[[bin]]` target. aprender#2558: FOUR
                   crates declared a bin named `pv` (this repo owned two of
-                  them) and `cargo install` overwrites ~/.cargo/bin/pv without
-                  warning. The facades yield the name; `aprender-contracts-cli`
-                  keeps it. Enforced here AND, across both workspaces, by
+                  them), all targeting ~/.cargo/bin/pv. MEASURED: `cargo
+                  install` does NOT overwrite across packages -- it FAILS
+                  CLOSED (exit 101, "binary `pv` already exists in destination
+                  as part of <package>") and the FIRST binary survives. So the
+                  hazard is BLOCKING, not clobbering: a user holding the old
+                  facade cannot install the real tool. The facades yield the
+                  name; `aprender-contracts-cli` keeps it. Enforced here AND,
+                  across both workspaces, by
                   scripts/check_duplicate_bin_names.sh.
 
 The read-only accessors share this file so the guard never has to embed a


### PR DESCRIPTION
MEASURED on c22fe88ef, and the reason nothing reported it: TIERS[] in
scripts/cascade-publish.sh was EXACTLY the 70 publishable crates of the ROOT
workspace, with zero drift in either direction.

    comm -13 <TIERS names> <root publishable>  ->  empty
    comm -23 <TIERS names> <root publishable>  ->  empty

The table was complete with respect to the wrong universe. crates/facades/ is a
second workspace, `exclude`d from the root, holding three publishable crates.
FINAL VERIFICATION iterated the same TIERS[], so the crates skipped by the
publish loop were also skipped by the loop that checks it, and their absence
printed as "ALL crates at 0.63.0".

It is not hypothetical. A registry census run from the fixed cascade:

    T14  provable-contracts:        0.3.1 (want 0.4.0)
    T14  provable-contracts-macros: 0.3.1 (want 0.4.0)
    T14  provable-contracts-cli:    0.3.1 (want 0.4.0)

Still on the frozen 0.3.1 that aprender#2546 was filed about. They have never
shipped, through every green cascade.

Adding three names would not have been enough, twice over:

  cargo publish -p provable-contracts   rc=101, "package ID specification
  `provable-contracts` did not match any packages" -- an excluded crate has no
  package ID here and must be selected by --manifest-path.

  The facades version INDEPENDENTLY of the aprender line (0.4.0 vs 0.63.0;
  deliberate, aprender#2546). Comparing them to one $TARGET_VERSION marks them
  permanently behind, so the drain never reaches N/N and exits 2 STUCK -- a
  false failure on an append-only registry, the most dangerous thing it says.

WHAT CHANGED

  scripts/lib/cascade_universe.py   NEW. The publish universe, read from cargo
        across EVERY workspace, carrying each crate's manifest path and its own
        expected version. One source for the cascade, the drain, the coverage
        guard and the publish-safety scan, so they cannot disagree.

  cascade-publish.sh   TIERS[14] = the facades. Selects by --manifest-path for
        anything outside the root workspace, compares each crate to its OWN
        expected version, and FINAL VERIFICATION now iterates the UNIVERSE, not
        TIERS[] -- verifying the list you published is circular.

  ORDER IS ENFORCED, NOT ASSUMED. It was a printf note in
        check_facade_compat.sh; a note is not a mechanism. Now two halves:
        `facade_upstream_ready` refuses to upload a facade until the exact
        upstream version that facade's own manifest requires is live on the
        sparse index (DEFER, so the drain resolves it like any other layer);
        and R3 of the new guard fails if the tier table puts a facade at or
        before its upstream. New --order-check mode runs the precondition alone,
        which is what makes it testable.

  cascade-drain.sh   universe from cargo instead of grepping the cascade's own
        TIERS[]. Two checks sharing one blind list is one check. Per-crate
        expected version.

  check_cascade_covers_all_crates.sh   NEW guard, 7-row case table. R1 coverage,
        R2 no ghosts, R3 order. Wired into ci.yml.

  check_publish_safety.sh   scanned 70 of 73; `cargo package -p <facade>` is
        rc=101 and `|| continue` turned that into a silent skip. Now scans all
        73 by manifest path and FAILS if fewer than 70 were actually scanned.

  check_publishable_deps_publishable.sh   merges both workspaces into ONE graph.
        Run per-workspace it is VACUOUS for the facades: aprender-contracts is
        not a member of the facade workspace, so the edge that matters is
        invisible. Two new self-test rows, one of which asserts the
        single-workspace scan is blind.

  bump-version.sh   NEW. `cargo set-version --workspace` cannot reach an
        excluded workspace and does not warn. Three files must ride in the bump
        commit; a written reminder is not a mechanism. Bumps the root, rewrites
        the facade upstream pins, regenerates crates/facades/Cargo.lock, and
        ASSERTS crates/facades/Cargo.toml version = 0.4.0 did not move -- that
        independence is deliberate (aprender#2546) and a plausible "fix" would
        couple the two version lines. 6-row case table.

  Makefile publish:   resolves CRATE through the universe and switches to
        --manifest-path for the excluded workspace; rejects an unknown crate
        instead of handing it to cargo. PUBLISH_DRY_RUN=1 makes the selection
        path exercisable without an upload.

MUTATION-VERIFIED, BOTH DIRECTIONS, EACH PROVED TO ENGAGE

  Delete TIERS[14]  -> guard rc=1, names all three facades and both order edges
  Restore           -> rc=0
  Pin upstream 0.64.0 (absent from the index; the exact post-bump state)
      -> --order-check rc=1, ORDER-WAIT on that facade ONLY, other two READY
  Restore           -> rc=0
  2.7 MB blob in crates/facades/provable-contracts/src/
      -> publish-safety rc=1 naming provable-contracts; the OLD enumeration
         could not reach it at all (cargo package -p = rc=101, and the crate was
         absent from publishable_crates.py output entirely)
  publish = false on aprender-contracts
      -> deps guard rc=1, "provable-contracts -> aprender-contracts"

INCIDENTAL, STATED RATHER THAN SLIPPED IN: two surviving copies of the claim
that `cargo install` silently overwrites ~/.cargo/bin/pv (ci.yml comment,
facade_facts.py docstring) are corrected. It FAILS CLOSED at exit 101 and the
first binary survives; bb56f31de removed that claim from 11 other places.

pv lint contracts/: 0 errors, 942 warnings -- unchanged, no contract touched.
bashrs: every file I added or edited has the same per-file error count as main
(new files 0, cascade-publish 3 pre-existing, drain 0); ratchet 97 vs baseline 876.
