### PR TITLE
fix(ci-infra): the disk guard's idle test sat one directory ABOVE the thing being written

### DIFF
--- a/scripts/runner-infra/README.md
+++ b/scripts/runner-infra/README.md
@@ -33,7 +33,42 @@ Each runner's `.env` must point to the pre-job hook:
 ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/bin/runner-pre-job.sh
 ```
 
-(Already wired on intel's 16 clean-room runners as of 2026-04-22.)
+**This is no longer true, and has not been since GH-202 (2026-08-16.)** MEASURED
+on mac-server, 2026-08-22:
+
+```
+$ grep -rhs ACTIONS_RUNNER_HOOK_JOB_STARTED /etc/systemd/system/actions.runner.*.service.d/*.conf | sort | uniq -c
+     17 Environment="ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/noah/data/actions-runner/pre-job.sh"
+$ ls -la /usr/local/bin/runner-pre-job.sh
+-rwxr-xr-x 1 root root 2879 Aug 18 17:18 /usr/local/bin/runner-pre-job.sh     # orphaned
+```
+
+All 17 runners invoke `/home/noah/data/actions-runner/pre-job.sh` — a different
+script, owned by paiml/infra, which calls `ci-reaper.sh` and never mentions
+`runner-disk-guard.sh`. So `runner-pre-job.sh` here, and with it the
+`--pre-job` mode of `runner-disk-guard.sh`, is DEAD on the fleet; the installed
+copy at `/usr/local/bin/runner-pre-job.sh` is a shadowed artifact that nothing
+executes. Only the `--nightly` timer path of `runner-disk-guard.sh` actually
+runs. Editing the `--pre-job` path and expecting a fleet effect will do nothing
+— check `type -aP` / the unit drop-ins first.
+
+## Case table
+
+```bash
+bash scripts/runner-infra/runner-disk-guard.sh --self-test   # 7 rows, rc=0
+```
+
+Seven rows over a throwaway tree, covering both directions of the only judgement
+this guard makes: which directories it refuses to touch. R3 and R6 are the ones
+that matter — a live build under a parent whose mtime froze hours ago, in both
+the `<PR>/run-<ID>` and the merge-queue `gh-readonly-queue/…/run-<ID>` shapes.
+They are RED against the pre-2026-08-22 selection, which tested the mtime of the
+depth-1 directory rather than of anything actually being written. R1, R5 and R7
+fail if a "fix" simply stops reclaiming, which would trade a deleted build for a
+full disk.
+
+NOT WIRED INTO CI. This is a host script, deployed by hand (see Installation),
+so nothing re-runs the table on a change to it. Run it before you `scp`.
 
 ## Tuning
 
@@ -42,8 +77,9 @@ Environment variables honored by `runner-disk-guard.sh`:
 | Var | Default | Meaning |
 |---|---|---|
 | `HIGH_WATER_PCT` | 85 | Pre-job prune threshold |
-| `STALE_DAYS` | 7 | Nightly: mtime age cutoff for target/ |
+| `STALE_DAYS` | 7 | Nightly: age cutoff — no write ANYWHERE below the dir |
 | `RUNNERS_ROOT` | `/home/noah/data` | Parent of `actions-runner*` dirs |
+| `BIND_MOUNT_ROOTS` | `/mnt/nvme-raid0/targets/aprender-ci` | CI bind-mount target roots |
 
 ## Manual recovery
 

--- a/scripts/runner-infra/runner-disk-guard.sh
+++ b/scripts/runner-infra/runner-disk-guard.sh
@@ -97,16 +97,40 @@ prune_target_dirs() {
     log "freed approximately ${total_freed_kb} KiB (mode=$mode)"
 }
 
+# A candidate directory is IDLE only if NOTHING anywhere underneath it was
+# modified within the window. Its OWN mtime does not answer that question, and
+# has not since 2026-05-15, when ci.yml moved the bind mount one level down —
+# from `<root>/<PR_OR_REF>` to `<root>/<PR_OR_REF>/run-<RUN_ID>` (the
+# cancel-corrupt-state fix, aprender#1693). A directory's mtime changes only
+# when an entry is created or removed DIRECTLY inside it, so the parent's mtime
+# freezes the instant its `run-<RUN_ID>` child is created and stays frozen while
+# cargo writes gigabytes underneath. An in-flight build's parent therefore reads
+# as arbitrarily idle, and `rm -rf` on it takes the live build with it — cargo
+# then dies ENOENT on its own `target/debug/...` paths mid-compile, which is
+# exactly how aprender `workspace-test` failed on main and on the merge-queue
+# ref within the same minute on 2026-08-21 (runs 32520690533 / 32520753928).
+# The header comment this replaces asserted the opposite ("a container touching
+# the dir keeps mtime current") and was true only of the pre-#1693 layout.
+#
+# `-newermt "-N minutes"` is a half-open comparison with no gap at exactly N,
+# and `-print -quit` stops the walk at the FIRST recent entry, so the check
+# costs a directory descent rather than a full stat of a 50GB tree. Command
+# substitution, not a pipe: `find ... | grep -q` under `set -o pipefail` returns
+# 141 when grep exits first and find takes SIGPIPE.
+tree_is_idle() {
+    local dir="$1" min_idle_min="$2" recent
+    recent="$(find "$dir" -newermt "-${min_idle_min} minutes" -print -quit 2>/dev/null)"
+    [ -z "$recent" ]
+}
+
 # Prune bind-mount target roots (/mnt/nvme-raid0/targets/aprender-ci/*).
 # Subdirs are per-PR target dirs isolated per task #134. Remove:
 #   - "debug" subdir unconditionally (orphan from pre-isolation era)
-#   - numeric PR-named subdirs with mtime older than MIN_IDLE_MIN minutes.
-# Minute-resolution idle check protects in-flight CI bind-mounts; a container
-# touching the dir keeps mtime current. Nightly uses $((STALE_DAYS*24*60));
-# pre-job uses a 60-min floor so a full-disk situation can still reclaim most
-# stale PR dirs while sparing fresh ones.
+#   - PR-named subdirs with NOTHING under them touched in MIN_IDLE_MIN minutes.
+# Nightly uses $((STALE_DAYS*24*60)); pre-job uses a 60-min floor so a full-disk
+# situation can still reclaim most stale PR dirs while sparing fresh ones.
 prune_bind_mount_target_roots() {
-    local min_idle_min="$1"  # minutes since last mtime that counts as "stale"
+    local min_idle_min="$1"  # minutes with no write anywhere below = "stale"
     local root subdir
     for root in $BIND_MOUNT_ROOTS; do
         [ -d "$root" ] || continue
@@ -117,18 +141,101 @@ prune_bind_mount_target_roots() {
             rm -rf --one-file-system "$root/debug" 2>/dev/null \
                 || sudo rm -rf --one-file-system "$root/debug" 2>/dev/null || true
         fi
-        # Stale numeric PR dirs (mtime > min_idle_min). "main" is explicitly
-        # preserved — it hosts push-to-main CI target cache and is legitimately
-        # re-used; stale-days protection still applies via find -mmin below.
+        # "main" is explicitly preserved — it hosts push-to-main CI target cache
+        # and is legitimately re-used.
         while IFS= read -r -d '' subdir; do
             local name
             name="$(basename "$subdir")"
             [ "$name" = "main" ] && continue
+            if ! tree_is_idle "$subdir" "$min_idle_min"; then
+                log "skip (write below it within ${min_idle_min}m): $subdir"
+                continue
+            fi
             log "prune stale bind-mount: $subdir"
             rm -rf --one-file-system "$subdir" 2>/dev/null \
                 || sudo rm -rf --one-file-system "$subdir" 2>/dev/null || true
-        done < <(find "$root" -mindepth 1 -maxdepth 1 -type d -mmin "+$min_idle_min" -print0 2>/dev/null)
+        done < <(find "$root" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
     done
+}
+
+# Case table. The only thing separating this guard from `rm -rf` is which
+# directories it refuses to touch, and that judgement was wrong in production.
+# R3 and R6 are RED against the pre-fix selection
+# (`find -mindepth 1 -maxdepth 1 -type d -mmin "+$min_idle_min"`); R1/R5/R7
+# fail if a "fix" simply stops reclaiming, which would trade a deleted build
+# for a full disk.
+self_test() {
+    local tmp root fails=0
+    tmp="$(mktemp -d)"
+    if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+        echo "self-test: mktemp -d failed" >&2
+        return 1
+    fi
+    # shellcheck disable=SC2064  # $tmp must be expanded now, not at trap time
+    trap "rm -rf '$tmp'" EXIT
+    root="$tmp/aprender-ci"
+    mkdir -p "$root"
+
+    # R1: stale PR dir, nothing below it recent                  -> PRUNE
+    mkdir -p "$root/1111/debug"
+    touch -d '5 hours ago' "$root/1111/debug" "$root/1111"
+    # R2: fresh PR dir, written just now                         -> KEEP
+    mkdir -p "$root/2222/debug"
+    # R3: THE REGRESSION. Parent mtime frozen 5h ago by the creation of its
+    #     run-<ID> child; cargo is writing inside that child RIGHT NOW.
+    mkdir -p "$root/3333/run-99/debug/deps"
+    : > "$root/3333/run-99/debug/deps/libfoo.rlib"
+    touch -d '5 hours ago' "$root/3333/run-99" "$root/3333"   # parents only
+    # R4: "main" is exempt even when stale                       -> KEEP
+    mkdir -p "$root/main/run-1/debug"
+    touch -d '5 hours ago' "$root/main/run-1/debug" "$root/main/run-1" "$root/main"
+    # R5: pre-isolation orphan                                   -> PRUNE always
+    mkdir -p "$root/debug/deps"
+    # R6: merge-queue ref. PR_OR_REF carries slashes, so the depth-1 dir is
+    #     `gh-readonly-queue` and the live build is THREE levels below it.
+    mkdir -p "$root/gh-readonly-queue/main/pr-2554-abc/run-77/debug"
+    : > "$root/gh-readonly-queue/main/pr-2554-abc/run-77/debug/live.rlib"
+    touch -d '5 hours ago' \
+        "$root/gh-readonly-queue/main/pr-2554-abc/run-77" \
+        "$root/gh-readonly-queue/main/pr-2554-abc" \
+        "$root/gh-readonly-queue/main" \
+        "$root/gh-readonly-queue"
+    # R7: stale run-<ID> tree, no live write                     -> PRUNE
+    mkdir -p "$root/7777/run-1/debug"
+    touch -d '5 hours ago' "$root/7777/run-1/debug" "$root/7777/run-1" "$root/7777"
+
+    BIND_MOUNT_ROOTS="$root" prune_bind_mount_target_roots 60 >/dev/null 2>&1 || true
+
+    check_row() {  # label, path, gone|kept
+        if [ "$3" = "gone" ]; then
+            if [ -e "$2" ]; then
+                echo "FAIL $1: expected PRUNED, survived"
+                fails=$((fails + 1))
+            else
+                echo "ok   $1 (pruned)"
+            fi
+        elif [ -e "$2" ]; then
+            echo "ok   $1 (kept)"
+        else
+            echo "FAIL $1: expected KEPT, was DELETED"
+            fails=$((fails + 1))
+        fi
+    }
+    check_row "R1 stale PR dir"                  "$root/1111"                               gone
+    check_row "R2 fresh PR dir"                  "$root/2222"                               kept
+    check_row "R3 live build, stale parent"      "$root/3333/run-99/debug/deps/libfoo.rlib" kept
+    check_row "R4 main is exempt"                "$root/main"                               kept
+    check_row "R5 orphan debug"                  "$root/debug"                              gone
+    check_row "R6 live merge-queue build"        \
+        "$root/gh-readonly-queue/main/pr-2554-abc/run-77/debug/live.rlib"                   kept
+    check_row "R7 stale run-<ID> tree"           "$root/7777"                               gone
+
+    if [ "$fails" -gt 0 ]; then
+        echo "SELF-TEST FAILED: $fails of 7 rows" >&2
+        return 1
+    fi
+    echo "SELF-TEST PASSED: 7 rows"
+    return 0
 }
 
 case "${1:-}" in
@@ -147,8 +254,11 @@ case "${1:-}" in
         prune_target_dirs stale
         prune_bind_mount_target_roots "$(( STALE_DAYS * 24 * 60 ))"
         ;;
+    --self-test)
+        self_test
+        ;;
     *)
-        echo "usage: $0 --pre-job | --nightly" >&2
+        echo "usage: $0 --pre-job | --nightly | --self-test" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
NOT the cause of main going red on 2026-08-21 — this guard did not run that
night (journalctl -t runner-disk-guard on mac-server has no entry between the
04:20 nightly and the next one). It is the same loaded gun pointed at the same
target, and it is in this repo, byte-identical to what is deployed:

    md5  921e055c55a2c8f1838aac6809d60840  /usr/local/bin/runner-disk-guard.sh   (mac-server)
    md5  921e055c55a2c8f1838aac6809d60840  scripts/runner-infra/runner-disk-guard.sh

WHAT IS WRONG

prune_bind_mount_target_roots selected victims with

    find "$root" -mindepth 1 -maxdepth 1 -type d -mmin "+$min_idle_min"

and its header claimed "a container touching the dir keeps mtime current".
That was true until 2026-05-15, when ci.yml moved the bind mount one level
down — from `<root>/<PR_OR_REF>` to `<root>/<PR_OR_REF>/run-<RUN_ID>` (the
cancel-corrupt-state fix, #1693). A directory's mtime changes only when an
entry is created or removed DIRECTLY inside it, so the parent's mtime freezes
the instant its `run-<RUN_ID>` child is created and stays frozen while cargo
writes gigabytes underneath. MEASURED, on a tree built for the purpose:

    parent  mtime  06:46:05   <- frozen when run-999/ was created
    run dir mtime  06:46:05
    deps    mtime  09:46:06   <- 8MB written into it one second ago
    find <root> -mindepth 1 -maxdepth 1 -type d -mmin +60  ->  selects the parent

So an in-flight build reads as arbitrarily idle and `rm -rf` takes it. Cargo
then dies ENOENT on its own `target/debug/...` paths mid-compile — which is
exactly the shape of the failure that took main red:

    run 32520690533 (push, main, intel-clean-room-15)
        error: failed to create directory `/workspace/target/debug`
        Caused by: No such file or directory (os error 2)          20:17:49Z
    run 32520753928 (merge_group, intel-clean-room-5)
        error: failed to write `/workspace/target/debug/.fingerprint/...`
        Caused by: No such file or directory (os error 2)          20:17:14Z

Two runners, 35 seconds apart, and
/mnt/nvme-raid0/targets/aprender-ci/main/run-32520690533 is still on disk,
EMPTY, mtime 20:17:50. Whatever ran that night was out-of-band (no reaper
logged a reclaim; free on / went 409GB -> 1686GB in the same window), but this
guard would produce it on schedule. The merge-queue shape is worse, not better:
PR_OR_REF carries slashes for a `gh-readonly-queue/main/pr-NNNN-…` ref, so the
depth-1 directory is `gh-readonly-queue`, whose mtime on mac-server right now is
15 hours stale while merge-queue builds have been using it all night. Under the
pre-job 60-minute floor that is one `rm -rf` across every queued build at once.

THE FIX

Idleness is now asked of the tree, not of the directory entry: a candidate is
pruned only if NOTHING anywhere below it was modified inside the window.
`-newermt "-N minutes"` is a half-open comparison with no gap at exactly N, and
`-print -quit` stops at the first recent entry, so the check costs a descent
rather than a full stat of a 50GB tree. Command substitution, not a pipe —
`find … | grep -q` under `set -o pipefail` returns 141 when grep exits first and
find takes SIGPIPE.

Nothing else moves: same candidate set, same `main` exemption, same
unconditional `debug` orphan prune, same two windows.

CASE TABLE — `--self-test`, 7 rows, and it discriminates

    R1 stale PR dir                 -> PRUNE
    R2 fresh PR dir                 -> KEEP
    R3 live build, stale parent     -> KEEP    <-- the defect
    R4 `main` is exempt             -> KEEP
    R5 orphan `debug`               -> PRUNE
    R6 live merge-queue build       -> KEEP    <-- the defect, queue shape
    R7 stale run-<ID> tree          -> PRUNE

MUTATION — both directions, run twice, proved to ENGAGE

    fixed                                              rc=0   7/7 rows
    mutant: delete the recursive idle test AND restore
            `-mmin "+$min_idle_min"` on the depth-1 find
            (i.e. exactly the pre-fix selection)       rc=1
        FAIL R3 live build, stale parent: expected KEPT, was DELETED
        FAIL R6 live merge-queue build:  expected KEPT, was DELETED
    revert                                             rc=0   7/7 rows

ENGAGED: only the two live-build rows move, and they move by having their
`.rlib` deleted — the mutation is what turned them red, not an unrelated error.
R1/R5/R7 stay green under the mutant, which is the other half of the proof: the
fix does not buy R3/R6 by refusing to reclaim anything.

bashrs, this file alone (per the multi-file cross-contamination rule):
    baseline (HEAD)  7 errors, 19 warnings
    this commit      7 errors, 21 warnings
Error count unchanged; the +2 warnings are style notes on the new ~110 lines.

DEFERRED, STATED RATHER THAN IMPLIED
  - Not wired into CI. This is a host script deployed by hand, and wiring a row
    into .github/workflows/ci.yml is a workflow edit, which is a check-in item.
    README now says NOT WIRED in as many words rather than leaving a case table
    that looks enforced.
  - Not deployed. /usr/local/bin/runner-disk-guard.sh on mac-server still holds
    the old copy; installing it touches a live CI host mid-release.
  - The identical defect in paiml/infra's pre-job hook is untouched — its
    documented manual remediation is
    `find /mnt/nvme-raid0/targets -mindepth 2 -maxdepth 2 -type d -mtime +1 -exec rm -rf {} +`,
    whose `-mtime` lands on the same frozen parent. Belongs in that repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VX2s9nQPbWDB3Vze4JM3Wg
