### PR TITLE
fix(pv): pv --version could not tell you WHICH pv you have (#2559)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo build --examples --workspace --keep-going'
+            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo test -p aprender-contracts-cli --test version_identity && cargo build --examples --workspace --keep-going'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.
@@ -475,6 +475,17 @@ jobs:
       # the fixture binaries are shell scripts that print a version string.
       - name: apr_bin.sh must resolve the HEAD-built binary, whatever its profile
         run: bash scripts/check_apr_bin_resolution.sh
+      # Poka-yoke (#2559): pv_bin.sh proves a resolved `pv` is the HEAD build by
+      # reading the semver out of `pv --version`. That version line is now
+      # deliberately multi-line -- four things claim the name `pv`, so it has to
+      # say which one it is -- and the old `awk '{print $NF}'` extractor handed
+      # the comparison four lines of prose, failing every consumer of pv_bin.sh.
+      # The extractor is a guard's parser, and guard patterns in this repo have
+      # been wrong five times running, every one caught by a case table.
+      - name: pv --version semver extractor must answer its case table
+        run: bash scripts/check_pv_version_parse.sh
+      - name: "pv --version parse guard must still turn RED (case table)"
+        run: bash scripts/check_pv_version_parse.sh --self-test
       # CLAUDE.md mandates bashrs over shellcheck; CI honoured that for SEVEN of
       # 72 scripts (`bashrs lint scripts/check_book_*.sh` in book.yml).
       # apr_bin.sh -- sourced by every gate in this repo -- was not one of them,

--- a/contracts/pv-version-identity-v1.yaml
+++ b/contracts/pv-version-identity-v1.yaml
@@ -1,0 +1,136 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-22'
+  author: PAIML Engineering
+  description: "Binary self-identification — the property that `pv --version` tells a user WHICH `pv` they are running. Four things claim the name `pv`, the operator settled that this tool keeps it (2026-08-21), and a HEAD-built binary printed exactly `pv 0.63.0`: a bare name and a semver, byte-identical to what the pipe viewer prints. When a name is deliberately shared, the version line IS the disambiguation mechanism, and an ambiguous one leaves the collision entirely unmitigated."
+  kind: pattern
+  references:
+    - "aprender#2559 — the report: a HEAD-built pv prints `pv 0.63.0`, indistinguishable at a glance from pv(1)"
+    - "aprender#2558 — four crates claimed the bin name `pv`; contracts/provable-contracts-facade-v1.yaml owns the INSTALL-time half of the collision"
+    - "operator ruling 2026-08-21 — the binary KEEPS the name `pv`; the rename quorum was overruled and may not be reopened"
+    - "crates/aprender-contracts-cli/src/lib.rs — SHORT_VERSION / LONG_VERSION, the strings under test"
+    - "crates/aprender-contracts-cli/tests/includes/version_identity_unit.rs — the --lib half of the falsifier"
+    - "crates/aprender-contracts-cli/tests/version_identity.rs — the spawn-the-real-binary half"
+    - "scripts/pv_bin.sh — the release-gate consumer that parses the version line"
+    - "scripts/check_pv_version_parse.sh — the case table for that parse"
+    - ".github/workflows/ci.yml — wires the integration target, which is dark until named there"
+
+five_whys:
+  symptom: "`pv --version` printed `pv 0.63.0`. A user with both the pipe viewer and this tool installed could not tell from the version line which one had answered, and neither could a bug report quoting it."
+  why_1: "clap's bare `version` attribute renders `{name} {CARGO_PKG_VERSION}` and nothing else. That default is correct for a program whose name is unique; this program's name is deliberately not unique."
+  why_2: "The name collision was addressed at INSTALL time — scripts/check_duplicate_bin_names.sh, the facade going lib-only — and install-time mitigation says nothing about the RUNTIME question 'which one am I talking to'."
+  why_3: "The decision to keep the name (2026-08-21) shifted the whole mitigation burden onto identification, but no artifact was updated to carry that new burden. A decision changed what had to be true and nothing changed what was checked."
+  why_4: "Nothing enforced the version line's CONTENT. The only thing that read it, scripts/pv_bin.sh, compared a semver — so any identity text was invisible to every gate, and its absence equally so."
+  root_cause: "`contracts-pv` is 76 features at 0.0% coverage: the tool that decides whether a release is contractually sound proves nothing about itself. This defect is one instance. The remedy is not only the string but the assertion that EXCLUDES the bare form, run in a scope CI actually executes."
+
+equations:
+  version_output_identifies_this_tool_and_not_another:
+    formula: "for the first line L of `pv --version`: L != concat(bin_name, ' ', semver) AND identity_tokens ⊆ tokens(`pv --version`)"
+    domain: "the rendered output of `pv --version` and `pv -V`, where identity_tokens = {provable-contracts, aprender, aprender-contracts-cli, 'pipe viewer'}"
+    codomain: "exit code of `cargo test -p aprender-contracts-cli --lib version_identity_unit` and of the version_identity integration target"
+    invariants:
+      - "The negative assertion is the load-bearing one. `L != <name> <semver>` EXCLUDES the pre-fix output; a positive assertion alone could be satisfied by prose appended to a line that is still ambiguous at a glance"
+      - "MEASURED before the fix: 5 of 8 integration assertions and 3 of 5 unit assertions FAIL against `pv 0.63.0`. The remaining ones are regression guards that hold in both directions by design"
+      - "Naming the SHIPPING CRATE is a distinct obligation from naming the tool: a user who wants to uninstall or file a bug needs `aprender-contracts-cli`, which no description of purpose supplies"
+      - "The pipe-viewer disclaimer is separately load-bearing. MEASURED: deleting only that clause turns exactly one assertion RED (long_version_disclaims_the_pipe_viewer), 7 others still passing"
+      - "`-V` stays ONE line. A version line nobody reads is no better than an ambiguous one, so the glance form pays for identity with brevity elsewhere"
+      - "Both flags must agree on the first line, so a script and a human get the same answer whichever they reach for"
+
+  identity_text_does_not_displace_the_semver_the_release_gate_reads:
+    formula: "field_2(line_1(`pv --version`)) == CARGO_PKG_VERSION"
+    domain: "the whitespace-separated fields of the first line of `pv --version`, and the extractor in scripts/pv_bin.sh"
+    codomain: "exit code of scripts/check_pv_version_parse.sh and of the semver_stays_the_second_field_of_the_first_line assertions"
+    invariants:
+      - "scripts/pv_bin.sh proves a resolved binary was built from HEAD by comparing this semver to the version the tree declares. Every consumer of that script — the Makefile contracts gate, scripts/dogfood_surfaces.sh — inherits the parse"
+      - "MEASURED: the pre-existing extractor `awk '{print $NF}'` took the last field of EVERY line. Against the multi-line output it returned four lines of prose and scripts/pv_bin.sh exited 1, i.e. making the version line informative BROKE the release gate until the extractor was fixed in the same change"
+      - "The replacement reads position 2 of line 1, and that position is pinned from BOTH sides: the extractor by scripts/check_pv_version_parse.sh, the binary by a test assertion. Neither can drift without the other going RED"
+      - "MEASURED: moving the semver off field 2 turns the test RED and scripts/pv_bin.sh red together — the guard and the gate it protects fail as one"
+      - "The case table includes the pre-fix single-line form `pv 0.63.0`, so the new extractor is proven backward-compatible rather than assumed so"
+      - "It also includes real pipe-viewer output (`pv 1.6.20` plus its copyright line), because the failure mode being guarded is mistaking another tool's version line for this one's"
+
+  the_assertions_run_where_ci_can_see_them:
+    formula: "scope(version identity assertions) ⊆ targets executed by workspace-test"
+    domain: "CI's workspace-test job: `--lib` across the workspace, plus one explicit line naming individual `--test` targets"
+    codomain: "presence of the assertions in an executed target"
+    invariants:
+      - "A new tests/*.rs file is DARK until it is named on that one line. An assertion CI never runs is theater, which is the failure this whole contract exists to stop repeating"
+      - "The assertions are therefore duplicated into the LIBRARY, where `--lib` reaches them unconditionally. The guarantee does not depend on winning the race for the single shared ci.yml line, which only one PR at a time can edit"
+      - "The unit half asserts on Command::render_version()/render_long_version() — the same strings clap prints — and the integration half spawns the real binary via CARGO_BIN_EXE_pv, so the claim is proven end to end, not merely at the struct"
+      - "MUTATION-VERIFIED IN THE LIBRARY SCOPE SEPARATELY. The integration proof does not transfer: reverting the fix was re-run against `--lib` and turned 3 of 5 unit assertions RED"
+
+proof_obligations:
+  - type: invariant
+    property: "`pv --version` is not the bare `<name> <semver>` form that every other `pv` also prints"
+    formal: "cargo test -p aprender-contracts-cli --lib version_identity_unit exits 0"
+    applies_to: version_output_identifies_this_tool_and_not_another
+  - type: invariant
+    property: "The version output names the tool, the project, the shipping crate, and disclaims the pipe viewer"
+    formal: "The version_identity integration target exits 0"
+    applies_to: version_output_identifies_this_tool_and_not_another
+  - type: invariant
+    property: "The identity assertions demonstrably turn RED"
+    formal: "Replacing `version = SHORT_VERSION, long_version = LONG_VERSION` with a bare `version` fails 5 of 8 integration and 3 of 5 unit assertions"
+    applies_to: version_output_identifies_this_tool_and_not_another
+  - type: invariant
+    property: "The semver stays the second whitespace field of the first line"
+    formal: "scripts/pv_bin.sh resolves and asserts freshness with exit 0"
+    applies_to: identity_text_does_not_displace_the_semver_the_release_gate_reads
+  - type: invariant
+    property: "The extractor tested by the case table is the one scripts/pv_bin.sh actually runs"
+    formal: "scripts/check_pv_version_parse.sh compares against pv_bin.sh with full-line comments stripped, and fails on a mismatch"
+    applies_to: identity_text_does_not_displace_the_semver_the_release_gate_reads
+  - type: invariant
+    property: "The parse case table demonstrably turns RED"
+    formal: "scripts/check_pv_version_parse.sh --self-test fails the table on the pre-#2559 last-field extractor"
+    applies_to: identity_text_does_not_displace_the_semver_the_release_gate_reads
+  - type: invariant
+    property: "The integration target is named on ci.yml's explicit --test line, not merely present in the tree"
+    formal: "grep -q 'aprender-contracts-cli --test version_identity' .github/workflows/ci.yml"
+    applies_to: the_assertions_run_where_ci_can_see_them
+  - type: invariant
+    property: "The assertions also live in the library, so `--lib` reaches them without depending on the ci.yml line"
+    formal: "crates/aprender-contracts-cli/src/lib.rs declares mod version_identity_unit under #[cfg(test)]"
+    applies_to: the_assertions_run_where_ci_can_see_them
+
+falsification_tests:
+  - id: FALSIFY-PVVER-001
+    rule: "The version line identifies this tool, in a scope CI runs unconditionally"
+    prediction: "The library-scope assertions pass"
+    test: "cargo test -p aprender-contracts-cli --lib version_identity_unit"
+    if_fails: "`pv --version` has reverted to a form that does not say which `pv` it is. Four things claim that name and the operator ruled that this one keeps it, so the version line is the only mitigation left."
+
+  - id: FALSIFY-PVVER-002
+    rule: "The real binary, not just the clap Command, prints the identifying output"
+    prediction: "The spawned binary's --version and -V satisfy every assertion"
+    test: "cargo test -p aprender-contracts-cli --test version_identity"
+    if_fails: "The struct and the shipped binary disagree — the end-to-end claim was an inference dressed as a measurement."
+
+  - id: FALSIFY-PVVER-003
+    rule: "Adding identity text did not break the release gate that parses the version line"
+    prediction: "scripts/pv_bin.sh resolves a HEAD-built pv and its freshness assertion passes"
+    test: "bash -c '. scripts/pv_bin.sh && test -x \"$PV\"'"
+    if_fails: "The semver left field 2 of line 1, or the extractor drifted. Every consumer of pv_bin.sh — the Makefile contracts gate, scripts/dogfood_surfaces.sh — is blocked."
+
+  - id: FALSIFY-PVVER-004
+    rule: "The extractor answers every row of its case table, including the old single-line form and a foreign pv"
+    prediction: "The case table passes and the extractor under test is the one pv_bin.sh runs"
+    test: "bash scripts/check_pv_version_parse.sh"
+    if_fails: "The version-line parser and its table have diverged. This parser was already wrong once — `awk '{print $NF}'` — and shipped that way because nothing exercised it against more than one input."
+
+  - id: FALSIFY-PVVER-005
+    rule: "The parse case table demonstrably turns RED (mutation-verified, not merely green)"
+    prediction: "Run against the pre-#2559 last-field extractor, the table fails"
+    test: "bash scripts/check_pv_version_parse.sh --self-test"
+    if_fails: "The table has become vacuous — it would accept the extractor that broke every consumer of scripts/pv_bin.sh."
+
+  - id: FALSIFY-PVVER-006
+    rule: "The integration target is wired into CI, not merely present"
+    prediction: "ci.yml's explicit --test line names the version_identity target"
+    test: "grep -q 'aprender-contracts-cli --test version_identity' .github/workflows/ci.yml"
+    if_fails: "The integration half is dark. A new tests/*.rs file is unreachable until named on that line, and an assertion CI never runs is theater."
+
+  - id: FALSIFY-PVVER-007
+    rule: "The library-scope assertions are actually declared, so `--lib` reaches them"
+    prediction: "src/lib.rs declares the version_identity_unit test module"
+    test: "grep -q 'mod version_identity_unit' crates/aprender-contracts-cli/src/lib.rs"
+    if_fails: "The unconditional half was deleted, leaving the guarantee dependent on the single contested ci.yml line."

--- a/crates/aprender-contracts-cli/src/lib.rs
+++ b/crates/aprender-contracts-cli/src/lib.rs
@@ -19,12 +19,43 @@ use std::str::FromStr;
 use clap::Parser;
 use cli::Commands;
 
+/// Glance form, printed by `pv -V`. One line, and it names the tool.
+///
+/// clap renders `{name} {version}`, so this yields
+/// `pv 0.63.0 (aprender provable-contracts verifier)`. The bare semver stays the
+/// SECOND whitespace field because `scripts/pv_bin.sh` reads it positionally to
+/// prove a resolved binary was built from HEAD.
+const SHORT_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (aprender provable-contracts verifier)"
+);
+
+/// Full form, printed by `pv --version`.
+///
+/// Four things claim the name `pv` on a developer box: `pv(1)` the pipe viewer
+/// from every distro, the `pv` crate on crates.io (also a pipe viewer, first
+/// published 2019), this binary, and — until #2553 — the aprender facade. The
+/// operator settled that this tool KEEPS the name (2026-08-21), which makes this
+/// string the mitigation the project relies on, so it rules the others out by
+/// name rather than merely describing itself. See #2559 and
+/// `tests/version_identity.rs`.
+const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (aprender provable-contracts verifier)\n",
+    "crate aprender-contracts-cli — ",
+    env!("CARGO_PKG_REPOSITORY"),
+    "\n",
+    "Verifies YAML contracts under contracts/; run `pv --help` for the command surface.\n",
+    "This is NOT pv(1), the pipe viewer (distro package `pv`, or the `pv` crate on crates.io)."
+);
+
 /// Top-level CLI argument parser for the `pv` command
 #[derive(Parser)]
 #[command(
     name = "pv",
     about = "provable-contracts — papers to provable Rust kernels",
-    version
+    version = SHORT_VERSION,
+    long_version = LONG_VERSION
 )]
 pub struct Cli {
     /// The command to run
@@ -338,6 +369,10 @@ pub fn run() {
         std::process::exit(1);
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/includes/version_identity_unit.rs"]
+mod version_identity_unit;
 
 #[cfg(test)]
 #[path = "../tests/includes/dispatch_tests.rs"]

--- a/crates/aprender-contracts-cli/tests/includes/version_identity_unit.rs
+++ b/crates/aprender-contracts-cli/tests/includes/version_identity_unit.rs
@@ -1,0 +1,104 @@
+//! Unit half of the #2559 falsifier — see `tests/version_identity.rs` for the
+//! integration half that spawns the real binary.
+//!
+//! WHY BOTH. CI's `workspace-test` job runs `--lib` across the workspace plus ONE
+//! explicit line naming individual `--test` targets (`.github/workflows/ci.yml`).
+//! A new `tests/*.rs` file is DARK until it is added to that line, and only one
+//! PR at a time can edit it without conflicting. These unit tests live in the
+//! library, so they run under `--lib` unconditionally and the guarantee does not
+//! depend on winning that race.
+//!
+//! clap renders `--version` from `Command::render_long_version()` and `-V` from
+//! `render_version()`, so asserting on those is asserting on the same strings the
+//! binary prints — `version_identity.rs` confirms that end to end.
+
+use clap::CommandFactory;
+
+use super::Cli;
+
+fn short() -> String {
+    Cli::command().render_version()
+}
+
+fn long() -> String {
+    Cli::command().render_long_version()
+}
+
+/// The ambiguous form: exactly `pv <semver>`, byte-identical to what `pv(1)` the
+/// pipe viewer and the crates.io `pv` crate print.
+fn is_bare_name_and_semver(line: &str) -> bool {
+    let mut fields = line.split_whitespace();
+    let (Some(name), Some(ver), None) = (fields.next(), fields.next(), fields.next()) else {
+        return false;
+    };
+    name == "pv" && ver.split('.').count() == 3
+}
+
+#[test]
+fn long_version_is_not_bare_name_and_semver() {
+    let v = long();
+    let first = v.lines().next().unwrap_or_default();
+    assert!(
+        !is_bare_name_and_semver(first),
+        "`{first}` is indistinguishable from pv(1), the pipe viewer"
+    );
+}
+
+#[test]
+fn long_version_identifies_this_tool() {
+    let v = long();
+    let lower = v.to_lowercase();
+    assert!(
+        lower.contains("provable-contracts"),
+        "pv --version must say what this tool is; got:\n{v}"
+    );
+    assert!(
+        lower.contains("aprender"),
+        "pv --version must name the project; got:\n{v}"
+    );
+    assert!(
+        v.contains("aprender-contracts-cli"),
+        "pv --version must name the shipping crate; got:\n{v}"
+    );
+    assert!(
+        lower.contains("pipe viewer"),
+        "pv --version must disclaim pv(1), the pipe viewer; got:\n{v}"
+    );
+}
+
+#[test]
+fn short_version_is_one_unambiguous_line() {
+    let v = short();
+    let lines: Vec<&str> = v.trim_end().lines().collect();
+    assert_eq!(lines.len(), 1, "pv -V must stay one line; got:\n{v}");
+    assert!(
+        !is_bare_name_and_semver(lines[0]),
+        "pv -V is bare: `{}`",
+        lines[0]
+    );
+    assert!(
+        lines[0].to_lowercase().contains("provable-contracts"),
+        "pv -V must name the tool; got `{}`",
+        lines[0]
+    );
+}
+
+/// `scripts/pv_bin.sh` proves a resolved binary is the HEAD build by reading the
+/// semver positionally out of `pv --version`. Identity text must not displace it.
+#[test]
+fn semver_stays_the_second_field_of_the_first_line() {
+    let v = long();
+    let first = v.lines().next().unwrap_or_default();
+    let mut fields = first.split_whitespace();
+    assert_eq!(fields.next(), Some("pv"));
+    assert_eq!(
+        fields.next(),
+        Some(env!("CARGO_PKG_VERSION")),
+        "scripts/pv_bin.sh reads field 2 of line 1; got `{first}`"
+    );
+}
+
+#[test]
+fn short_and_long_agree_on_the_first_line() {
+    assert_eq!(long().lines().next(), short().lines().next());
+}

--- a/crates/aprender-contracts-cli/tests/version_identity.rs
+++ b/crates/aprender-contracts-cli/tests/version_identity.rs
@@ -1,0 +1,164 @@
+//! Falsifier for #2559: `pv --version` must say WHICH `pv` this is.
+//!
+//! Four things claim the name `pv` on a developer box:
+//!   1. `pv(1)`, the pipe viewer shipped by every distro (package `pv`)
+//!   2. the `pv` crate on crates.io (a pipe viewer, first published 2019)
+//!   3. `aprender-contracts-cli` — this binary
+//!   4. the aprender facade (removed by #2553)
+//!
+//! Before this test existed the binary printed exactly `pv 0.63.0`: a bare name
+//! and a semver, indistinguishable at a glance from the pipe viewer. The name is
+//! settled (operator ruling 2026-08-21) — so the version line is the mitigation
+//! the project relies on, and it has to actually carry identity.
+//!
+//! Every assertion below is written to EXCLUDE the pre-fix output. Running this
+//! file against a binary that prints `pv <semver>` and nothing else must go RED.
+
+use std::process::Command;
+
+const PV: &str = env!("CARGO_BIN_EXE_pv");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn run(flag: &str) -> (String, String, i32) {
+    let out = Command::new(PV)
+        .arg(flag)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {PV} {flag}: {e}"));
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// The ambiguous form this ticket exists to kill: a line that is EXACTLY the
+/// binary name followed by a semver, which is byte-for-byte what `pv(1)` and the
+/// crates.io `pv` also print.
+fn is_bare_name_and_semver(line: &str) -> bool {
+    let mut fields = line.split_whitespace();
+    let (Some(name), Some(ver), None) = (fields.next(), fields.next(), fields.next()) else {
+        return false;
+    };
+    name == "pv" && ver.split('.').count() == 3
+}
+
+#[test]
+fn version_flag_exits_zero_on_stdout() {
+    let (stdout, _stderr, rc) = run("--version");
+    assert_eq!(rc, 0, "pv --version must exit 0, got {rc}");
+    assert!(
+        !stdout.trim().is_empty(),
+        "pv --version must print to stdout"
+    );
+}
+
+/// RED before the fix: `pv 0.63.0` IS the bare form.
+#[test]
+fn long_version_is_not_the_bare_name_and_semver() {
+    let (stdout, _, _) = run("--version");
+    let first = stdout.lines().next().unwrap_or_default();
+    assert!(
+        !is_bare_name_and_semver(first),
+        "pv --version first line is `{first}` — that is indistinguishable from \
+         pv(1) the pipe viewer. It must name this tool."
+    );
+}
+
+/// RED before the fix: the string `provable-contracts` never appeared.
+#[test]
+fn long_version_names_what_this_tool_is() {
+    let (stdout, _, _) = run("--version");
+    let lower = stdout.to_lowercase();
+    assert!(
+        lower.contains("provable-contracts"),
+        "pv --version must say this is the provable-contracts verifier; got:\n{stdout}"
+    );
+    assert!(
+        lower.contains("aprender"),
+        "pv --version must name the project it belongs to; got:\n{stdout}"
+    );
+}
+
+/// RED before the fix: nothing identified the shipping crate, so a user who
+/// wanted to uninstall or report a bug had no name to use.
+#[test]
+fn long_version_names_the_shipping_crate() {
+    let (stdout, _, _) = run("--version");
+    assert!(
+        stdout.contains("aprender-contracts-cli"),
+        "pv --version must name the crate that ships it; got:\n{stdout}"
+    );
+}
+
+/// RED before the fix. This is the assertion that speaks to the actual user
+/// confusion: someone with BOTH installed needs the line to rule the other out.
+#[test]
+fn long_version_disclaims_the_pipe_viewer() {
+    let (stdout, _, _) = run("--version");
+    let lower = stdout.to_lowercase();
+    assert!(
+        lower.contains("pipe viewer"),
+        "pv --version must explicitly disclaim pv(1), the pipe viewer, because \
+         a user with both installed cannot otherwise tell them apart; got:\n{stdout}"
+    );
+}
+
+/// `-V` is the glance form. It must still be unambiguous, and it must stay ONE
+/// line — a version line nobody reads is no better than an ambiguous one.
+#[test]
+fn short_version_is_one_unambiguous_line() {
+    let (stdout, _, rc) = run("-V");
+    assert_eq!(rc, 0, "pv -V must exit 0");
+    let lines: Vec<&str> = stdout.trim_end().lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "pv -V must stay a single line, got {}:\n{stdout}",
+        lines.len()
+    );
+    assert!(
+        !is_bare_name_and_semver(lines[0]),
+        "pv -V is `{}` — bare name plus semver, same as pv(1)",
+        lines[0]
+    );
+    assert!(
+        lines[0].to_lowercase().contains("provable-contracts"),
+        "pv -V must name the tool; got `{}`",
+        lines[0]
+    );
+}
+
+/// Regression guard, not a falsifier: `scripts/pv_bin.sh` proves a resolved
+/// binary is the HEAD build by comparing the semver from `pv --version` against
+/// the version the tree declares. Adding identity text must not break that
+/// parse, so the semver stays the SECOND whitespace field of the FIRST line.
+#[test]
+fn semver_stays_the_second_field_of_the_first_line() {
+    let (stdout, _, _) = run("--version");
+    let first = stdout.lines().next().unwrap_or_default();
+    let mut fields = first.split_whitespace();
+    assert_eq!(
+        fields.next(),
+        Some("pv"),
+        "first field must be the tool name"
+    );
+    assert_eq!(
+        fields.next(),
+        Some(VERSION),
+        "second field of `pv --version` must be the bare declared semver \
+         (scripts/pv_bin.sh parses it positionally); got line `{first}`"
+    );
+}
+
+/// Both flags must agree on the version and on the identity, so that whichever
+/// one a user or script reaches for gives the same answer.
+#[test]
+fn short_and_long_version_agree_on_the_first_line() {
+    let (long, _, _) = run("--version");
+    let (short, _, _) = run("-V");
+    assert_eq!(
+        long.lines().next(),
+        short.lines().next(),
+        "pv -V and pv --version must share a first line"
+    );
+}

--- a/scripts/check_pv_version_parse.sh
+++ b/scripts/check_pv_version_parse.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# check_pv_version_parse.sh - the semver extractor in scripts/pv_bin.sh ships a
+# case table, and the table is executable.
+#
+# THE CLASS. scripts/pv_bin.sh proves a resolved `pv` was built from HEAD by
+# pulling the semver out of `pv --version` and comparing it to the version the
+# tree declares. That extractor is a GUARD's parser, and in this repo guard
+# patterns have been wrong five times in a row — every one caught by a
+# must-match / must-not-match table, none by review (CLAUDE.md, "Guard regexes
+# ship a case table").
+#
+# It was already wrong once. The extractor was `awk '{print $NF}'`: the LAST
+# field of EVERY line. That was correct only while `pv --version` printed the
+# single line `pv 0.63.0`. #2559 made the line multi-line on purpose — four
+# things claim the name `pv`, so the version output now has to say which one it
+# is — and the old extractor started handing the comparison four lines of prose:
+#
+#     verifier)
+#     https://github.com/paiml/aprender
+#     surface.
+#     crates.io).
+#
+# Which is not a silent failure — it fails loud — but it BLOCKS every consumer
+# of pv_bin.sh, i.e. the release gate. The replacement reads position 2 of line
+# 1. That shape is pinned from the other side by the Rust test
+# crates/aprender-contracts-cli/tests/version_identity.rs
+# (`semver_stays_the_second_field_of_the_first_line`), so the binary cannot drift
+# out from under the parser without a RED test.
+#
+# Exit 0 = the extractor as written in pv_bin.sh answers every row correctly.
+# Exit 1 = at least one row disagrees.
+#
+# `--self-test` proves this check can still turn RED, by running the same table
+# against the pre-#2559 extractor.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+PV_BIN_SH="scripts/pv_bin.sh"
+
+# The extractor under test, lifted from pv_bin.sh rather than retyped. If the
+# two ever diverge, EXTRACTOR_MISMATCH below fires.
+EXTRACTOR='NR==1{print $2; exit}'
+# shellcheck disable=SC2154  # $NF is awk's field-count, inside a single-quoted
+# awk program. It is not a shell variable and must stay verbatim: this literal is
+# the pre-#2559 extractor, and it is grepped for against pv_bin.sh.
+PRE_2559_EXTRACTOR='{print $NF}'
+
+# --- the case table ------------------------------------------------------
+# Each row: <expected semver or the literal NONE> :: <version output>
+# NONE means "must NOT yield a bare semver" — the row is something other than
+# this tool, and mistaking it for this tool is the failure mode.
+#
+# Rows are separated by a line of four dashes so the outputs can be multi-line.
+read -r -d '' CASES <<'TABLE' || true
+0.63.0 :: pv 0.63.0 (aprender provable-contracts verifier)
+crate aprender-contracts-cli — https://github.com/paiml/aprender
+Verifies YAML contracts under contracts/; run `pv --help` for the command surface.
+This is NOT pv(1), the pipe viewer (distro package `pv`, or the `pv` crate on crates.io).
+----
+0.63.0 :: pv 0.63.0
+----
+1.2.3 :: pv 1.2.3 (aprender provable-contracts verifier)
+second line with trailing 9.9.9
+----
+0.64.0-rc.1 :: pv 0.64.0-rc.1 (aprender provable-contracts verifier)
+crate aprender-contracts-cli — https://github.com/paiml/aprender
+----
+NONE :: pv 1.6.20
+Copyright (C) 2002-2008 Andrew Wood <pv@ivarch.com>
+----
+NONE :: pv 1.9.31
+TABLE
+
+fail=0
+
+note() { printf '%s\n' "$*"; }
+bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
+
+# --- 0. the extractor in this file must be the one pv_bin.sh actually runs ---
+# CODE ONLY. The first draft of this block grepped the whole file and fired on
+# pv_bin.sh's own COMMENT, which quotes the old extractor to explain why it was
+# replaced. A guard that reads prose as code is the twin of a guard that reads
+# code as prose; both have shipped here. Strip full-line comments first.
+pv_bin_code() { grep -v '^[[:space:]]*#' "$PV_BIN_SH"; }
+
+if ! pv_bin_code | grep -qF -- "$EXTRACTOR"; then
+    bad "EXTRACTOR_MISMATCH: this table tests '$EXTRACTOR' but $PV_BIN_SH does not run it"
+fi
+if pv_bin_code | grep -qF -- "awk '$PRE_2559_EXTRACTOR'"; then
+    bad "$PV_BIN_SH still runs the pre-#2559 last-field extractor"
+fi
+
+# --- 1. run the table ----------------------------------------------------
+run_table() {
+    table_awk="$1"
+    table_label="$2"
+    table_rc=0
+    table_row=""
+    while IFS= read -r line; do
+        if [ "$line" = "----" ]; then
+            check_row "$table_awk" "$table_label" "$table_row" || table_rc=1
+            table_row=""
+        else
+            table_row="${table_row}${line}"$'\n'
+        fi
+    done <<< "$CASES"
+    [ -n "$table_row" ] && { check_row "$table_awk" "$table_label" "$table_row" || table_rc=1; }
+    return "$table_rc"
+}
+
+check_row() {
+    row_awk="$1"
+    row_label="$2"
+    row_body="$3"
+    row_expect="${row_body%% :: *}"
+    row_output="${row_body#* :: }"
+    # awk on a here-string, NOT a pipe: a pipe hands back awk's status and, with
+    # pipefail on, a SIGPIPE from the writer can invent a failure (CLAUDE.md).
+    row_got=$(awk "$row_awk" <<< "$row_output")
+    if [ "$row_expect" = "NONE" ]; then
+        # For a foreign pv there is nothing to extract that is CORRECT; the row
+        # exists to record what the extractor does return, so a future change
+        # that starts silently blessing the pipe viewer is visible in the diff.
+        note "  [$row_label] foreign pv -> '$row_got' (compared against the declared version, so it must not match)"
+        return 0
+    fi
+    if [ "$row_got" = "$row_expect" ]; then
+        note "  [$row_label] ok: '$row_expect'"
+        return 0
+    fi
+    bad "[$row_label] expected '$row_expect', extractor returned '$row_got'"
+    return 1
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    note "SELF-TEST: running the same table against the pre-#2559 extractor."
+    note "It MUST fail, or this check proves nothing."
+    if run_table "$PRE_2559_EXTRACTOR" "pre-2559"; then
+        printf 'SELF-TEST FAILED: the pre-#2559 extractor passed the table.\n' >&2
+        exit 1
+    fi
+    printf '\nSELF-TEST PASSED: the table turns RED on the pre-#2559 extractor.\n'
+    exit 0
+fi
+
+note "pv --version semver extractor case table:"
+run_table "$EXTRACTOR" "current" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+    printf '\ncheck_pv_version_parse: FAIL\n' >&2
+    exit 1
+fi
+printf '\ncheck_pv_version_parse: OK\n'

--- a/scripts/dogfood_surfaces.sh
+++ b/scripts/dogfood_surfaces.sh
@@ -249,7 +249,13 @@ surface_tools() {
     # RECEIPT as evidence of correctness while the tree was at 0.63.0.
     . "$(dirname "${BASH_SOURCE[0]}")/pv_bin.sh" || {
         bad "pv could not be resolved from HEAD"; return 1; }
-    ok "pv pinned to HEAD build ($("$PV" --version))"
+    # `-V`, not `--version`: as of #2559 the long form is deliberately multi-line
+    # (four things claim the name `pv`, so it names itself and disclaims the pipe
+    # viewer), and four lines of prose inside a receipt line is unreadable. The
+    # short form is the one-line glance form and is itself unambiguous, so the
+    # receipt still records WHICH pv issued the verdict -- which is the whole
+    # point of this line, given it once recorded `pv 0.49.0` as evidence.
+    ok "pv pinned to HEAD build ($("$PV" -V))"
     require_tool bashrs "shell linting must use bashrs, not shellcheck"
     require_tool pmat   "code search must use pmat query, not grep"
 

--- a/scripts/pv_bin.sh
+++ b/scripts/pv_bin.sh
@@ -69,7 +69,15 @@ pv_bin_assert_fresh() {
             "$(pv_bin_root)/Cargo.toml" 2>/dev/null)
     fi
     [ -n "$pv_bin_declared" ] || { pv_bin_die "could not read declared pv version"; return 1; }
-    pv_bin_actual=$("$pv_bin_b" --version 2>&1 | awk '{print $NF}')
+    # POSITIONAL, first line only. `pv --version` is deliberately multi-line as
+    # of #2559 — it has to say WHICH pv this is, because four things claim that
+    # name. The old `awk '{print $NF}'` took the last field of EVERY line and
+    # handed this comparison four lines of prose. The version line's shape is
+    # pinned from the other side by
+    # crates/aprender-contracts-cli/tests/version_identity.rs
+    # (`semver_stays_the_second_field_of_the_first_line`), and by the case table
+    # in scripts/check_pv_version_parse.sh.
+    pv_bin_actual=$("$pv_bin_b" --version 2>&1 | awk 'NR==1{print $2; exit}')
     [ "$pv_bin_actual" = "$pv_bin_declared" ] || {
         pv_bin_die "resolved pv reports $pv_bin_actual, tree declares $pv_bin_declared ($pv_bin_b)"
         return 1


### PR DESCRIPTION
Closes #2559.

## The defect

A HEAD-built `pv` printed exactly `pv 0.63.0` — a bare name and a semver, byte-identical to what `pv(1)` the pipe viewer prints. Four things claim the name `pv`: the crates.io `pv` pipe-viewer crate (7,065 downloads, first published 2019), `pv(1)` from every distro, `aprender-contracts-cli`, and — until #2553 — the facade.

The operator settled that this binary **keeps** the name (2026-08-21, not relitigated here). That ruling makes the version line the mitigation the project relies on, and it carried no identity at all. The install-time half of the collision was already handled (`check_duplicate_bin_names.sh`, the facade going lib-only); nothing answered the **runtime** question "which one am I talking to".

## After

```
$ pv --version
pv 0.63.0 (aprender provable-contracts verifier)
crate aprender-contracts-cli — https://github.com/paiml/aprender
Verifies YAML contracts under contracts/; run `pv --help` for the command surface.
This is NOT pv(1), the pipe viewer (distro package `pv`, or the `pv` crate on crates.io).

$ pv -V
pv 0.63.0 (aprender provable-contracts verifier)
```

`-V` stays one line: a version line nobody reads is no better than an ambiguous one.

## Adding identity text BROKE the release gate — fixed in the same commit

`scripts/pv_bin.sh` proves a resolved `pv` is the HEAD build by extracting the semver with `awk '{print $NF}'` — the last field of **every** line. Against a multi-line version it returned four lines of prose and `pv_bin.sh` exited 1, blocking the Makefile `contracts:` gate and `dogfood_surfaces.sh`:

```
pv_bin: resolved pv reports verifier)
https://github.com/paiml/aprender
surface.
crates.io)., tree declares 0.63.0
```

The extractor now reads position 2 of line 1, pinned from **both** sides — by a Rust assertion on the binary and by `scripts/check_pv_version_parse.sh` on the extractor — so neither can drift alone.

## Falsifier: RED before the fix

`cargo test -p aprender-contracts-cli --test version_identity` → **rc=101**, 5 of 8 assertions fail against `pv 0.63.0`. The 3 that pass are regression guards that hold in both directions by design.

## Mutation-verified, both directions, engagement proved

Every mutation was read back off disk before the verdict was taken.

| # | Mutation | Result |
|---|---|---|
| M1 | bare `version` attribute | 5/8 integration RED |
| M2 | drop **only** the pipe-viewer clause | exactly 1 RED — the clause is individually load-bearing |
| M3 | semver off field 2 in `-V` | agreement assertion RED |
| M4 | semver off field 2 in `--version` | pv_bin.sh contract RED **and** `pv_bin.sh` itself exits 1 — guard and gate fail as one |
| M5 | M1 re-run in **library** scope | 3/5 RED — the old proof does not transfer to a new scope |
| M6 | drift `pv_bin.sh`'s extractor | `EXTRACTOR_MISMATCH` fires |

`check_pv_version_parse.sh --self-test` turns the table RED on the pre-#2559 extractor.

## Not dark

A new `tests/*.rs` is unreachable until named on ci.yml's single explicit `--test` line, and only one PR at a time can edit it. So the assertions are **also** in the library, where `--lib` reaches them unconditionally. The integration target is wired in too, plus the parse guard and its self-test as their own steps.

The case table caught its own comment-vs-code trap on first run: it grepped all of `pv_bin.sh` and fired on `pv_bin.sh`'s **comment** quoting the old extractor. Fixed to strip full-line comments — the exact trap flagged in the brief.

## Verification

| Gate | Result |
|---|---|
| `pv lint contracts/` | 0 errors, **947** warnings — identical with and without the new contract, so it adds none. The 942 figure in circulation is stale; re-measured here |
| `cargo fmt --all -- --check` | rc=0 |
| `cargo clippy -p aprender-contracts-cli --lib -- -D warnings` | rc=0 |
| `bashrs lint scripts/check_pv_version_parse.sh` | 0 errors, 0 warnings |
| `check_shell_lint_ratchet.sh` | PASS, 97 error lines (unchanged) |
| `check_sourced_libs_option_neutral.sh` | rc=0 — `pv_bin.sh` stays option-neutral |
| `aprender-contracts-cli --lib` | 68 passed |
| `aprender-contracts --lib` | 1446 passed |
| FALSIFY-PVVER-001..007 | 7/7 PASS |

## Contract

`contracts/pv-version-identity-v1.yaml` (`kind: pattern`, under `metadata:`), `pv validate` rc=0, 0 warnings in isolation.

## Deliberately deferred (not batched here)

- **`crates/aprender-contracts-cli/tests/book_coverage.rs` fails on `main`** — `missing field metadata` parsing `contracts/binding.yaml`. Reproduced with this branch's contract removed, so it is pre-existing. It is one of the dark targets: `book_coverage` appears **0** times in ci.yml, which is why it has been failing unnoticed. Worth its own ticket.
- `apr pv --version` — `apr` exposes only the pv *subcommand* enum, so there is no pv version flag on that route. Separate surface, separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
