### PR TITLE
fix(mcp): the EOF drop is fixed — but three of the read loop's four exits still walked away from an answer (#2608)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |

--- a/contracts/apr-mcp-stdio-drain-v1.yaml
+++ b/contracts/apr-mcp-stdio-drain-v1.yaml
@@ -1,0 +1,150 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-22'
+  author: apr-cli team
+  kind: kernel
+  description: |
+    #2608 — the `apr mcp` stdio loop answers `tools/call` on a worker thread,
+    so every exit from the read loop is a point at which the server can walk
+    away from an answer it already owes. The measured 0.63.0 defect was the
+    EOF exit: `printf '<initialize>\n<tools/call>\n' | apr mcp` answered
+    initialize, exited 0 with empty stderr, and NEVER answered the tools/call.
+    Holding stdin open for 5s with byte-identical input answered both — the
+    only variable was whether the client had closed its write end.
+
+    A JSON-RPC request that receives neither a result nor an error is a
+    protocol violation (JSON-RPC 2.0 §5: a Request object with an `id` MUST be
+    replied to). Out-of-order responses are NOT a violation and are explicitly
+    permitted here — the pipelined worker model is the intended design and the
+    ids may return in any order.
+
+    This contract states the invariant as ONE property over ALL exits rather
+    than as the single EOF case that was measured, because the same drop is
+    reachable through three further routes that no EOF test can see:
+
+      * the read loop leaving through an I/O error (`?` on the stdin read or on
+        a stdout write) instead of through EOF;
+      * a tool that PANICS inside dispatch — the worker wrote a response only
+        on the success path and `join_workers` deliberately swallows the panic,
+        so the request went unanswered exactly as at EOF.
+
+    Numbering note: the gates below are namespaced `FALSIFY-MCP-DRAIN-*` rather
+    than continuing the `FALSIFY-MCP-0NN` sequence owned by
+    apr-mcp-server-v1.yaml, so that contract's "001..N with no gaps or
+    duplicates" gate (crates/aprender-contracts/tests/apr_mcp_server_contract.rs)
+    stays exactly as it is.
+  references:
+  - 'https://github.com/paiml/aprender/issues/2608 (measured on published apr 0.63.0, Xeon W-3245 receipt host)'
+  - 'contracts/apr-mcp-server-v1.yaml (FALSIFY-MCP-010: the EOF case, shipped)'
+  - 'crates/aprender-mcp/src/server.rs (serve_stream / read_loop / join_workers / worker_response)'
+  - 'crates/aprender-mcp/tests/falsify_mcp_stdio_protocol.rs (FALSIFY-MCP-010 over the real binary)'
+  - 'JSON-RPC 2.0 Specification §4.1, §5'
+  - 'Model Context Protocol Specification v2024-11-05 (stdio transport)'
+  depends_on:
+  - apr-mcp-server-v1
+
+kind: KernelContract
+name: apr-mcp-stdio-drain
+version: 1.0.0
+status: ACTIVE
+scope: the `apr mcp` stdio read loop's obligation to answer every request carrying an id
+
+equations:
+  answered_requests:
+    formula: answered(S) = accepted(S)
+    domain: S a stdio session; accepted(S) = the requests carrying an `id` that the loop parsed and routed
+    codomain: answered(S) = the set of ids for which exactly one response line was written
+    invariants:
+    - 'every id in accepted(S) appears exactly once in answered(S), whatever the session exit was (EOF, stdin error, stdout error)'
+    - 'response ORDER is unconstrained: ids may be written in any permutation (workers are concurrent by design)'
+    - 'a tool that panics contributes an error response for its id, never silence'
+    - 'the session outcome (Ok / Err) is reported only AFTER the drain'
+    preconditions:
+    - the request carried an `id` (a Notification per JSON-RPC §4.1 must NOT be answered)
+    - the request was routed as `tools/call` (the only asynchronously answered method)
+    postconditions:
+    - 'serve_stream returns only after every worker it spawned has run to completion'
+    - '|answered(S)| == |accepted(S)| for every terminating session'
+
+proof_obligations:
+- type: invariant
+  property: drain-on-every-exit — no exit from the read loop abandons an in-flight worker
+  formal: |
+    For every session S and every exit reason R in {EOF, stdin io::Error,
+    stdout io::Error}, serve_stream calls join_workers before returning R.
+    Structurally: the drain is on serve_stream's single return path and the
+    loop body lives in read_loop, so no `?` inside the loop can skip it.
+- type: invariant
+  property: panic-is-an-error-not-silence — a panicking tool still answers its id
+  formal: |
+    For every tools/call with id i whose dispatch panics, the worker writes a
+    JsonRpcResponse with id == i and error.code == -32603 whose message carries
+    the panic payload. catch_unwind wraps ONLY dispatch, so a caught panic
+    always precedes any byte written for i and cannot produce a second response.
+- type: invariant
+  property: no-false-error — the guards do not convert successful calls into failures
+  formal: |
+    For every tools/call whose dispatch returns normally, the response is a
+    success carrying that ToolCallResult verbatim, and a session that reaches
+    EOF cleanly still returns Ok.
+
+falsification_tests:
+- id: FALSIFY-MCP-DRAIN-001
+  obligation: drain-on-every-exit — no exit from the read loop abandons an in-flight worker
+  rule: an in-flight tools/call is answered even when the read loop exits through an I/O error rather than EOF
+  prediction: with a 2s-slow tool designated via $APR_BIN and a reader that fails after the last line, serve_stream returns Err AND stdout already carries the id=2 response
+  test: cargo test -p aprender-mcp --lib serve_stream_drains_in_flight_workers_when_the_read_loop_aborts
+  if_fails: the drain moved back onto one exit of the read loop; a stdin/stdout error silently abandons every in-flight tools/call
+- id: FALSIFY-MCP-DRAIN-002
+  obligation: panic-is-an-error-not-silence — a panicking tool still answers its id
+  rule: a tool that panics is answered with -32603 for the same id, never with silence
+  prediction: worker_response(id, || panic!(...)) yields an error response with code -32603, the id echoed, and the panic message included
+  test: cargo test -p aprender-mcp --lib worker_response_turns_a_tool_panic_into_32603_for_the_same_id
+  if_fails: catch_unwind was removed from the worker; a panicking tool leaves its request answered by neither a result nor an error
+- id: FALSIFY-MCP-DRAIN-003
+  obligation: no-false-error — the guards do not convert successful calls into failures
+  rule: the panic guard does not turn ordinary tool results into errors
+  prediction: worker_response(id, || ToolCallResult::success("payload")) yields a success response carrying that payload verbatim
+  test: cargo test -p aprender-mcp --lib worker_response_passes_a_normal_tool_result_through_unchanged
+  if_fails: the guard answers -32603 unconditionally, which would satisfy DRAIN-002 while breaking every call
+- id: FALSIFY-MCP-DRAIN-004
+  obligation: drain-on-every-exit — no exit from the read loop abandons an in-flight worker
+  rule: the originally measured EOF case stays fixed (regression lock for #2608 / FALSIFY-MCP-010)
+  prediction: a session whose last line is a tools/call and whose stdin then closes answers BOTH ids before exiting 0
+  test: cargo test -p aprender-mcp --lib serve_stream_answers_tools_call_before_returning_on_eof
+  if_fails: the EOF drain regressed; `printf ... | apr mcp` loses tool results again while exiting 0
+
+kani_harnesses:
+- id: KANI-MCP-DRAIN-001
+  obligation: panic-is-an-error-not-silence — a panicking tool still answers its id
+  property: |
+    For all ids i drawn from the bounded set {integer 0..=8, the strings "0".."8"}:
+    worker_response(i, f).id == Some(i) for both f = a returning dispatch and
+    f = a panicking dispatch, and the panicking case additionally carries
+    error.code == -32603.
+    STATUS: DECLARED, NOT IMPLEMENTED. The property is stated so the obligation
+    is auditable; the shipped evidence for it today is FALSIFY-MCP-DRAIN-002/003
+    (cargo test), not a model-checking run. Do not read this entry as a proof.
+  bound: 8
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_worker_response_preserves_the_id
+- id: KANI-MCP-DRAIN-002
+  obligation: panic-is-an-error-not-silence — a panicking tool still answers its id
+  property: |
+    For all payload shapes in {&'static str, String, other}: panic_message
+    returns a non-empty String and never itself panics, so the -32603 the client
+    receives is never an empty diagnostic.
+    STATUS: DECLARED, NOT IMPLEMENTED — same caveat as KANI-MCP-DRAIN-001.
+  bound: 3
+  strategy: bounded_int
+  solver: cadical
+  harness: verify_panic_message_is_total
+
+qa_gate:
+  id: F-MCP-DRAIN-001
+  name: apr-mcp-stdio-drain-v1 Contract
+  description: Every `apr mcp` request carrying an id is answered exactly once — on EOF, on an I/O error, and when the tool panics. Response order is unconstrained.
+  checks:
+  - validation
+  - falsification

--- a/contracts/apr-mcp-stdio-drain-v1.yaml
+++ b/contracts/apr-mcp-stdio-drain-v1.yaml
@@ -26,7 +26,11 @@ metadata:
         a stdout write) instead of through EOF;
       * a tool that PANICS inside dispatch — the worker wrote a response only
         on the success path and `join_workers` deliberately swallows the panic,
-        so the request went unanswered exactly as at EOF.
+        so the request went unanswered exactly as at EOF;
+      * a panic guard that is CORRECT but never REACHED. A helper-level test of
+        the guard passes whether or not the worker calls it, so the panic
+        obligation is stated over what a client reading stdout receives and is
+        gated end-to-end through serve_stream (FALSIFY-MCP-DRAIN-005).
 
     Numbering note: the gates below are namespaced `FALSIFY-MCP-DRAIN-*` rather
     than continuing the `FALSIFY-MCP-0NN` sequence owned by
@@ -81,6 +85,9 @@ proof_obligations:
     JsonRpcResponse with id == i and error.code == -32603 whose message carries
     the panic payload. catch_unwind wraps ONLY dispatch, so a caught panic
     always precedes any byte written for i and cannot produce a second response.
+    The obligation is on the SESSION, not on the helper: it is discharged only
+    if spawn_tools_call_worker actually routes dispatch through worker_response,
+    so it is stated over what a client reading stdout receives.
 - type: invariant
   property: no-false-error — the guards do not convert successful calls into failures
   formal: |
@@ -92,7 +99,7 @@ falsification_tests:
 - id: FALSIFY-MCP-DRAIN-001
   obligation: drain-on-every-exit — no exit from the read loop abandons an in-flight worker
   rule: an in-flight tools/call is answered even when the read loop exits through an I/O error rather than EOF
-  prediction: with a 2s-slow tool designated via $APR_BIN and a reader that fails after the last line, serve_stream returns Err AND stdout already carries the id=2 response
+  prediction: with a writer that stalls 2s on the id=2 line and a reader that fails after the last line, serve_stream returns Err AND the id=2 response has already been written
   test: cargo test -p aprender-mcp --lib serve_stream_drains_in_flight_workers_when_the_read_loop_aborts
   if_fails: the drain moved back onto one exit of the read loop; a stdin/stdout error silently abandons every in-flight tools/call
 - id: FALSIFY-MCP-DRAIN-002
@@ -113,6 +120,18 @@ falsification_tests:
   prediction: a session whose last line is a tools/call and whose stdin then closes answers BOTH ids before exiting 0
   test: cargo test -p aprender-mcp --lib serve_stream_answers_tools_call_before_returning_on_eof
   if_fails: the EOF drain regressed; `printf ... | apr mcp` loses tool results again while exiting 0
+- id: FALSIFY-MCP-DRAIN-005
+  obligation: panic-is-an-error-not-silence — a panicking tool still answers its id
+  rule: the panic guard is REACHED by the real stdio dispatch path, not merely correct in isolation
+  prediction: a tools/call whose tool panics, fed to serve_stream, produces on stdout an error response for the SAME id with code -32603 carrying the panic message, while initialize is still answered and serve_stream returns Ok
+  test: cargo test -p aprender-mcp --lib a_panicking_tool_is_answered_through_the_real_stdio_path
+  if_fails: the worker calls dispatch BESIDE the guard instead of inside it (the pre-#2608 shape) — worker_response stays correct and is simply never reached, so DRAIN-002/003 remain green while every panicking tool goes unanswered
+- id: FALSIFY-MCP-DRAIN-006
+  obligation: no-false-error — the guards do not convert successful calls into failures
+  rule: the injection seam DRAIN-005 uses cannot hide a stubbed production dispatcher
+  prediction: an untouched AprMcpServer's worker_dispatch answers apr.version with the real inventory-backed payload (server == "aprender-mcp")
+  test: cargo test -p aprender-mcp --lib default_worker_dispatch_is_the_real_tool_dispatcher
+  if_fails: the default dispatch is not the shipped one, so DRAIN-005 would be proving the wiring of something the server never runs
 
 kani_harnesses:
 - id: KANI-MCP-DRAIN-001

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -300,8 +300,8 @@ impl AprMcpServer {
     /// Workers write their responses directly to `out` (guarded by a mutex)
     /// so the main loop never has to wait on them mid-stream.
     ///
-    /// Two transport invariants live here, both found by the 0.63.0 dogfood
-    /// and both invisible to a dispatcher-level test:
+    /// Three transport invariants live here, all found by dogfooding the
+    /// shipped binary and all invisible to a dispatcher-level test:
     ///
     /// * **FALSIFY-MCP-010** — on EOF the loop MUST join every worker it
     ///   spawned before returning. Without that join the process exits the
@@ -313,14 +313,40 @@ impl AprMcpServer {
     ///   A line that is not valid UTF-8 is a malformed *message*, answered
     ///   with `-32700`, not a transport failure that takes the session down
     ///   with it.
+    /// * **FALSIFY-MCP-DRAIN-001** (#2608) — EOF is not the only way out of
+    ///   the read loop. Every `?` inside it (a stdin read error, a stdout
+    ///   write error) is an exit too, and each one used to abandon the
+    ///   in-flight workers exactly the way the 0.63.0 EOF path did. The drain
+    ///   therefore lives here, on the *only* return path, rather than at the
+    ///   bottom of the loop where three of the four exits skip it.
     ///
     /// `W` must be `Send + 'static` because the same handle is shared with
     /// every worker thread.
     ///
     /// # Errors
-    /// Returns an error if reading or writing the streams fails.
+    /// Returns an error if reading or writing the streams fails. The error is
+    /// reported only AFTER the drain, so a failed session still delivers the
+    /// answers it already owes.
     #[cfg(feature = "native")]
-    pub fn serve_stream<R, W>(&mut self, mut reader: R, out: Arc<Mutex<W>>) -> anyhow::Result<()>
+    pub fn serve_stream<R, W>(&mut self, reader: R, out: Arc<Mutex<W>>) -> anyhow::Result<()>
+    where
+        R: std::io::BufRead,
+        W: std::io::Write + Send + 'static,
+    {
+        let outcome = self.read_loop(reader, &out);
+
+        // FALSIFY-MCP-010 / FALSIFY-MCP-DRAIN-001: drain before returning, on
+        // EVERY exit. EOF means the client sent everything it intends to, NOT
+        // that it stopped wanting answers — and an I/O error mid-session says
+        // even less about the requests already accepted.
+        self.join_workers();
+        outcome
+    }
+
+    /// The read loop proper. Separated from [`Self::serve_stream`] so that the
+    /// worker drain wraps it, rather than sitting on one of its exits.
+    #[cfg(feature = "native")]
+    fn read_loop<R, W>(&mut self, mut reader: R, out: &Arc<Mutex<W>>) -> anyhow::Result<()>
     where
         R: std::io::BufRead,
         W: std::io::Write + Send + 'static,
@@ -343,7 +369,7 @@ impl AprMcpServer {
             let Ok(line) = std::str::from_utf8(&buf) else {
                 let resp =
                     JsonRpcResponse::error(None, -32700, "Parse error: message is not valid UTF-8");
-                write_response(&out, &resp)?;
+                write_response(out, &resp)?;
                 continue;
             };
 
@@ -352,16 +378,13 @@ impl AprMcpServer {
             }
 
             match parse_incoming(line) {
-                Ok(req) => self.route_stdio_message(req, &out)?,
-                Err(resp) => write_response(&out, &resp)?,
+                Ok(req) => self.route_stdio_message(req, out)?,
+                Err(resp) => write_response(out, &resp)?,
             }
 
             self.reap_finished_workers();
         }
 
-        // FALSIFY-MCP-010: drain before returning. EOF means the client sent
-        // everything it intends to, NOT that it stopped wanting answers.
-        self.join_workers();
         Ok(())
     }
 
@@ -373,12 +396,52 @@ impl AprMcpServer {
         self.workers.retain(|h| !h.is_finished());
     }
 
+    /// Build the response a `tools/call` worker owes its client, converting a
+    /// panic inside tool dispatch into a `-32603` for the SAME id.
+    ///
+    /// FALSIFY-MCP-DRAIN-002 (#2608): the worker wrote a response only on the
+    /// success path, and [`Self::join_workers`] deliberately swallows a
+    /// worker panic (`let _ = handle.join()`). A tool that panicked therefore
+    /// left its request answered by NEITHER a result NOR an error — the same
+    /// protocol violation as the EOF drop, reached by a different route, and
+    /// equally silent: rc stays 0 and the client waits forever.
+    ///
+    /// Only dispatch runs under `catch_unwind`; the write and the registry
+    /// cleanup stay outside it, so a caught panic is always one that happened
+    /// BEFORE any bytes were written and can never produce a second response
+    /// for the same id.
+    #[cfg(feature = "native")]
+    fn worker_response<F>(id: &serde_json::Value, dispatch: F) -> JsonRpcResponse
+    where
+        F: FnOnce() -> ToolCallResult,
+    {
+        // AssertUnwindSafe: on the panic path every captured value is dropped
+        // untouched — nothing is read back, so there is no broken invariant to
+        // observe. The alternative (propagating) is the silent drop itself.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(dispatch)) {
+            Ok(result) => JsonRpcResponse::success(
+                Some(id.clone()),
+                serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+            ),
+            Err(payload) => JsonRpcResponse::error(
+                Some(id.clone()),
+                -32603,
+                format!(
+                    "Internal error: tool panicked: {}",
+                    panic_message(payload.as_ref())
+                ),
+            ),
+        }
+    }
+
     /// Block until every in-flight `tools/call` worker has written its
-    /// response. Called once, on EOF, by [`Self::serve_stream`].
+    /// response. Called once, on the single exit path of
+    /// [`Self::serve_stream`].
     ///
     /// A panicking worker is ignored rather than propagated: the client is
-    /// owed whatever the surviving workers produced, and the panic message
-    /// has already reached stderr.
+    /// owed whatever the surviving workers produced, and the panicking
+    /// worker's own request was already answered with a `-32603` by
+    /// [`Self::worker_response`].
     #[cfg(feature = "native")]
     fn join_workers(&mut self) {
         for handle in std::mem::take(&mut self.workers) {
@@ -482,13 +545,10 @@ impl AprMcpServer {
         // error rather than unwrapping so we stay in the "no panics" lane.
         let builder = std::thread::Builder::new().name(format!("apr-mcp-call-{id}"));
         let spawn_result = builder.spawn(move || {
-            let sink_ref = progress_token.as_ref().map(|_| &sink);
-            let result =
-                dispatch_tool_call_with_sink(&params, &cancel_rx, sink_ref, progress_token);
-            let resp = JsonRpcResponse::success(
-                Some(id_for_worker.clone()),
-                serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
-            );
+            let resp = Self::worker_response(&id_for_worker, || {
+                let sink_ref = progress_token.as_ref().map(|_| &sink);
+                dispatch_tool_call_with_sink(&params, &cancel_rx, sink_ref, progress_token)
+            });
             // Best-effort: a broken stdout means the client disconnected,
             // which we can't recover from anyway.
             let _ = write_response(&stdout_clone, &resp);
@@ -706,6 +766,22 @@ fn parse_incoming(line: &str) -> Result<JsonRpcRequest, Box<JsonRpcResponse>> {
     })
 }
 
+/// Best-effort rendering of a `catch_unwind` payload.
+///
+/// `panic!("msg")` yields a `&'static str`, `panic!("{x}")` a `String`; a
+/// payload of any other type carries no message we can read, so the client is
+/// told that rather than being handed an empty error.
+#[cfg(feature = "native")]
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "panic payload is not a string".to_string()
+    }
+}
+
 fn write_response<W: std::io::Write>(
     stdout: &Arc<Mutex<W>>,
     resp: &JsonRpcResponse,
@@ -849,6 +925,120 @@ mod tests {
                 responses.len()
             );
         }
+    }
+
+    /// A reader that replays `bytes` and then fails, so the read loop leaves
+    /// through an `io::Error` instead of through EOF.
+    #[cfg(feature = "native")]
+    struct FailsAfterInput {
+        bytes: Vec<u8>,
+        pos: usize,
+    }
+
+    #[cfg(feature = "native")]
+    impl std::io::Read for FailsAfterInput {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.pos == self.bytes.len() {
+                return Err(std::io::Error::other("simulated stdin failure"));
+            }
+            let n = std::cmp::min(buf.len(), self.bytes.len() - self.pos);
+            buf[..n].copy_from_slice(&self.bytes[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    /// A writer that stalls for [`SLOW_WRITE`] on the line carrying `"id":2`,
+    /// and records every completed write in a sink the test can read WITHOUT
+    /// waiting on the server's own stdout mutex.
+    ///
+    /// The separate sink is the whole point: the worker holds the stdout mutex
+    /// for the duration of its stalled write, so a test that inspected the
+    /// stdout buffer directly would block until the worker finished and would
+    /// then see the very response it was supposed to prove missing — green on
+    /// the defect.
+    #[cfg(feature = "native")]
+    struct StallsOnId2 {
+        sink: Arc<Mutex<Vec<u8>>>,
+    }
+
+    #[cfg(feature = "native")]
+    const SLOW_WRITE: std::time::Duration = std::time::Duration::from_secs(2);
+
+    #[cfg(feature = "native")]
+    impl std::io::Write for StallsOnId2 {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            if String::from_utf8_lossy(data).contains(r#""id":2"#) {
+                std::thread::sleep(SLOW_WRITE);
+            }
+            self.sink
+                .lock()
+                .expect("sink mutex not poisoned")
+                .extend_from_slice(data);
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// FALSIFY-MCP-DRAIN-001 (#2608): EOF is not the only exit from the read
+    /// loop, and the other exits owe the client the same answers.
+    ///
+    /// `serve_stream` drained on EOF only. Every `?` in the loop — a stdin
+    /// read error, a stdout write error — returned straight past the drain and
+    /// the process exited on top of workers that still owed responses. That is
+    /// the identical protocol violation #2608 measured at EOF: a JSON-RPC
+    /// request answered by neither a result nor an error.
+    ///
+    /// Determinism, not scheduling luck: the worker's own write stalls for two
+    /// seconds. Without the drain `serve_stream` returns in microseconds with
+    /// the id=2 bytes still unwritten, so the assertion below is RED by a
+    /// two-second margin. (An ordering variant of the EOF falsifier was
+    /// deleted from `tests/falsify_mcp_stdio_protocol.rs` for exactly the
+    /// opposite reason: it stayed green on the defect.)
+    ///
+    /// No wall-clock value is ASSERTED here — the stall is the fixture, and
+    /// the assertions are all about which bytes exist.
+    #[cfg(feature = "native")]
+    #[test]
+    fn serve_stream_drains_in_flight_workers_when_the_read_loop_aborts() {
+        let input = format!("{INIT_LINE}\n{CALL_LINE}\n");
+        let reader = std::io::BufReader::new(FailsAfterInput {
+            bytes: input.into_bytes(),
+            pos: 0,
+        });
+        let sink = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let out = Arc::new(Mutex::new(StallsOnId2 {
+            sink: Arc::clone(&sink),
+        }));
+        let mut server = AprMcpServer::new();
+
+        let outcome = server.serve_stream(reader, Arc::clone(&out));
+
+        assert!(
+            outcome.is_err(),
+            "the stdin failure must still be reported after the drain"
+        );
+        let written = {
+            let guard = sink.lock().expect("sink mutex not poisoned");
+            String::from_utf8_lossy(&guard).into_owned()
+        };
+        assert!(
+            written.contains(r#""id":2"#),
+            "the in-flight tools/call was answered by NEITHER a result NOR an error \
+             when the read loop aborted; stdout was: {written:?}"
+        );
+        assert!(
+            written.contains("aprender-mcp"),
+            "the answer must be the real apr.version payload, not an empty envelope: {written:?}"
+        );
+        assert!(
+            server.workers.is_empty(),
+            "{} worker(s) were abandoned instead of joined",
+            server.workers.len()
+        );
     }
 
     /// FALSIFY-MCP-011: an invalid UTF-8 byte is a malformed MESSAGE. It must
@@ -1210,6 +1400,65 @@ mod tests {
         );
         assert_eq!(resp.result, Some(serde_json::json!({})));
         assert_eq!(resp.id, Some(serde_json::json!(1)), "id echoed");
+    }
+
+    /// FALSIFY-MCP-DRAIN-002 (#2608): a tool that panics must still answer.
+    ///
+    /// The worker built a response only on the success path, and
+    /// `join_workers` swallows the panic, so a panicking tool left its request
+    /// answered by neither a result nor an error — the client waits forever
+    /// while the server exits 0. The panic message reaches stderr and is
+    /// expected noise in this test's output.
+    #[cfg(feature = "native")]
+    #[test]
+    fn worker_response_turns_a_tool_panic_into_32603_for_the_same_id() {
+        let resp = AprMcpServer::worker_response(&serde_json::json!(7), || {
+            panic!("tool exploded while dispatching")
+        });
+
+        assert_eq!(
+            resp.id,
+            Some(serde_json::json!(7)),
+            "the id the client must correlate on has to survive the panic: {resp:?}"
+        );
+        assert!(
+            resp.result.is_none(),
+            "a panic must not also produce a result: {resp:?}"
+        );
+        let err = resp
+            .error
+            .expect("a panicking tool must produce an ERROR, never silence");
+        assert_eq!(
+            err.code, -32603,
+            "a tool panic is an Internal error: {err:?}"
+        );
+        assert!(
+            err.message.contains("panicked"),
+            "the -32603 must name the cause: {err:?}"
+        );
+        assert!(
+            err.message.contains("tool exploded while dispatching"),
+            "the panic message itself must reach the client: {err:?}"
+        );
+    }
+
+    /// The other direction of FALSIFY-MCP-DRAIN-002: the panic guard must not
+    /// turn ordinary results into errors. Without this, "always answer
+    /// -32603" would satisfy the test above.
+    #[cfg(feature = "native")]
+    #[test]
+    fn worker_response_passes_a_normal_tool_result_through_unchanged() {
+        let resp = AprMcpServer::worker_response(&serde_json::json!("abc"), || {
+            ToolCallResult::success("payload".to_string())
+        });
+
+        assert_eq!(resp.id, Some(serde_json::json!("abc")), "id echoed");
+        assert!(resp.error.is_none(), "no error on the happy path: {resp:?}");
+        let result = resp.result.expect("result present");
+        assert_eq!(
+            result["content"][0]["text"], "payload",
+            "the tool's own payload must reach the client verbatim: {result:?}"
+        );
     }
 
     /// FALSIFY-MCP-012: valid JSON that is not a valid Request object is

--- a/crates/aprender-mcp/src/server.rs
+++ b/crates/aprender-mcp/src/server.rs
@@ -58,7 +58,7 @@ type InFlight = Arc<Mutex<HashMap<serde_json::Value, CancelHandle>>>;
 ///
 /// M1: `initialize`, `tools/list`, `tools/call` with `apr.version`.
 /// M3: `notifications/cancelled` routed to in-flight `apr.run` workers.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AprMcpServer {
     in_flight: InFlight,
     /// Join handles for `tools/call` workers spawned by
@@ -68,6 +68,38 @@ pub struct AprMcpServer {
     /// [`Self::serve_stream`].
     #[cfg(feature = "native")]
     workers: Vec<std::thread::JoinHandle<()>>,
+    /// The dispatch function a `tools/call` worker runs, always
+    /// [`dispatch_tool_call_with_sink`] outside tests.
+    ///
+    /// It is a field rather than a hardcoded call so that
+    /// FALSIFY-MCP-DRAIN-005 can drive a PANICKING tool through the whole
+    /// real stdio path — `serve_stream` → `read_loop` →
+    /// `route_stdio_message` → `spawn_tools_call_worker` → the worker thread
+    /// — and observe what the client actually receives. Every registered tool
+    /// is a subprocess wrapper or a pure metadata read, so no real
+    /// `tools/call` argument can be made to panic on demand, and without this
+    /// seam the panic guard could only ever be tested one hop away from the
+    /// wiring that has to call it.
+    ///
+    /// The seam cannot hide a stubbed default: the other `serve_stream_*`
+    /// tests run an untouched server and assert the genuine `apr.version`
+    /// payload comes back out of stdout, and
+    /// `default_worker_dispatch_is_the_real_tool_dispatcher` asserts it
+    /// directly.
+    #[cfg(feature = "native")]
+    worker_dispatch: crate::tools::DispatchFn,
+}
+
+impl Default for AprMcpServer {
+    fn default() -> Self {
+        Self {
+            in_flight: InFlight::default(),
+            #[cfg(feature = "native")]
+            workers: Vec::new(),
+            #[cfg(feature = "native")]
+            worker_dispatch: dispatch_tool_call_with_sink,
+        }
+    }
 }
 
 impl AprMcpServer {
@@ -544,10 +576,16 @@ impl AprMcpServer {
         // Thread spawn is infallible here in practice, but propagate the
         // error rather than unwrapping so we stay in the "no panics" lane.
         let builder = std::thread::Builder::new().name(format!("apr-mcp-call-{id}"));
+        let dispatch = self.worker_dispatch;
         let spawn_result = builder.spawn(move || {
+            // FALSIFY-MCP-DRAIN-002/005: dispatch runs INSIDE worker_response,
+            // never beside it. Calling `dispatch(...)` directly here and
+            // building the success response from its return value is exactly
+            // the pre-#2608 code, and is what FALSIFY-MCP-DRAIN-005 exists to
+            // turn red.
             let resp = Self::worker_response(&id_for_worker, || {
                 let sink_ref = progress_token.as_ref().map(|_| &sink);
-                dispatch_tool_call_with_sink(&params, &cancel_rx, sink_ref, progress_token)
+                dispatch(&params, &cancel_rx, sink_ref, progress_token)
             });
             // Best-effort: a broken stdout means the client disconnected,
             // which we can't recover from anyway.
@@ -843,6 +881,12 @@ mod tests {
             .serve_stream(std::io::Cursor::new(input.to_vec()), Arc::clone(&out))
             .expect("serve_stream must not propagate an error out of the session");
 
+        parse_written_lines(&out)
+    }
+
+    /// Parse whatever a session wrote to `out` into one JSON value per line.
+    #[cfg(feature = "native")]
+    fn parse_written_lines(out: &Arc<Mutex<Vec<u8>>>) -> Vec<serde_json::Value> {
         let guard = out.lock().expect("output mutex not poisoned");
         String::from_utf8_lossy(&guard)
             .lines()
@@ -1458,6 +1502,130 @@ mod tests {
         assert_eq!(
             result["content"][0]["text"], "payload",
             "the tool's own payload must reach the client verbatim: {result:?}"
+        );
+    }
+
+    /// A tool dispatch that panics. Every registered tool is a subprocess
+    /// wrapper or a pure metadata read, so none can be made to panic from a
+    /// `tools/call` argument; this stands in for the tool that does.
+    ///
+    /// The marker string is unique so the assertion below cannot be satisfied
+    /// by some other error the server might produce for id=2.
+    #[cfg(feature = "native")]
+    fn panicking_dispatch(
+        _args: &serde_json::Value,
+        _cancel_rx: &mpsc::Receiver<()>,
+        _sink: Option<&NotificationSink>,
+        _progress_token: Option<serde_json::Value>,
+    ) -> ToolCallResult {
+        panic!("PANIC-PROBE-2608 exploded inside tool dispatch")
+    }
+
+    /// FALSIFY-MCP-DRAIN-005 (#2608): the panic guard must be REACHED.
+    ///
+    /// [`AprMcpServer::worker_response`] can be perfectly correct while the
+    /// server never calls it — that is the whole defect class this PR is
+    /// about, and the two `worker_response_*` tests above exercise the helper
+    /// directly, so both stay green when the call site is deleted. This test
+    /// never mentions `worker_response`: it feeds a `tools/call` into
+    /// [`AprMcpServer::serve_stream`] and reads what came out of the client's
+    /// end of stdout, the same surface #2608 measured. The route under test is
+    /// `serve_stream` → `read_loop` → `route_stdio_message` →
+    /// `spawn_tools_call_worker` → the worker thread.
+    ///
+    /// Mutation (the pre-#2608 shape — dispatch called BESIDE the guard rather
+    /// than inside it):
+    ///
+    /// ```ignore
+    /// let result = dispatch(&params, &cancel_rx, sink_ref, progress_token);
+    /// let resp = JsonRpcResponse::success(Some(id_for_worker.clone()), ...);
+    /// ```
+    ///
+    /// The worker then unwinds, `join_workers` swallows the panic exactly as
+    /// documented, and nothing is ever written for id=2 — this test fails on
+    /// "answered by NEITHER a result NOR an error", while
+    /// `worker_response_turns_a_tool_panic_into_32603_for_the_same_id` stays
+    /// green. That asymmetry is what makes this a wiring guard and not a
+    /// restatement of the helper.
+    ///
+    /// The worker's panic message reaches stderr; it is expected noise.
+    #[cfg(feature = "native")]
+    #[test]
+    fn a_panicking_tool_is_answered_through_the_real_stdio_path() {
+        let out = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let mut server = AprMcpServer::new();
+        server.worker_dispatch = panicking_dispatch;
+
+        let outcome = server.serve_stream(
+            std::io::Cursor::new(format!("{INIT_LINE}\n{CALL_LINE}\n").into_bytes()),
+            Arc::clone(&out),
+        );
+
+        assert!(
+            outcome.is_ok(),
+            "a panicking TOOL must not take the SESSION down: {outcome:?}"
+        );
+        let responses = parse_written_lines(&out);
+        let call = find_id(&responses, 2).unwrap_or_else(|| {
+            panic!(
+                "the tools/call whose tool panicked was answered by NEITHER a result NOR an \
+                 error — the worker never routed through the panic guard; got {} response(s): \
+                 {responses:?}",
+                responses.len()
+            )
+        });
+        assert!(
+            call.get("result").is_none(),
+            "a panic must not also produce a result: {call:?}"
+        );
+        assert_eq!(
+            call["error"]["code"],
+            serde_json::json!(-32603),
+            "a tool panic is an Internal error for the SAME id: {call:?}"
+        );
+        let message = call["error"]["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("error message must be a string: {call:?}"));
+        assert!(
+            message.contains("PANIC-PROBE-2608 exploded inside tool dispatch"),
+            "the panic's own message must reach the client, not a generic envelope: {message:?}"
+        );
+        assert!(
+            find_id(&responses, 1).is_some(),
+            "initialize must still be answered: {responses:?}"
+        );
+        assert!(
+            server.workers.is_empty(),
+            "{} worker(s) were abandoned instead of joined",
+            server.workers.len()
+        );
+    }
+
+    /// The seam FALSIFY-MCP-DRAIN-005 uses must not be able to hide a stubbed
+    /// production default: a server nobody touched dispatches through the real
+    /// inventory-backed tool dispatcher.
+    #[cfg(feature = "native")]
+    #[test]
+    fn default_worker_dispatch_is_the_real_tool_dispatcher() {
+        let server = AprMcpServer::new();
+        let (_cancel_tx, cancel_rx) = mpsc::channel();
+
+        let result = (server.worker_dispatch)(
+            &serde_json::json!({ "name": "apr.version", "arguments": {} }),
+            &cancel_rx,
+            None,
+            None,
+        );
+
+        assert!(
+            result.is_error.is_none(),
+            "the real dispatcher answers apr.version: {result:?}"
+        );
+        let payload: serde_json::Value = serde_json::from_str(&result.content[0].text)
+            .unwrap_or_else(|e| panic!("apr.version payload is JSON: {e}"));
+        assert_eq!(
+            payload["server"], "aprender-mcp",
+            "the default must be the real dispatcher, not a stub: {payload:?}"
         );
     }
 


### PR DESCRIPTION
Refs #2608. **Do not auto-merge** (per the work order); the issue is left open for the reporter.

## What I re-measured first

#2608's own note says one lane observed the async dispatch but never re-ran the EOF-drop A/B, so I ran it before touching anything — against a **real process built from this HEAD**, not the published 0.63.0 and not a unit test. The driver is two lines over `AprMcpServer::run_stdio`, byte-identical to `crates/apr-cli/src/commands/mcp.rs`, so the full `apr` binary's 40-minute cold build was not needed to exercise the stdio loop.

| build | D1 — stdin closed immediately | D2 — byte-identical, stdin held 5s |
|---|---|---|
| HEAD (`origin/main` bb2bd5e73) | 2 lines, `"id":3` present, rc=0 | 2 lines, `"id":3` present, rc=0 |
| HEAD with the drain deleted | **1 line, `"id":3` ABSENT**, rc=0, stderr empty | 2 lines, `"id":3` present, rc=0 |

3/3 each. **The measured EOF drop is already fixed on `main`** — it landed in e759af233 (FALSIFY-MCP-010) *after* 0.63.0 was cut, which is why the published binary still drops.

The mutation was proven to **engage** before its verdict was read: the deleted `join_workers()` was replaced by `eprintln!("MUT-NO-DRAIN-2608-XYZZY")`, found by `strings -a <bin> | grep -c` (count 1) and printed on the child's stderr during the failing run. My first attempt used `let _ = "MUT-…"`, which the compiler dropped (strings count 0) — the behaviour delta was real but unattributed until the marker was made observable.

## What was still broken

The drain sat on **one of the read loop's four exits**. Every `?` inside the loop — a stdin read error, a stdout write error — returned straight past it, and the process then exited on top of workers that still owed responses. Identical protocol violation to #2608 (JSON-RPC 2.0 §5: a request carrying an `id` MUST be replied to), reached by a different route.

A **panicking tool** was a third route: the worker built a response only on the success path, and `join_workers` deliberately swallows the panic (`let _ = handle.join()`), so that request was answered by neither a result nor an error.

### Fix

- The loop body moves to `read_loop`; `serve_stream` drains on its **single** return path and reports the I/O error only afterwards.
- Tool dispatch runs under `catch_unwind`; a panic becomes `-32603` carrying the panic message, for the **same id**. Only dispatch is wrapped, so a caught panic always precedes any byte written and can never emit a second response for that id.

Out-of-order responses are legal and were left alone; the contract states response order as explicitly unconstrained.

## Falsifiers, and both mutation directions

All three are `--lib` tests, so CI's `--lib`-only `workspace-test` actually runs them.

| falsifier | mutation | engagement proof | verdict |
|---|---|---|---|
| `serve_stream_drains_in_flight_workers_when_the_read_loop_aborts` | drain restored to EOF-only (`if outcome.is_ok() { self.join_workers(); }`) | `MUT-EOF-ONLY-DRAIN-2608-XYZZY` printed by the mutated line | **RED**: *"the in-flight tools/call was answered by NEITHER a result NOR an error when the read loop aborted; stdout was: …only the id=1 line"* — the same shape as #2608's measurement. Restored → GREEN. The five pre-existing `serve_stream_*` tests stayed green under the mutation, which is what makes this a distinct exit path rather than a duplicate of FALSIFY-MCP-010. |
| `worker_response_turns_a_tool_panic_into_32603_for_the_same_id` | `catch_unwind` replaced by a direct call | `MUT-NO-CATCH-2608-XYZZY` printed by the mutated line | **RED** (the panic propagates). Restored → GREEN. |
| `worker_response_passes_a_normal_tool_result_through_unchanged` | — | — | stays GREEN under the mutation above; it exists so "always answer -32603" cannot satisfy the previous row. |

The drain falsifier is deterministic **by construction, not by scheduling luck**: the worker's own write stalls two seconds, so without the drain `serve_stream` returns in microseconds with the id=2 bytes still unwritten. Its recording sink is deliberately a *second* mutex — reading the server's stdout buffer directly would block on the worker's stalled write and then observe the very response it is meant to prove missing, i.e. green on the defect. That is exactly how the ordering variant of the EOF falsifier failed and got deleted from `tests/falsify_mcp_stdio_protocol.rs`. No wall-clock value is asserted; the stall is fixture, the assertions are about which bytes exist.

Full crate: `cargo test -p aprender-mcp --lib` → 124 passed. `cargo clippy -p aprender-mcp --all-targets -- -D warnings` clean. `cargo fmt --all -- --check` clean.

## Contract

`contracts/apr-mcp-stdio-drain-v1.yaml` — `pv validate`: 0 errors, 0 warnings; `pv audit`: no findings; falsification dimension 1.00. States the invariant once over **all** exits (`answered(S) = accepted(S)`), and names response order as unconstrained so nobody "fixes" the interleaving later. Gates are namespaced `FALSIFY-MCP-DRAIN-*` rather than continuing `FALSIFY-MCP-0NN`, precisely so `apr-mcp-server-v1`'s "001..014, no gaps, no duplicates" gate is untouched — and so this cannot collide with whatever ids #2613 adds to that file. Its two `kani_harnesses` entries are marked `STATUS: DECLARED, NOT IMPLEMENTED` in the body; the shipped evidence is the `cargo test` row above, and they should not be read as proofs.

## Round 2 — the panic guard was unguarded at the WIRING

An adversarial pass returned UNSOUND on the panic-guard half, and it was right. The
EOF-drain half reproduced (fix and mutation both), but the two `worker_response_*`
tests call the helper **directly**. Nothing asserted the real dispatch path routes
through it, so `worker_response` could be perfectly correct while the server never
calls it — the same shape as a guard that restates its implementation.

**FALSIFY-MCP-DRAIN-005** (`a_panicking_tool_is_answered_through_the_real_stdio_path`)
closes it. It never mentions `worker_response`: it feeds a `tools/call` whose tool
panics into `serve_stream` and reads the **client's end of stdout**, the surface #2608
measured. Route under test: `serve_stream` → `read_loop` → `route_stdio_message` →
`spawn_tools_call_worker` → the worker thread.

Every registered tool is a subprocess wrapper or a pure metadata read, so no
`tools/call` argument can make one panic on demand. The worker's dispatch is therefore
a field, `AprMcpServer::worker_dispatch`, whose production default is
`dispatch_tool_call_with_sink`. **FALSIFY-MCP-DRAIN-006**
(`default_worker_dispatch_is_the_real_tool_dispatcher`) exists so that seam cannot hide
a stubbed default — and the pre-existing `serve_stream_*` tests already assert the real
`apr.version` payload comes out of an untouched server.

| mutation | engagement proof | verdict |
|---|---|---|
| **wiring removed** — `dispatch(...)` called BESIDE the guard and the success response built from its return value, i.e. the exact pre-#2608 shape | `MUT-NO-GUARD-WIRING-2608-XYZZY`; `strings -a <test bin> \| grep -c` = **1**, and printed on the failing run's stdout | **DRAIN-005 RED** — *"the tools/call whose tool panicked was answered by NEITHER a result NOR an error … got 1 response(s)"*. Critically, `worker_response_turns_a_tool_panic_into_32603_for_the_same_id` and `worker_response_passes_a_normal_tool_result_through_unchanged` both stayed **GREEN** under it: that asymmetry is the proof they cannot guard the wiring and DRAIN-005 can. Restored → 126/126 GREEN |
| **default dispatcher stubbed** — `worker_dispatch` defaults to a stub returning `ToolCallResult::error("stubbed")` | `MUT-STUB-DEFAULT-DISPATCH-2608-XYZZY`; `strings` = **1**, printed | **DRAIN-006 RED** (and `serve_stream_answers_tools_call_before_returning_on_eof` with it). Restored → GREEN |

`cargo test -p aprender-mcp --lib` → **126 passed** (was 124). `cargo clippy -p aprender-mcp
--all-targets -- -D warnings` rc=0. `cargo fmt --all -- --check` rc=0. `pv validate` 0/0,
`pv audit` no findings, `pv score` falsification dimension still **1.00** with the two new
gates matched. `Cargo.lock` and `.github/` are byte-identical to `origin/main`.

## Coordination with the PRs in flight

- **Contract file:** new, so no overlap with #2613's edit of `contracts/apr-mcp-server-v1.yaml`.
- **`README.md` is NOT touched by this branch** (`git diff origin/main -- README.md` is empty), and the earlier `1778` → `1779` bump has been reverted. Six open PRs each add exactly one contract and four of them independently bump that same hardcoded figure, so only one could ever merge green and it would red the other five — filed as **#2630**. `check_readme_claims.sh` will therefore be **RED on this PR, and that is correct and expected**: the integration branch that folds these PRs sets the count ONCE, from a real `find contracts/ -name '*.yaml' | wc -l`, after they are all merged together. **Please do not "helpfully" re-add the bump.**
- I did **not** touch `.github/workflows/ci.yml` (owned by #2617), so the pre-existing `tests/falsify_mcp_stdio_protocol.rs` (the real-binary FALSIFY-MCP-010 suite) remains **dark in CI** — `workspace-test` is `--lib` only and no aprender-mcp `--test` target is on the integration line. That is why every falsifier here is a `--lib` test. Wiring that file in is a follow-up for whoever next owns that line.
- `Cargo.lock` was restored with `git checkout` after each build (cargo kept appending `[[patch.unused]]` entries).

## Deferred

- The **shipped 0.63.0 binary is still broken**; only `main` is fixed. Nothing here changes what users have until 0.64.0 ships.
- `crates/aprender-orchestrate/src/mcp/server.rs` (the `batuta mcp` stdio loop) is fully synchronous — no drop of this class — but it *does* still use `BufRead::lines()`, i.e. the FALSIFY-MCP-011 defect that was fixed in `aprender-mcp`: one invalid UTF-8 byte kills that session. Different binary, out of scope here, worth its own issue.
- `crates/aprender-mcp/src/tools/subprocess.rs` cannot be edited at all right now: the PMAT pre-commit complexity gate rejects the file as a whole (cyclomatic 30 / cognitive 25) the moment it is staged. My first draft needed a two-line test-only change there and had to be redesigned around it — the redesign is strictly better, but the file is effectively frozen to anyone who does not first pay down its complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR

