### PR TITLE
fix/2568 oom guard fail closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1340,6 +1340,7 @@ dependencies = [
  "serde_yaml_ng",
  "serial_test",
  "smallvec",
+ "sysinfo 0.32.1",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4045,7 +4046,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5207,7 +5208,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5538,7 +5539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6225,7 +6226,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -7144,7 +7145,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7517,7 +7518,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8823,7 +8824,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9286,7 +9287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10207,7 +10208,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10245,7 +10246,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11029,7 +11030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11109,7 +11110,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11888,7 +11889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12214,6 +12215,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
@@ -12323,7 +12338,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12342,7 +12357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14764,7 +14779,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/contracts/apr-qa-chaos-v1.yaml
+++ b/contracts/apr-qa-chaos-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-04-08'
   author: PAIML Engineering
   registry: true
@@ -9,6 +9,7 @@ metadata:
   - 'GH-352 — apr pull using 55 GB RAM'
   - 'GH-471 — GPU hangs on large MoE models'
   - 'GH-478 — per-layer dequantization OOM on 32B'
+  - '#2568 — the GH-478 OOM guard failed OPEN on macOS (no /proc/meminfo)'
   description: >
     Chaos engineering contract for apr CLI. Inject resource constraints,
     truncated files, and concurrent load to verify graceful degradation.
@@ -70,6 +71,20 @@ equations:
     - "Never silently overwrites existing files"
     - "--force flag required for intentional overwrite"
 
+  oom_guard_fails_closed:
+    formula: |
+      let mem = system_memory_bytes()   # /proc/meminfo | sysctl hw.memsize | unknown
+      dequant_admitted(peak) <=>
+        mem == Some(total) AND peak <= total * 0.8
+      # mem == None  =>  REFUSED, never admitted
+    domain: "host RAM measurement × estimated F32 dequant peak"
+    codomain: bool
+    invariants:
+    - "An unmeasurable host refuses every dequant: unknown is not unlimited"
+    - "system_memory_bytes() is Some on every supported platform (Linux, macOS)"
+    - "The admission decision never substitutes a sentinel (u64::MAX) for a missing measurement"
+    - "No test of this gate may be skipped by target_os — a skip hides the broken platform"
+
 falsification_tests:
 - id: F-CHAOS-001
   rule: memory budget
@@ -117,6 +132,23 @@ falsification_tests:
     test $? -ne 0
   if_fails: "partial file written on full disk"
 
+- id: F-CHAOS-006
+  rule: OOM guard fails closed
+  prediction: "an unmeasurable host RAM refuses the dequant instead of admitting it"
+  test: cargo test -p aprender-serve --lib contract_gate::tests::test_dequant_verdict_fails_closed_when_memory_unknown
+  if_fails: "unknown memory is being treated as unlimited again (the #2568 u64::MAX substitution)"
+  ship_blocking: true
+
+- id: F-CHAOS-007
+  rule: OOM guard is armed on every platform
+  prediction: "system_memory_bytes() returns Some on every target the workspace builds for"
+  test: cargo test -p aprender-serve --lib contract_gate::tests::test_system_memory_bytes_is_measurable_on_this_platform
+  if_fails: "this platform has no memory probe, so the dequant guard cannot be armed here"
+  ship_blocking: true
+  counter_example_classes:
+  - "macOS: no /proc/meminfo and no sysctl hw.memsize fallback (#2568)"
+  - "a cfg!(target_os = ...) guard added around the assertion, which hides exactly the broken platform"
+
 proof_obligations:
 - type: bound
   property: "Peak RSS of `apr run` on a small model stays under the 3x-model-size + 512 MB budget (F-CHAOS-001)"
@@ -133,9 +165,15 @@ proof_obligations:
 - type: safety
   property: "A full filesystem produces a non-zero exit, not a partial corrupt output file (F-CHAOS-005)"
   formal: "full_fs implies exit_code(apr_convert(M, -o out)) != 0"
+- type: safety
+  property: "When host RAM cannot be measured the F32 dequant gate refuses rather than admits; the probe is Some on every supported platform (F-CHAOS-006)"
+  formal: "system_memory_bytes() == None implies not admitted(dequant(M))"
+- type: liveness
+  property: "The host RAM probe resolves on every supported platform, so the gate is armed rather than merely present (F-CHAOS-007)"
+  formal: "forall os in supported_targets: system_memory_bytes() != None"
 
 verification_summary:
-  total_obligations: 5
+  total_obligations: 7
   proven: 0
-  tested: 0
+  tested: 2
   status: proposed

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -688,3 +688,9 @@ shared-version = true
 file = "CHANGELOG.md"
 search = "## \\[Unreleased\\]"
 replace = "## [{{version}}] - {{date}}"
+
+# Windows-only: the OOM guard's memory probe (#2568). Gated on cfg(windows) so
+# Linux and macOS builds do not carry it -- the two native probes there are
+# cheaper than a crate.
+[target.'cfg(windows)'.dependencies]
+sysinfo = { workspace = true }

--- a/crates/aprender-serve/src/contract_gate.rs
+++ b/crates/aprender-serve/src/contract_gate.rs
@@ -406,6 +406,9 @@ fn validate_completeness(
 /// If the estimated peak exceeds 80% of system RAM, returns an error
 /// so callers can route to a memory-efficient loading path.
 ///
+/// #2568: if the host's RAM cannot be determined this **refuses** the dequant.
+/// See [`dequant_verdict`] for why an unknown limit is not an infinite one.
+///
 /// # Arguments
 ///
 /// * `tensor_entries` — slice of `(byte_size, dtype)` for each tensor in the file
@@ -421,11 +424,46 @@ pub fn validate_f32_dequant_limits(
         estimated_f32_bytes += elements as u64 * 4;
     }
 
-    // Peak = file in Vec<u8> + all F32 dequantized tensors
-    let estimated_peak = file_size + estimated_f32_bytes;
+    dequant_verdict(file_size, estimated_f32_bytes, system_memory_bytes())
+}
 
-    let mem_total = system_memory_bytes().unwrap_or(u64::MAX);
-    let threshold = mem_total * 80 / 100;
+/// The dequant decision itself, isolated from *how* memory was measured.
+///
+/// `mem_total` is `None` when this platform has no memory probe (see
+/// [`system_memory_bytes`]). #2568: the shipped 0.63.0 code substituted
+/// `u64::MAX` there, which made the 80% threshold ~12.8 EiB and the comparison
+/// `estimated_peak > threshold` unsatisfiable — the OOM guard could never fire
+/// on macOS, the one platform where the probe returned `None`. A safety
+/// threshold must **fail closed**: an unknown limit is not an unlimited one, so
+/// the dequant is refused and the reason says which measurement is missing.
+fn dequant_verdict(
+    file_size: u64,
+    estimated_f32_bytes: u64,
+    mem_total: Option<u64>,
+) -> std::result::Result<(), ModelLoadError> {
+    // Peak = file in Vec<u8> + all F32 dequantized tensors
+    let estimated_peak = file_size.saturating_add(estimated_f32_bytes);
+
+    let Some(mem_total) = mem_total else {
+        return Err(ModelLoadError {
+            gate: "resource_limits",
+            reason: format!(
+                "cannot determine total system RAM on this platform ({}), so the F32 \
+                 dequant OOM guard cannot be evaluated; refusing to dequant ~{} GB \
+                 (file {} GB + dequant {} GB). An unknown memory limit is not an \
+                 unlimited one (#2568). Use the quantized inference path.",
+                std::env::consts::OS,
+                estimated_peak / (1 << 30),
+                file_size / (1 << 30),
+                estimated_f32_bytes / (1 << 30),
+            ),
+        });
+    };
+
+    // 80% of RAM, written as /5*4 so it cannot overflow for any u64 input
+    // (the old `mem_total * 80 / 100` panicked in debug builds on the
+    // u64::MAX fallback and wrapped in release builds).
+    let threshold = mem_total / 5 * 4;
 
     if estimated_peak > threshold {
         return Err(ModelLoadError {
@@ -458,18 +496,90 @@ fn estimate_elements(byte_size: usize, dtype: u8) -> usize {
     }
 }
 
-/// Read total system memory from /proc/meminfo (Linux).
+/// Absolute paths to try for macOS's `sysctl(8)`.
 ///
-/// Returns `None` on non-Linux or if /proc/meminfo is unreadable.
+/// Absolute, not PATH-resolved, on purpose: a `sysctl` shadowed earlier on
+/// `$PATH` could report an arbitrary number into a *safety* threshold.
+const SYSCTL_PATHS: &[&str] = &["/usr/sbin/sysctl", "/sbin/sysctl"];
+
+/// Total physical memory of this host, or `None` if it cannot be measured here.
+///
+/// | Platform | Probe |
+/// |----------|-------|
+/// | Linux (incl. Android, WSL) | `MemTotal:` in `/proc/meminfo` |
+/// | macOS | `sysctl -n hw.memsize` |
+/// | anything else | `None` — **callers must fail closed** |
+///
+/// #2568: this used to read `/proc/meminfo` and nothing else. macOS has no
+/// `/proc`, so it returned `None` there and the one caller
+/// ([`validate_f32_dequant_limits`]) turned that `None` into `u64::MAX`,
+/// disarming the OOM guard on every Mac. `None` now means exactly "unknown",
+/// and [`dequant_verdict`] refuses rather than assumes.
 pub fn system_memory_bytes() -> Option<u64> {
+    if let Some(bytes) = proc_meminfo_total_bytes() {
+        return Some(bytes);
+    }
+    sysctl_hw_memsize_bytes()
+}
+
+/// Linux probe: `MemTotal:` from `/proc/meminfo`.
+fn proc_meminfo_total_bytes() -> Option<u64> {
     let content = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_meminfo_total_bytes(&content)
+}
+
+/// Parse `MemTotal: <n> kB` out of `/proc/meminfo` contents.
+///
+/// Split out from the file read so the parse is testable on any platform.
+/// A reported total of zero is treated as *unknown*, not as "no memory".
+fn parse_meminfo_total_bytes(content: &str) -> Option<u64> {
     for line in content.lines() {
-        if line.starts_with("MemTotal:") {
-            let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
-            return Some(kb * 1024);
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return kb.checked_mul(1024).filter(|&b| b > 0);
         }
     }
     None
+}
+
+/// macOS probe: `sysctl -n hw.memsize`.
+///
+/// Runs the tool rather than calling `sysctlbyname(3)` so the whole path stays
+/// safe Rust and — apart from the kernel key itself — is exercised by tests on
+/// every platform via [`run_sysctl_memsize`].
+fn sysctl_hw_memsize_bytes() -> Option<u64> {
+    // A runtime `cfg!` rather than `#[cfg]`: the code below is then compiled
+    // and type-checked on Linux CI too, instead of only on a Mac.
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    run_sysctl_memsize(SYSCTL_PATHS)
+}
+
+/// Invoke the first `sysctl` in `paths` that exists and parse its output.
+fn run_sysctl_memsize(paths: &[&str]) -> Option<u64> {
+    for path in paths {
+        let Ok(output) = std::process::Command::new(path)
+            .args(["-n", "hw.memsize"])
+            .output()
+        else {
+            continue; // not installed at this path, or could not be spawned
+        };
+        if !output.status.success() {
+            continue; // e.g. Linux procps sysctl, which has no hw.memsize
+        }
+        if let Some(bytes) = parse_sysctl_memsize(&String::from_utf8_lossy(&output.stdout)) {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+/// Parse the single decimal number `sysctl -n hw.memsize` prints.
+///
+/// Zero is treated as *unknown* so a degenerate reading cannot disarm the guard.
+fn parse_sysctl_memsize(stdout: &str) -> Option<u64> {
+    stdout.trim().parse::<u64>().ok().filter(|&b| b > 0)
 }
 
 // ============================================================================
@@ -886,27 +996,165 @@ mod tests {
 
     #[test]
     fn test_small_model_passes_resource_check() {
-        // 7B Q4K: ~4 GB file, ~28 GB F32 dequant — fits in most systems
-        let tensors: Vec<(usize, u8)> = vec![
-            (144 * 1000, 12), // Q4K tensor: 256K elements
-        ];
-        // Should pass on any system with >40 GB RAM
-        let result = validate_f32_dequant_limits(&tensors, 4_000_000_000);
-        // We can't assert pass/fail without knowing test machine RAM,
-        // but we can verify it doesn't panic
-        let _ = result;
+        // A ~1 MB APR file whose F32 dequant is ~4 MB. This fits under 80% of
+        // any machine that can run the test suite, so — unlike the previous
+        // `let _ = result;` version, which excluded no outcome — it may assert.
+        let tensors: Vec<(usize, u8)> = vec![(144 * 1000, 12)]; // Q4K, 256K elements
+        let result = validate_f32_dequant_limits(&tensors, 1_000_000);
+        assert!(
+            result.is_ok(),
+            "a ~5 MB peak must pass the resource gate on any host that can run \
+             this test, got: {:?}",
+            result.err()
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // #2568: the OOM guard must FAIL CLOSED when RAM cannot be measured.
+    // These run on every platform — the decision is separated from the probe
+    // precisely so no target_os can skip them.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_dequant_verdict_fails_closed_when_memory_unknown() {
+        // Before #2568 the unknown case became u64::MAX and this returned Ok.
+        let err = dequant_verdict(1 << 30, 8 << 30, None)
+            .expect_err("unknown system memory MUST refuse the dequant, not allow it");
+        assert_eq!(err.gate, "resource_limits");
+        assert!(
+            err.reason.contains("cannot determine total system RAM"),
+            "the refusal must name the missing measurement, got: {}",
+            err.reason
+        );
     }
 
     #[test]
-    fn test_system_memory_bytes_returns_some_on_linux() {
-        // On Linux CI, /proc/meminfo should exist
-        if cfg!(target_os = "linux") {
-            let mem = system_memory_bytes();
-            assert!(
-                mem.is_some(),
-                "system_memory_bytes should return Some on Linux"
-            );
-            assert!(mem.unwrap() > 0, "system memory should be > 0");
+    fn test_dequant_verdict_fails_closed_even_for_a_tiny_model() {
+        // "Unknown" is not "unlimited" at ANY size: a 1-byte file is refused
+        // too, because the guard has nothing to compare against.
+        assert!(
+            dequant_verdict(1, 0, None).is_err(),
+            "an unmeasurable host must refuse every dequant, however small"
+        );
+    }
+
+    #[test]
+    fn test_dequant_verdict_refuses_over_80_percent() {
+        // 16 GiB host, 14 GiB peak: over the 12.8 GiB threshold.
+        let err = dequant_verdict(2 << 30, 12 << 30, Some(16 << 30))
+            .expect_err("14 GiB peak on a 16 GiB host must be refused");
+        assert!(
+            err.reason.contains("exceeds 80% of system RAM"),
+            "{}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn test_dequant_verdict_allows_under_80_percent() {
+        // 16 GiB host, 8 GiB peak: under the 12.8 GiB threshold.
+        assert!(dequant_verdict(2 << 30, 6 << 30, Some(16 << 30)).is_ok());
+    }
+
+    #[test]
+    fn test_dequant_verdict_threshold_does_not_overflow() {
+        // `mem_total * 80 / 100` panicked in debug builds at u64::MAX (that is
+        // what the old unwrap_or(u64::MAX) fed it). `/5*4` cannot.
+        assert!(dequant_verdict(0, 0, Some(u64::MAX)).is_ok());
+        assert!(
+            dequant_verdict(1, 0, Some(0)).is_err(),
+            "a host reporting 0 bytes of RAM fits nothing"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // #2568: the probe. NOTE — no `if cfg!(target_os = ...)` guard here.
+    // The deleted guard was the whole defect: it skipped macOS, the only
+    // platform where the probe was broken, so the test read as coverage while
+    // proving nothing there.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_system_memory_bytes_is_measurable_on_this_platform() {
+        let mem = system_memory_bytes();
+        assert!(
+            mem.is_some(),
+            "no memory probe for target_os={}: the F32 dequant OOM guard cannot \
+             be armed here. Add a probe to system_memory_bytes() (#2568) — do \
+             NOT skip this assertion by platform.",
+            std::env::consts::OS,
+        );
+        assert!(mem.expect("checked is_some above") > 0);
+    }
+
+    #[test]
+    fn test_parse_meminfo_total_bytes() {
+        let sample = "MemTotal:       131377776 kB\nMemFree:         2000 kB\n";
+        assert_eq!(parse_meminfo_total_bytes(sample), Some(131_377_776 * 1024));
+        // MemTotal absent, malformed, or zero => unknown, never a wrong number
+        assert_eq!(parse_meminfo_total_bytes("MemFree: 2000 kB\n"), None);
+        assert_eq!(parse_meminfo_total_bytes("MemTotal:       kB\n"), None);
+        assert_eq!(parse_meminfo_total_bytes("MemTotal:       0 kB\n"), None);
+        assert_eq!(parse_meminfo_total_bytes(""), None);
+    }
+
+    #[test]
+    fn test_parse_sysctl_memsize() {
+        // What `/usr/sbin/sysctl -n hw.memsize` prints on macOS 26.5.2 arm64.
+        assert_eq!(parse_sysctl_memsize("17179869184\n"), Some(17_179_869_184));
+        assert_eq!(
+            parse_sysctl_memsize("  17179869184  "),
+            Some(17_179_869_184)
+        );
+        assert_eq!(parse_sysctl_memsize(""), None);
+        assert_eq!(parse_sysctl_memsize("hw.memsize: 17179869184\n"), None);
+        assert_eq!(parse_sysctl_memsize("0\n"), None);
+    }
+
+    /// Exercise the macOS probe's exec+status+parse path on ANY platform by
+    /// pointing it at a stub that behaves like `sysctl -n hw.memsize`.
+    #[test]
+    fn test_run_sysctl_memsize_against_a_stub() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let good = dir.path().join("sysctl_ok");
+        std::fs::write(&good, "#!/bin/sh\necho 17179869184\n").expect("write stub");
+        set_executable(&good);
+
+        // A stub that exits non-zero must NOT be believed, even though it
+        // prints a number — that is the Linux `sysctl` case.
+        let bad = dir.path().join("sysctl_fail");
+        std::fs::write(&bad, "#!/bin/sh\necho 999\nexit 1\n").expect("write stub");
+        set_executable(&bad);
+
+        let missing = dir.path().join("sysctl_absent");
+        let (good, bad, missing) = (
+            good.to_string_lossy().into_owned(),
+            bad.to_string_lossy().into_owned(),
+            missing.to_string_lossy().into_owned(),
+        );
+
+        assert_eq!(run_sysctl_memsize(&[&good]), Some(17_179_869_184));
+        assert_eq!(
+            run_sysctl_memsize(&[&bad]),
+            None,
+            "non-zero exit must not be trusted"
+        );
+        assert_eq!(run_sysctl_memsize(&[&missing]), None);
+        // A missing/failing path falls through to the next candidate.
+        assert_eq!(
+            run_sysctl_memsize(&[&missing, &bad, &good]),
+            Some(17_179_869_184)
+        );
+        assert_eq!(run_sysctl_memsize(&[]), None);
+    }
+
+    fn set_executable(path: &std::path::Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod stub");
         }
     }
 }

--- a/crates/aprender-serve/src/contract_gate.rs
+++ b/crates/aprender-serve/src/contract_gate.rs
@@ -508,6 +508,7 @@ const SYSCTL_PATHS: &[&str] = &["/usr/sbin/sysctl", "/sbin/sysctl"];
 /// |----------|-------|
 /// | Linux (incl. Android, WSL) | `MemTotal:` in `/proc/meminfo` |
 /// | macOS | `sysctl -n hw.memsize` |
+/// | Windows | `sysinfo::System::total_memory` (`GlobalMemoryStatusEx`) |
 /// | anything else | `None` — **callers must fail closed** |
 ///
 /// #2568: this used to read `/proc/meminfo` and nothing else. macOS has no
@@ -515,11 +516,49 @@ const SYSCTL_PATHS: &[&str] = &["/usr/sbin/sysctl", "/sbin/sysctl"];
 /// ([`validate_f32_dequant_limits`]) turned that `None` into `u64::MAX`,
 /// disarming the OOM guard on every Mac. `None` now means exactly "unknown",
 /// and [`dequant_verdict`] refuses rather than assumes.
+///
+/// #2568 SECOND ROUND: the macOS fix, shipped alone, BROKE WINDOWS. Fail-closed
+/// is only safe where a probe exists — with just the Linux and macOS arms,
+/// Windows fell through to `None` and the guard refused EVERY dequant, hard-
+/// breaking the APR v2 load path on a target .github/workflows/nightly.yml
+/// builds and packages (x86_64-pc-windows-msvc). Found by adversarial review,
+/// not by CI, because no Windows job runs this code.
+///
+/// That is the multi-platform dogfood gate (#2573) earning its keep against the
+/// very change that accompanied it: fixing one platform in isolation broke
+/// another, and only a matrix could see it.
 pub fn system_memory_bytes() -> Option<u64> {
     if let Some(bytes) = proc_meminfo_total_bytes() {
         return Some(bytes);
     }
-    sysctl_hw_memsize_bytes()
+    if let Some(bytes) = sysctl_hw_memsize_bytes() {
+        return Some(bytes);
+    }
+    windows_total_bytes()
+}
+
+/// Windows probe: `sysinfo` wraps `GlobalMemoryStatusEx`.
+///
+/// `sysinfo::System::total_memory` returns BYTES as of 0.30. That unit is the
+/// whole correctness question here — the Win32 primitive
+/// `GetPhysicallyInstalledSystemMemory` returns KILOBYTES, and a crate that
+/// changed to match it would silently make this threshold 1024x too large,
+/// which is the disarmed-guard failure #2568 is about. Asserted by
+/// `windows_probe_reports_bytes_not_kilobytes` rather than trusted.
+#[cfg(windows)]
+fn windows_total_bytes() -> Option<u64> {
+    use sysinfo::System;
+    let mut sys = System::new();
+    sys.refresh_memory();
+    // Zero is "unknown", never "no memory" -- same rule as the other two probes.
+    Some(sys.total_memory()).filter(|&b| b > 0)
+}
+
+/// Non-Windows builds have no third probe; the two above are exhaustive for the
+/// platforms this repo ships. Anything else yields `None` and the caller refuses.
+#[cfg(not(windows))]
+fn windows_total_bytes() -> Option<u64> {
+    None
 }
 
 /// Linux probe: `MemTotal:` from `/proc/meminfo`.
@@ -618,6 +657,49 @@ pub fn transpose_f32(data: &[f32], rows: usize, cols: usize) -> Vec<f32> {
 
 #[cfg(test)]
 mod tests {
+    /// #2568: the guard must WORK on every platform this repo ships, not merely
+    /// refuse where the probe is absent. A test asserting only "None refuses"
+    /// passed on the build that hard-broke Windows -- it proved the fail-closed
+    /// branch and said nothing about whether the probe branch existed.
+    ///
+    /// This runs on whatever platform CI is on, so between the Linux runners,
+    /// the macOS box and the Windows nightly it is asserted on all three.
+    #[test]
+    fn memory_probe_exists_on_every_shipped_platform() {
+        let got = system_memory_bytes();
+        assert!(
+            got.is_some(),
+            "no memory probe on this platform ({}). Fail-closed is only safe \
+             where a probe EXISTS: without one the guard refuses every dequant \
+             and the load path is dead. Add a probe for this target (#2568).",
+            std::env::consts::OS
+        );
+        let bytes = got.unwrap_or(0);
+        // A plausibility band, not an equality: 256 MiB..=8 TiB. Its job is to
+        // catch a UNIT error, which is the live risk here -- sysinfo reports
+        // BYTES, while the Win32 primitive GetPhysicallyInstalledSystemMemory
+        // reports KILOBYTES. Reading kB as bytes would land ~1024x low and
+        // silently disarm the threshold in the opposite direction from #2568.
+        assert!(
+            bytes >= 256 * 1024 * 1024 && bytes <= 8 * 1024 * 1024 * 1024 * 1024,
+            "implausible total memory {bytes} bytes on {} -- suspect a unit \
+             error (kB read as bytes, or the reverse)",
+            std::env::consts::OS
+        );
+    }
+
+    /// The unit contract for the Windows probe, asserted rather than trusted.
+    #[cfg(windows)]
+    #[test]
+    fn windows_probe_reports_bytes_not_kilobytes() {
+        let b = windows_total_bytes().expect("windows probe must report a total");
+        assert!(
+            b >= 1024 * 1024 * 1024,
+            "windows total_memory returned {b}; a value this small means \
+             KILOBYTES were read as BYTES (#2568)"
+        );
+    }
+
     use super::*;
 
     fn valid_config() -> ModelLoadConfig {


### PR DESCRIPTION
- **fix(serve): the F32 dequant OOM guard failed OPEN on macOS (#2568)**
- **fix(serve): the macOS OOM-guard fix broke Windows — add the third probe**
