### PR TITLE
test(pv): contracts-pv was 0% because CI ran none of pv's tests (#2589)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,18 @@ jobs:
         # the experiment"), this step is left AS-IS so the nextest signal stays
         # attributable to the lib step alone. Revisit after the lib-step
         # measurement lands.
+        #
+        # #2589 (contracts-pv, 76 features / 0.0% covered): the same trap this
+        # comment describes had swallowed `pv` whole. All three of
+        # aprender-contracts-cli's integration targets — 651 lines that SPAWN the
+        # pv binary — were absent from this line, so CI ran none of them, and the
+        # audit correctly read 0% for the tool that decides whether a release is
+        # contractually sound. Tests that never execute are not coverage.
+        # `pv_surface_gate` (new), `cli_integration` (64) and `ground_truth` (34)
+        # are wired in below. `book_coverage` is deliberately NOT: it is RED at
+        # 4bbfeb07f — it walks contracts/*.yaml and chokes on contracts/binding.yaml
+        # ("missing field `metadata`"), a binding registry rather than a contract.
+        # It rotted precisely because nothing watched it; fixing it is separate work.
         run: |
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
@@ -343,7 +355,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo build --examples --workspace --keep-going'
+            bash -c 'cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo test -p aprender-contracts-cli --test pv_surface_gate && cargo test -p aprender-contracts-cli --test cli_integration && cargo test -p aprender-contracts-cli --test ground_truth && cargo build --examples --workspace --keep-going'
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.

--- a/contracts/pv-cli-surface-v1.yaml
+++ b/contracts/pv-cli-surface-v1.yaml
@@ -1,0 +1,206 @@
+contract: pv-cli-surface
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    contracts-pv first-tranche surface contract (#2589). `pv` is the tool that
+    decides whether a release is contractually sound; the surface audit read
+    "cluster contracts-pv: 76 features, 0.0% covered, 0 UNKNOWN hardware" — the
+    features were hardware-verified and simply UNGATED. This contract pins the
+    invariants that the gate `crates/aprender-contracts-cli/tests/pv_surface_gate.rs`
+    enforces against the pv binary built from HEAD.
+
+    TWO measured causes at 4bbfeb07f, both addressed:
+    (1) pv's three integration targets spawned the binary but appeared in ZERO
+        CI invocations — `workspace-test` is `--workspace --lib`, and the
+        explicit integration list named 23 targets, none from
+        aprender-contracts-cli. Tests that never execute are not coverage.
+    (2) The tests that did exist asserted `status.success()` on GOOD contracts,
+        which `fn main() { exit(0) }` also satisfies. Per
+        project_assertions_exclude_guard, an assertion no wrong behaviour can
+        violate is not a control.
+  references:
+    - "https://github.com/paiml/aprender/issues/2589"
+    - "crates/aprender-contracts-cli/tests/pv_surface_gate.rs"
+    - "crates/aprender-contracts/src/schema/validator.rs"
+
+equations:
+  rule_reachability:
+    formula: >
+      forall r in rules(validator.rs) . exists c . pv_validate(trip(c, r))
+      emits line "[{severity(r)}] {r}:"
+    domain: "r ∈ rule ids of shape FAMILY-NNN declared in validator.rs"
+    codomain: "{reported, unreported}"
+    invariants:
+      - "the rule universe is read from validator.rs, never from the test's own table"
+      - "a rule added to the validator must ENTER the loop, never fall outside it"
+
+  baseline_silence:
+    formula: "rules(pv_validate(clean_contract)) = {}"
+    domain: "a contract with zero defects"
+    codomain: "the empty set of rule ids"
+    invariants:
+      - "without this, a pv printing all rules unconditionally satisfies every trip case"
+
+  exit_code_follows_severity:
+    formula: "exit_code(pv validate c) = 0 iff count(errors(c)) = 0"
+    domain: "any contract file"
+    codomain: "{0, 1}"
+    invariants:
+      - "warnings alone must NOT fail the command"
+      - "any error must fail it"
+
+  advertised_implies_reachable:
+    formula: "forall s in subcommands(pv --help) . exit_code(pv s --help) = 0"
+    domain: "the subcommand list parsed from the binary AT RUNTIME"
+    codomain: "{0, non-zero}"
+    invariants:
+      - "the universe is enumerated from the binary, not hardcoded"
+
+  unusable_input_is_rejected:
+    formula: >
+      forall s in contract_taking(pv), forall i in {nonexistent, malformed_yaml,
+      empty, well_formed_non_contract} . exit_code(pv s i) != 0
+    domain: "every subcommand whose usage line names <CONTRACT>|<PATH>|<FILE>"
+    codomain: "{0, non-zero}"
+    invariants:
+      - "this is the assertion the pre-existing pv suite never made"
+
+proof_obligations:
+  - type: invariant
+    property: "Every validator rule is reachable through the CLI at its declared severity"
+    formal: "PV-SURFACE-RULE-REACH"
+    applies_to: all
+  - type: invariant
+    property: "A clean contract emits no rule id and exits 0"
+    formal: "PV-SURFACE-BASELINE-SILENT"
+    applies_to: all
+  - type: invariant
+    property: "The decision table stays exhaustive over the validator's rule set"
+    formal: "PV-SURFACE-TABLE-EXHAUSTIVE"
+    applies_to: all
+  - type: invariant
+    property: "Every subcommand advertised by --help is reachable"
+    formal: "PV-SURFACE-ADVERTISED-REACHABLE"
+    applies_to: all
+  - type: invariant
+    property: "Contract-taking subcommands reject input they cannot process"
+    formal: "PV-SURFACE-REJECTS-GARBAGE"
+    applies_to: all
+  - type: invariant
+    property: "pv --version reports the version of the crate it was built from"
+    formal: "PV-SURFACE-VERSION-PINNED"
+    applies_to: all
+
+falsification_tests:
+  - id: FALSIFY-PV-SURFACE-001
+    rule: "PV-SURFACE-RULE-REACH"
+    prediction: >
+      Deleting the violation-printing loop from
+      crates/aprender-contracts-cli/src/commands/validate.rs turns the gate RED
+      while `cargo test -p aprender-contracts library schema:: tests` stay GREEN.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate"
+    expected_output: "exit 0 on an unmutated tree"
+    if_fails: >
+      MEASURED 2026-08-22: mutation engaged (3 lines removed), gate rc=101 with
+      3 tests failing, library rc=0 with 55 passed. The GREEN library result is
+      the point: it proves this gate covers CLI surface the library tests cannot
+      see, i.e. it is new coverage rather than a duplicate.
+
+  - id: FALSIFY-PV-SURFACE-002
+    rule: "PV-SURFACE-BASELINE-SILENT"
+    prediction: >
+      `pv validate` on the gate's clean fixture reports 0 errors, 0 warnings and
+      none of the known rule ids.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate validate_baseline"
+    expected_output: "exit 0"
+    if_fails: >
+      Either the fixture is no longer clean or pv emits rule ids unconditionally.
+      The second case would make every trip case in the table vacuous.
+
+  - id: FALSIFY-PV-SURFACE-003
+    rule: "PV-SURFACE-RULE-REACH"
+    prediction: >
+      Replacing the error return in validate.rs with Ok(()) turns the gate RED on
+      the exit-code half.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate"
+    expected_output: "exit 0 on an unmutated tree"
+    if_fails: >
+      MEASURED 2026-08-22: mutation engaged (1 line replaced), gate rc=101, 2
+      tests failing. This is the mutation the pre-existing suite could not detect,
+      because it only ever asserted success on good input.
+
+  - id: FALSIFY-PV-SURFACE-004
+    rule: "PV-SURFACE-TABLE-EXHAUSTIVE"
+    prediction: >
+      Renaming a validator rule to an id with no row in the table turns the
+      exhaustiveness guard RED and names the orphan.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate every_rule_in_the_validator"
+    expected_output: "exit 0 on an unmutated tree"
+    if_fails: >
+      MEASURED 2026-08-22: SCHEMA-013 -> SCHEMA-999, mutation engaged, gate
+      rc=101 naming the orphan. This guard found a real gap on first run:
+      BEAT-001 had no row. Widening the extractor then revealed BEAT-002..007,
+      which are emitted through a closure rather than a `rule: "..."` literal and
+      were invisible to the first version of the extractor.
+
+  - id: FALSIFY-PV-SURFACE-005
+    rule: "PV-SURFACE-RULE-REACH"
+    prediction: >
+      Disabling the BEAT_INCUMBENTS membership arm turns the gate RED on the
+      BEAT-002 membership row, proving that row exercises the list.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate validate_reaches_every_beat_rule"
+    expected_output: "exit 0 on an unmutated tree"
+    if_fails: >
+      MEASURED 2026-08-22: membership condition replaced with `false`, mutation
+      engaged, gate rc=101 with exactly the BEAT test failing.
+
+  - id: FALSIFY-PV-SURFACE-006
+    rule: "PV-SURFACE-ADVERTISED-REACHABLE"
+    prediction: >
+      Every one of the 38 subcommands `pv --help` advertises exits 0 for
+      `pv <cmd> --help`.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate every_advertised_subcommand"
+    expected_output: "exit 0"
+    if_fails: >
+      A command is advertised but unreachable — the `apr test llm` defect class
+      (#2527), where the advertised command's own remedy was impossible to run.
+
+  - id: FALSIFY-PV-SURFACE-007
+    rule: "PV-SURFACE-REJECTS-GARBAGE"
+    prediction: >
+      Each of the 16 contract-taking subcommands exits non-zero on a nonexistent
+      path, malformed YAML, an empty file, and well-formed YAML that is not a
+      contract.
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate contract_taking_subcommands"
+    expected_output: "exit 0"
+    if_fails: >
+      A subcommand accepted input it cannot process. Assertions that only check
+      success on good input cannot see this; that is why the tranche adds it.
+
+  - id: FALSIFY-PV-SURFACE-008
+    rule: "PV-SURFACE-VERSION-PINNED"
+    prediction: "`pv --version` contains this crate's CARGO_PKG_VERSION."
+    test_harness: "cargo test -p aprender-contracts-cli --test pv_surface_gate version_reports"
+    expected_output: "exit 0"
+    if_fails: >
+      #2552: a `pv` on PATH was 0.49.0 while in-tree was 0.63.0 and the two
+      disagreed on the release-deciding gate, with the stale one cited in the
+      release receipt as evidence of correctness. The gate resolves the binary
+      via CARGO_BIN_EXE_pv, which cannot fall back to PATH. The check is a
+      substring match on the semver only, so #2559's work on --version IDENTITY
+      is free to change the surrounding text.
+
+qa_gate:
+  id: F-PV-SURFACE-001
+  name: "pv CLI surface gate (contracts-pv tranche 1)"
+  checks:
+    - "rule_reachability"
+    - "baseline_silence"
+    - "exit_code_follows_severity"
+    - "advertised_implies_reachable"
+    - "unusable_input_is_rejected"
+  pass_criteria: >
+    All 8 falsification tests pass via
+    `cargo test -p aprender-contracts-cli --test pv_surface_gate`, which is wired
+    into the required `workspace-test` integration step in .github/workflows/ci.yml.

--- a/crates/aprender-contracts-cli/tests/pv_surface_gate.rs
+++ b/crates/aprender-contracts-cli/tests/pv_surface_gate.rs
@@ -1,0 +1,812 @@
+//! `contracts-pv` first-tranche coverage gate (#2589).
+//!
+//! WHY THIS FILE EXISTS
+//! ====================
+//! `pv` is the tool that decides whether a release is contractually sound, and
+//! the surface audit reads `cluster contracts-pv: 76 features, 0.0% covered,
+//! 0 UNKNOWN hardware`. That last column matters: the features are not
+//! unlooked-at, they are **ungated**. The tool that makes every other subsystem
+//! prove things proved nothing about itself.
+//!
+//! Two distinct causes were measured at 4bbfeb07f, and this file addresses both:
+//!
+//! 1. **pv's CLI tests were DARK.** `crates/aprender-contracts-cli/tests/` held
+//!    651 lines of binary-spawning tests, and CI ran **none** of them:
+//!    `workspace-test` is `cargo nextest run --workspace --lib` (library targets
+//!    only), and the explicit integration list in `ci.yml` names 23 targets,
+//!    not one of them from `aprender-contracts-cli`. A test that never executes
+//!    is 0% coverage however many lines it has. This PR wires pv's integration
+//!    targets into that list.
+//!
+//! 2. **The tests that did exist EXCLUDED NOTHING.** Nearly every one asserted
+//!    `status.success()` on a good contract. That assertion passes unchanged
+//!    against `fn main() { std::process::exit(0) }`. Per
+//!    `project_assertions_exclude_guard`: an assertion that no wrong behaviour
+//!    can violate is not a control. Every test below is written so that some
+//!    concrete wrong behaviour makes it RED.
+//!
+//! SCOPE OF THIS TRANCHE — read `docs/` note in the PR body for what is deferred.
+//!   COVERED: `pv validate` field/rule decision table (all 18 diagnostic rules,
+//!            both directions), subcommand reachability, contract-input
+//!            rejection across every contract-taking subcommand, `--version`
+//!            parseability.
+//!   NOT COVERED: `pv lint` warning ratchet, `pv diff` semver suggestions,
+//!            `pv score`, `pv certify`, `pv coverage`, and the generator
+//!            subcommands' output *content* (kani/probar/coq/flux/tla/...).
+//!
+//! DISCRIMINATION. `gate_self_test` at the bottom is the control on the control:
+//! it proves the rule table cannot be satisfied by a `pv` that prints every rule
+//! id unconditionally, nor by one that prints none.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The `pv` binary built from THIS tree.
+///
+/// `CARGO_BIN_EXE_pv` is set by cargo for the crate's own `[[bin]]`, so this
+/// cannot silently resolve a stale `pv` off `$PATH` — the exact defect #2552
+/// was filed for (PATH pv was 0.49.0 while in-tree was 0.63.0, and the two
+/// disagreed on the release-deciding gate).
+fn pv_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pv"))
+}
+
+fn pv(args: &[&str]) -> (i32, String) {
+    let out = Command::new(pv_bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn pv");
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.code().unwrap_or(-1), text)
+}
+
+// ============================================================================
+// Contract fixture builder
+// ============================================================================
+
+/// A minimal contract that `pv validate` accepts with 0 errors and 0 warnings.
+///
+/// Every case below is this contract with exactly ONE part swapped, so a
+/// reported rule is attributable to that swap and to nothing else.
+struct Fixture {
+    metadata: String,
+    equations: String,
+    obligations: String,
+    ftests: String,
+    harnesses: String,
+    qa_gate: String,
+}
+
+const METADATA_OK: &str = "metadata:\n  version: \"1.0.0\"\n  kind: kernel\n  \
+     description: \"pv surface gate fixture\"\n  references:\n    - \"#2589\"\n";
+const EQUATIONS_OK: &str = "equations:\n  probe_eq:\n    formula: \"y = x\"\n";
+const OBLIGATION_OK: &str =
+    "  - type: invariant\n    property: \"P\"\n    formal: \"F-OK\"\n    applies_to: all\n";
+const FTEST_OK: &str = "  - id: FALSIFY-PVGATE-001\n    prediction: \"p\"\n    if_fails: \"f\"\n";
+const HARNESS_OK: &str =
+    "  - id: KANI-PVGATE-001\n    obligation: OB-1\n    property: \"P\"\n    bound: 8\n";
+const QA_GATE_OK: &str = "qa_gate:\n  id: F-PVGATE-001\n  name: \"pv gate\"\n  \
+     checks:\n    - \"c\"\n  pass_criteria: \"all\"\n";
+
+impl Default for Fixture {
+    fn default() -> Self {
+        Self {
+            metadata: METADATA_OK.to_string(),
+            equations: EQUATIONS_OK.to_string(),
+            obligations: OBLIGATION_OK.to_string(),
+            ftests: FTEST_OK.to_string(),
+            harnesses: HARNESS_OK.to_string(),
+            qa_gate: QA_GATE_OK.to_string(),
+        }
+    }
+}
+
+impl Fixture {
+    fn render(&self) -> String {
+        format!(
+            "{}\n{}\nproof_obligations:\n{}\nfalsification_tests:\n{}\n\
+             kani_harnesses:\n{}\n{}",
+            self.metadata,
+            self.equations,
+            self.obligations,
+            self.ftests,
+            self.harnesses,
+            self.qa_gate,
+        )
+    }
+
+    /// Write to a temp dir and run `pv validate` on it.
+    fn validate(&self) -> (i32, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fixture-v1.yaml");
+        std::fs::write(&path, self.render()).expect("write fixture");
+        pv(&["validate", path.to_str().expect("utf8 path")])
+    }
+}
+
+/// Severity a rule is expected to be reported at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sev {
+    Error,
+    Warn,
+}
+
+impl Sev {
+    fn tag(self) -> &'static str {
+        match self {
+            Sev::Error => "[ERROR]",
+            Sev::Warn => "[WARN]",
+        }
+    }
+    /// `pv validate` exits nonzero iff at least one ERROR was reported.
+    fn expected_rc(self) -> i32 {
+        match self {
+            Sev::Error => 1,
+            Sev::Warn => 0,
+        }
+    }
+}
+
+/// One row of the decision table: a rule id, the severity it must be reported
+/// at, and the single-field mutation that must trip it.
+struct Case {
+    rule: &'static str,
+    sev: Sev,
+    build: fn(&mut Fixture),
+}
+
+/// THE DECISION TABLE.
+///
+/// Every diagnostic `pv validate` can emit appears exactly once. Each row is a
+/// falsifier: it asserts the CLI *reaches* that rule. The library unit tests in
+/// `aprender-contracts` call `validate_contract()` directly and stay green even
+/// if the CLI stops printing violations entirely — these rows do not.
+///
+/// Severities and exit codes here were MEASURED against the binary at
+/// 4bbfeb07f, not assumed. `SCHEMA-006` is deliberately absent from the trip
+/// table and covered separately: tripping it needs a second obligation, which
+/// also trips `PROVABILITY-001`, so it cannot be attributed to one swap.
+const CASES: &[Case] = &[
+    Case {
+        rule: "SCHEMA-001",
+        sev: Sev::Error,
+        build: |f| {
+            f.metadata = "metadata:\n  version: \"1.0.0\"\n  kind: kernel\n  \
+                 description: \"d\"\n  references: []\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-002",
+        sev: Sev::Error,
+        build: |f| {
+            f.metadata = "metadata:\n  version: \"\"\n  kind: kernel\n  \
+                 description: \"d\"\n  references:\n    - \"r\"\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-003",
+        sev: Sev::Error,
+        build: |f| f.equations = "equations: {}\n".to_string(),
+    },
+    Case {
+        rule: "SCHEMA-004",
+        sev: Sev::Error,
+        build: |f| {
+            f.equations = "equations:\n  probe_eq:\n    formula: \"\"\n".to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-005",
+        sev: Sev::Error,
+        build: |f| {
+            f.obligations = "  - type: invariant\n    property: \"\"\n    \
+                 formal: \"F-OK\"\n    applies_to: all\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-007",
+        sev: Sev::Error,
+        build: |f| {
+            // Same id twice — and a second falsification test keeps the
+            // ftest/obligation ratio satisfied, so PROVABILITY-001 stays quiet.
+            f.ftests = format!(
+                "{FTEST_OK}  - id: FALSIFY-PVGATE-001\n    prediction: \"q\"\n    \
+                 if_fails: \"f\"\n"
+            );
+        },
+    },
+    Case {
+        rule: "SCHEMA-008",
+        sev: Sev::Error,
+        build: |f| {
+            f.ftests = "  - id: FALSIFY-PVGATE-001\n    prediction: \"\"\n    \
+                 if_fails: \"f\"\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-009",
+        sev: Sev::Warn,
+        build: |f| {
+            f.ftests = "  - id: FALSIFY-PVGATE-001\n    prediction: \"p\"\n    \
+                 if_fails: \"\"\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-010",
+        sev: Sev::Error,
+        build: |f| {
+            f.harnesses = format!(
+                "{HARNESS_OK}  - id: KANI-PVGATE-001\n    obligation: OB-2\n    \
+                 property: \"Q\"\n    bound: 8\n"
+            );
+        },
+    },
+    Case {
+        rule: "SCHEMA-011",
+        sev: Sev::Error,
+        build: |f| {
+            f.harnesses = "  - id: KANI-PVGATE-001\n    obligation: \"\"\n    \
+                 property: \"P\"\n    bound: 8\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-012",
+        sev: Sev::Warn,
+        build: |f| {
+            f.harnesses =
+                "  - id: KANI-PVGATE-001\n    obligation: OB-1\n    property: \"P\"\n".to_string();
+        },
+    },
+    Case {
+        rule: "SCHEMA-013",
+        sev: Sev::Warn,
+        build: |f| f.qa_gate = String::new(),
+    },
+    Case {
+        rule: "SCHEMA-014",
+        sev: Sev::Error,
+        build: |f| {
+            f.obligations = format!("{OBLIGATION_OK}    requires: \"x > 0\"\n");
+        },
+    },
+    Case {
+        rule: "SCHEMA-015",
+        sev: Sev::Error,
+        build: |f| {
+            f.obligations = format!("{OBLIGATION_OK}    applies_to_phase: \"phase1\"\n");
+        },
+    },
+    Case {
+        rule: "SCHEMA-016",
+        sev: Sev::Error,
+        build: |f| {
+            f.obligations = format!("{OBLIGATION_OK}    parent_contract: \"other-v1\"\n");
+        },
+    },
+    Case {
+        rule: "SCHEMA-017",
+        sev: Sev::Error,
+        build: |f| {
+            f.obligations = "  - type: subcontract\n    property: \"P\"\n    \
+                 formal: \"F-OK\"\n    applies_to: all\n    \
+                 parent_contract: \"not-listed-v1\"\n"
+                .to_string();
+        },
+    },
+    Case {
+        rule: "PROVABILITY-001",
+        sev: Sev::Error,
+        build: |f| {
+            // Two obligations, one falsification test: unfalsifiable claim.
+            f.obligations = format!(
+                "{OBLIGATION_OK}  - type: bound\n    property: \"Q\"\n    \
+                 formal: \"F-2\"\n    applies_to: all\n"
+            );
+        },
+    },
+];
+
+// ---------------------------------------------------------------------------
+// The BEAT family — reachable only for `kind: beat-benchmark`
+// ---------------------------------------------------------------------------
+
+/// A `beat-benchmark` contract whose `beat:` block is complete and valid.
+///
+/// The BEAT rules were nearly missed by this gate: `BEAT-002..007` are emitted
+/// through a local closure rather than a `rule: "..."` literal, so a scan for
+/// that literal saw only `BEAT-001`. The rule-id extractor below therefore takes
+/// its universe from every rule-id-SHAPED string literal in the validator, not
+/// from one syntactic form.
+const BEAT_BLOCK_OK: &str = "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  \
+     metric: wall_clock_ratio\n  direction: lower_is_better\n  \
+     beat_threshold: 0.9\n  approved_compute: CPU\n  \
+     ci_gate_name: \"beat_pv_surface_gate\"\n";
+
+/// Build a beat-benchmark contract body with `beat:` replaced wholesale.
+fn beat_fixture(beat_block: &str) -> String {
+    format!(
+        "metadata:\n  kind: beat-benchmark\n  version: \"1.0.0\"\n  \
+         description: \"pv surface gate beat fixture\"\n  references:\n    - \"#2589\"\n\
+         \n{EQUATIONS_OK}\n{beat_block}"
+    )
+}
+
+fn validate_beat(beat_block: &str) -> (i32, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("beat-fixture-v1.yaml");
+    std::fs::write(&path, beat_fixture(beat_block)).expect("write beat fixture");
+    pv(&["validate", path.to_str().expect("utf8 path")])
+}
+
+/// One row of the BEAT decision table.
+struct BeatCase {
+    rule: &'static str,
+    /// The `beat:` block that must trip `rule`.
+    block: &'static str,
+}
+
+/// THE BEAT DECISION TABLE. Every row omits or corrupts exactly one field.
+///
+/// `BEAT-002` gets two rows because the rule has two arms — empty and
+/// not-an-incumbent — and only the second exercises the `BEAT_INCUMBENTS`
+/// membership list.
+const BEAT_CASES: &[BeatCase] = &[
+    BeatCase {
+        rule: "BEAT-001",
+        // No `beat:` block at all.
+        block: "",
+    },
+    BeatCase {
+        rule: "BEAT-002",
+        block: "beat:\n  pillar: 1\n  incumbent: \"\"\n  metric: m\n  \
+                direction: lower_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: CPU\n  ci_gate_name: \"g\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-002",
+        // Membership arm: a plausible-looking but unlisted incumbent.
+        block: "beat:\n  pillar: 1\n  incumbent: THIS-INCUMBENT-DOES-NOT-EXIST\n  \
+                metric: m\n  direction: lower_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: CPU\n  ci_gate_name: \"g\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-003",
+        block: "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  metric: \"  \"\n  \
+                direction: lower_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: CPU\n  ci_gate_name: \"g\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-004",
+        block: "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  metric: m\n  \
+                direction: sideways_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: CPU\n  ci_gate_name: \"g\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-005",
+        block: "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  metric: m\n  \
+                direction: lower_is_better\n  approved_compute: CPU\n  \
+                ci_gate_name: \"g\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-006",
+        block: "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  metric: m\n  \
+                direction: lower_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: CPU\n  ci_gate_name: \"\"\n",
+    },
+    BeatCase {
+        rule: "BEAT-007",
+        block: "beat:\n  pillar: 1\n  incumbent: scikit-learn\n  metric: m\n  \
+                direction: lower_is_better\n  beat_threshold: 0.9\n  \
+                approved_compute: TPU\n  ci_gate_name: \"g\"\n",
+    },
+];
+
+/// Rule ids the tables do not trip directly but which must still never appear
+/// on a clean baseline.
+///
+/// `SCHEMA-006` (duplicate `formal:` predicate) needs a second proof obligation,
+/// which unavoidably also trips `PROVABILITY-001` — so it cannot be attributed
+/// to a single swap and is asserted absent-from-baseline only.
+const ALSO_ABSENT_FROM_BASELINE: &[&str] = &["SCHEMA-006"];
+
+fn all_rule_ids() -> BTreeSet<&'static str> {
+    CASES
+        .iter()
+        .map(|c| c.rule)
+        .chain(BEAT_CASES.iter().map(|c| c.rule))
+        .chain(ALSO_ABSENT_FROM_BASELINE.iter().copied())
+        .collect()
+}
+
+// ============================================================================
+// A. `pv validate` decision table — the priority-1 target of #2589
+// ============================================================================
+
+/// NEGATIVE DIRECTION: a contract with nothing wrong must produce NO rule id
+/// and exit 0.
+///
+/// Without this, a `pv` that printed all 18 rules unconditionally would satisfy
+/// every trip case below. This is the half that makes the table discriminating.
+#[test]
+fn validate_baseline_is_silent_and_exits_zero() {
+    let (rc, out) = Fixture::default().validate();
+    assert_eq!(
+        rc, 0,
+        "clean fixture must exit 0.\n--- pv output ---\n{out}"
+    );
+    assert!(
+        out.contains("0 error(s), 0 warning(s)"),
+        "clean fixture must report zero of both.\n--- pv output ---\n{out}"
+    );
+    for rule in all_rule_ids() {
+        assert!(
+            !out.contains(rule),
+            "clean fixture tripped {rule} — either the fixture is not clean or \
+             pv reports rules unconditionally.\n--- pv output ---\n{out}"
+        );
+    }
+}
+
+/// POSITIVE DIRECTION: every rule is reachable THROUGH THE CLI, at the right
+/// severity, with the exit code that severity implies.
+///
+/// The exit-code half is what excludes `fn main() { exit(0) }`; the rule-id half
+/// is what excludes a `pv` that swallows the violation list.
+#[test]
+fn validate_reaches_every_rule_at_the_right_severity() {
+    let mut failures = Vec::new();
+    for case in CASES {
+        let mut fixture = Fixture::default();
+        (case.build)(&mut fixture);
+        let (rc, out) = fixture.validate();
+
+        let expected_line = format!("{} {}:", case.sev.tag(), case.rule);
+        if !out.contains(&expected_line) {
+            failures.push(format!(
+                "{}: expected a `{}` line, got:\n{}",
+                case.rule,
+                expected_line.trim_end_matches(':'),
+                indent(&out)
+            ));
+            continue;
+        }
+        if rc != case.sev.expected_rc() {
+            failures.push(format!(
+                "{}: reported at {:?} so pv must exit {}, got rc={rc}:\n{}",
+                case.rule,
+                case.sev,
+                case.sev.expected_rc(),
+                indent(&out)
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} validate rules are not reachable through the CLI:\n\n{}",
+        failures.len(),
+        CASES.len(),
+        failures.join("\n")
+    );
+}
+
+/// Every rule-id-SHAPED string literal in the validator source.
+///
+/// The universe is deliberately taken from the SHAPE (`FAMILY-NNN`), not from
+/// one syntactic form. An earlier version of this extractor matched only
+/// `rule: "..."` and consequently saw `BEAT-001` but none of `BEAT-002..007`,
+/// which are emitted through a local closure — the exact "guard's universe
+/// built from the wrong side" failure this repo has hit before. A new rule must
+/// ADD to the loop, never quietly fall outside it.
+fn declared_rule_ids() -> BTreeSet<String> {
+    let src = include_str!("../../aprender-contracts/src/schema/validator.rs");
+    let mut ids = BTreeSet::new();
+    for chunk in src.split('"').skip(1).step_by(2) {
+        if is_rule_id_shaped(chunk) {
+            ids.insert(chunk.to_string());
+        }
+    }
+    ids
+}
+
+/// `FAMILY-NNN` where FAMILY is upper-case ASCII (possibly hyphenated) and NNN
+/// is exactly three digits.
+fn is_rule_id_shaped(s: &str) -> bool {
+    let Some((family, num)) = s.rsplit_once('-') else {
+        return false;
+    };
+    num.len() == 3
+        && num.chars().all(|c| c.is_ascii_digit())
+        && !family.is_empty()
+        && family
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// The BEAT family, reachable only through `kind: beat-benchmark`.
+///
+/// This half of the table nearly did not exist: the first extractor missed
+/// `BEAT-002..007` entirely. It is also where the brief's `BEAT_INCUMBENTS`
+/// question lives — the `BEAT-002` membership row below is what makes that list
+/// a load-bearing, falsifiable check rather than dead code.
+#[test]
+fn validate_reaches_every_beat_rule() {
+    let (rc, out) = validate_beat(BEAT_BLOCK_OK);
+    assert_eq!(
+        rc,
+        0,
+        "the clean beat-benchmark fixture must validate.\n{}",
+        indent(&out)
+    );
+    for id in all_rule_ids() {
+        assert!(
+            !out.contains(id),
+            "clean beat fixture tripped {id}:\n{}",
+            indent(&out)
+        );
+    }
+
+    let mut failures = Vec::new();
+    for case in BEAT_CASES {
+        let (rc, out) = validate_beat(case.block);
+        let expected = format!("[ERROR] {}:", case.rule);
+        if !out.contains(&expected) {
+            failures.push(format!(
+                "{}: expected `{}` line, got:\n{}",
+                case.rule,
+                expected.trim_end_matches(':'),
+                indent(&out)
+            ));
+        } else if rc == 0 {
+            failures.push(format!(
+                "{}: reported as an ERROR but pv still exited 0:\n{}",
+                case.rule,
+                indent(&out)
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} BEAT rules are not reachable through the CLI:\n\n{}",
+        failures.len(),
+        BEAT_CASES.len(),
+        failures.join("\n")
+    );
+}
+
+/// The table must stay exhaustive as rules are added.
+///
+/// Without this, adding `SCHEMA-018` to the validator leaves it ungated forever
+/// and every test here still passes — the "guard's universe built from the wrong
+/// side" failure. The universe is taken from the VALIDATOR SOURCE, not from the
+/// table, so a new rule removes nothing from the loop.
+#[test]
+fn every_rule_in_the_validator_source_appears_in_the_table() {
+    let declared = declared_rule_ids();
+    assert!(
+        declared.len() >= 25,
+        "parsed only {} rule ids out of validator.rs — the extractor broke, \
+         which would make this guard vacuously green. Found: {declared:?}",
+        declared.len()
+    );
+
+    let covered = all_rule_ids();
+    let missing: Vec<_> = declared
+        .iter()
+        .filter(|d| !covered.contains(d.as_str()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "validator.rs declares rules with no row in the pv-surface decision \
+         table: {missing:?}. Add a Case (or ALSO_ABSENT_FROM_BASELINE) so the \
+         new rule is gated through the CLI, not only in library unit tests."
+    );
+}
+
+// ============================================================================
+// B. Whole-surface invariants, enumerated AT RUNTIME from the binary
+// ============================================================================
+
+/// Read the subcommand list out of `pv --help`.
+///
+/// Enumerating at runtime rather than hardcoding a list is deliberate: a
+/// hardcoded list silently stops covering commands added after it was written.
+fn advertised_subcommands() -> Vec<String> {
+    let (rc, out) = pv(&["--help"]);
+    assert_eq!(rc, 0, "`pv --help` must exit 0, got {rc}:\n{out}");
+    let cmds: Vec<String> = commands_section(&out)
+        .filter_map(subcommand_name)
+        .map(str::to_string)
+        .collect();
+    assert!(
+        cmds.len() >= 30,
+        "parsed only {} subcommands out of `pv --help` — the parser broke and \
+         every test built on it would be vacuously green:\n{out}",
+        cmds.len()
+    );
+    cmds
+}
+
+/// The lines of `--help` between the `Commands:` and `Options:` headings.
+fn commands_section(help: &str) -> impl Iterator<Item = &str> {
+    help.lines()
+        .skip_while(|l| !l.starts_with("Commands:"))
+        .skip(1)
+        .take_while(|l| !l.starts_with("Options:"))
+}
+
+/// The subcommand name on one clap listing line, if it is one.
+///
+/// clap prints `"  <name>   <description>"`; wrapped description lines are
+/// indented further, so only exactly-two-space indentation counts. `help` is
+/// excluded — it is clap's own, not part of pv's surface.
+fn subcommand_name(line: &str) -> Option<&str> {
+    if !line.starts_with("  ") || line.starts_with("   ") {
+        return None;
+    }
+    let word = line.split_whitespace().next()?;
+    let plausible = word
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    (word != "help" && plausible).then_some(word)
+}
+
+/// Every subcommand `pv --help` ADVERTISES must actually be reachable.
+///
+/// This is the `apr test llm` defect class (#2527): a command listed in `--help`
+/// but permanently unreachable because its feature was never declared, so its
+/// own remedy was impossible to run. Advertising is a promise; this checks it.
+#[test]
+fn every_advertised_subcommand_is_reachable() {
+    let mut unreachable = Vec::new();
+    for cmd in advertised_subcommands() {
+        let (rc, out) = pv(&[&cmd, "--help"]);
+        if rc != 0 {
+            unreachable.push(format!("pv {cmd} --help -> rc={rc}\n{}", indent(&out)));
+        }
+    }
+    assert!(
+        unreachable.is_empty(),
+        "{} advertised subcommand(s) are not reachable:\n{}",
+        unreachable.len(),
+        unreachable.join("\n")
+    );
+}
+
+/// Every subcommand that takes a contract path must REJECT bad input.
+///
+/// This is the assertion the pre-existing suite never made. `pv validate <good>
+/// == 0` is satisfied by a binary that does nothing; `pv <cmd> <garbage> != 0`
+/// is not. Applied across every contract-taking subcommand at once, discovered
+/// by parsing each command's own usage line.
+#[test]
+fn contract_taking_subcommands_reject_unusable_input() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("does-not-exist.yaml");
+    let garbage = dir.path().join("garbage.yaml");
+    std::fs::write(&garbage, "{{{ not yaml at all: [\n").expect("write");
+    let empty = dir.path().join("empty.yaml");
+    std::fs::write(&empty, "").expect("write");
+    let wrong_shape = dir.path().join("wrong-shape.yaml");
+    std::fs::write(&wrong_shape, "hello: world\nlist:\n  - 1\n").expect("write");
+
+    let inputs = [
+        ("nonexistent", &missing),
+        ("malformed-yaml", &garbage),
+        ("empty", &empty),
+        ("well-formed-but-not-a-contract", &wrong_shape),
+    ];
+
+    let mut checked = 0usize;
+    let mut accepted = Vec::new();
+    for cmd in advertised_subcommands() {
+        let (_, help) = pv(&[&cmd, "--help"]);
+        let Some(usage) = help.lines().find(|l| l.starts_with("Usage:")) else {
+            continue;
+        };
+        if !(usage.contains("<CONTRACT>") || usage.contains("<PATH>") || usage.contains("<FILE>")) {
+            continue;
+        }
+        checked += 1;
+        for (label, path) in &inputs {
+            let (rc, out) = pv(&[&cmd, path.to_str().expect("utf8 path")]);
+            if rc == 0 {
+                accepted.push(format!(
+                    "pv {cmd} <{label}> exited 0 — it accepted unusable input:\n{}",
+                    indent(&out)
+                ));
+            }
+        }
+    }
+    assert!(
+        checked >= 10,
+        "only {checked} contract-taking subcommands were found; the usage-line \
+         parser probably broke, which would make this guard vacuously green"
+    );
+    assert!(
+        accepted.is_empty(),
+        "{} subcommand/input pair(s) accepted input they cannot possibly \
+         process:\n{}",
+        accepted.len(),
+        accepted.join("\n")
+    );
+}
+
+/// `pv --version` must report the version of THIS crate.
+///
+/// #2552: a `pv` on `$PATH` was 0.49.0 while the in-tree crate was 0.63.0, and
+/// the two disagreed on the release-deciding gate — with the stale one cited in
+/// the release receipt as evidence of correctness. This is a substring check on
+/// the semver only, so the separate work on `--version` IDENTITY (#2559 — making
+/// it distinguishable from the `pv(1)` pipe viewer) is free to change the
+/// surrounding text without touching this test.
+#[test]
+fn version_reports_this_crates_version() {
+    let (rc, out) = pv(&["--version"]);
+    assert_eq!(rc, 0, "`pv --version` must exit 0, got {rc}:\n{out}");
+    assert!(
+        out.contains(env!("CARGO_PKG_VERSION")),
+        "`pv --version` printed {out:?} which does not contain this crate's \
+         version {:?}",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+// ============================================================================
+// C. The control on the control
+// ============================================================================
+
+/// Prove the decision table can distinguish the two degenerate `pv`s.
+///
+/// A rule table is only a control if BOTH degenerate binaries fail it:
+///   * a `pv` that prints NO rule ids   -> the trip cases must fail
+///   * a `pv` that prints ALL rule ids  -> the baseline case must fail
+///
+/// The real binary must satisfy both halves simultaneously, i.e. the observed
+/// rule set must depend on the input. This test asserts exactly that dependency
+/// rather than re-reading the assertions above.
+#[test]
+fn gate_self_test_rule_output_depends_on_input() {
+    let (_, baseline) = Fixture::default().validate();
+    let baseline_rules: BTreeSet<&str> = all_rule_ids()
+        .into_iter()
+        .filter(|r| baseline.contains(r))
+        .collect();
+    assert!(
+        baseline_rules.is_empty(),
+        "a `pv` that prints rules unconditionally would pass every trip case; \
+         the baseline must print none, saw {baseline_rules:?}"
+    );
+
+    let mut tripped: BTreeSet<&str> = BTreeSet::new();
+    for case in CASES {
+        let mut fixture = Fixture::default();
+        (case.build)(&mut fixture);
+        let (_, out) = fixture.validate();
+        if out.contains(case.rule) {
+            tripped.insert(case.rule);
+        }
+    }
+    assert_eq!(
+        tripped.len(),
+        CASES.len(),
+        "a `pv` that prints no rules would pass the baseline case; {} of {} \
+         trip cases produced no rule id. Reached: {tripped:?}",
+        CASES.len() - tripped.len(),
+        CASES.len()
+    );
+}
+
+fn indent(s: &str) -> String {
+    s.lines()
+        .map(|l| format!("    {l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
`contracts-pv` read **76 features, 0.0% covered, 0 UNKNOWN hardware**. That last
column says the features are hardware-verified and simply **ungated**. Two causes were
measured at `4bbfeb07f`; both are fixed here.

## 1. pv's CLI tests were DARK — this is why the number was 0%

`crates/aprender-contracts-cli/tests/` already held **651 lines of tests that spawn the
pv binary**, and CI ran **zero** of them:

- `workspace-test` is `cargo nextest run --profile ci --workspace --lib` — library
  targets only.
- The one explicit integration line in `ci.yml` names **23** `--test` targets. None is
  from `aprender-contracts-cli`.

```
$ grep -o "cargo test -p [a-z-]* [^&]*--test [a-z_0-9]*" .github/workflows/ci.yml | sort -u | wc -l
23
$ grep -c "aprender-contracts-cli" <that list>
0
```

A test that never executes is 0% coverage however many lines it has. This is the exact
trap the comment above that line already warns about — it had swallowed `pv` whole.

## 2. The tests that did exist EXCLUDED NOTHING

Nearly every one asserted `status.success()` on a **good** contract. That assertion is
satisfied unchanged by `fn main() { std::process::exit(0) }`. Per
`project_assertions_exclude_guard`, an assertion no wrong behaviour can violate is not a
control.

---

## Tranche 1 — `tests/pv_surface_gate.rs`, 8 tests

| Area | What is gated |
|---|---|
| `pv validate` decision table | **All 25** diagnostic rules the validator can emit (`SCHEMA-001..017`, `PROVABILITY-001`, `BEAT-001..007`), **both directions**: tripped → reached through the CLI at its measured severity with the exit code that severity implies; clean contract → **none** of them. |
| Exhaustiveness | The rule universe is read out of `validator.rs`, so a new rule **enters** the loop rather than falling outside it. |
| Reachability | All **38** subcommands `pv --help` advertises must exit 0 for `pv <cmd> --help` — the `apr test llm` class (#2527). |
| Input rejection | Each of the **16** contract-taking subcommands must exit non-zero on a nonexistent path, malformed YAML, an empty file, and well-formed YAML that is not a contract (**64 assertions**). This is the assertion the pre-existing suite never made. |
| Version pinning | `pv --version` reports this crate's version, resolved via `CARGO_BIN_EXE_pv` so it cannot fall back to a stale PATH pv (#2552). |

Severities and exit codes were **measured** against the binary, not assumed.

### The exhaustiveness guard earned its keep on first run

It failed immediately, naming `BEAT-001` as ungated. Widening the extractor then exposed
`BEAT-002..007`, which are emitted through a local closure rather than a `rule: "..."`
literal and were invisible to the first version — **this guard's own universe had been
built from the wrong side.** The extractor now takes its universe from the rule-id
*shape*, not from one syntactic form.

## Mutation verification — 4 mutations, each proven to ENGAGE first

Every mutation asserts a non-empty `git diff` before any verdict is read. A `sed` that
silently fails to match reads exactly like "the guard is fine".

| # | Mutation | Result |
|---|---|---|
| **M1** | delete the violation-print loop in `commands/validate.rs` | gate **rc=101** (3 RED); library `-p aprender-contracts` **rc=0, 55 passed** |
| **M2** | replace validate.rs's error return with `Ok(())` | gate **rc=101** (2 RED) on the exit-code half |
| **M3** | rename `SCHEMA-013` → `SCHEMA-999` | exhaustiveness guard **RED**, naming the orphan |
| **M4** | disable the `BEAT_INCUMBENTS` membership arm | **RED** on exactly the `BEAT-002` membership row |
| **CONTROL** | restored tree | **rc=0, 8/8 green** |

**M1 is the load-bearing result.** The gate goes RED while the library tests stay GREEN
— mechanical proof that this covers CLI surface the library tests cannot see, i.e. it is
*new* coverage rather than a duplicate of `validator_tests.rs`.

All four were **re-run after** the complexity refactor of the help parser, since the old
proof does not transfer across a refactor.

## CI wiring — without it, a passing gate is still 0%

`pv_surface_gate`, `cli_integration` (64 tests, green) and `ground_truth` (34, green) are
added to the integration line.

`book_coverage` is **deliberately not** wired: it is **RED at `4bbfeb07f`** —

```
Failed to parse contracts/binding.yaml: Failed to parse YAML: missing field `metadata`
```

It walks `contracts/*.yaml` and chokes on `binding.yaml`, a binding registry rather than
a contract. It rotted precisely because nothing watched it. Fixing it is separate work
and belongs near #2554's schema changes.

## Contract

`contracts/pv-cli-surface-v1.yaml`, `kind: pattern`, 8 falsification tests carrying the
measured mutation results. `pv validate` → **0 errors, 0 warnings**.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p aprender-contracts-cli --test pv_surface_gate` | rc=0, 8/8 |
| `--test cli_integration` | rc=0, 64/64 |
| `--test ground_truth` | rc=0, 34/34 |
| `cargo fmt --all -- --check` | rc=0 |
| `pv validate contracts/pv-cli-surface-v1.yaml` | rc=0 |
| `pv lint contracts/` | 0 errors, **947** warnings — byte-identical to my measured `origin/main` baseline, so this contract adds none |
| pmat pre-commit gates | fmt / complexity / docs PASS |

> The `942` warning figure in circulation is stale; re-measured at 947 on `origin/main`
> before and after. (Task 2's agent independently measured 947.)

## Deliberately NOT in this tranche

`pv lint`'s warning ratchet (its numeric baseline belongs in the Makefile gate, not a
unit test, and a run over 1229 contracts is too slow for the integration step),
`pv diff` semver suggestions, `pv score`, `pv certify`, `pv coverage`, and the *content*
of the generator subcommands' output (`kani`/`probar`/`coq`/`flux`/`tla`/…). Those are
tranche 2.

## Judgement on CLUS-004 (#2596): do not land it here

The ticket proposes that expressing clustering invariants as a `pv` contract "closes two
zeros with one ticket". It does not, for two independent reasons:

1. **Category error.** `contracts-pv`'s 76 features are *pv's own CLI features*. Adding a
   YAML file that pv validates exercises the clustering code, not pv. It would move the
   clustering zero and leave contracts-pv at 0%.
2. **Its input does not exist.** `docs/audits/surface_audit_clustered.csv` — the 830-row
   matrix both #2591 and #2596 recluster — is **not in the tree** (`docs/audits/` holds
   only the two 0.63.0 dogfood markdown files). CLUS-004 also needs sklearn as a
   differential oracle and thresholds "set from measurement"; none of that is available
   here, and forcing it would produce exactly the round-number threshold #2596 warns
   against.

CLUS-004 is good work on its own merits under `epic:clustering`. It is not
contracts-pv coverage, and pairing them would make bisection harder for no gain.

## Note for reviewers

- **`ci.yml` is touched** (one command appended to the single integration line, plus a
  comment). Per the warning in that file's own comment, **only one PR at a time may edit
  that physical line** — if another PR in flight also edits it, land them in sequence.
- Clippy note: `cargo clippy -p aprender-contracts-cli --all-targets -- -D warnings` is
  **already rc=101 on `origin/main`** with 72 pre-existing `disallowed_methods`
  (`unwrap`) findings in `contract_walk.rs`, `equations.rs`, `graph.rs`, `certify.rs`,
  `verify_pipeline.rs` and `tests/book_coverage.rs`. This PR's new file contributes
  **0** of them. CI's lint step does not currently reach this crate's non-lib targets;
  that pre-existing debt is out of scope here but worth its own ticket.

Refs #2589, #2552, #2527, #2596
