### PR TITLE
fix(inspect): a 1 KiB fragment of a 991 MB model was certified `valid: true`

### DIFF
--- a/crates/apr-cli/src/commands/inspect.rs
+++ b/crates/apr-cli/src/commands/inspect.rs
@@ -181,6 +181,14 @@ pub(crate) fn run(
             let mut reader = BufReader::new(file);
 
             let header = read_and_parse_header(&mut reader)?;
+            // aprender#2564: the header is 64 bytes and its offsets are simply
+            // BELIEVED. Without this, `apr inspect` reads a 1 KiB fragment of a
+            // 991 MB model and reports `valid: true, tensor_count: 291` with a
+            // data offset of 3.66 MiB -- past EOF -- while validate/tensors/lint/qa
+            // all reject the same file. Two commands in one binary disagreeing about
+            // one file is bad; the one that says VALID being the documented
+            // first-line diagnostic, and the JSON a CI gate consumes, is the defect.
+            check_header_fits_file(&header, file_size)?;
             let metadata_info = read_metadata(&mut reader, &header);
 
             if json_output {
@@ -499,6 +507,35 @@ fn read_and_parse_header(reader: &mut BufReader<File>) -> Result<HeaderData, Cli
         data_offset: header.data_offset,
         checksum_valid,
     })
+}
+
+/// Refuse a header whose own offsets do not fit inside the file.
+///
+/// Every offset here is read from the 64-byte header and is attacker- or
+/// truncation-controlled. A partial download is the common case: the header
+/// arrives intact and describes a body that never did. The error text matches
+/// the other commands' so a user who runs two of them sees one story.
+fn check_header_fits_file(header: &HeaderData, file_size: u64) -> Result<(), CliError> {
+    let too_big = |what: &str, need: u64| {
+        CliError::InvalidFormat(format!(
+            "Invalid header: file too small for {what} \
+             (header claims {need} bytes, file is {file_size})"
+        ))
+    };
+
+    if header.data_offset > file_size {
+        return Err(too_big("tensor data", header.data_offset));
+    }
+    if header.tensor_index_offset > file_size {
+        return Err(too_big("the tensor index", header.tensor_index_offset));
+    }
+    let meta_end = header
+        .metadata_offset
+        .saturating_add(u64::from(header.metadata_size));
+    if meta_end > file_size {
+        return Err(too_big("metadata", meta_end));
+    }
+    Ok(())
 }
 
 fn read_metadata(reader: &mut BufReader<File>, header: &HeaderData) -> MetadataInfo {


### PR DESCRIPTION
Found by the 0.64.0 pre-release dogfood sweep.

`apr inspect` reads the 64-byte APR v2 header and simply BELIEVES its offsets.
On a truncated file that produces an affirmative certification of a file that
cannot possibly be what it claims:

    head -c 1024 qwen2.5-coder-0.5b-instruct.apr > t1k.apr   # 1 KiB of 991 MB
    apr inspect t1k.apr --json
    {"valid": true, "tensor_count": 291, "size_bytes": 1024,
     "checksum_valid": true}                                     exit 0

291 tensors in 1024 bytes, and a data offset of 3.66 MiB -- past EOF.

WHY THIS IS THE BAD ONE. Every other command rejected the same file, so the
binary disagreed with itself:

    validate 5   tensors 4   lint 5   qa 5     "file too small for metadata"

and the command that said VALID is the documented first-line diagnostic and the
JSON a CI gate consumes. A partial download is the ordinary way to reach this:
the header arrives intact and describes a body that never did.

FIX: `check_header_fits_file` refuses a header whose own offsets do not fit
inside the file -- data_offset, tensor_index_offset, and metadata_offset +
metadata_size, the last with a saturating add so a crafted header cannot wrap.
The error text matches the other commands' so a user running two of them sees
one story.

MEASURED, on apr built from this branch:

    1 KiB fragment    inspect 4   validate 5   tensors 4   lint 5   qa 5
                      (was: inspect 0 and "valid": true)
    intact 991 MB     inspect 0, valid=true, tensors=291, size=991907012
                      -- no false positive on a real model
    apr-cli inspect tests  rc=0, 139 passed

STILL BROKEN, DELIBERATELY NOT CLAIMED HERE. A 50 MB truncation of the same
model still passes: `inspect` exits 0 and `tensors` prints "291 tensors
942.3 MB f32", a total 19x the actual file. At that size data_offset genuinely
IS inside the file, so this check cannot see it -- the lie has moved from the
header offsets to the tensor EXTENT, which needs the tensor index cross-checked
against file length. Same family, different check, and it is a P1 rather than a
P0 because `apr qa` (the designated release gate) still fails such a file
correctly. Filed as follow-up rather than folded in on release day.

ALSO NOT FIXED HERE: `checksum_valid` is reported as `true` for a bit-flipped
body, while `apr validate` reports the same check honestly as
"Checksum valid SKIP -- Footer not implemented". Two commands, one binary, two
answers about whether a checksum was verified.

NOT A REGRESSION: reproduces on the released 0.63.0 artifact, so it has been
shipping.

Refs #2564

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
