### PR TITLE
fix/tensors tune file bounds

### DIFF
--- a/contracts/apr-load-fail-closed-truncated-v1.yaml
+++ b/contracts/apr-load-fail-closed-truncated-v1.yaml
@@ -1,7 +1,7 @@
 contract: apr-load-fail-closed-truncated
 metadata:
   kind: pattern
-  version: "1.1.0"
+  version: "1.2.0"
   description: >
     realizar's GGUF loader must FAIL CLOSED on a truncated/corrupt model. The
     chokepoint OwnedQuantizedTensor::from_ref_with_dims silently substitutes an empty
@@ -26,12 +26,32 @@ metadata:
     Pillar-4 BEAT, not parity. The NaN/Inf guarantee already existed on the SafeTensors
     path (F-DATA-QUALITY-002, safetensors/validation.rs); PMAT-895 wires it into the
     quantized load path by scanning the f16 scale field(s) per block (O(num_blocks)).
+    #2569 (v1.2.0) extends the SAME fail-closed-on-truncation guarantee from the LOAD
+    path to the INSPECTION path. `apr tensors` computed each row's size_bytes from the
+    declared shape and never asked whether those bytes exist: on a 128-byte GGUF
+    declaring 8192 bytes of tensor data it printed the full table and exited 0 while
+    `apr validate` on the same file exited 5 with "(file is 1 bytes too short)". The
+    surface that said OK is the JSON the MCP tool and CI consume. format::tensors
+    ::check_tensor_table_fits now requires every tensor's full extent
+    (data_offset + offset + size) to lie inside the file, on the GGUF path and BOTH APR
+    v2 paths, before the --filter loop. It is strictly stronger than the check
+    RosettaStone::validate_gguf already had, which asks only whether the LAST tensor's
+    FIRST byte exists and so cannot see a file short by less than the final tensor's
+    length. #2570 rides on the same check: `apr tune` read its "Model parameters" from
+    the file's BYTE LENGTH times a constant chosen by extension (982,800,128 where
+    `apr inspect` read 630,167,424 from the same bytes; an empty file reported as a
+    model that "fits in 16.0 GB VRAM", exit 0), and now reads the real count through
+    format::tensors::list_tensors, inheriting the truncation refusal.
   references:
   - "crates/aprender-serve/src/gguf/quantized.rs (from_ref_with_dims, is_truncated)"
   - "crates/aprender-serve/src/gguf/embedding.rs (OwnedQuantizedModel::from_mapped + validate_quantized_tensors + quant_scale_first_nonfinite)"
   - "crates/aprender-serve/src/gguf/quantized_tests.rs (test_pmat750_truncated_tensor_detected)"
   - "crates/aprender-serve/src/gguf/tests/beat_fail_closed_naninf.rs (PMAT-895 gguf_naninf_quant_scale_rejected_at_load)"
   - "crates/aprender-serve/src/safetensors/validation.rs (F-DATA-QUALITY-002 NaN/Inf gate, mirrored)"
+  - "crates/aprender-core/src/format/tensors.rs (check_tensor_table_fits; APR v2 + mmap call sites)"
+  - "crates/aprender-core/src/format/safetensors.rs (list_tensors_gguf call site, --stats fail-closed)"
+  - "crates/aprender-core/src/format/tensors_tests_bounds_2569.rs (#2569 falsifiers)"
+  - "crates/apr-cli/src/commands/tune.rs (read_params_from_file, #2570)"
 version: 1
 status: enforced
 date: 2026-06-22
@@ -63,6 +83,33 @@ proof_obligations:
       F-DATA-QUALITY-002 NaN/Inf guarantee into the quantized load path; llama.cpp /
       Ollama load such a model by default, so apr fails closed where they do not.
 
+  - type: invariant
+    property: >
+      INSPECT-FAIL-CLOSED-TRUNCATED (#2569): format::tensors::list_tensors returns
+      Err(FormatError) naming the first tensor whose declared extent
+      (data_offset + tensor.offset + size_bytes) runs past the end of the file, for GGUF
+      and for both APR v2 paths (in-memory and mmap). The check runs over EVERY tensor in
+      the index before any --filter is applied, so a filter matching zero tensors cannot
+      turn a truncated file into a clean exit, and it uses checked arithmetic so a crafted
+      header cannot wrap u64 into a small end offset. A tensor whose last byte is the
+      file's last byte fits (end == file_len is accepted); an intact model of any size
+      lists unchanged, so the check raises no false positive.
+  - type: invariant
+    property: >
+      STATS-FAIL-CLOSED (#2569): when compute_stats is requested and a tensor's data
+      cannot be read, list_tensors returns Err naming the tensor and its dtype rather than
+      leaving mean/std/min/max as None. Rendering None prints an em-dash, which is
+      byte-for-byte what a run WITHOUT --stats prints, so "could not compute" and "you did
+      not ask" were indistinguishable on the only surface that reports them.
+  - type: invariant
+    property: >
+      TUNE-PARAMS-MEASURED (#2570): apr tune's model parameter count is the sum of the
+      declared tensor shapes read out of the model header, never a function of the file's
+      byte length. A header that cannot be parsed, or one describing zero parameters, is a
+      non-zero exit naming --model <SIZE> as the way to plan without a model file — an
+      unknown parameter count is not a small one. apr tune and apr inspect report the same
+      number for the same file.
+
 falsification_tests:
   - id: FALSIFY-LOAD-TRUNCATED-001
     name: test_pmat750_truncated_tensor_detected
@@ -76,3 +123,21 @@ falsification_tests:
     test_harness: "cargo test -p aprender-serve --lib gguf_naninf_quant_scale_rejected_at_load"
     expected_output: "test result: ok"
     if_fails: "a quantized GGUF with a non-finite f16 scale loads silently → apr dequantizes it to NaN/Inf and emits garbage at inference instead of failing closed at load (Pillar-4 beat regressed to parity with llama.cpp/Ollama)."
+  - id: FALSIFY-INSPECT-TRUNCATED-2569
+    name: tensors_tests_bounds_2569
+    prediction: "a GGUF with its data section removed, and one one byte short of its declared extent, both make list_tensors return Err containing 'Truncated GGUF' and the offending tensor name; a --filter matching zero tensors still errors; the intact file still lists 1 tensor of 8192 bytes; the same holds for APR v2 through the mmap path"
+    test_harness: "cargo test -p aprender-core --lib format::tensors::tests::tensors_tests_bounds_2569"
+    expected_output: "test result: ok"
+    if_fails: "apr tensors again prints a table asserting bytes the file does not contain, and exits 0 while apr validate on the same file exits 5 — with the affirmative answer on the JSON surface the MCP tool and CI read."
+  - id: FALSIFY-INSPECT-TRUNCATED-JSON-2569
+    name: tensors_json_refuses_a_truncated_gguf_2569
+    prediction: "apr tensors' run() returns Err for a truncated GGUF in BOTH --json and text mode, and still returns Ok (all three of --json, text, --stats) for the intact file"
+    test_harness: "cargo test -p apr-cli --lib commands::tensors::tests::tensors_"
+    expected_output: "test result: ok"
+    if_fails: "the machine-read surface certifies a truncated model, which is the form of the defect that reaches CI."
+  - id: FALSIFY-TUNE-PARAMS-2570
+    name: read_params_from_file_reads_the_shapes_not_the_file_size
+    prediction: "read_params_from_file returns 2048 for a 64x32 F32 GGUF — neither file_len*2 nor file_len/2 — and returns Err for an empty file, for a megabyte of zeros named .gguf, for a structurally valid GGUF declaring zero tensors, and for a truncated GGUF"
+    test_harness: "cargo test -p apr-cli --lib commands::tune::tests::read_params_from_file"
+    expected_output: "test result: ok"
+    if_fails: "apr tune again labels a number derived from the file's byte length 'Model parameters' and feeds it to the VRAM feasibility verdict, disagreeing with apr inspect on the same file and planning a fine-tune for an empty one."

--- a/crates/apr-cli/src/commands/tensors_tests.rs
+++ b/crates/apr-cli/src/commands/tensors_tests.rs
@@ -3,6 +3,75 @@ use std::io::Write;
 use tempfile::{tempdir, NamedTempFile};
 
 // =========================================================================
+// #2569 — the JSON surface must refuse a file the table does not fit
+//
+// `apr tensors --json` is what the MCP tool and CI consume, so it is the
+// surface where the wrong answer does damage. On 0.63.0 a 128-byte GGUF
+// declaring 8192 bytes of tensor data produced rc=0 and
+// `"total_size_bytes": 8192` here while `apr validate` on the same bytes
+// exited 5. These assert the whole `run()` path, in both output modes.
+// =========================================================================
+
+/// A valid single-tensor GGUF: 64x32 F32 = 8192 bytes of tensor data.
+fn gguf_2569() -> Vec<u8> {
+    use aprender::format::gguf::{export_tensors_to_gguf, GgmlType, GgufTensor, GgufValue};
+
+    let data: Vec<u8> = (0..2048u32)
+        .flat_map(|i| (i as f32 + 1.0).to_le_bytes())
+        .collect();
+    let tensor = GgufTensor {
+        name: "test.weight".to_string(),
+        shape: vec![64, 32],
+        dtype: GgmlType::F32,
+        data,
+    };
+    let metadata = vec![(
+        "general.architecture".to_string(),
+        GgufValue::String("test".to_string()),
+    )];
+    let mut bytes = Vec::new();
+    export_tensors_to_gguf(&mut bytes, &[tensor], &metadata).expect("export GGUF");
+    bytes
+}
+
+#[test]
+fn tensors_json_refuses_a_truncated_gguf_2569() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("truncated.gguf");
+    let bytes = gguf_2569();
+    std::fs::write(&path, &bytes[..bytes.len() - 8192]).expect("write fixture");
+
+    let err = run(&path, false, None, true, 0)
+        .expect_err("--json must not certify a table that does not fit the file");
+    assert!(format!("{err}").contains("Truncated GGUF"), "got: {err}");
+}
+
+#[test]
+fn tensors_text_refuses_a_truncated_gguf_2569() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("truncated.gguf");
+    let bytes = gguf_2569();
+    std::fs::write(&path, &bytes[..bytes.len() - 8192]).expect("write fixture");
+
+    let err = run(&path, false, None, false, 0)
+        .expect_err("the text surface must agree with the JSON one");
+    assert!(format!("{err}").contains("Truncated GGUF"), "got: {err}");
+}
+
+/// Positive control: both surfaces still succeed on the intact file. Without
+/// this, a `run()` that always errored would satisfy both tests above.
+#[test]
+fn tensors_still_lists_an_intact_gguf_2569() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("intact.gguf");
+    std::fs::write(&path, gguf_2569()).expect("write fixture");
+
+    run(&path, false, None, true, 0).expect("--json must still list an intact GGUF");
+    run(&path, false, None, false, 0).expect("text must still list an intact GGUF");
+    run(&path, true, None, false, 0).expect("--stats must still work on an intact GGUF");
+}
+
+// =========================================================================
 // validate_path tests
 // =========================================================================
 

--- a/crates/apr-cli/src/commands/tune.rs
+++ b/crates/apr-cli/src/commands/tune.rs
@@ -9,7 +9,9 @@
 //! ```bash
 //! apr tune model.gguf --method lora --rank 8           # Plan LoRA config
 //! apr tune model.gguf --method qlora --vram 16         # Plan QLoRA for 16GB VRAM
-//! apr tune --plan 7B --vram 24                         # Memory planning
+//! apr tune --model 7B --vram 24                        # Memory planning, no model file
+//!                                                      # (`--plan` is a boolean; the
+//!                                                      #  size flag is `--model`)
 //! ```
 
 use crate::error::CliError;
@@ -89,7 +91,7 @@ pub fn run(
     let model_params = if let Some(size) = model_size {
         parse_model_size(size)?
     } else if let Some(path) = model_path {
-        estimate_params_from_file(path)?
+        read_params_from_file(path)?
     } else {
         return Err(CliError::ValidationFailed(
             "Either --model or model path required".to_string(),
@@ -243,26 +245,59 @@ fn parse_model_size(size: &str) -> Result<u64, CliError> {
     Ok((num * multiplier as f64) as u64)
 }
 
-/// Estimate parameters from model file size.
+/// Read the model's real parameter count from the tensor metadata in its header.
 ///
-/// GH-484: Use file extension to pick bytes-per-param ratio instead of
-/// blindly assuming Q4 (which overestimates fp16/bf16 models by 4x).
-fn estimate_params_from_file(path: &Path) -> Result<u64, CliError> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|e| CliError::ValidationFailed(format!("Cannot read model file: {e}")))?;
+/// #2570: this replaces `estimate_params_from_file`, which never opened the
+/// model. It multiplied the file's BYTE LENGTH by a constant picked from the
+/// filename extension — `size * 2` for `.gguf`, `size / 2` for everything
+/// else — and the result was then labelled "Model parameters" and fed into the
+/// VRAM feasibility verdict. Measured on the shipped 0.63.0 binary against
+/// `qwen2.5-coder-0.5b-instruct-q4_k_m.gguf` (491,400,064 bytes):
+///
+///     apr inspect ... | grep Parameters   ->  630,167,424   (read from the file)
+///     apr tune ... --json                 ->  982,800,128   (= 491,400,064 x 2)
+///
+/// and on a zero-byte file it printed "Model parameters: 0", "fits in 16.0 GB
+/// VRAM", exit 0 — an empty file certified as a model that fits.
+///
+/// The correct read already exists in this binary: `apr inspect` sums the
+/// tensor shapes the same GGUF/APR/SafeTensors readers parse. This uses
+/// `format::tensors::list_tensors`, the metadata-only path behind
+/// `apr tensors`, so it costs a header read rather than a dequantisation of
+/// every tensor.
+///
+/// # Errors
+/// Returns `ValidationFailed` if the tensor metadata cannot be read, or if it
+/// describes zero parameters. `apr tune` does not substitute a guess for a
+/// header it could not parse: an unknown parameter count is not a small one.
+fn read_params_from_file(path: &Path) -> Result<u64, CliError> {
+    use aprender::format::tensors::{list_tensors, TensorListOptions};
 
-    let size_bytes = metadata.len();
+    let listing = list_tensors(path, TensorListOptions::new()).map_err(|e| {
+        CliError::ValidationFailed(format!(
+            "Cannot read tensor metadata from {}: {e}\n\
+             apr tune needs the model's real parameter count and will not guess one \
+             from the file size. Use --model <SIZE> (e.g. --model 7B) to plan without a model file.",
+            path.display()
+        ))
+    })?;
 
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let params: u64 = listing
+        .tensors
+        .iter()
+        .map(|t| t.shape.iter().product::<usize>() as u64)
+        .sum();
 
-    let estimated_params = match ext {
-        // GGUF models are typically quantized (Q4-Q8), ~0.5-1.0 bytes/param
-        "gguf" => size_bytes * 2,
-        // SafeTensors/APR/bin are typically fp16/bf16 (2 bytes/param)
-        _ => size_bytes / 2,
-    };
+    if params == 0 {
+        return Err(CliError::ValidationFailed(format!(
+            "{} declares no tensor parameters ({} tensors listed), so there is nothing to \
+             plan a fine-tune for. Use --model <SIZE> (e.g. --model 7B) to plan without a model file.",
+            path.display(),
+            listing.tensor_count
+        )));
+    }
 
-    Ok(estimated_params)
+    Ok(params)
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/crates/apr-cli/src/commands/tune_tests.rs
+++ b/crates/apr-cli/src/commands/tune_tests.rs
@@ -181,37 +181,175 @@ fn test_format_params_billions() {
 }
 
 // =========================================================================
-// estimate_params_from_file tests
+// read_params_from_file — falsifiers for #2570
+//
+// These replace two tests that ASSERTED THE DEFECT. `test_estimate_params_from_file`
+// wrote a megabyte of zeros to `test_model.gguf` and demanded the answer be
+// exactly 2,000,000 parameters; `test_estimate_params_from_file_not_found` was
+// the only case that could ever fail, and it only checked that a MISSING file
+// errored. A file of a million zero bytes is not a model, and a green suite that
+// requires it to be reported as a 2M-parameter one is how `apr tune` came to
+// print "Model parameters: 982,800,128" for a model `apr inspect` reads as
+// 630,167,424 out of the same bytes.
 // =========================================================================
 
-#[test]
-fn test_estimate_params_from_file() {
-    let temp_dir = std::env::temp_dir().join("apr_tune_test");
-    let _ = fs::create_dir_all(&temp_dir);
-    let data = vec![0u8; 1_000_000];
+/// A GGUF whose true parameter count is deliberately nowhere near either of the
+/// old size heuristics: 2048 F32 params in a file of ~8.3 KB.
+fn tiny_gguf_bytes() -> Vec<u8> {
+    use aprender::format::gguf::{export_tensors_to_gguf, GgmlType, GgufTensor, GgufValue};
 
-    // GH-484: GGUF files use Q4 estimate (size * 2)
-    let gguf_file = temp_dir.join("test_model.gguf");
-    let _ = fs::write(&gguf_file, &data);
-    let params = estimate_params_from_file(&gguf_file).expect("value");
-    assert_eq!(params, 2_000_000, "GGUF: 1MB * 2 = 2M params (Q4 estimate)");
-
-    // GH-484: Non-GGUF files use fp16 estimate (size / 2)
-    let st_file = temp_dir.join("test_model.safetensors");
-    let _ = fs::write(&st_file, &data);
-    let params = estimate_params_from_file(&st_file).expect("value");
-    assert_eq!(params, 500_000, "SafeTensors: 1MB / 2 = 500K params (fp16)");
-
-    let _ = fs::remove_dir_all(&temp_dir);
+    let data: Vec<u8> = (0..2048u32)
+        .flat_map(|i| (i as f32 + 1.0).to_le_bytes())
+        .collect();
+    let tensor = GgufTensor {
+        name: "test.weight".to_string(),
+        shape: vec![64, 32],
+        dtype: GgmlType::F32,
+        data,
+    };
+    let metadata = vec![(
+        "general.architecture".to_string(),
+        GgufValue::String("test".to_string()),
+    )];
+    let mut bytes = Vec::new();
+    export_tensors_to_gguf(&mut bytes, &[tensor], &metadata).expect("export GGUF");
+    bytes
 }
 
 #[test]
-fn test_estimate_params_from_file_not_found() {
-    let result = estimate_params_from_file(Path::new("/nonexistent/model.bin"));
+fn read_params_from_file_reads_the_shapes_not_the_file_size() {
+    let dir = std::env::temp_dir().join("apr_tune_2570_real");
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("model.gguf");
+    let bytes = tiny_gguf_bytes();
+    let file_len = bytes.len() as u64;
+    fs::write(&path, &bytes).expect("write fixture");
+
+    let params = read_params_from_file(&path).expect("a valid GGUF must yield its param count");
+
+    // 64 x 32 tensor shape, read out of the header.
+    assert_eq!(params, 2048, "must sum the declared tensor shapes");
+    // The two constants the old estimator used. Naming them here is the point:
+    // if someone reintroduces a size heuristic, this fails and says which one.
+    assert_ne!(
+        params,
+        file_len * 2,
+        "must not be the .gguf heuristic (file_len {file_len} x 2)"
+    );
+    assert_ne!(
+        params,
+        file_len / 2,
+        "must not be the fp16 heuristic (file_len {file_len} / 2)"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The headline case from #2570: a zero-byte file was reported as
+/// "Model parameters: 0" that "fits in 16.0 GB VRAM", exit 0.
+#[test]
+fn read_params_from_file_refuses_an_empty_file() {
+    let dir = std::env::temp_dir().join("apr_tune_2570_empty");
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("empty.apr");
+    fs::write(&path, b"").expect("write fixture");
+
+    let err = read_params_from_file(&path)
+        .expect_err("an empty file must not be planned as a model that fits");
+    match err {
+        CliError::ValidationFailed(msg) | CliError::InvalidFormat(msg) => {
+            assert!(
+                msg.contains("--model <SIZE>"),
+                "the refusal must point at the flag that plans WITHOUT a model file, got: {msg}"
+            );
+        }
+        other => panic!("expected a validation failure, got {other:?}"),
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A megabyte of zeros named `.gguf` — the exact fixture the deleted test
+/// demanded be reported as 2,000,000 parameters.
+#[test]
+fn read_params_from_file_refuses_a_million_zero_bytes_named_gguf() {
+    let dir = std::env::temp_dir().join("apr_tune_2570_zeros");
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("test_model.gguf");
+    fs::write(&path, vec![0u8; 1_000_000]).expect("write fixture");
+
+    let err = read_params_from_file(&path)
+        .expect_err("a megabyte of zeros is not a 2,000,000-parameter model");
+    assert!(
+        !format!("{err:?}").contains("2000000"),
+        "must not report the old heuristic's answer: {err:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A truncated GGUF reaches `apr tune` through the same `list_tensors` bounds
+/// check added for #2569 — the two defects share one correct implementation.
+#[test]
+fn read_params_from_file_refuses_a_truncated_gguf() {
+    let dir = std::env::temp_dir().join("apr_tune_2570_truncated");
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("truncated.gguf");
+    let bytes = tiny_gguf_bytes();
+    // Keep the header and tensor info, drop the 8192-byte data section.
+    fs::write(&path, &bytes[..bytes.len() - 8192]).expect("write fixture");
+
+    let err = read_params_from_file(&path)
+        .expect_err("apr tune must not plan a fine-tune from a truncated model");
+    assert!(
+        format!("{err:?}").contains("Truncated"),
+        "the refusal must carry the reason, got: {err:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A structurally VALID GGUF that declares zero tensors. It parses cleanly, so
+/// the listing succeeds and the sum is 0 — the one path where the explicit
+/// `params == 0` refusal is the only thing standing between the user and a
+/// "Model parameters: 0 … fits in 16.0 GB VRAM" verdict.
+#[test]
+fn read_params_from_file_refuses_a_valid_gguf_with_no_tensors() {
+    let dir = std::env::temp_dir().join("apr_tune_2570_no_tensors");
+    let _ = fs::create_dir_all(&dir);
+    let path = dir.join("empty.gguf");
+
+    let mut bytes = b"GGUF".to_vec();
+    bytes.extend_from_slice(&3u32.to_le_bytes()); // version
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // tensor_count = 0
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // metadata_kv_count = 0
+    fs::write(&path, &bytes).expect("write fixture");
+
+    // Precondition: the listing itself succeeds — this is not the #2569 path.
+    let listing = aprender::format::tensors::list_tensors(
+        &path,
+        aprender::format::tensors::TensorListOptions::new(),
+    )
+    .expect("a zero-tensor GGUF is structurally valid and must list");
+    assert_eq!(listing.tensor_count, 0);
+
+    let err = read_params_from_file(&path)
+        .expect_err("zero parameters is not a model to plan a fine-tune for");
+    assert!(
+        format!("{err:?}").contains("no tensor parameters"),
+        "got: {err:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn read_params_from_file_not_found() {
+    let result = read_params_from_file(Path::new("/nonexistent/model.bin"));
     assert!(result.is_err());
     match result {
         Err(CliError::ValidationFailed(msg)) => {
-            assert!(msg.contains("Cannot read model file"));
+            assert!(msg.contains("Cannot read tensor metadata"), "got: {msg}");
         }
         other => panic!("Expected ValidationFailed, got {:?}", other),
     }
@@ -317,10 +455,12 @@ fn test_run_with_model_file() {
     let temp_dir = std::env::temp_dir().join("apr_tune_run_test");
     let _ = fs::create_dir_all(&temp_dir);
 
-    // Create a test model file (small for fast tests)
+    // #2570: this fixture used to be 100 KB of ZEROS named `.gguf`, and the test
+    // asserted `run(..).is_ok()` on it. That is precisely the defect — planning a
+    // fine-tune for a file that contains no model — so the assertion locked it in.
+    // A real (tiny) GGUF is what the success path is entitled to.
     let test_file = temp_dir.join("test_model.gguf");
-    let data = vec![0u8; 100_000]; // 100KB
-    let _ = fs::write(&test_file, &data);
+    fs::write(&test_file, tiny_gguf_bytes()).expect("write fixture");
 
     let result = run(
         Some(&test_file),
@@ -334,7 +474,36 @@ fn test_run_with_model_file() {
         false,
     );
 
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "a real GGUF must still plan: {result:?}");
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// The other half of the case above: the zero-filled file that used to pass.
+#[test]
+fn test_run_refuses_a_file_that_is_not_a_model() {
+    let temp_dir = std::env::temp_dir().join("apr_tune_run_zeros");
+    let _ = fs::create_dir_all(&temp_dir);
+
+    let test_file = temp_dir.join("test_model.gguf");
+    fs::write(&test_file, vec![0u8; 100_000]).expect("write fixture");
+
+    let result = run(
+        Some(&test_file),
+        TuneMethod::QLoRA,
+        None,
+        8.0,
+        true,
+        None,
+        false,
+        None,
+        false,
+    );
+
+    assert!(
+        result.is_err(),
+        "100 KB of zeros is not a model; apr tune must not plan for it"
+    );
 
     let _ = fs::remove_dir_all(&temp_dir);
 }

--- a/crates/aprender-core/src/format/safetensors.rs
+++ b/crates/aprender-core/src/format/safetensors.rs
@@ -25,6 +25,20 @@ fn list_tensors_gguf(data: &[u8], options: TensorListOptions) -> Result<TensorLi
         message: format!("Failed to parse GGUF: {e}"),
     })?;
 
+    // #2569: every row below asserts that `size_bytes` of tensor data exist at a
+    // declared offset. Prove that before printing it. Run over ALL tensors, ahead
+    // of the `--filter` loop, so a filtered listing cannot hide a truncation.
+    let extents: Vec<(&str, u64, u64)> = reader
+        .tensors
+        .iter()
+        .map(|meta| {
+            let num_elements: u64 = meta.dims.iter().product();
+            let size_bytes = (num_elements as f64 * ggml_dtype_element_size(meta.dtype)) as u64;
+            (meta.name.as_str(), meta.offset, size_bytes)
+        })
+        .collect();
+    check_tensor_table_fits("GGUF", data.len() as u64, reader.data_offset as u64, extents)?;
+
     let mut tensors = Vec::new();
     let mut total_size = 0usize;
     let mut total_matching = 0usize;
@@ -60,9 +74,21 @@ fn list_tensors_gguf(data: &[u8], options: TensorListOptions) -> Result<TensorLi
             };
 
             if options.compute_stats {
-                if let Ok((f32_data, _shape)) = reader.get_tensor_f32(&meta.name) {
-                    compute_tensor_stats(&mut info, &f32_data);
-                }
+                // #2569: this was `if let Ok(...)`, so a tensor whose data could not
+                // be read printed em-dashes in the mean/std/range columns — byte-for-byte
+                // what a run WITHOUT `--stats` prints. The user asked for statistics;
+                // "could not compute them" and "you did not ask" must not render the
+                // same. Fail closed and name the tensor and the reason.
+                let (f32_data, _shape) = reader.get_tensor_f32(&meta.name).map_err(|e| {
+                    AprenderError::FormatError {
+                        message: format!(
+                            "--stats requested but tensor '{}' ({}) could not be read: {e}",
+                            meta.name,
+                            ggml_dtype_name(meta.dtype)
+                        ),
+                    }
+                })?;
+                compute_tensor_stats(&mut info, &f32_data);
             }
 
             tensors.push(info);

--- a/crates/aprender-core/src/format/safetensors.rs
+++ b/crates/aprender-core/src/format/safetensors.rs
@@ -248,6 +248,38 @@ fn list_tensors_safetensors(data: &[u8], options: TensorListOptions) -> Result<T
         obj.iter().filter(|(k, _)| *k != "__metadata__").collect();
     tensor_entries.sort_by_key(|(k, _)| *k);
 
+    // #2569 (second round): SafeTensors was the third format and the only one the
+    // first fix missed -- GGUF and both APR v2 paths were wired, this was not.
+    // Covering two of three formats reproduces, one format over, exactly the
+    // asymmetry #2569 was filed about (a truncated GGUF passed where a truncated
+    // APR did not).
+    //
+    // BEFORE the filter loop, deliberately and for the same reason as the GGUF
+    // call site: a `--filter` matching zero tensors must not launder a truncated
+    // file into rc=0. The check runs over every tensor in the index.
+    //
+    // SafeTensors offsets are RELATIVE to data_start and are [begin, end) pairs,
+    // so the extent is end - begin rather than a declared size -- an end that
+    // precedes its begin is itself corruption and is reported as a zero-length
+    // extent starting past the file, which the checker rejects.
+    {
+        let extents: Vec<(&str, u64, u64)> = tensor_entries
+            .iter()
+            .filter_map(|(name, value)| {
+                let o = value.get("data_offsets")?.as_array()?;
+                let begin = o.first()?.as_u64()?;
+                let end = o.get(1)?.as_u64()?;
+                Some((name.as_str(), begin, end.saturating_sub(begin)))
+            })
+            .collect();
+        check_tensor_table_fits(
+            "SafeTensors",
+            data.len() as u64,
+            data_start as u64,
+            extents,
+        )?;
+    }
+
     for (name, value) in tensor_entries {
         if !matches_filter(name, options.filter.as_ref()) {
             continue;

--- a/crates/aprender-core/src/format/tensors.rs
+++ b/crates/aprender-core/src/format/tensors.rs
@@ -203,6 +203,73 @@ pub fn is_valid_apr_magic(magic: &[u8; 4]) -> bool {
 }
 
 // ============================================================================
+// Tensor Table Bounds Check (#2569)
+// ============================================================================
+
+/// Refuse a tensor table whose declared extents do not fit inside the file.
+///
+/// #2569: `apr tensors` computed each row's `size_bytes` from the DECLARED
+/// shape and never asked whether those bytes exist. On a 128-byte GGUF
+/// declaring 8192 bytes of tensor data it printed the whole table and exited 0
+/// while `apr validate` on the same file exited 5 with
+/// "(file is N bytes too short)" — two commands, one binary, one file, opposite
+/// answers, and the one that said OK is the JSON the MCP tool and CI consume.
+///
+/// The check and its wording are lifted from `RosettaStone::validate_gguf`
+/// (`format/rosetta/arch_inference.rs`, S1-FIX), which has had it all along.
+/// This one is stricter in the way that matters: `validate` only asks whether
+/// the LAST tensor's start byte exists, so it cannot see a file that is short
+/// by less than the final tensor's length. Here every tensor's full extent —
+/// `data_start + offset + size` — must be inside the file, because that extent
+/// is exactly what the printed row asserts.
+///
+/// `tensors` yields `(name, offset_within_data_section, size_bytes)` and must
+/// cover EVERY tensor in the file, not just the ones a `--filter` selected: a
+/// filtered listing must not be able to hide a truncation.
+///
+/// # Errors
+/// Returns `FormatError` naming the first tensor that overruns the file, or
+/// whose declared extent overflows `u64`.
+fn check_tensor_table_fits<'a, I>(
+    format: &str,
+    file_len: u64,
+    data_start: u64,
+    tensors: I,
+) -> Result<()>
+where
+    I: IntoIterator<Item = (&'a str, u64, u64)>,
+{
+    for (name, offset, size) in tensors {
+        let start = data_start
+            .checked_add(offset)
+            .ok_or_else(|| AprenderError::FormatError {
+                message: format!(
+                    "Corrupt {format}: tensor '{name}' offset {offset} overflows the data \
+                     section start {data_start} (file is {file_len} bytes)"
+                ),
+            })?;
+        let end = start
+            .checked_add(size)
+            .ok_or_else(|| AprenderError::FormatError {
+                message: format!(
+                    "Corrupt {format}: tensor '{name}' declares {size} bytes at {start}, which \
+                     overflows u64 (file is {file_len} bytes)"
+                ),
+            })?;
+        if end > file_len {
+            return Err(AprenderError::FormatError {
+                message: format!(
+                    "Truncated {format}: file is {file_len} bytes but tensor '{name}' declares \
+                     bytes {start}..{end} (file is {short} bytes too short)",
+                    short = end - file_len,
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
 // Tensor Listing - From Bytes
 // ============================================================================
 
@@ -292,6 +359,21 @@ fn list_tensors_v2(data: &[u8], options: TensorListOptions) -> Result<TensorList
         message: format!("Failed to parse APR v2: {e}"),
     })?;
 
+    // #2569 / follow-up filed in #2564: the APR v2 index carries each tensor's real
+    // byte size, and this listing believed it without checking the file was that
+    // long. A 50 MB head of a 991 MB model printed "291 tensors 942.3 MB", 19x the
+    // file. Unlike GGUF there is no dtype estimate here — `entry.size` is exact.
+    check_tensor_table_fits(
+        "APR v2",
+        data.len() as u64,
+        reader.header().data_offset,
+        reader
+            .tensor_names()
+            .into_iter()
+            .filter_map(|name| reader.get_tensor(name).map(|e| (name, e.offset, e.size)))
+            .collect::<Vec<_>>(),
+    )?;
+
     // Get tensor info from actual index
     let mut tensors = Vec::new();
     let mut total_size = 0usize;
@@ -334,6 +416,20 @@ fn list_tensors_v2_mmap(data: &[u8], options: TensorListOptions) -> Result<Tenso
     let reader = AprV2ReaderRef::from_bytes(data).map_err(|e| AprenderError::FormatError {
         message: format!("Failed to parse APR v2: {e}"),
     })?;
+
+    // #2569: same check as `list_tensors_v2`. This mmap path is the one `apr tensors`
+    // actually takes for an APR v2 file on disk, so leaving it out would have made
+    // the sibling fix theater.
+    check_tensor_table_fits(
+        "APR v2",
+        data.len() as u64,
+        reader.header().data_offset,
+        reader
+            .tensor_names()
+            .into_iter()
+            .filter_map(|name| reader.get_tensor(name).map(|e| (name, e.offset, e.size)))
+            .collect::<Vec<_>>(),
+    )?;
 
     let mut tensors = Vec::new();
     let mut total_size = 0usize;

--- a/crates/aprender-core/src/format/tensors_tests.rs
+++ b/crates/aprender-core/src/format/tensors_tests.rs
@@ -423,6 +423,8 @@ fn test_tensor_list_result_clone() {
     assert_eq!(cloned.format_version, result.format_version);
 }
 
+#[path = "tensors_tests_bounds_2569.rs"]
+mod tensors_tests_bounds_2569;
 #[path = "tensors_tests_workflow.rs"]
 mod tensors_tests_workflow;
 #[path = "tensors_tests_stats.rs"]

--- a/crates/aprender-core/src/format/tensors_tests_bounds_2569.rs
+++ b/crates/aprender-core/src/format/tensors_tests_bounds_2569.rs
@@ -1,0 +1,302 @@
+//! Falsifiers for #2569 — `apr tensors` reported a table that does not fit the file.
+//!
+//! Before the fix in `check_tensor_table_fits`, every test in this file that
+//! expects `Err` got `Ok` with a full, confident tensor table. The defect and
+//! its blast radius, measured on the 0.63.0 binary:
+//!
+//! ```text
+//! apr tensors  truncated.gguf          rc=0   "1 tensors 8.0 KB F32"
+//! apr tensors  truncated.gguf --json   rc=0   "total_size_bytes": 8192
+//! apr validate truncated.gguf          rc=5   "(file is 1 bytes too short)"
+//! ```
+//!
+//! on a 128-byte file. The JSON is what the MCP tool and CI consume, so the
+//! surface that said OK is the one that is machine-read.
+//!
+//! Coverage here is deliberately BOTH formats and BOTH the typed API and the
+//! path-dispatch entry point: #2564 recorded that a truncated GGUF passed where
+//! a truncated APR did not, so a gate that only exercises one of them proves
+//! nothing about the other.
+
+use super::*;
+use crate::format::gguf::{export_tensors_to_gguf, GgmlType, GgufTensor, GgufValue};
+use crate::format::test_factory::build_pygmy_apr;
+
+/// A valid single-tensor GGUF: 64x32 F32 = 2048 elements = 8192 bytes of data.
+fn valid_gguf() -> Vec<u8> {
+    let data: Vec<u8> = (0..2048u32)
+        .flat_map(|i| (i as f32 + 1.0).to_le_bytes())
+        .collect();
+    let tensor = GgufTensor {
+        name: "test.weight".to_string(),
+        shape: vec![64, 32],
+        dtype: GgmlType::F32,
+        data,
+    };
+    let metadata = vec![(
+        "general.architecture".to_string(),
+        GgufValue::String("test".to_string()),
+    )];
+    let mut bytes = Vec::new();
+    export_tensors_to_gguf(&mut bytes, &[tensor], &metadata).expect("export GGUF");
+    bytes
+}
+
+/// Byte offset where the GGUF data section starts, per the reader itself.
+fn gguf_data_offset(bytes: &[u8]) -> usize {
+    GgufReader::from_bytes(bytes.to_vec())
+        .expect("parse GGUF")
+        .data_offset
+}
+
+// ========================================================================
+// GGUF
+// ========================================================================
+
+/// Positive control. The check must not reject a file that IS complete —
+/// otherwise every assertion below is satisfied by a function that always
+/// errors, and this file would prove nothing.
+#[test]
+fn gguf_intact_file_still_lists() {
+    let bytes = valid_gguf();
+    let result = list_tensors_from_bytes(&bytes, TensorListOptions::default())
+        .expect("an intact GGUF must still list");
+    assert_eq!(result.tensor_count, 1);
+    assert_eq!(result.tensors[0].size_bytes, 8192);
+    assert_eq!(result.total_size_bytes, 8192);
+}
+
+/// The reported defect: the entire data section is missing and the listing
+/// still printed 8192 bytes of tensor.
+#[test]
+fn gguf_missing_data_section_is_refused() {
+    let bytes = valid_gguf();
+    let header_only = &bytes[..gguf_data_offset(&bytes)];
+
+    let err = list_tensors_from_bytes(header_only, TensorListOptions::default())
+        .expect_err("a GGUF with no data section must not list 8192 bytes of tensor");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Truncated GGUF") && msg.contains("test.weight"),
+        "error must name the format and the offending tensor, got: {msg}"
+    );
+    assert!(
+        msg.contains("8192 bytes too short"),
+        "error must quantify the shortfall like `apr validate` does, got: {msg}"
+    );
+}
+
+/// Strictly stronger than the check `apr validate` already had.
+///
+/// `RosettaStone::validate_gguf` asks only whether the LAST tensor's FIRST byte
+/// is inside the file (`data_start + offset + 1`). A file short by one byte
+/// satisfies that and is still a lie: the row asserts 8192 bytes exist and 8191
+/// do. This case is the reason the check here is on the tensor's full EXTENT.
+#[test]
+fn gguf_short_by_one_byte_is_refused() {
+    let bytes = valid_gguf();
+    let one_short = &bytes[..bytes.len() - 1];
+
+    let err = list_tensors_from_bytes(one_short, TensorListOptions::default())
+        .expect_err("a GGUF one byte short of its declared extent must be refused");
+    assert!(
+        err.to_string().contains("1 bytes too short"),
+        "got: {err}"
+    );
+}
+
+/// A `--filter` that selects nothing must not launder a truncated file into a
+/// clean exit. The check runs over every tensor in the index, before filtering.
+#[test]
+fn gguf_filter_cannot_hide_truncation() {
+    let bytes = valid_gguf();
+    let header_only = &bytes[..gguf_data_offset(&bytes)];
+
+    let options = TensorListOptions::default().with_filter("no-such-tensor");
+    let err = list_tensors_from_bytes(header_only, options)
+        .expect_err("a filter matching zero tensors must not turn a truncated file into rc=0");
+    assert!(err.to_string().contains("Truncated GGUF"), "got: {err}");
+}
+
+/// The same refusal through the path-dispatch entry point that `apr tensors`
+/// and `apr tune` call, not just the bytes API.
+#[test]
+fn gguf_truncated_on_disk_is_refused() {
+    let dir = std::env::temp_dir().join("apr_tensors_bounds_2569_gguf");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("truncated.gguf");
+    let bytes = valid_gguf();
+    std::fs::write(&path, &bytes[..gguf_data_offset(&bytes)]).expect("write fixture");
+
+    let err = list_tensors(&path, TensorListOptions::default())
+        .expect_err("list_tensors must refuse a truncated GGUF on disk");
+    assert!(err.to_string().contains("Truncated GGUF"), "got: {err}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// `--stats` that cannot read a tensor must not render identically to a run
+/// that never asked for stats. Before the fix the read was `if let Ok(..)` and
+/// the mean/std/range columns printed "—" either way.
+#[test]
+fn gguf_stats_failure_is_distinguishable_from_stats_not_requested() {
+    // Q8_1 (dtype 9): `ggml_dtype_element_size` knows its 1.125 bytes/element so
+    // the bounds check is satisfiable, but `GgufReader::get_tensor_f32` has no
+    // dequantiser arm for it — exactly the "all the bytes are here and I still
+    // cannot give you numbers" case that used to print an em-dash.
+    let mut bytes = b"GGUF".to_vec();
+    bytes.extend_from_slice(&3u32.to_le_bytes()); // version
+    bytes.extend_from_slice(&1u64.to_le_bytes()); // tensor_count
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // metadata_kv_count
+    let name = b"weird.weight";
+    bytes.extend_from_slice(&(name.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(name);
+    bytes.extend_from_slice(&1u32.to_le_bytes()); // n_dims
+    bytes.extend_from_slice(&256u64.to_le_bytes()); // dims[0]
+    bytes.extend_from_slice(&9u32.to_le_bytes()); // dtype Q8_1 — no dequantiser
+    bytes.extend_from_slice(&0u64.to_le_bytes()); // offset
+    while bytes.len() % 32 != 0 {
+        bytes.push(0);
+    }
+    // Q8_1 is 1.125 bytes/element: 256 * 1.125 = 288 bytes, all present.
+    bytes.extend_from_slice(&[7u8; 288]);
+
+    // Without --stats the listing is fine: the shape and size are knowable.
+    let listed = list_tensors_from_bytes(&bytes, TensorListOptions::default())
+        .expect("listing without stats must succeed — the bytes are all there");
+    assert_eq!(listed.tensor_count, 1);
+    assert!(
+        listed.tensors[0].mean.is_none(),
+        "no stats requested => no stats"
+    );
+
+    // With --stats the failure must be reported, not rendered as an em-dash.
+    let err = list_tensors_from_bytes(&bytes, TensorListOptions::default().with_stats())
+        .expect_err("--stats that cannot be computed must say so");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--stats") && msg.contains("weird.weight"),
+        "error must name the flag and the tensor, got: {msg}"
+    );
+}
+
+// ========================================================================
+// APR v2
+// ========================================================================
+
+/// Positive control for the APR path.
+#[test]
+fn apr_intact_file_still_lists() {
+    let bytes = build_pygmy_apr();
+    let result = list_tensors_from_bytes(&bytes, TensorListOptions::default())
+        .expect("an intact APR v2 must still list");
+    assert!(result.tensor_count > 0, "pygmy APR should have tensors");
+}
+
+/// #2564 filed this as an explicit follow-up: a 50 MB head of a 991 MB APR
+/// model printed "291 tensors 942.3 MB", 19x the file, because the header
+/// offsets it checks genuinely ARE inside the file at that size — the lie had
+/// moved to the tensor extent. One byte is the smallest version of that.
+#[test]
+fn apr_short_by_one_byte_is_refused() {
+    let bytes = build_pygmy_apr();
+    // Truncate to one byte short of the LAST DECLARED TENSOR BYTE, not one byte
+    // off the end of the file: an APR v2 file is 64-byte aligned and can carry
+    // trailing padding, so lopping one byte off EOF may still leave every tensor
+    // extent inside the file — a fixture that proves nothing.
+    let reader = AprV2Reader::from_bytes(&bytes).expect("parse pygmy APR");
+    let last_byte = reader.header().data_offset
+        + reader
+            .tensor_names()
+            .iter()
+            .filter_map(|n| reader.get_tensor(n))
+            .map(|e| e.offset + e.size)
+            .max()
+            .expect("pygmy APR has tensors");
+    let one_short = &bytes[..(last_byte as usize) - 1];
+
+    let err = list_tensors_from_bytes(one_short, TensorListOptions::default())
+        .expect_err("an APR v2 one byte short of its declared extent must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Truncated APR v2") && msg.contains("bytes too short"),
+        "got: {msg}"
+    );
+}
+
+/// The mmap path — the one `apr tensors <file>.apr` actually takes — must
+/// refuse it too, or the sibling check above is theater.
+#[test]
+fn apr_truncated_on_disk_is_refused() {
+    let dir = std::env::temp_dir().join("apr_tensors_bounds_2569_apr");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("truncated.apr");
+    let bytes = build_pygmy_apr();
+    // Drop the last quarter of the data section: big enough that a partial
+    // download is a realistic way to reach it.
+    std::fs::write(&path, &bytes[..bytes.len() * 3 / 4]).expect("write fixture");
+
+    let err = list_tensors(&path, TensorListOptions::default())
+        .expect_err("list_tensors must refuse a truncated APR v2 on disk");
+    assert!(err.to_string().contains("too short"), "got: {err}");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Positive control on the mmap path: an intact APR on disk still lists.
+#[test]
+fn apr_intact_on_disk_still_lists() {
+    let dir = std::env::temp_dir().join("apr_tensors_bounds_2569_apr_ok");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("intact.apr");
+    std::fs::write(&path, build_pygmy_apr()).expect("write fixture");
+
+    let result = list_tensors(&path, TensorListOptions::default())
+        .expect("an intact APR v2 on disk must still list");
+    assert!(result.tensor_count > 0);
+
+    let _ = std::fs::remove_file(&path);
+}
+
+// ========================================================================
+// The check itself
+// ========================================================================
+
+#[test]
+fn check_tensor_table_fits_accepts_an_exactly_full_file() {
+    // end == file_len is fine: the last byte of the tensor is the last byte of
+    // the file. An off-by-one here would reject every intact model.
+    check_tensor_table_fits("TEST", 100, 20, [("t", 0u64, 80u64)])
+        .expect("a tensor ending exactly at EOF fits");
+}
+
+#[test]
+fn check_tensor_table_fits_rejects_one_byte_over() {
+    let err = check_tensor_table_fits("TEST", 100, 20, [("t", 0u64, 81u64)])
+        .expect_err("81 bytes at offset 20 do not fit in 100");
+    assert!(err.to_string().contains("1 bytes too short"), "got: {err}");
+}
+
+#[test]
+fn check_tensor_table_fits_reports_the_first_offender_not_the_last() {
+    let err = check_tensor_table_fits(
+        "TEST",
+        100,
+        0,
+        [("ok", 0u64, 10u64), ("bad", 10u64, 200u64), ("also_bad", 0, 999)],
+    )
+    .expect_err("must reject");
+    assert!(err.to_string().contains("'bad'"), "got: {err}");
+}
+
+#[test]
+fn check_tensor_table_fits_refuses_an_overflowing_extent() {
+    // A crafted header must not be able to wrap u64 into a small end offset.
+    let err = check_tensor_table_fits("TEST", 100, 1, [("t", u64::MAX, 1u64)])
+        .expect_err("offset overflow must be refused, not wrapped");
+    assert!(err.to_string().contains("overflow"), "got: {err}");
+
+    let err = check_tensor_table_fits("TEST", 100, 0, [("t", u64::MAX, 2u64)])
+        .expect_err("size overflow must be refused, not wrapped");
+    assert!(err.to_string().contains("overflow"), "got: {err}");
+}

--- a/crates/aprender-core/src/format/tensors_tests_bounds_2569.rs
+++ b/crates/aprender-core/src/format/tensors_tests_bounds_2569.rs
@@ -300,3 +300,60 @@ fn check_tensor_table_fits_refuses_an_overflowing_extent() {
         .expect_err("size overflow must be refused, not wrapped");
     assert!(err.to_string().contains("overflow"), "got: {err}");
 }
+
+// ---- SafeTensors: the third format, missed by the first round of #2569 -------
+
+/// Build a minimal SafeTensors buffer: 8-byte LE header length, then JSON.
+fn safetensors_bytes(json: &str, body_len: usize) -> Vec<u8> {
+    let mut v = Vec::new();
+    v.extend_from_slice(&(json.len() as u64).to_le_bytes());
+    v.extend_from_slice(json.as_bytes());
+    v.extend(std::iter::repeat(0u8).take(body_len));
+    v
+}
+
+const ST_ONE: &str = r#"{"w":{"dtype":"F32","shape":[4],"data_offsets":[0,16]}}"#;
+
+#[test]
+fn safetensors_intact_file_still_lists() {
+    // POSITIVE CONTROL: 16 bytes declared, 16 bytes present.
+    let data = safetensors_bytes(ST_ONE, 16);
+    let r = list_tensors_from_bytes(&data, TensorListOptions::default());
+    assert!(r.is_ok(), "an intact SafeTensors file must still list: {r:?}");
+}
+
+#[test]
+fn safetensors_truncated_body_is_refused() {
+    // 16 bytes declared, 4 present. Before this fix `apr tensors` printed the
+    // declared row and exited 0 while `apr validate` rejected the same file.
+    let data = safetensors_bytes(ST_ONE, 4);
+    let err = list_tensors_from_bytes(&data, TensorListOptions::default())
+        .expect_err("a truncated SafeTensors body must be refused");
+    let msg = format!("{err}");
+    assert!(msg.contains("SafeTensors"), "error must name the format: {msg}");
+}
+
+#[test]
+fn safetensors_short_by_one_byte_is_refused() {
+    // The off-by-one that a last-tensor-first-byte check cannot see.
+    let data = safetensors_bytes(ST_ONE, 15);
+    assert!(
+        list_tensors_from_bytes(&data, TensorListOptions::default()).is_err(),
+        "a SafeTensors file one byte short must be refused"
+    );
+}
+
+#[test]
+fn safetensors_filter_cannot_hide_truncation() {
+    // The check runs BEFORE the filter loop on purpose: a filter matching
+    // nothing must not launder a truncated file into a success.
+    let data = safetensors_bytes(ST_ONE, 4);
+    let opts = TensorListOptions {
+        filter: Some("matches-nothing".to_string()),
+        ..TensorListOptions::default()
+    };
+    assert!(
+        list_tensors_from_bytes(&data, opts).is_err(),
+        "a filter matching zero tensors must not hide truncation"
+    );
+}


### PR DESCRIPTION
- **fix(tensors,tune): two commands asserted things about a file neither had read**
- **fix(tensors): SafeTensors was the third format, and the only one the first fix missed**
