### PR TITLE
fix(security): drop thrift 0.17 (CVE-2026-43868) by bumping arrow/parquet 57 -> 59, and close the GHSA-vs-RustSec hole that hid it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,6 +845,17 @@ jobs:
       # deleting a line.
       - name: Every deny.toml exemption must still be live
         run: bash scripts/check_deny_exemptions_live.sh
+      # cargo-deny and cargo-audit read ONE database: RustSec. GHSA (what
+      # Dependabot reads) is a superset, and when an advisory lives only there
+      # every gate above is green while the crate sits in Cargo.lock. #2531:
+      # `thrift 0.17.0` (CVE-2026-43868 / GHSA-2f9f-gq7v-9h6m) arrived via
+      # `parquet ^57` and RustSec has NO thrift advisory at all, so
+      # `cargo deny check advisories` printed "advisories ok" throughout. It was
+      # found by a Dependabot alert on a DOWNSTREAM repo. Text-only, no build.
+      - name: No GHSA-only vulnerable crate in Cargo.lock
+        run: bash scripts/check_no_ghsa_banned_crates.sh
+      - name: "GHSA guard must still turn RED (case table)"
+        run: bash scripts/check_no_ghsa_banned_crates.sh --self-test
       # A test gated on a path outside the workspace is green on every machine
       # that lacks it, which is every machine but one. The monorepo merged 20
       # sibling repos in-tree, so gates like

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ dependencies = [
  "aprender-viz",
  "aprender-zram-cli",
  "aprender-zram-core",
- "arrow-array 57.3.1",
+ "arrow-array 59.2.0",
  "assert_cmd",
  "async-stream",
  "axum 0.7.9",
@@ -595,7 +595,7 @@ dependencies = [
  "aes-gcm",
  "aprender-test-lib",
  "argon2",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "arrow-csv",
  "arrow-json",
  "assert_cmd",
@@ -647,7 +647,7 @@ dependencies = [
  "anyhow",
  "aprender-common",
  "aprender-compute",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "axum 0.7.9",
  "bytemuck",
  "cargo-llvm-cov",
@@ -692,7 +692,7 @@ dependencies = [
  "aprender-compute",
  "aprender-db",
  "aprender-test-lib",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "bincode",
  "criterion 0.5.1",
  "crossterm 0.28.1",
@@ -778,7 +778,7 @@ dependencies = [
  "anyhow",
  "aprender-compute",
  "aprender-core",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "bytemuck",
  "criterion 0.6.0",
  "futures-intrusive",
@@ -1306,7 +1306,7 @@ dependencies = [
  "aprender-test-lib",
  "aprender-viz",
  "arc-swap",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "assert_cmd",
  "async-stream",
  "axum 0.7.9",
@@ -1570,7 +1570,7 @@ dependencies = [
  "aprender-serve",
  "aprender-test-lib",
  "aprender-viz",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "axum 0.8.9",
  "bytemuck",
  "chrono",
@@ -1763,7 +1763,7 @@ dependencies = [
  "aprender-core",
  "aprender-profile",
  "aprender-train",
- "arrow 57.3.1",
+ "arrow 59.2.0",
  "clap",
  "criterion 0.7.0",
  "indicatif 0.18.4",
@@ -1919,27 +1919,6 @@ checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "arrow"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
-dependencies = [
- "arrow-arith 57.3.1",
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-cast 57.3.1",
- "arrow-csv",
- "arrow-data 57.3.1",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord 57.3.1",
- "arrow-row 57.3.1",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
- "arrow-string 57.3.1",
-]
-
-[[package]]
-name = "arrow"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
@@ -1957,17 +1936,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-arith"
-version = "57.3.1"
+name = "arrow"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "chrono",
- "num-traits",
+ "arrow-arith 59.2.0",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-cast 59.2.0",
+ "arrow-csv",
+ "arrow-data 59.2.0",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord 59.2.0",
+ "arrow-row 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
+ "arrow-string 59.2.0",
 ]
 
 [[package]]
@@ -1985,20 +1971,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-array"
-version = "57.3.1"
+name = "arrow-arith"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
- "ahash 0.8.12",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-complex",
- "num-integer",
  "num-traits",
 ]
 
@@ -2021,14 +2003,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-buffer"
-version = "57.3.1"
+name = "arrow-array"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
- "bytes",
+ "ahash 0.8.12",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "chrono",
  "half",
- "num-bigint",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2040,30 +2028,20 @@ checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "57.3.1"
+name = "arrow-buffer"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-ord 57.3.1",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "comfy-table 7.2.2",
+ "bytes",
  "half",
- "lexical-core",
+ "num-bigint 0.5.1",
  "num-traits",
- "ryu",
 ]
 
 [[package]]
@@ -2089,31 +2067,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "57.3.1"
+name = "arrow-cast"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-cast 57.3.1",
- "arrow-schema 57.3.1",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-ord 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
+ "atoi",
+ "base64 0.23.1",
+ "chrono",
+ "comfy-table 7.2.2",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
+dependencies = [
+ "arrow-array 59.2.0",
+ "arrow-cast 59.2.0",
+ "arrow-schema 59.2.0",
  "chrono",
  "csv",
  "csv-core",
  "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
-dependencies = [
- "arrow-buffer 57.3.1",
- "arrow-schema 57.3.1",
- "half",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2130,30 +2117,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ipc"
-version = "57.3.1"
+name = "arrow-data"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
+ "arrow-buffer 59.2.0",
+ "arrow-schema 59.2.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
+dependencies = [
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "57.3.1"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-cast 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-cast 59.2.0",
+ "arrow-ord 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "chrono",
  "half",
  "indexmap 2.14.0",
@@ -2165,19 +2166,6 @@ dependencies = [
  "serde_core",
  "serde_json",
  "simdutf8",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
-dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
 ]
 
 [[package]]
@@ -2194,16 +2182,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-row"
-version = "57.3.1"
+name = "arrow-ord"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "half",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
 ]
 
 [[package]]
@@ -2220,10 +2208,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-schema"
-version = "57.3.1"
+name = "arrow-row"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
+dependencies = [
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "half",
+]
 
 [[package]]
 name = "arrow-schema"
@@ -2235,18 +2230,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-select"
-version = "57.3.1"
+name = "arrow-schema"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "num-traits",
-]
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 
 [[package]]
 name = "arrow-select"
@@ -2263,20 +2250,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-string"
-version = "57.3.1"
+name = "arrow-select"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-data 57.3.1",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
- "memchr",
+ "ahash 0.8.12",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "num-traits",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -2290,6 +2274,23 @@ dependencies = [
  "arrow-data 58.3.0",
  "arrow-schema 58.3.0",
  "arrow-select 58.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
+dependencies = [
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "memchr",
  "num-traits",
  "regex",
@@ -3147,6 +3148,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64-simd"
@@ -4045,7 +4052,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5207,7 +5214,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5538,7 +5545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6225,7 +6232,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -7144,7 +7151,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7467,12 +7474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "interpol"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7517,7 +7518,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8007,18 +8008,18 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -8804,7 +8805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0e759e014e630f90af745101b614f761306ddc541681e546649068e25ec1b9"
 dependencies = [
  "byteorder",
- "num-bigint",
+ "num-bigint 0.4.6",
  "py_literal",
 ]
 
@@ -8823,7 +8824,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8832,7 +8833,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -8849,6 +8850,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -8912,7 +8923,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "serde",
@@ -9230,15 +9241,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -9286,7 +9288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9362,34 +9364,31 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.1"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array 57.3.1",
- "arrow-buffer 57.3.1",
- "arrow-cast 57.3.1",
- "arrow-data 57.3.1",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
  "arrow-ipc",
- "arrow-schema 57.3.1",
- "arrow-select 57.3.1",
- "base64 0.22.1",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "half",
- "hashbrown 0.16.1",
- "lz4_flex 0.12.2",
- "num-bigint",
+ "hashbrown 0.17.1",
+ "lz4_flex 0.14.0",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
- "paste",
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "twox-hash",
  "zstd",
 ]
@@ -10114,7 +10113,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-traits",
  "pest",
@@ -10207,7 +10206,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10245,7 +10244,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11029,7 +11028,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11109,7 +11108,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11888,7 +11887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12323,7 +12322,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12342,7 +12341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12404,17 +12403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -13376,7 +13364,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-rational",
  "num-traits",
@@ -14764,7 +14752,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -539,6 +539,8 @@ deps-validate:
 deny:
 	@echo "🔒 Running cargo-deny checks..."
 	@bash scripts/check_deny_exemptions_live.sh
+	@bash scripts/check_no_ghsa_banned_crates.sh --self-test
+	@bash scripts/check_no_ghsa_banned_crates.sh
 	@if command -v cargo-deny >/dev/null 2>&1; then \
 		cargo deny check; \
 	else \

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -178,8 +178,8 @@ which = "7"
 # Stack v1.2 / codeparrot Python corpora ship as parquet, not JSONL; this
 # enables `apr tokenize encode-corpus --corpus <path>.parquet` end-to-end
 # without a Python shim (per `feedback_stack_tool_extension_not_cli_shim.md`).
-parquet = { version = "57", default-features = false, features = ["arrow", "snap", "zstd"] }
-arrow-array = "57"
+parquet = { version = "59", default-features = false, features = ["arrow", "snap", "zstd"] }
+arrow-array = "59"
 
 # HTTP client for downloads
 ureq = "2.10"

--- a/crates/aprender-data/Cargo.toml
+++ b/crates/aprender-data/Cargo.toml
@@ -33,10 +33,10 @@ dhat-heap = ["dep:dhat"]
 [dependencies]
 # Core (always)
 # NOTE: arrow 57+ fixes comfy-table let_chains compatibility
-arrow = { version = "57", default-features = false, features = ["prettyprint", "ipc"] }
-arrow-csv = { version = "57" }
-arrow-json = { version = "57" }
-parquet = { version = "57", default-features = false, features = ["arrow", "snap", "zstd"] }
+arrow = { version = "59", default-features = false, features = ["prettyprint", "ipc"] }
+arrow-csv = { version = "59" }
+arrow-json = { version = "59" }
+parquet = { version = "59", default-features = false, features = ["arrow", "snap", "zstd"] }
 thiserror = "2"
 bytes = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-db/Cargo.toml
+++ b/crates/aprender-db/Cargo.toml
@@ -33,8 +33,8 @@ futures-intrusive = { version = "0.5", optional = true }  # Async primitives for
 # Storage (Arrow columnar format)
 # NOTE: arrow 54+ fixes chrono 0.4.42 conflict (quarter() method ambiguity)
 # Minimal features: drops arrow-csv, arrow-json, arrow-ipc, flatbuffers (~50 fewer transitive deps)
-arrow = { version = "57", default-features = false }
-parquet = { version = "57", default-features = false, features = ["arrow"], optional = true }  # Parquet I/O (opt-in)
+arrow = { version = "59", default-features = false }
+parquet = { version = "59", default-features = false, features = ["arrow"], optional = true }  # Parquet I/O (opt-in)
 
 # Query parsing
 sqlparser = "0.52"         # SQL parsing

--- a/crates/aprender-db/benches/storage_benchmarks.rs
+++ b/crates/aprender-db/benches/storage_benchmarks.rs
@@ -45,7 +45,7 @@ fn create_test_parquet(path: &str, num_rows: i32) {
 
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
-        .set_max_row_group_size(usize::try_from(num_rows).unwrap() / 2) // 2 row groups
+        .set_max_row_group_row_count(Some(usize::try_from(num_rows).unwrap() / 2)) // 2 row groups
         .build();
 
     let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();

--- a/crates/aprender-db/tests/integration_test.rs
+++ b/crates/aprender-db/tests/integration_test.rs
@@ -41,7 +41,7 @@ fn create_test_parquet<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error
     // Write to Parquet file
     let file = File::create(path.as_ref())?;
     let props = WriterProperties::builder()
-        .set_max_row_group_size(5000) // 2 row groups
+        .set_max_row_group_row_count(Some(5000)) // 2 row groups
         .build();
     let mut writer = ArrowWriter::try_new(file, Arc::new(schema), Some(props))?;
     writer.write(&batch)?;

--- a/crates/aprender-distribute/Cargo.toml
+++ b/crates/aprender-distribute/Cargo.toml
@@ -73,8 +73,8 @@ trueno-db = { workspace = true, optional = true, features = ["distributed"] }
 trueno = { workspace = true, optional = true, features = ["parallel"] }
 
 # v2.0: Parquet checkpoint storage (Apache Arrow ecosystem)
-arrow = { version = "57.0", optional = true }
-parquet = { version = "57.0", optional = true }
+arrow = { version = "59", optional = true }
+parquet = { version = "59", optional = true }
 
 # v2.0: Pepita - Sovereign AI kernel interfaces and infrastructure
 pepita = { version = "0.1.0", optional = true }

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -17,8 +17,8 @@ name = "trueno_graph"
 [dependencies]
 # Data formats (columnar) - MVP uses Arrow/Parquet directly
 # Minimal features: drops arrow-csv, arrow-json (~fewer transitive deps)
-arrow = { version = "57", default-features = false, optional = true }  # RecordBatch zero-copy
-parquet = { version = "57", optional = true }                       # Persistent storage
+arrow = { version = "59", default-features = false, optional = true }  # RecordBatch zero-copy
+parquet = { version = "59", optional = true }                       # Persistent storage
 
 # Async runtime (required for I/O)
 tokio = { version = "1", features = ["rt", "fs", "sync", "macros"] }

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -189,7 +189,7 @@ console = "0.15"
 comfy-table = "6"
 
 # Arrow for data pipeline example
-arrow = { version = "57", default-features = false }
+arrow = { version = "59", default-features = false }
 
 # Property-based testing
 proptest = "1.4"

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -121,7 +121,7 @@ jsonschema = "0.28"  # JSON Schema validation for declarative config (AI-05)
 validator = { version = "0.20", features = ["derive"] }  # Declarative struct validation (AI-05)
 schemars = "0.8"  # JSON Schema generation from Rust structs (AI-05)
 fs4 = "0.13"  # Cross-platform file locking for VRAM ledger (GPU-SHARE-001)
-arrow = { version = "57", default-features = false, optional = true }  # Arrow array types for alimentar integration
+arrow = { version = "59", default-features = false, optional = true }  # Arrow array types for alimentar integration
 nvml-wrapper = { version = "0.10", optional = true }  # NVIDIA NVML bindings for GPU monitoring
 hostname = "0.4.2"
 ctrlc = "3.4"  # Signal handling for graceful shutdown (R-008)
@@ -143,8 +143,8 @@ proptest = "1.4"
 approx = "0.5"
 tempfile = "3.8"
 criterion = { workspace = true }
-arrow = { version = "57", default-features = false }  # For MNIST example array access
-parquet = { version = "57", default-features = false }  # For ALB-007 Parquet writing in tests
+arrow = { version = "59", default-features = false }  # For MNIST example array access
+parquet = { version = "59", default-features = false }  # For ALB-007 Parquet writing in tests
 insta = { version = "1.42", features = ["json", "yaml"] }  # Snapshot testing for PMAT QA
 dirs = "5.0"  # Cache directory detection for examples
 jugar-probar = { workspace = true }  # TUI snapshot testing (ENT-140)

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -30,8 +30,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Parquet data output
-parquet = { version = "57.0", optional = true }
-arrow = { version = "57.0", optional = true }
+parquet = { version = "59", optional = true }
+arrow = { version = "59", optional = true }
 
 # Random number generation for sampling
 rand = "0.9"

--- a/scripts/check_no_ghsa_banned_crates.sh
+++ b/scripts/check_no_ghsa_banned_crates.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# check_no_ghsa_banned_crates.sh — Cargo.lock may not contain a crate version
+# carrying a KNOWN advisory that the RustSec database does not publish.
+#
+# WHY THIS EXISTS
+# ---------------
+# `cargo audit` and `cargo deny check advisories` both read ONE database:
+# RustSec. GitHub's advisory database (GHSA), which Dependabot reads, is a
+# strict superset for several ecosystems. When an advisory exists only in GHSA,
+# every advisory gate in this repo is green while the vulnerable crate sits in
+# Cargo.lock.
+#
+# That is not hypothetical. #2531: `parquet ^57` pulls `thrift 0.17.0`, which
+# carries CVE-2026-43868 / GHSA-2f9f-gq7v-9h6m (excessive-size memory
+# allocation, fixed in thrift 0.23.0). RustSec has NO thrift advisory at all --
+#
+#     git -C ~/.cargo/advisory-db grep -il thrift -- crates   # returns nothing
+#
+# -- so `cargo deny check advisories` printed "advisories ok" while the crate
+# was in the graph. It was found by a Dependabot alert on a DOWNSTREAM repo
+# (paiml-mcp-agent-toolkit #66), i.e. by a tool this repo does not run, about
+# this repo's dependency. The advisory surface had a hole exactly the width of
+# "GHSA minus RustSec", and nothing here could see into it.
+#
+# This guard closes that hole with an explicit, reviewable table. It is
+# deliberately NOT a general vulnerability scanner: entries are added by hand
+# when a GHSA-only advisory is found, and REMOVED when RustSec picks the
+# advisory up (at which point cargo-deny owns it and a duplicate here is dead
+# weight, exactly like a dead deny.toml exemption -- see
+# scripts/check_deny_exemptions_live.sh).
+#
+# Text-only: reads Cargo.lock, builds nothing.
+#
+#   bash scripts/check_no_ghsa_banned_crates.sh
+#   bash scripts/check_no_ghsa_banned_crates.sh --self-test
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# THE TABLE
+#
+#   name|first_fixed_version|advisory-id|reason
+#
+# A locked version STRICTLY LESS THAN first_fixed_version fails the guard.
+# Every entry must name a real advisory and a real fixed version; "we do not
+# like this crate" belongs in deny.toml [bans], not here.
+# ---------------------------------------------------------------------------
+GHSA_TABLE="
+thrift|0.23.0|GHSA-2f9f-gq7v-9h6m (CVE-2026-43868)|Memory allocation with excessive size value. Not in RustSec. Entered via parquet <=58 (parquet >=59 dropped thrift for an in-tree codec); see #2531.
+"
+
+# version_lt A B -> true when A < B under `sort -V` ordering.
+version_lt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n 1)" = "$1" ]
+}
+
+# scan_lockfile <path> -> prints one "name version advisory reason" line per
+# violation; returns 0 when clean, 1 when any violation was found, 2 when the
+# lockfile could not be read (a scan that read nothing certifies nothing).
+scan_lockfile() {
+  lockfile="$1"
+  if [ ! -r "$lockfile" ]; then
+    printf 'UNREADABLE %s\n' "$lockfile"
+    return 2
+  fi
+
+  # Emit "name<TAB>version" for every [[package]] block.
+  pkgs="$(awk '
+    /^\[\[package\]\]/ { name=""; version=""; next }
+    /^name = / { gsub(/^name = "|"$/, ""); name=$0; next }
+    /^version = / { gsub(/^version = "|"$/, ""); version=$0;
+                    if (name != "") print name "\t" version; next }
+  ' "$lockfile")"
+
+  if [ -z "$pkgs" ]; then
+    printf 'EMPTY %s\n' "$lockfile"
+    return 2
+  fi
+
+  found=0
+  while IFS='|' read -r banned_name fixed advisory reason; do
+    [ -z "${banned_name:-}" ] && continue
+    while IFS=$'\t' read -r pkg_name pkg_version; do
+      [ "$pkg_name" = "$banned_name" ] || continue
+      if version_lt "$pkg_version" "$fixed"; then
+        printf '%s %s %s %s\n' "$pkg_name" "$pkg_version" "$advisory" "$reason"
+        found=1
+      fi
+    done <<< "$pkgs"
+  done <<< "$GHSA_TABLE"
+
+  return "$found"
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: prove the matcher can turn RED and can turn GREEN.
+#
+# A guard that has never been shown failing is a guard that may be structurally
+# incapable of failing. Both directions are asserted against synthetic
+# lockfiles, so the case table runs on every CI invocation rather than only
+# when someone remembers to mutate the real tree.
+# ---------------------------------------------------------------------------
+self_test() {
+  printf '=== case table: check_no_ghsa_banned_crates.sh ===\n'
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp:?}"' RETURN
+
+  make_lock() {
+    printf '# synthetic\n[[package]]\nname = "%s"\nversion = "%s"\n' "$1" "$2" > "$tmp/Cargo.lock"
+  }
+
+  fails=0
+  assert() {  # assert <label> <expected_rc> <actual_rc>
+    if [ "$2" -eq "$3" ]; then
+      printf '  ok   %-46s rc=%s\n' "$1" "$3"
+    else
+      printf '  FAIL %-46s expected rc=%s got rc=%s\n' "$1" "$2" "$3"
+      fails=$((fails + 1))
+    fi
+  }
+
+  # MUST MATCH (rc=1): the exact version #2531 found, and anything below the fix.
+  make_lock thrift 0.17.0; scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'thrift 0.17.0 (the #2531 version)' 1 $?
+  make_lock thrift 0.22.9; scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'thrift 0.22.9 (just below the fix)'  1 $?
+  make_lock thrift 0.9.0;  scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'thrift 0.9.0 (not lexically < 0.23)' 1 $?
+
+  # MUST NOT MATCH (rc=0): the fixed version, a later one, and an unrelated crate.
+  make_lock thrift 0.23.0; scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'thrift 0.23.0 (the fixed version)'   0 $?
+  make_lock thrift 1.0.0;  scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'thrift 1.0.0 (above the fix)'        0 $?
+  make_lock serde 1.0.0;   scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'serde 1.0.0 (unrelated crate)'       0 $?
+
+  # VACUITY (rc=2): a scan that parsed nothing must not report "clean".
+  : > "$tmp/Cargo.lock";   scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'empty lockfile is NOT clean'         2 $?
+  rm -f "$tmp/Cargo.lock"; scan_lockfile "$tmp/Cargo.lock" > /dev/null 2>&1; assert 'missing lockfile is NOT clean'       2 $?
+
+  if [ "$fails" -gt 0 ]; then
+    printf '\nFAIL: %s case(s) failed. The guard does not do what it claims.\n' "$fails"
+    return 1
+  fi
+  printf 'PASS: all cases behave as declared.\n'
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+printf '=== no GHSA-only vulnerable crate in Cargo.lock (check_no_ghsa_banned_crates.sh) ===\n'
+
+entries="$(printf '%s\n' "$GHSA_TABLE" | grep -c '|' || true)"
+if [ "$entries" -lt 1 ]; then
+  printf 'FAIL (vacuity): the GHSA table parsed 0 entries. Fix the table, not this check.\n'
+  exit 1
+fi
+
+violations="$(scan_lockfile "$REPO_ROOT/Cargo.lock")"
+rc=$?
+
+if [ "$rc" -eq 2 ]; then
+  printf 'FAIL: could not read Cargo.lock -- %s\n' "$violations"
+  exit 1
+fi
+
+if [ "$rc" -ne 0 ]; then
+  printf '\nFAIL: Cargo.lock contains a crate version with a known advisory that\n'
+  printf 'RustSec does NOT carry, so `cargo deny check advisories` cannot see it:\n\n'
+  printf '%s\n' "$violations" | sed 's|^|  |'
+  printf '\nUpgrade the dependency that pulls it. Do not add it to deny.toml:\n'
+  printf 'deny.toml exemptions are keyed by RUSTSEC id and there is no id to key.\n'
+  exit 1
+fi
+
+printf 'PASS: %s GHSA-only advisory table entry/entries checked, none present in Cargo.lock.\n' "$entries"
+exit 0


### PR DESCRIPTION
Fixes the only SECURITY item in the 0.64.0 blocker set. Refs #2531 (not closing it here).

## Established state first, rather than trusting the ticket

| Probe | Result |
|---|---|
| `cargo tree -i thrift --workspace --all-features` | `thrift 0.17.0 <- parquet 57.3.1 <- ` **7 crates**, not just `aprender-db` |
| `cargo deny check advisories` | **`advisories ok`, rc=0** — on the vulnerable tree |
| RustSec DB | **no thrift advisory exists at all** |
| crates.io sparse index, `parquet` 56.x–59.2.0 | `56.0.0`–`58.4.0` → `thrift ^0.17`; **`59.0.0`–`59.2.0` → no thrift dependency** |

So the advisory is real (CVE-2026-43868 / GHSA-2f9f-gq7v-9h6m, fixed in thrift 0.23.0) but **is not the advisory the ticket implies CI missed** — every advisory gate in this repo was correct-by-its-own-lights and green. `cargo audit` and `cargo deny` read one database, RustSec; GHSA is a superset; Dependabot found this as an alert on a *downstream* repo. The hole is exactly "GHSA minus RustSec", and nothing here could see into it.

No exemption was added. **There is an upgrade path and it is taken** — parquet 59 removes the crate rather than updating it (arrow-rs replaced thrift with an in-tree codec).

## Scope correction

The ticket scoped this to `aprender-db`. thrift is a shared graph node, so bumping one crate would have left `thrift 0.17.0` in `Cargo.lock` via the other six. All arrow **and** parquet declarations move together (parquet 59 needs arrow-array 59): `aprender-data`, `aprender-db`, `aprender-distribute`, `aprender-graph`, `aprender-serve`, `aprender-train`, `aprender-verify-ml`, `apr-cli`.

`Cargo.lock`: `thrift 0.17.0` gone, plus its own deps `integer-encoding` and `ordered-float`.

## The falsifier

`scripts/check_no_ghsa_banned_crates.sh` — a hand-maintained table of `(crate, first-fixed-version, advisory, reason)` checked against `Cargo.lock`. Deliberately *not* a general scanner: entries are added by hand and **removed** once RustSec carries the advisory, so it cannot rot into a stale second copy of `deny.toml` (same discipline `check_deny_exemptions_live.sh` enforces there). Wired into `ci.yml`'s security-advisories job beside the other text-only guards, and into `make deny`.

RED before the fix, GREEN after, on the real tree:

```
before:  FAIL: thrift 0.17.0 GHSA-2f9f-gq7v-9h6m (CVE-2026-43868) ...     rc=1
after:   PASS: 1 table entry checked, none present in Cargo.lock          rc=0
```

## Mutation-verified both directions, engagement proved before reading any verdict

| # | Mutation | Engagement proof | Verdict |
|---|---|---|---|
| A | re-inject a `thrift 0.17.0` package block into the **real** `Cargo.lock` | `MUTATION-MARKER-2531` count `1`, `^name = "thrift"` blocks `1` | guard **rc=1** — it reads the lockfile, not a cached answer |
| B | neuter the table bound to `0.0.0` in a copy placed inside `scripts/`, same lockfile still carrying thrift | mutated pattern present `1`, original pattern absent `0` | guard **rc=0** — the bound is load-bearing; a wrong table goes *blind* rather than failing closed |

Mutation B is the one worth reading: it shows the guard's verdict comes from the version comparison, not merely from crate presence — which is why `--self-test` asserts both edges of that bound on every CI run.

`--self-test` case table (8 cases, run in CI, not a one-off):

```
ok   thrift 0.17.0 (the #2531 version)         rc=1
ok   thrift 0.22.9 (just below the fix)        rc=1
ok   thrift 0.9.0  (not lexically < 0.23)      rc=1   <- a lexical compare passes this
ok   thrift 0.23.0 (the fixed version)         rc=0
ok   thrift 1.0.0  (above the fix)             rc=0
ok   serde 1.0.0   (unrelated crate)           rc=0
ok   empty lockfile is NOT clean               rc=2
ok   missing lockfile is NOT clean             rc=2
```

## parquet 59 API change

`WriterPropertiesBuilder::set_max_row_group_size` → `set_max_row_group_row_count(Option<usize>)`. Two call sites updated (aprender-db integration test + bench). Left alone they are `deprecated` warnings — which CI's `clippy -D warnings` turns into errors. The deprecation firing is also the proof the 59 crate is what compiled: that diagnostic cannot exist under parquet 57.

## Verification

- `cargo check --all-targets` clean: aprender-db, aprender-graph, aprender-data, aprender-verify-ml (`--features parquet`), aprender-distribute (`--features checkpoint`)
- `cargo check --lib --tests --examples` clean: aprender-train, aprender-serve, apr-cli
- Real parquet round-trips **run**, not just typechecked: aprender-db `integration_test` 3/3, aprender-db `--lib` 66/66, aprender-data `--lib` 1824/1824
- `cargo fmt --all -- --check` clean; `clippy -p aprender-db --all-targets -D warnings` clean
- `cargo deny check advisories` ok; `check_deny_exemptions_live.sh` 8/8 still live (no exemption went dead)
- `check_lockfile_current.sh` passes (`cargo metadata --locked` resolves)
- `check_shell_lint_ratchet.sh` passes: 100 error lines vs baseline 876

## Pre-existing, NOT caused here

`cargo check -p aprender-serve --all-targets` fails on `benches/comparative.rs` (`E0063` missing `query_pre_attn_scalar` / `lm_head_tied`). That file contains **zero** references to arrow or parquet, is untouched by this branch, and is a dark target — CI builds no bench there. Unrelated struct-field drift; worth its own ticket.

## Deferred

- The other 8 arrow-family crates were checked, not exercised end-to-end; only aprender-db and aprender-data had their tests run.
- `arrow 58.3.0` remains in the lock via `duckdb` (optional, `competitive-benchmarks`). It pulls no thrift, so it is out of scope here, but it is a second arrow major in the graph.
- The GHSA table has one entry. Systematically reconciling GHSA against RustSec for the whole graph is a larger piece of work (and belongs upstream, cf. paiml/.github#48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
