### PR TITLE
feat(release): dogfood every supported platform before a cut, and prove it happened

### DIFF
--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -220,6 +220,70 @@ exist. Run Gate 11 before `cargo set-version`; after the bump, the equivalent
 signal is Gate 5 on a zero-sibling crate plus
 `scripts/check_gate5_stage.sh --explain <crate>`.
 
+
+### Gate 12: Multi-Platform Dogfood (MANDATORY — aprender#2566)
+
+```bash
+bash scripts/check_multiplatform_dogfood.sh
+```
+
+**Every release is dogfooded on EVERY supported platform, not just the one the release
+engineer is sitting at.** This gate does not check that someone ran a sweep — it checks
+that a dated **receipt** exists for each host, for the version being cut. A receipt is
+evidence; a checklist tick is not. A receipt from a previous release is STALE and fails.
+
+| host | platform | why it is in the matrix |
+|---|---|---|
+| `lambda` | x86_64 Linux + RTX 4090 (sm_89) | consumer x86, AVX2 path |
+| `intel` | x86_64 Linux, Xeon W-3245 | **AVX-512 + VNNI** path |
+| `gx10` | aarch64 Linux + GB10 (sm_121) | ARM server, unified memory |
+| `mini` | arm64 macOS + Metal | Apple silicon, **no /proc**, APFS case-insensitive |
+
+Each host is in the matrix because it is a distinct combination of **ISA, OS and
+accelerator** — not because we happen to own it.
+
+**What one afternoon of this bought (the 0.64.0 cut).** The published crate had never
+been verified on either arm64 platform:
+
+- **#2567** — Q4_K GEMV, the hottest kernel in quantized inference, has **zero aarch64
+  SIMD**, and `matmul_q4k_f32_parallel` on non-x86 is a direct call to the *serial
+  scalar* routine. The numbers are correct and only the speed is wrong, so **no
+  correctness gate could ever have caught it.**
+- **#2568** — the OOM guard reads `/proc/meminfo` and `.unwrap_or(u64::MAX)`, so on macOS
+  the threshold becomes ~12.8 **exabytes** and the guard can never fire. Its only test
+  self-skips with `cfg!(target_os = "linux")` — the platform where it is broken.
+- **#2572** — `block v0.1.6` faces future-rustc rejection and sits under `wgpu -> metal`,
+  the only GPU backend macOS has. Entirely absent from the Linux dependency graph.
+
+Each is invisible from a single host **by construction**. That is the argument for this
+gate: not diligence theatre, but the only way to see this class of defect.
+
+**Recording a receipt.** Run the sweep on the host, then write
+`evidence/dogfood/<version>/<host>.json` with at least:
+
+```json
+{"host":"gx10","arch":"aarch64-unknown-linux-gnu","version_tested":"0.64.0",
+ "date":"2026-08-22","install_rc":0}
+```
+
+Richer fields (surface counts, findings, notable, verdict) are encouraged — the receipts
+already under `evidence/dogfood/` are the worked examples.
+
+**The sweep must `cargo install` the PUBLISHED crate**, not build the local tree.
+Building the tree tests what you have; installing tests what a user gets. On a box with a
+pre-existing `apr` the install correctly fails closed (rc=101) *before* compiling — use
+`--force` and record that in the receipt.
+
+**Watch the CI host.** `intel` runs all 16 self-hosted runners. Build there with
+`-j 6`, not the default 32: the merge-queue timeout counts runner wait, so a build that
+steals cores is indistinguishable from a flake and can evict queued PRs.
+
+**Non-vacuity:** the gate refuses a matrix of fewer than 4 hosts, because a shrinking
+matrix silently narrows what "verified" means. Mutation-verified in all three directions —
+a stale receipt version, a non-zero `install_rc`, and a shortened host list each turn it
+RED.
+
+
 ## Verdict
 
 After running all gates, provide:

--- a/evidence/dogfood/0.63.0/gx10.json
+++ b/evidence/dogfood/0.63.0/gx10.json
@@ -1,0 +1,24 @@
+{
+  "host": "gx10",
+  "arch": "aarch64-unknown-linux-gnu",
+  "os": "Linux 6.17.0-1014-nvidia",
+  "accelerator": "NVIDIA GB10, sm_121, unified memory",
+  "version_tested": "0.63.0",
+  "date": "2026-08-22",
+  "install_rc": 0,
+  "install_wall_seconds": 99.8,
+  "crates_compiled": 515,
+  "binary_sha256": "5e7f60b41a16389c713c0682c03ae9b657ad657b4446856ad7e7ccabb8852ce7",
+  "surface": {
+    "cli_subcommands": 104,
+    "mcp_tools": 9,
+    "http_routes": "enumerated at runtime"
+  },
+  "findings": {
+    "p0_arch_specific": 0,
+    "p1": 4,
+    "p2": 1
+  },
+  "notable": "Q4_K GEMV has no aarch64 SIMD and its _parallel variant calls scalar (#2567). apr gpu reports GB10 unified memory honestly; --backend cuda fails closed rc=5. Default install links NO CUDA.",
+  "verdict": "CONDITIONAL GO"
+}

--- a/evidence/dogfood/0.63.0/mini.json
+++ b/evidence/dogfood/0.63.0/mini.json
@@ -1,0 +1,24 @@
+{
+  "host": "mini",
+  "arch": "aarch64-apple-darwin",
+  "os": "macOS 26.5.2 (Darwin 25.5.0)",
+  "accelerator": "Apple M4 / Metal",
+  "version_tested": "0.63.0",
+  "date": "2026-08-22",
+  "install_rc": 0,
+  "install_wall_seconds": 201.7,
+  "peak_rss_bytes": 2543255552,
+  "swaps": 0,
+  "surface": {
+    "cli_subcommands": 104,
+    "cli_second_level": 41,
+    "mcp_tools": 9
+  },
+  "findings": {
+    "p0_arch_specific": 0,
+    "p1": 3,
+    "p2": 2
+  },
+  "notable": "OOM guard fails OPEN: /proc/meminfo + unwrap_or(u64::MAX) => ~12.8 exabyte threshold, and its only test self-skips on macOS (#2568). block v0.1.6 under wgpu->metal faces future-rustc rejection (#2572). NEON is used, not scalar. No Gatekeeper quarantine.",
+  "verdict": "GO"
+}

--- a/scripts/check_multiplatform_dogfood.sh
+++ b/scripts/check_multiplatform_dogfood.sh
@@ -41,14 +41,57 @@ rc=0
 
 printf -- '--- multi-platform dogfood receipts for %s -------------------------\n' "$VERSION"
 
-# ANTI-VACUITY. An empty matrix would make every check below pass over nothing,
-# which is exactly how a gate ends up reporting success while discriminating
-# nothing. Assert the universe is non-trivial before trusting any verdict from it.
+# ANTI-VACUITY, TWO LAYERS. The first layer alone was UNSOUND and the hole was
+# found by adversarial review before this gate ever landed:
+#
+#   `HOSTS=...` and the floor `-lt 4` were BOTH literals in THIS file, so ONE
+#   commit editing both to two exited 0 -- measured, rc=0 with the matrix
+#   silently halved. The original mutation evidence proved the floor FIRES at 2;
+#   it never proved the floor could not be LOWERED. That is the same defect the
+#   competitive-parity ledger spent five rounds on:
+#
+#       ANY STATE THE AUTHOR WRITES AND THE GATE READS CAN BE MOVED IN THE SAME
+#       COMMIT.
+#
+# Layer 2 is the fix, and it is the parity resolution: the comparand lives on
+# PROTECTED main. `main` requires a PR, review and passing CI to change, so the
+# host list as it exists at origin/main is the one prior state this branch
+# cannot rewrite in its own PR. The matrix may GROW freely and may never SHRINK.
 n_hosts=$(printf '%s\n' $HOSTS | grep -c .)
+
+# Layer 1: an absolute floor. Weak on its own (editable here), kept because it
+# is the only thing that works during bootstrap, when main has no copy yet.
 if [ "$n_hosts" -lt 4 ]; then
     printf 'FAIL  the platform matrix has %s host(s); at least 4 are required.\n' "$n_hosts"
     printf '      A shrinking matrix silently narrows what "verified" means.\n'
     exit 1
+fi
+
+# Layer 2: the matrix at origin/main is the floor, and this file cannot move it.
+main_hosts=$(git show origin/main:scripts/check_multiplatform_dogfood.sh 2>/dev/null \
+             | sed -n 's/^HOSTS="\(.*\)"$/\1/p' | head -1)
+if [ -z "$main_hosts" ]; then
+    # BOOTSTRAP, and it is self-limiting rather than renewable: reachable only
+    # while this script does not exist at the protected ref. Once it lands, this
+    # branch is unreachable forever. A renewable bootstrap is the fifth hat of
+    # `registry: true` and is exactly what parity round 5 was caught on.
+    printf '!     BOOTSTRAP: this gate is not yet on origin/main, so the matrix\n'
+    printf '      has no protected floor this run. It gains one the moment this\n'
+    printf '      script lands.\n'
+else
+    missing=""
+    for h in $main_hosts; do
+        case " $HOSTS " in *" $h "*) ;; *) missing="$missing $h" ;; esac
+    done
+    if [ -n "$missing" ]; then
+        printf 'FAIL  the matrix DROPPED host(s) present at origin/main:%s\n' "$missing"
+        printf '      The host list at the protected ref is the floor. Editing it in\n'
+        printf '      the same commit that reads it is the defect this layer exists\n'
+        printf '      to close -- growing the matrix is free, shrinking it is not.\n'
+        exit 1
+    fi
+    printf 'ok    matrix covers every host present at origin/main (%s)\n' \
+        "$(printf '%s\n' $main_hosts | grep -c .)"
 fi
 
 for h in $HOSTS; do

--- a/scripts/check_multiplatform_dogfood.sh
+++ b/scripts/check_multiplatform_dogfood.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Every release must be dogfooded on EVERY supported platform, not just the one
+# the release engineer happens to be sitting at.
+#
+# WHY THIS EXISTS. The 0.64.0 pre-release sweep ran `cargo install aprender` on
+# four hosts for the first time. The published crate had NEVER been verified on
+# either arm64 platform. What that bought, in one afternoon:
+#
+#   aprender#2567  Q4_K GEMV -- the hottest kernel in quantized inference -- has
+#                  ZERO aarch64 SIMD, and `matmul_q4k_f32_parallel` on non-x86 is
+#                  a direct call to the SERIAL scalar routine. Numbers correct,
+#                  speed wrong, so no correctness gate could ever have caught it.
+#   aprender#2568  The OOM guard reads /proc/meminfo and `.unwrap_or(u64::MAX)`,
+#                  so on macOS the threshold is ~12.8 EXABYTES and the guard can
+#                  never fire. Its only test self-skips with
+#                  `cfg!(target_os = "linux")` -- the platform where it is broken.
+#   aprender#2572  `block v0.1.6` faces future-rustc rejection and sits under
+#                  wgpu->metal, the ONLY GPU backend macOS has. Entirely absent
+#                  from the Linux dependency graph.
+#
+# Every one of those is invisible from a single host BY CONSTRUCTION. That is the
+# argument: this is not diligence theatre, it is the only way to see this class.
+#
+# WHAT THIS GATE CHECKS. Not that someone ran a sweep -- that a dated RECEIPT
+# exists for each host, for the version being cut. A receipt is evidence; a
+# checklist tick is not.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+# The supported platform matrix. A host is here because it is a DISTINCT
+# combination of ISA, OS and accelerator -- not because we happen to own it.
+#   lambda      x86_64 Linux  + RTX 4090 (sm_89)     consumer x86, AVX2
+#   intel       x86_64 Linux  + no discrete GPU      Xeon, AVX-512 + VNNI
+#   gx10        aarch64 Linux + GB10 (sm_121)        ARM server, unified memory
+#   mini        arm64 macOS   + Metal                Apple silicon, no /proc, APFS
+HOSTS="lambda intel gx10 mini"
+
+VERSION="$(awk -F'"' '/^version *=/{print $2; exit}' Cargo.toml)"
+DIR="evidence/dogfood/$VERSION"
+rc=0
+
+printf -- '--- multi-platform dogfood receipts for %s -------------------------\n' "$VERSION"
+
+# ANTI-VACUITY. An empty matrix would make every check below pass over nothing,
+# which is exactly how a gate ends up reporting success while discriminating
+# nothing. Assert the universe is non-trivial before trusting any verdict from it.
+n_hosts=$(printf '%s\n' $HOSTS | grep -c .)
+if [ "$n_hosts" -lt 4 ]; then
+    printf 'FAIL  the platform matrix has %s host(s); at least 4 are required.\n' "$n_hosts"
+    printf '      A shrinking matrix silently narrows what "verified" means.\n'
+    exit 1
+fi
+
+for h in $HOSTS; do
+    f="$DIR/$h.json"
+    if [ ! -f "$f" ]; then
+        printf 'FAIL  %-7s no receipt at %s\n' "$h" "$f"
+        printf '        run the dogfood on %s and record its receipt before cutting.\n' "$h"
+        rc=1
+        continue
+    fi
+
+    got_ver=$(python3 -c "import json,sys;print(json.load(open('$f')).get('version_tested',''))" 2>/dev/null)
+    inst=$(python3 -c "import json,sys;print(json.load(open('$f')).get('install_rc','MISSING'))" 2>/dev/null)
+    when=$(python3 -c "import json,sys;print(json.load(open('$f')).get('date',''))" 2>/dev/null)
+
+    if [ "$got_ver" != "$VERSION" ]; then
+        printf 'FAIL  %-7s receipt is for %s, this cut is %s -- STALE\n' "$h" "${got_ver:-<none>}" "$VERSION"
+        printf '        a receipt from a previous release says nothing about this one.\n'
+        rc=1
+    elif [ "$inst" != "0" ]; then
+        printf 'FAIL  %-7s install_rc=%s -- `cargo install aprender` did not succeed\n' "$h" "$inst"
+        rc=1
+    else
+        printf 'ok    %-7s %s verified %s (install rc=0)\n' "$h" "$VERSION" "${when:-undated}"
+    fi
+done
+
+if [ "$rc" -eq 0 ]; then
+    printf '\nPASS  all %s platforms carry a receipt for %s.\n' "$n_hosts" "$VERSION"
+else
+    printf '\nFAIL  see rows above. Record receipts under %s/ as <host>.json with at\n' "$DIR"
+    printf '      least: {"host","arch","version_tested","date","install_rc"}.\n'
+fi
+exit "$rc"

--- a/scripts/unwired_guards_baseline.txt
+++ b/scripts/unwired_guards_baseline.txt
@@ -1,1 +1,9 @@
 check_book_examples_executable.sh
+# check_multiplatform_dogfood.sh — a RELEASE gate, not a PR gate. Deliberately
+# unwired from CI: it asserts that a dated dogfood receipt exists for every
+# supported platform for the version being CUT, which is meaningless on a PR
+# (no version is being cut) and would red every PR from the moment it landed.
+# It is Gate 12 of .claude/skills/pre-release/SKILL.md and runs at release time.
+# Mutation-verified there in three directions (stale receipt version, non-zero
+# install_rc, shortened host matrix).
+check_multiplatform_dogfood.sh


### PR DESCRIPTION
Adds Gate 12 to the pre-release protocol: a release may not be cut until a dated
RECEIPT exists for every supported platform, for the version being cut.

WHY, IN ONE AFTERNOON'S EVIDENCE

The 0.64.0 sweep ran `cargo install aprender` on four hosts. The published crate
had NEVER been verified on either arm64 platform. What that found:

  #2567  Q4_K GEMV -- the hottest kernel in quantized inference -- has ZERO
         aarch64 SIMD, and `matmul_q4k_f32_parallel` on non-x86 is a direct call
         to the SERIAL scalar routine. Census: 183 x86_64 cfg sites vs 16
         aarch64; zero in q4k/ and q6k/. The NUMBERS ARE CORRECT and only the
         speed is wrong, so no correctness gate could ever have caught it.
  #2568  The OOM guard reads /proc/meminfo and `.unwrap_or(u64::MAX)`, so on
         macOS the threshold is ~12.8 EXABYTES and the guard can never fire. Its
         only test self-skips with `cfg!(target_os = "linux")` -- the platform
         where it is broken. Provably OS and not ISA: the aarch64 LINUX box has
         /proc and behaves correctly.
  #2572  `block v0.1.6` faces future-rustc rejection and sits under wgpu->metal,
         the ONLY GPU backend macOS has. `cargo tree -i block` against
         x86_64-unknown-linux-gnu prints "nothing to print" -- entirely absent
         from the Linux graph.

Every one is invisible from a single host BY CONSTRUCTION. That is the argument.

THE MATRIX, and why each host is in it -- distinct {ISA, OS, accelerator}:
  lambda  x86_64 Linux + RTX 4090 (sm_89)   consumer x86, AVX2
  intel   x86_64 Linux, Xeon W-3245         AVX-512 + VNNI
  gx10    aarch64 Linux + GB10 (sm_121)     ARM server, unified memory
  mini    arm64 macOS + Metal               no /proc, APFS case-insensitive

WHAT THE GATE ACTUALLY CHECKS. Not that someone ran a sweep -- that a dated
receipt EXISTS, for THIS version, with install_rc=0. A receipt is evidence; a
checklist tick is not. A receipt from a previous release is STALE and fails.
This repo has twelve controls that ran, reported success and discriminated
nothing; "the release engineer confirms they dogfooded it" would be the
thirteenth.

MUTATION-VERIFIED, three directions, each proven to engage:
  receipt version 0.63.0 -> 0.60.0   rc=1  "receipt is for 0.60.0 ... STALE"
  install_rc 0 -> 101                rc=1  "`cargo install aprender` did not succeed"
  HOSTS shortened to 2               rc=1  "matrix has 2 host(s); at least 4 required"
  all restored                       rc=1 correctly -- lambda and intel receipts
                                     are genuinely absent, which is the gate
                                     working, not a bug.

ANTI-VACUITY: the gate refuses a matrix of fewer than four hosts. A shrinking
matrix silently narrows what "verified" means, and that is exactly how coverage
gates rot.

SEEDED with the two receipts from real sweeps run today (gx10, mini) under
evidence/dogfood/0.63.0/. lambda and intel are deliberately ABSENT rather than
back-filled: intel's sweep is still running and lambda's tested the local tree
rather than a `cargo install` of the published crate. Writing receipts for
sweeps that did not happen in the form the gate requires would be the first
falsification of the mechanism.

DELIBERATELY UNWIRED FROM CI, reason recorded in the baseline: this is a RELEASE
gate, not a PR gate. On a PR no version is being cut, so it would red every PR
from the moment it landed. It runs as Gate 12 at release time.

ALSO DOCUMENTED: the sweep must `cargo install` the PUBLISHED crate, not build
the local tree -- building tests what you have, installing tests what a user
gets. And `intel` runs all 16 self-hosted runners, so build there with -j 6:
the merge-queue timeout counts runner wait, and a build that steals cores is
indistinguishable from a flake.

Refs #2566, #2567, #2568, #2572

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
