### PR TITLE
fix(pacha): the encryption that shipped was a homebrew XOR, and the real one had never compiled (#2590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1778 provable YAML contracts
+├── contracts/                      # 1779 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1778 contracts across inference, training, quantization, attention, FFN,
+1779 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/pacha-crypto-surface-v1.yaml
+++ b/contracts/pacha-crypto-surface-v1.yaml
@@ -1,0 +1,130 @@
+contract: pacha-crypto-surface
+metadata:
+  kind: pattern
+  version: "1.0.0"
+  description: >
+    The pacha crypto surface (keygen / sign / verify / encrypt / decrypt) must
+    never substitute a homebrew primitive for the one it advertises, and every
+    entry point must fail closed when the real primitive is unavailable.
+
+    Issue #2590 recorded this cluster as 0% covered with 17/17 features at
+    verified_hardware=UNKNOWN. The audit found something stronger than "nobody
+    wrote tests": 26 encryption round-trip tests already existed and ran green in
+    CI on every PR — against the WRONG IMPLEMENTATION. `encryption` was not a
+    default feature of aprender-registry, so `cargo nextest run --workspace --lib`
+    compiled the `not(feature = "encryption")` arm, which substituted a
+    `wrapping_mul(i as u8 + 1)` XOR keystream for ChaCha20, an FNV-shaped
+    checksum for Poly1305, a 10 000-round add/multiply loop for Argon2id, and a
+    `SystemTime` nanosecond reading shifted by `i % 16` for the salt and nonce.
+    Every one returned Ok, and `apr pacha encrypt` printed
+    "Model encrypted successfully". Separately, `--features encryption` did not
+    compile at all (rand 0.9 dropped the `RngCore` impl on `OsRng`), so the real
+    ChaCha20-Poly1305 + Argon2id path had never been built on any machine —
+    which is exactly what UNKNOWN meant.
+
+    The fix deletes every fallback primitive, makes `encryption` a default
+    feature so the shipped build and CI both exercise the real AEAD, and makes
+    the no-feature build return UnsupportedOperation instead of encrypting with
+    something else. A build with no authenticated cipher must REFUSE, not
+    silently downgrade.
+  references:
+  - "crates/aprender-registry/src/crypto.rs (encrypt_model/decrypt_model, EncryptedHeader::new, mod falsify_2590)"
+  - "crates/aprender-registry/src/signing.rs (SigningKey/VerifyingKey/ModelSignature, mod adversarial_2590)"
+  - "crates/aprender-registry/Cargo.toml (default features include `encryption`)"
+  - "crates/aprender-orchestrate/src/pacha/crypto.rs (apr/batuta pacha keygen|sign|verify|encrypt|decrypt)"
+  - "https://github.com/paiml/aprender/issues/2590"
+version: 1
+status: enforced
+date: 2026-08-22
+
+proof_obligations:
+  - type: invariant
+    property: >
+      CRYPTO-NO-SUBSTITUTE: no build configuration of aprender-registry may
+      return Ok from encrypt_model / encrypt_model_with_config using anything
+      other than ChaCha20-Poly1305 with an Argon2id-derived key. When the
+      `encryption` feature is absent the crate has no authenticated cipher, and
+      both encrypt and decrypt must return PachaError::UnsupportedOperation
+      naming the missing feature. Silently downgrading to a non-authenticated
+      cipher is forbidden, because the CLI's success message is identical in
+      both cases and the operator cannot tell them apart.
+  - type: invariant
+    property: >
+      CRYPTO-KEYSTREAM-OPAQUE: ciphertext must carry no algebraic structure
+      derived from the byte index. The deleted fallback built
+      ks[i] = (key[i%32] + nonce[i%12] + block_idx).wrapping_mul(i as u8 + 1),
+      making ks[31] a multiple of 32 and ks[63] a multiple of 64 in every
+      64-byte block; encrypting all-zero plaintext publishes the keystream
+      verbatim, so those probes are a direct discriminator. Under ChaCha20 all
+      16 probes match with probability 32^-8 * 64^-8.
+  - type: invariant
+    property: >
+      CRYPTO-SALT-IS-ENTROPY: EncryptedHeader::new must draw salt and nonce from
+      a CSPRNG, never from a clock. The deleted fallback used
+      salt[i] = ((nanos >> (i % 16)) ^ (i * 7)) as u8, so salt[i] ^ 7i equalled
+      salt[i+16] ^ 7(i+16) for every i regardless of the time, and 256
+      back-to-back headers could collide. Real entropy satisfies that 16-fold
+      relation with probability 2^-128.
+  - type: invariant
+    property: >
+      CRYPTO-REJECTS-TAMPERING: decryption must reject EVERY single-bit flip at
+      EVERY byte offset of the ciphertext (header included), EVERY truncation
+      length, any appended bytes, and a body spliced under a foreign header —
+      including for empty plaintext, whose tag must be no more forgeable than
+      any other. One passing tamper offset is an anecdote; the obligation is
+      over the whole sweep.
+  - type: invariant
+    property: >
+      SIGN-REJECTS-FORGERY: verification must reject all 512 single-bit
+      forgeries of a 64-byte Ed25519 signature, all-zero and all-ones
+      signatures, any signature length other than 64, and the same signature
+      presented against a different message (including one bit off, truncated,
+      extended, and empty). A verifier that returns Ok(()) unconditionally
+      passes every positive test, so only the negatives measure anything.
+  - type: invariant
+    property: >
+      SIGN-PROVENANCE-NEEDS-A-KEY: verify_model establishes only that a
+      ModelSignature envelope is internally consistent, NOT who produced it — an
+      attacker who can rewrite the .sig file can re-sign the same model with
+      their own key and verify_model reports VALID. Only verify_model_with_key
+      establishes provenance, and it must reject an envelope signed by any key
+      other than the expected one. This boundary is pinned by test so a green
+      `apr pacha verify` is never read as proof of authorship.
+
+falsification_tests:
+  - id: FALSIFY-2590-A
+    name: falsify_2590_a_build_without_aead_refuses_rather_than_substituting_xor
+    prediction: "with the `encryption` feature absent, encrypt_model returns Err whose message names the feature; with it present, encrypt_model returns a buffer carrying the PACHAENC magic. On origin/main (default = compression,cli,signing) this test is RED: encrypt_model returns Ok from the XOR fallback."
+    test_harness: "cargo test -p aprender-registry --lib falsify_2590_a && cargo test -p aprender-registry --lib --no-default-features falsify_2590_a"
+    expected_output: "test result: ok"
+    if_fails: "a build with no authenticated cipher silently encrypts with something else, and `apr pacha encrypt` reports success for a file that is not encrypted."
+  - id: FALSIFY-2590-B
+    name: falsify_2590_b_ciphertext_has_no_toy_multiply_structure
+    prediction: "encrypting 512 zero bytes and probing offsets 31 and 63 of each 64-byte block finds fewer than 16 of 16 probes congruent to 0 mod 32 / mod 64; restoring the wrapping_mul keystream inside the encryption path makes all 16 match"
+    test_harness: "cargo test -p aprender-registry --lib falsify_2590_b"
+    expected_output: "test result: ok"
+    if_fails: "the ciphertext is a byte-index-derived keystream, not ChaCha20 output — recoverable without the key."
+  - id: FALSIFY-2590-C
+    name: falsify_2590_c_salt_is_not_a_timestamp_expansion
+    prediction: "EncryptedHeader::new produces a salt for which fewer than 16 of the 16 relations salt[i] ^ 7i == salt[i+16] ^ 7(i+16) hold; restoring the SystemTime-nanosecond derivation makes all 16 hold"
+    test_harness: "cargo test -p aprender-registry --lib falsify_2590_c"
+    expected_output: "test result: ok"
+    if_fails: "salt and nonce are a shifted clock reading, so an attacker who knows approximately when a file was encrypted can enumerate the key-derivation salt, and a tight loop can reuse a (key, nonce) pair."
+  - id: FALSIFY-2590-D
+    name: adversarial_2590_every_single_bit_flip_is_rejected
+    prediction: "for a 48-byte plaintext, flipping bits 0/3/7 of each of the 117 ciphertext bytes yields 351 decryptions and all 351 return Err"
+    test_harness: "cargo test -p aprender-registry --lib adversarial_2590_every_single_bit_flip_is_rejected"
+    expected_output: "test result: ok"
+    if_fails: "the ciphertext is not authenticated end to end and a tampered model file decrypts to attacker-chosen bytes."
+  - id: FALSIFY-2590-E
+    name: adversarial_2590_every_bit_flip_in_the_signature_is_rejected
+    prediction: "all 512 single-bit forgeries of a valid 64-byte Ed25519 signature are rejected, while the unmodified signature verifies"
+    test_harness: "cargo test -p aprender-registry --lib adversarial_2590_every_bit_flip_in_the_signature_is_rejected"
+    expected_output: "test result: ok"
+    if_fails: "the verifier accepts signatures it should not, so `apr pacha verify` reporting VALID means nothing."
+  - id: FALSIFY-2590-F
+    name: adversarial_2590_resigned_envelope_needs_an_expected_key_to_be_caught
+    prediction: "verify_model accepts an envelope re-signed by an attacker over the same model (internally consistent), and verify_model_with_key against the honest key rejects it"
+    test_harness: "cargo test -p aprender-registry --lib adversarial_2590_resigned_envelope_needs_an_expected_key_to_be_caught"
+    expected_output: "test result: ok"
+    if_fails: "either verify_model_with_key stopped checking the signer, or the documented boundary moved without anyone noticing that a green `apr pacha verify` is not provenance."

--- a/contracts/pacha-crypto-surface-v1.yaml
+++ b/contracts/pacha-crypto-surface-v1.yaml
@@ -27,6 +27,15 @@ metadata:
     the no-feature build return UnsupportedOperation instead of encrypting with
     something else. A build with no authenticated cipher must REFUSE, not
     silently downgrade.
+
+    Changing the primitive changed the ON-DISK BODY, so the format's IDENTIFIER
+    had to change with it. The header (`PACHAENC` + version + salt[32] +
+    nonce[12]) is byte-identical across the two formats, and the first cut of the
+    fix left `VERSION = 1` untouched — which would have left the XOR format that
+    0.63.0 actually shipped and the ChaCha20-Poly1305 format that replaces it
+    both claiming version 1 under the same magic, mutually undecodable and
+    indistinguishable from the file. `VERSION` is now 2, and version 1 is
+    recognised only to be refused with a diagnosis that says what it was.
   references:
   - "crates/aprender-registry/src/crypto.rs (encrypt_model/decrypt_model, EncryptedHeader::new, mod falsify_2590)"
   - "crates/aprender-registry/src/signing.rs (SigningKey/VerifyingKey/ModelSignature, mod adversarial_2590)"
@@ -75,6 +84,17 @@ proof_obligations:
       over the whole sweep.
   - type: invariant
     property: >
+      CRYPTO-FORMAT-VERSION-DISCRIMINATES: two incompatible on-disk bodies may
+      never share one version byte under the PACHAENC magic. Version 1 is the
+      unauthenticated XOR format pacha <= 0.63.x wrote; version 2 is
+      ChaCha20-Poly1305 over an Argon2id key. Fresh output must never be stamped
+      1, and a version-1 header must be refused with a diagnosis naming the
+      format — never routed into the AEAD, whose failure mode for a v1 file is
+      "invalid password or corrupted data", a wrong answer for a file that has
+      neither problem and whose contents were never confidentiality-protected.
+      A reader must be able to classify an archive from its own first nine bytes.
+  - type: invariant
+    property: >
       SIGN-REJECTS-FORGERY: verification must reject all 512 single-bit
       forgeries of a 64-byte Ed25519 signature, all-zero and all-ones
       signatures, any signature length other than 64, and the same signature
@@ -110,6 +130,12 @@ falsification_tests:
     test_harness: "cargo test -p aprender-registry --lib falsify_2590_c"
     expected_output: "test result: ok"
     if_fails: "salt and nonce are a shifted clock reading, so an attacker who knows approximately when a file was encrypted can enumerate the key-derivation salt, and a tight loop can reuse a (key, nonce) pair."
+  - id: FALSIFY-2590-G
+    name: falsify_2590_g_legacy_v1_and_aead_v2_are_distinguishable_from_the_file
+    prediction: "fresh ciphertext is stamped version 2, not 1; a header whose version byte is 1 is refused by both EncryptedHeader::from_bytes and decrypt_model_with_config with a message that says v1 was not encryption and never says 'invalid password'. Reverting VERSION to 1 fails the first assertion (observed: left 1, right 1); removing the VERSION_LEGACY_XOR arm from from_bytes degrades the refusal to 'unsupported encryption version: 1' and fails the last."
+    test_harness: "cargo test -p aprender-registry --lib falsify_2590_g"
+    expected_output: "test result: ok"
+    if_fails: "the XOR format 0.63.0 shipped and the ChaCha20-Poly1305 format that replaces it both claim version 1 under the same magic, so an archive cannot be classified from its own bytes and a v1 file is misreported as a password problem."
   - id: FALSIFY-2590-D
     name: adversarial_2590_every_single_bit_flip_is_rejected
     prediction: "for a 48-byte plaintext, flipping bits 0/3/7 of each of the 117 ciphertext bytes yields 351 decryptions and all 351 return Err"

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -66,7 +66,7 @@ tempfile = "3"
 criterion = { version = "0.6", features = ["html_reports"] }
 
 [features]
-default = ["compression", "cli", "signing"]
+default = ["compression", "cli", "signing", "encryption"]
 compression = ["zstd"]
 cli = ["clap"]
 remote = ["reqwest", "tokio"]

--- a/crates/aprender-registry/src/crypto.rs
+++ b/crates/aprender-registry/src/crypto.rs
@@ -60,39 +60,24 @@ pub struct EncryptedHeader {
 }
 
 impl EncryptedHeader {
-    /// Create a new header with random salt and nonce
+    /// Create a new header with a cryptographically random salt and nonce
+    ///
+    /// Only available with the `encryption` feature. The removed
+    /// `not(encryption)` arm derived salt and nonce from a nanosecond
+    /// `SystemTime` reading shifted by `i % 16`, so both were a 16-byte
+    /// repetition of a low-entropy, attacker-predictable timestamp (#2590).
     #[must_use]
+    #[cfg(feature = "encryption")]
     pub fn new() -> Self {
-        #[cfg(feature = "encryption")]
-        {
-            use rand::rngs::OsRng;
-            use rand::RngCore;
-            let mut salt = [0u8; SALT_LEN];
-            let mut nonce = [0u8; NONCE_LEN];
-            OsRng.fill_bytes(&mut salt);
-            OsRng.fill_bytes(&mut nonce);
-            Self { version: VERSION, salt, nonce }
-        }
-        #[cfg(not(feature = "encryption"))]
-        {
-            // Fallback: simple PRNG for salt and nonce
-            let seed = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-
-            let mut salt = [0u8; SALT_LEN];
-            let mut nonce = [0u8; NONCE_LEN];
-
-            for (i, byte) in salt.iter_mut().enumerate() {
-                *byte = ((seed >> (i % 16)) ^ (i as u128 * 7)) as u8;
-            }
-            for (i, byte) in nonce.iter_mut().enumerate() {
-                *byte = ((seed >> ((i + 32) % 16)) ^ (i as u128 * 13)) as u8;
-            }
-
-            Self { version: VERSION, salt, nonce }
-        }
+        // rand 0.9 removed the `RngCore` impl on `OsRng` (it is `TryRngCore` only),
+        // which is why this arm had never compiled. `rand::rng()` is the same
+        // CSPRNG-seeded-from-OS-entropy handle `SigningKey::generate` already uses.
+        use rand::RngCore;
+        let mut salt = [0u8; SALT_LEN];
+        let mut nonce = [0u8; NONCE_LEN];
+        rand::rng().fill_bytes(&mut salt);
+        rand::rng().fill_bytes(&mut nonce);
+        Self { version: VERSION, salt, nonce }
     }
 
     /// Serialize header to bytes
@@ -135,6 +120,7 @@ impl EncryptedHeader {
     }
 }
 
+#[cfg(feature = "encryption")]
 impl Default for EncryptedHeader {
     fn default() -> Self {
         Self::new()
@@ -185,38 +171,6 @@ fn derive_key(
     Ok(key)
 }
 
-/// Fallback key derivation when encryption feature is disabled
-#[cfg(not(feature = "encryption"))]
-fn derive_key(
-    password: &str,
-    salt: &[u8; SALT_LEN],
-    _config: &EncryptionConfig,
-) -> Result<[u8; 32]> {
-    // Simple key derivation using iterated hashing (NOT SECURE - fallback only)
-    let mut key = [0u8; 32];
-    let mut state = [0u8; 64];
-
-    for (i, &b) in password.as_bytes().iter().enumerate() {
-        state[i % 64] ^= b;
-    }
-    for (i, &b) in salt.iter().enumerate() {
-        state[(i + 32) % 64] ^= b;
-    }
-
-    for iteration in 0..10000u32 {
-        let iter_bytes = iteration.to_le_bytes();
-        for (i, &b) in iter_bytes.iter().enumerate() {
-            state[i] ^= b;
-        }
-        for i in 0..64 {
-            state[i] = state[i].wrapping_add(state[(i + 1) % 64]).wrapping_mul(33);
-        }
-    }
-
-    key.copy_from_slice(&state[0..32]);
-    Ok(key)
-}
-
 /// Encrypt data using ChaCha20-Poly1305
 #[cfg(feature = "encryption")]
 fn chacha_encrypt(data: &[u8], key: &[u8; 32], nonce: &[u8; NONCE_LEN]) -> Result<Vec<u8>> {
@@ -255,87 +209,6 @@ fn chacha_decrypt(ciphertext: &[u8], key: &[u8; 32], nonce: &[u8; NONCE_LEN]) ->
     })
 }
 
-/// Fallback XOR-based encryption (NOT SECURE - only for when feature disabled)
-#[cfg(not(feature = "encryption"))]
-fn chacha_encrypt(data: &[u8], key: &[u8; 32], nonce: &[u8; NONCE_LEN]) -> Result<Vec<u8>> {
-    let mut output = data.to_vec();
-    let mut keystream = [0u8; 64];
-
-    for (block_idx, chunk) in output.chunks_mut(64).enumerate() {
-        for (i, ks) in keystream.iter_mut().enumerate() {
-            *ks = key[i % 32]
-                .wrapping_add(nonce[i % NONCE_LEN])
-                .wrapping_add(block_idx as u8)
-                .wrapping_mul(i as u8 + 1);
-        }
-        for (i, byte) in chunk.iter_mut().enumerate() {
-            *byte ^= keystream[i];
-        }
-    }
-
-    // Append simplified tag
-    let tag = compute_fallback_tag(&output, key);
-    output.extend_from_slice(&tag);
-
-    Ok(output)
-}
-
-#[cfg(not(feature = "encryption"))]
-fn chacha_decrypt(ciphertext: &[u8], key: &[u8; 32], nonce: &[u8; NONCE_LEN]) -> Result<Vec<u8>> {
-    if ciphertext.len() < TAG_LEN {
-        return Err(PachaError::InvalidFormat("ciphertext too short".to_string()));
-    }
-
-    let data = &ciphertext[..ciphertext.len() - TAG_LEN];
-    let stored_tag = &ciphertext[ciphertext.len() - TAG_LEN..];
-
-    // Verify tag
-    let computed_tag = compute_fallback_tag(data, key);
-    if computed_tag != stored_tag {
-        return Err(PachaError::InvalidFormat(
-            "decryption failed: invalid password or corrupted data".to_string(),
-        ));
-    }
-
-    // Decrypt
-    let mut output = data.to_vec();
-    let mut keystream = [0u8; 64];
-
-    for (block_idx, chunk) in output.chunks_mut(64).enumerate() {
-        for (i, ks) in keystream.iter_mut().enumerate() {
-            *ks = key[i % 32]
-                .wrapping_add(nonce[i % NONCE_LEN])
-                .wrapping_add(block_idx as u8)
-                .wrapping_mul(i as u8 + 1);
-        }
-        for (i, byte) in chunk.iter_mut().enumerate() {
-            *byte ^= keystream[i];
-        }
-    }
-
-    Ok(output)
-}
-
-#[cfg(not(feature = "encryption"))]
-fn compute_fallback_tag(ciphertext: &[u8], key: &[u8; 32]) -> [u8; TAG_LEN] {
-    let mut tag = [0u8; TAG_LEN];
-    let mut state = [0u64; 4];
-
-    for (i, &b) in key.iter().enumerate() {
-        state[i % 4] ^= (b as u64) << ((i * 8) % 64);
-    }
-
-    for (i, &b) in ciphertext.iter().enumerate() {
-        state[i % 4] = state[i % 4].wrapping_add(b as u64).wrapping_mul(0x100000001b3);
-    }
-
-    for (i, byte) in tag.iter_mut().enumerate() {
-        *byte = (state[i % 4] >> ((i % 8) * 8)) as u8;
-    }
-
-    tag
-}
-
 /// Encrypt model data with password
 ///
 /// Uses ChaCha20-Poly1305 for authenticated encryption and Argon2id for
@@ -345,6 +218,13 @@ pub fn encrypt_model(data: &[u8], password: &str) -> Result<Vec<u8>> {
 }
 
 /// Encrypt model data with password and custom config
+///
+/// # Errors
+///
+/// Returns [`PachaError::UnsupportedOperation`] when the crate was built without the
+/// `encryption` feature. It used to return `Ok` with an XOR keystream and a
+/// homebrew checksum instead — see [`unavailable`] (#2590).
+#[cfg(feature = "encryption")]
 pub fn encrypt_model_with_config(
     data: &[u8],
     password: &str,
@@ -373,6 +253,12 @@ pub fn decrypt_model(encrypted_data: &[u8], password: &str) -> Result<Vec<u8>> {
 }
 
 /// Decrypt model data with password and custom config
+///
+/// # Errors
+///
+/// Returns [`PachaError::UnsupportedOperation`] when the crate was built without the
+/// `encryption` feature (#2590).
+#[cfg(feature = "encryption")]
 pub fn decrypt_model_with_config(
     encrypted_data: &[u8],
     password: &str,
@@ -393,6 +279,58 @@ pub fn decrypt_model_with_config(
 
     // Decrypt and verify (ChaCha20-Poly1305 verifies tag internally)
     chacha_decrypt(ciphertext, &key, &header.nonce)
+}
+
+// ============================================================================
+// #2590: fail closed when the crate is built WITHOUT the `encryption` feature.
+//
+// Before this, `not(feature = "encryption")` selected a homebrew replacement for
+// every primitive — a `wrapping_mul(i + 1)` XOR keystream, an FNV-shaped
+// "auth tag", a 10 000-round add/multiply KDF, and a `SystemTime` nanosecond
+// salt. Those returned `Ok(..)` and the CLI printed "Model encrypted
+// successfully", so the insecure build was indistinguishable from the secure
+// one at every observable surface. `encryption` was not a default feature, so
+// that insecure build was the one that shipped.
+// ============================================================================
+
+/// Error returned by every crypto entry point when built without `encryption`
+#[cfg(not(feature = "encryption"))]
+fn unavailable() -> PachaError {
+    PachaError::UnsupportedOperation {
+        operation: "model encryption".to_string(),
+        reason: "pacha was built without the `encryption` feature \
+                 (ChaCha20-Poly1305 + Argon2id); refusing to fall back to a \
+                 non-authenticated cipher. Rebuild with `--features encryption`."
+            .to_string(),
+    }
+}
+
+/// Encrypt model data with password and custom config — unavailable build
+///
+/// # Errors
+///
+/// Always errors: this build has no authenticated cipher.
+#[cfg(not(feature = "encryption"))]
+pub fn encrypt_model_with_config(
+    _data: &[u8],
+    _password: &str,
+    _config: &EncryptionConfig,
+) -> Result<Vec<u8>> {
+    Err(unavailable())
+}
+
+/// Decrypt model data with password and custom config — unavailable build
+///
+/// # Errors
+///
+/// Always errors: this build has no authenticated cipher.
+#[cfg(not(feature = "encryption"))]
+pub fn decrypt_model_with_config(
+    _encrypted_data: &[u8],
+    _password: &str,
+    _config: &EncryptionConfig,
+) -> Result<Vec<u8>> {
+    Err(unavailable())
 }
 
 /// Check if data appears to be encrypted
@@ -416,7 +354,11 @@ pub fn get_version(data: &[u8]) -> Result<u8> {
 // Tests - Extreme TDD
 // ============================================================================
 
-#[cfg(test)]
+// These exercise the AEAD itself, so they need it to exist. Before #2590 this
+// module was `#[cfg(test)]` and `encryption` was NOT a default feature, so every
+// one of these 26 tests ran against the XOR fallback and none had ever run
+// against ChaCha20-Poly1305 on any machine.
+#[cfg(all(test, feature = "encryption"))]
 mod tests {
     use super::*;
 
@@ -748,5 +690,366 @@ mod tests {
         let decrypted = decrypt_model(&encrypted, password).unwrap();
 
         assert_eq!(original, decrypted);
+    }
+}
+
+// ============================================================================
+// #2590 — falsifiers and adversarial cases for the crypto surface
+//
+// Issue #2590: "an encrypt/decrypt round-trip that passes proves nothing about
+// whether the ciphertext is actually secure". What the audit found was worse
+// than an untested surface: `encryption` was not a default feature, the
+// `not(feature = "encryption")` arm silently substituted a homebrew cipher, and
+// `--features encryption` did not compile at all (rand 0.9 dropped `RngCore`
+// for `OsRng`). Every one of the 26 round-trip tests above was green against a
+// cipher no one intended to ship.
+//
+// Each test below must EXCLUDE an outcome. The three `falsify_*` cases are the
+// discrimination checks; the `adversarial_*` cases are the negatives the issue
+// asked for (wrong key, truncation, tampering, empty input).
+// ============================================================================
+
+#[cfg(test)]
+mod falsify_2590 {
+    #[allow(unused_imports)]
+    use super::*;
+
+    /// Argon2id parameters for the sweep tests ONLY.
+    ///
+    /// The sweeps below run hundreds of decryptions; at the production default
+    /// (64 MiB, t=3) that is minutes of KDF. These tests measure whether the
+    /// AEAD *rejects* bad input, which is independent of KDF hardness. Tests
+    /// that assert anything about the default configuration call
+    /// `encrypt_model`/`decrypt_model` directly.
+    #[cfg(feature = "encryption")]
+    fn cheap_kdf() -> EncryptionConfig {
+        EncryptionConfig { memory_cost_kib: 64, time_cost: 1, parallelism: 1 }
+    }
+
+    // ------------------------------------------------------------------------
+    // FALSIFIER A — RED on origin/main as it stands.
+    // ------------------------------------------------------------------------
+
+    /// A build with no authenticated cipher must REFUSE, never substitute one.
+    ///
+    /// On origin/main `default = ["compression", "cli", "signing"]`, so the
+    /// shipped build took the `not(feature = "encryption")` arm and returned
+    /// `Ok` from a `wrapping_mul` XOR keystream with an FNV-shaped checksum
+    /// standing in for Poly1305. `apr pacha encrypt` then printed
+    /// "Model encrypted successfully". This test is RED there.
+    #[test]
+    fn falsify_2590_a_build_without_aead_refuses_rather_than_substituting_xor() {
+        let result = encrypt_model(b"model weights", "correct horse battery staple");
+
+        #[cfg(not(feature = "encryption"))]
+        {
+            let err = result.expect_err(
+                "a build without ChaCha20-Poly1305 must refuse to encrypt, not XOR the \
+                 plaintext and report success",
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("encryption"),
+                "the refusal must name the missing feature so the operator can act; got: {msg}"
+            );
+        }
+
+        #[cfg(feature = "encryption")]
+        {
+            let ciphertext = result.expect("the default build must have a real AEAD available");
+            assert!(is_encrypted(&ciphertext), "output must carry the PACHAENC magic");
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // FALSIFIER B — the cipher is not the deleted toy.
+    // ------------------------------------------------------------------------
+
+    /// Ciphertext must carry none of the deleted fallback's multiply structure.
+    ///
+    /// The removed keystream was
+    ///   `ks[i] = (key[i % 32] + nonce[i % 12] + block_idx).wrapping_mul(i as u8 + 1)`
+    /// so `ks[31]` was always a multiple of 32 and `ks[63]` always a multiple of
+    /// 64, in every 64-byte block. Encrypting all-zero plaintext publishes the
+    /// keystream verbatim, so those 16 probes are all-zero under the toy cipher
+    /// and all match under ChaCha20 with probability 32^-8 * 64^-8 = 3e-27.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn falsify_2590_b_ciphertext_has_no_toy_multiply_structure() {
+        const BLOCKS: usize = 8;
+        let plaintext = vec![0u8; 64 * BLOCKS];
+        let ciphertext =
+            encrypt_model_with_config(&plaintext, "falsify-2590-b", &cheap_kdf()).expect("encrypt");
+        let body = &ciphertext[HEADER_SIZE..];
+
+        let mut toy_shaped = 0usize;
+        for block in 0..BLOCKS {
+            if body[64 * block + 31] % 32 == 0 {
+                toy_shaped += 1;
+            }
+            if body[64 * block + 63] % 64 == 0 {
+                toy_shaped += 1;
+            }
+        }
+
+        assert!(
+            toy_shaped < 2 * BLOCKS,
+            "all {} keystream probes matched the deleted toy cipher's multiply structure — \
+             this ciphertext is not ChaCha20 output",
+            2 * BLOCKS
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // FALSIFIER C — the salt is entropy, not a clock reading.
+    // ------------------------------------------------------------------------
+
+    /// Salt must not be a 16-byte periodic expansion of a timestamp.
+    ///
+    /// The removed fallback used
+    ///   `salt[i] = ((nanos >> (i % 16)) ^ (i as u128 * 7)) as u8`
+    /// so `salt[i] ^ 7i == salt[i+16] ^ 7(i+16)` held for every `i` no matter
+    /// what the clock read. This is the issue's "a keygen producing low-entropy
+    /// or deterministic keys looks identical to a correct one" made checkable:
+    /// real entropy matches all 16 positions with probability 2^-128.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn falsify_2590_c_salt_is_not_a_timestamp_expansion() {
+        let header = EncryptedHeader::new();
+
+        let mut periodic = 0usize;
+        for i in 0..16usize {
+            let lhs = header.salt[i] ^ (i.wrapping_mul(7) as u8);
+            let rhs = header.salt[i + 16] ^ ((i + 16).wrapping_mul(7) as u8);
+            if lhs == rhs {
+                periodic += 1;
+            }
+        }
+
+        assert!(
+            periodic < 16,
+            "salt repeats with period 16 — it is a shifted clock reading, not entropy"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Adversarial: key material
+    // ------------------------------------------------------------------------
+
+    /// Salt and nonce must be distinct across rapid successive invocations.
+    ///
+    /// The removed fallback seeded both from `SystemTime` nanoseconds, so a
+    /// tight loop could reuse a (key, nonce) pair — the single failure that
+    /// breaks a stream cipher outright.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_salt_and_nonce_never_repeat_in_a_tight_loop() {
+        use std::collections::HashSet;
+
+        const N: usize = 256;
+        let mut salts = HashSet::new();
+        let mut nonces = HashSet::new();
+        for _ in 0..N {
+            let header = EncryptedHeader::new();
+            salts.insert(header.salt);
+            nonces.insert(header.nonce);
+        }
+
+        assert_eq!(salts.len(), N, "salt collided within {N} back-to-back headers");
+        assert_eq!(nonces.len(), N, "nonce collided within {N} back-to-back headers");
+    }
+
+    /// Two encryptions of different plaintexts must not share a keystream.
+    ///
+    /// Under keystream reuse `ct_a ^ ct_b == pt_a ^ pt_b`, which for these
+    /// inputs is 0xFF in every position. That is the classic two-time-pad
+    /// break, and it is invisible to any round-trip test.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_no_two_time_pad_across_encryptions() {
+        let zeros = vec![0u8; 256];
+        let ones = vec![0xFFu8; 256];
+
+        let ct_a =
+            encrypt_model_with_config(&zeros, "same-password", &cheap_kdf()).expect("encrypt a");
+        let ct_b =
+            encrypt_model_with_config(&ones, "same-password", &cheap_kdf()).expect("encrypt b");
+
+        let body_a = &ct_a[HEADER_SIZE..HEADER_SIZE + 256];
+        let body_b = &ct_b[HEADER_SIZE..HEADER_SIZE + 256];
+
+        let leaked = body_a.iter().zip(body_b.iter()).filter(|(a, b)| (*a ^ *b) == 0xFF).count();
+
+        assert!(
+            leaked < 256,
+            "ct_a ^ ct_b equals pt_a ^ pt_b in every byte — the keystream was reused"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Adversarial: wrong key
+    // ------------------------------------------------------------------------
+
+    /// A password differing by one character must not decrypt.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_off_by_one_password_is_rejected() {
+        let plaintext = b"weights that matter";
+        let ciphertext =
+            encrypt_model_with_config(plaintext, "hunter2", &cheap_kdf()).expect("encrypt");
+
+        for wrong in ["hunter3", "hunter", "hunter22", "Hunter2", " hunter2", "hunter2 "] {
+            let result = decrypt_model_with_config(&ciphertext, wrong, &cheap_kdf());
+            assert!(
+                result.is_err(),
+                "password {wrong:?} must not decrypt a ciphertext made for \"hunter2\""
+            );
+        }
+    }
+
+    /// Decrypting with the right password but the wrong KDF cost must fail.
+    ///
+    /// The Argon2id parameters are not stored in the header, so they are part of
+    /// the key. A build that silently ignored them would decrypt anyway.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_wrong_kdf_parameters_are_rejected() {
+        let plaintext = b"weights that matter";
+        let ciphertext = encrypt_model_with_config(plaintext, "pw", &cheap_kdf()).expect("encrypt");
+
+        let other = EncryptionConfig { memory_cost_kib: 128, time_cost: 2, parallelism: 1 };
+        let result = decrypt_model_with_config(&ciphertext, "pw", &other);
+        assert!(result.is_err(), "different Argon2id parameters must derive a different key");
+    }
+
+    // ------------------------------------------------------------------------
+    // Adversarial: tampering
+    // ------------------------------------------------------------------------
+
+    /// EVERY single-bit flip anywhere in the ciphertext must be rejected.
+    ///
+    /// `test_corrupted_ciphertext_fails` flipped one byte at one offset. One
+    /// position passing is an anecdote; this sweeps all of them, header
+    /// included, so a cipher that authenticates only part of its output cannot
+    /// pass.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_every_single_bit_flip_is_rejected() {
+        let plaintext: Vec<u8> = (0..48u8).collect();
+        let ciphertext =
+            encrypt_model_with_config(&plaintext, "pw", &cheap_kdf()).expect("encrypt");
+
+        for byte_index in 0..ciphertext.len() {
+            for bit in [0u8, 3, 7] {
+                let mut tampered = ciphertext.clone();
+                tampered[byte_index] ^= 1 << bit;
+                let result = decrypt_model_with_config(&tampered, "pw", &cheap_kdf());
+                assert!(
+                    result.is_err(),
+                    "flipping bit {bit} of byte {byte_index} was accepted — the ciphertext is \
+                     not authenticated end to end"
+                );
+            }
+        }
+    }
+
+    /// EVERY truncation length must be rejected — none may return plaintext.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_every_truncation_is_rejected() {
+        let plaintext: Vec<u8> = (0..48u8).collect();
+        let ciphertext =
+            encrypt_model_with_config(&plaintext, "pw", &cheap_kdf()).expect("encrypt");
+
+        for len in 0..ciphertext.len() {
+            let result = decrypt_model_with_config(&ciphertext[..len], "pw", &cheap_kdf());
+            assert!(
+                result.is_err(),
+                "a {len}-byte prefix of a {}-byte ciphertext was accepted",
+                ciphertext.len()
+            );
+        }
+    }
+
+    /// Appending trailing bytes must be rejected, not silently ignored.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_appended_bytes_are_rejected() {
+        let plaintext = b"exactly what was encrypted";
+        let ciphertext = encrypt_model_with_config(plaintext, "pw", &cheap_kdf()).expect("encrypt");
+
+        for extra in [1usize, 16, 64] {
+            let mut padded = ciphertext.clone();
+            padded.extend(std::iter::repeat_n(0x41u8, extra));
+            let result = decrypt_model_with_config(&padded, "pw", &cheap_kdf());
+            assert!(result.is_err(), "{extra} appended bytes were silently ignored");
+        }
+    }
+
+    /// Splicing the body of one ciphertext onto the header of another must fail.
+    ///
+    /// This is the attack a per-message tag alone does not stop if the header is
+    /// unauthenticated and the key does not depend on it.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_spliced_header_and_body_is_rejected() {
+        let a = encrypt_model_with_config(b"alpha payload", "pw", &cheap_kdf()).expect("encrypt a");
+        let b = encrypt_model_with_config(b"bravo payload", "pw", &cheap_kdf()).expect("encrypt b");
+        assert_eq!(a.len(), b.len(), "same-length plaintexts give same-length ciphertexts");
+
+        let mut spliced = a[..HEADER_SIZE].to_vec();
+        spliced.extend_from_slice(&b[HEADER_SIZE..]);
+
+        let result = decrypt_model_with_config(&spliced, "pw", &cheap_kdf());
+        assert!(result.is_err(), "a body spliced under a foreign header was accepted");
+    }
+
+    // ------------------------------------------------------------------------
+    // Adversarial: empty and degenerate input
+    // ------------------------------------------------------------------------
+
+    /// Empty plaintext still produces an authenticated ciphertext.
+    ///
+    /// `test_empty_data_encrypt` only round-tripped it. An empty payload whose
+    /// tag can be flipped without detection is a forgery oracle.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn adversarial_2590_empty_plaintext_is_still_authenticated() {
+        let ciphertext = encrypt_model_with_config(b"", "pw", &cheap_kdf()).expect("encrypt");
+        assert_eq!(
+            ciphertext.len(),
+            HEADER_SIZE + TAG_LEN,
+            "empty plaintext must still carry a full-size tag"
+        );
+
+        let round_tripped =
+            decrypt_model_with_config(&ciphertext, "pw", &cheap_kdf()).expect("decrypt");
+        assert!(round_tripped.is_empty());
+
+        for index in HEADER_SIZE..ciphertext.len() {
+            let mut tampered = ciphertext.clone();
+            tampered[index] ^= 0x01;
+            assert!(
+                decrypt_model_with_config(&tampered, "pw", &cheap_kdf()).is_err(),
+                "the tag of an empty payload was forgeable at byte {index}"
+            );
+        }
+    }
+
+    /// An all-zero buffer of plausible length must never look like a ciphertext.
+    #[test]
+    fn adversarial_2590_zero_buffer_is_not_mistaken_for_ciphertext() {
+        let zeros = vec![0u8; HEADER_SIZE + TAG_LEN + 64];
+        assert!(!is_encrypted(&zeros), "an all-zero buffer must not carry the magic");
+        assert!(get_version(&zeros).is_err(), "an all-zero buffer has no version");
+    }
+
+    /// An empty password must be refused, in every build.
+    #[test]
+    fn adversarial_2590_empty_password_is_refused() {
+        assert!(
+            encrypt_model(b"data", "").is_err(),
+            "an empty password must never be accepted for encryption"
+        );
     }
 }

--- a/crates/aprender-registry/src/crypto.rs
+++ b/crates/aprender-registry/src/crypto.rs
@@ -11,6 +11,21 @@
 //! - Memory-hard password hashing (Argon2id)
 //! - Authenticated encryption prevents tampering
 //!
+//! ## On-disk format
+//!
+//! `PACHAENC` ‖ version:u8 ‖ salt[32] ‖ nonce[12] ‖ body
+//!
+//! | version | body | status |
+//! |---------|------|--------|
+//! | 1 | XOR keystream + FNV-shaped checksum, clock-derived salt | **not encryption**; written by pacha ≤ 0.63.x, refused here (#2590) |
+//! | 2 | ChaCha20-Poly1305 over an Argon2id-derived key | current |
+//!
+//! Version 2 exists because the body changed and the header did not. #2590
+//! replaced the primitive but not the identifier, which would have left two
+//! mutually undecodable formats both claiming version 1 under the same magic.
+//! The version byte is the discriminator, so an archive can be classified from
+//! its own first nine bytes; see [`get_version`].
+//!
 //! # Example
 //!
 //! ```no_run
@@ -33,8 +48,30 @@ use serde::{Deserialize, Serialize};
 /// Magic bytes identifying encrypted pacha files
 const MAGIC: &[u8; 8] = b"PACHAENC";
 
-/// Current encryption format version
-const VERSION: u8 = 1;
+/// Current encryption format version: ChaCha20-Poly1305 body, Argon2id-derived key.
+///
+/// **Bumped 1 → 2 by #2590, and the bump is load-bearing.** The header layout
+/// (`PACHAENC` + version + 32-byte salt + 12-byte nonce) is byte-identical
+/// across the two, but the body is not: version 1 as *shipped* in 0.63.0 was
+/// the `not(feature = "encryption")` fallback — a
+/// `wrapping_mul(i as u8 + 1)` XOR keystream followed by an FNV-shaped 16-byte
+/// checksum, keyed by a 10 000-round add/multiply KDF over a `SystemTime`
+/// nanosecond salt. `encryption` was not a default feature and the real arm did
+/// not compile, so version 1 on disk means the XOR format and nothing else.
+///
+/// Leaving this at 1 would have made two mutually undecodable formats claim the
+/// same identifier. A v1 file fed to this code would fail the Poly1305 check and
+/// be reported as "invalid password or corrupted data" — the wrong diagnosis for
+/// a file that is neither. [`VERSION_LEGACY_XOR`] keeps the two distinguishable
+/// from the file itself.
+const VERSION: u8 = 2;
+
+/// Version byte written by the pre-#2590 XOR fallback. Never produced or read here.
+///
+/// [`EncryptedHeader::from_bytes`] recognises it only to say what it is; there is
+/// no decryption path, because reading it would mean re-implementing the homebrew
+/// cipher #2590 deleted. See [`VERSION`] for what the two versions mean.
+const VERSION_LEGACY_XOR: u8 = 1;
 
 /// Salt length for key derivation (32 bytes)
 const SALT_LEN: usize = 32;
@@ -103,6 +140,21 @@ impl EncryptedHeader {
         }
 
         let version = data[8];
+        if version == VERSION_LEGACY_XOR {
+            // Do NOT let this fall through to the AEAD, which would fail the
+            // Poly1305 check and report "invalid password or corrupted data" —
+            // a wrong diagnosis that sends the operator hunting for a password
+            // that never existed.
+            return Err(PachaError::InvalidFormat(
+                "this file is pacha encryption format v1, which was not encryption: \
+                 pacha 0.63.0 shipped without the `encryption` feature and wrote an \
+                 unauthenticated XOR keystream under this same PACHAENC magic (#2590). \
+                 It cannot be read by a build that has only ChaCha20-Poly1305, and its \
+                 contents were never confidentiality-protected. Recover the plaintext \
+                 with pacha 0.63.x and re-encrypt to v2."
+                    .to_string(),
+            ));
+        }
         if version != VERSION {
             return Err(PachaError::InvalidFormat(format!(
                 "unsupported encryption version: {}",
@@ -340,6 +392,10 @@ pub fn is_encrypted(data: &[u8]) -> bool {
 }
 
 /// Get encryption format version from encrypted data
+///
+/// `1` means the pre-#2590 XOR format (not encryption, and not readable here);
+/// `2` means ChaCha20-Poly1305 + Argon2id. This is the only way to tell the two
+/// apart — the magic and header layout are identical. See the module docs.
 pub fn get_version(data: &[u8]) -> Result<u8> {
     if data.len() < 9 {
         return Err(PachaError::InvalidFormat("data too short for version check".to_string()));
@@ -1050,6 +1106,73 @@ mod falsify_2590 {
         assert!(
             encrypt_model(b"data", "").is_err(),
             "an empty password must never be accepted for encryption"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // FALSIFIER G — the format's IDENTIFIER changed with the format.
+    // ------------------------------------------------------------------------
+
+    /// Two incompatible bodies must not share one version byte.
+    ///
+    /// #2590 replaced the on-disk body — XOR keystream + FNV checksum becomes
+    /// ChaCha20-Poly1305 — while `MAGIC` and `VERSION` stayed put. That leaves a
+    /// reader holding a `PACHAENC`/`\x01` file with no way to know which of two
+    /// mutually undecodable formats it has, and the AEAD's failure mode for a v1
+    /// file is the *wrong* message: "invalid password or corrupted data" for a
+    /// file that has neither problem.
+    ///
+    /// This test fails in both directions, and both were run. Reverting `VERSION`
+    /// to 1 fails the first assertion (`left: 1, right: 1` — fresh output is
+    /// stamped with the legacy identifier again). Removing the
+    /// `VERSION_LEGACY_XOR` arm from `from_bytes` fails the last, because the
+    /// refusal degrades to `unsupported encryption version: 1`, which tells the
+    /// operator the file is unreadable but not that it was never encrypted.
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn falsify_2590_g_legacy_v1_and_aead_v2_are_distinguishable_from_the_file() {
+        // 1. What we write now is NOT stamped with the legacy identifier.
+        let ciphertext =
+            encrypt_model_with_config(b"weights", "pw", &cheap_kdf()).expect("encrypt");
+        let stamped = get_version(&ciphertext).expect("fresh output must carry a version");
+        assert_ne!(
+            stamped, VERSION_LEGACY_XOR,
+            "the AEAD format is stamped with the same version byte the deleted XOR \
+             fallback used — the two formats are indistinguishable on disk"
+        );
+        assert_eq!(stamped, VERSION, "fresh output must be stamped v{VERSION}");
+
+        // 2. A legacy v1 file is still recognisably a pacha encrypted file...
+        let mut legacy = ciphertext.clone();
+        legacy[8] = VERSION_LEGACY_XOR;
+        assert!(is_encrypted(&legacy), "the magic is shared, so `is_encrypted` still holds");
+        assert_eq!(get_version(&legacy).expect("version readable"), VERSION_LEGACY_XOR);
+
+        // 3. ...and is refused with a diagnosis that names the format, never a
+        //    password. This is the assertion that excludes the silent-collision
+        //    outcome: a generic AEAD failure here would pass every other check.
+        let err = EncryptedHeader::from_bytes(&legacy)
+            .expect_err("a v1 header must not parse as the v2 AEAD format");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("invalid password"),
+            "a v1 file is not a wrong-password case, and saying so sends the operator \
+             after a password that never existed; got: {msg}"
+        );
+        assert!(
+            msg.contains("not encryption"),
+            "a bare 'unsupported version' is not enough: the operator must be told that \
+             v1 never protected the contents, or they will assume the data was \
+             confidential and is merely unreadable; got: {msg}"
+        );
+
+        // The whole-file entry point must reach the same verdict, not just the
+        // header parser the test called directly.
+        let err = decrypt_model_with_config(&legacy, "pw", &cheap_kdf())
+            .expect_err("decrypt_model must refuse a v1 file");
+        assert!(
+            err.to_string().contains("not encryption"),
+            "decrypt must give the same diagnosis as the header parser; got: {err}"
         );
     }
 }

--- a/crates/aprender-registry/src/signing.rs
+++ b/crates/aprender-registry/src/signing.rs
@@ -1187,3 +1187,233 @@ mod tests {
         assert!(verifying.verify(message, &recovered).is_ok());
     }
 }
+
+// ============================================================================
+// #2590 — adversarial cases for the signing surface
+//
+// Issue #2590: "a `sign` that verifies against its own verifier proves nothing
+// about interoperability or about rejecting a forged signature. A verifier that
+// accepts everything passes the positive test perfectly."
+//
+// The suite above verifies one wrong message and one wrong key. That is one
+// input, i.e. an anecdote. These sweep the whole signature and the whole
+// `ModelSignature` envelope, and pin the one property `verify_model` genuinely
+// does NOT provide.
+// ============================================================================
+
+#[cfg(test)]
+mod adversarial_2590 {
+    use super::*;
+
+    fn fixture() -> (SigningKey, VerifyingKey, Vec<u8>, Signature) {
+        let key = SigningKey::generate();
+        let verifying = key.verifying_key();
+        let message = b"tensor bytes that must not be swapped".to_vec();
+        let signature = key.sign(&message);
+        (key, verifying, message, signature)
+    }
+
+    /// EVERY single-bit flip in the 64-byte signature must be rejected.
+    ///
+    /// This is the check that separates a real verifier from one that returns
+    /// `Ok(())` unconditionally: 512 forgeries, all of which must fail.
+    #[test]
+    fn adversarial_2590_every_bit_flip_in_the_signature_is_rejected() {
+        let (_key, verifying, message, signature) = fixture();
+        assert!(
+            verifying.verify(&message, &signature).is_ok(),
+            "control: the real signature verifies"
+        );
+
+        let bytes = *signature.as_bytes();
+        for index in 0..64usize {
+            for bit in 0..8u8 {
+                let mut forged = bytes;
+                forged[index] ^= 1 << bit;
+                let forged_sig =
+                    Signature::from_bytes(&forged).expect("64 bytes is a well-formed signature");
+                assert!(
+                    verifying.verify(&message, &forged_sig).is_err(),
+                    "a signature with bit {bit} of byte {index} flipped was ACCEPTED"
+                );
+            }
+        }
+    }
+
+    /// Degenerate signatures must be rejected, not treated as "unset".
+    #[test]
+    fn adversarial_2590_degenerate_signatures_are_rejected() {
+        let (_key, verifying, message, _signature) = fixture();
+
+        for (label, raw) in [("all zero", [0u8; 64]), ("all ones", [0xFFu8; 64])] {
+            let sig = Signature::from_bytes(&raw).expect("64 bytes");
+            assert!(
+                verifying.verify(&message, &sig).is_err(),
+                "an {label} signature was accepted as valid"
+            );
+        }
+    }
+
+    /// A signature of the wrong length must be refused at construction.
+    #[test]
+    fn adversarial_2590_truncated_signature_bytes_are_refused() {
+        let (_key, _verifying, _message, signature) = fixture();
+        let bytes = signature.as_bytes().to_vec();
+
+        for len in [0usize, 1, 32, 63, 65, 128] {
+            let mut candidate = bytes.clone();
+            candidate.resize(len, 0);
+            assert!(
+                Signature::from_bytes(&candidate).is_err(),
+                "a {len}-byte buffer was accepted as a 64-byte Ed25519 signature"
+            );
+        }
+    }
+
+    /// A signature is bound to its message: no other message may verify.
+    ///
+    /// Includes the empty message and a single-bit edit, which is the case a
+    /// hash-prefix comparison would let through.
+    #[test]
+    fn adversarial_2590_signature_does_not_transfer_to_another_message() {
+        let (_key, verifying, message, signature) = fixture();
+
+        let mut one_bit_off = message.clone();
+        one_bit_off[0] ^= 0x01;
+
+        let mut truncated = message.clone();
+        truncated.pop();
+
+        let mut extended = message.clone();
+        extended.push(0x00);
+
+        for (label, other) in [
+            ("one bit off", one_bit_off),
+            ("truncated", truncated),
+            ("extended with a NUL", extended),
+            ("empty", Vec::new()),
+        ] {
+            assert!(
+                verifying.verify(&other, &signature).is_err(),
+                "the signature transferred to a {label} message"
+            );
+        }
+    }
+
+    /// Tampering with the model bytes must be caught by the content hash.
+    #[test]
+    fn adversarial_2590_model_signature_rejects_edited_model_bytes() {
+        let key = SigningKey::generate();
+        let model = vec![0xABu8; 512];
+        let signature = sign_model(&model, &key).expect("sign");
+        assert!(verify_model(&model, &signature).is_ok(), "control: the real model verifies");
+
+        for index in [0usize, 1, 255, 511] {
+            let mut edited = model.clone();
+            edited[index] ^= 0x01;
+            assert!(
+                verify_model(&edited, &signature).is_err(),
+                "a model with byte {index} edited was accepted"
+            );
+        }
+
+        assert!(verify_model(&[], &signature).is_err(), "an empty model was accepted");
+        assert!(
+            verify_model(&vec![0xABu8; 511], &signature).is_err(),
+            "a truncated model was accepted"
+        );
+    }
+
+    /// Editing the envelope's own fields must not make it verify.
+    #[test]
+    fn adversarial_2590_model_signature_envelope_fields_are_not_forgeable() {
+        let key = SigningKey::generate();
+        let model = vec![7u8; 128];
+        let signature = sign_model(&model, &key).expect("sign");
+
+        // Rewriting content_hash to the hash of a DIFFERENT model must fail:
+        // the signature covers the hash string.
+        let other_model = vec![8u8; 128];
+        let other = sign_model(&other_model, &key).expect("sign other");
+        let mut swapped = signature.clone();
+        swapped.content_hash = other.content_hash.clone();
+        assert!(
+            verify_model(&other_model, &swapped).is_err(),
+            "a content_hash swapped in from another signing was accepted"
+        );
+
+        // Replacing signer_key with an unrelated key must fail.
+        let mut wrong_signer = signature.clone();
+        wrong_signer.signer_key = SigningKey::generate().verifying_key().to_hex();
+        assert!(
+            verify_model(&model, &wrong_signer).is_err(),
+            "a signature attributed to an unrelated key was accepted"
+        );
+
+        // A malformed hex signature must be refused, not silently skipped.
+        let mut malformed = signature.clone();
+        malformed.signature = "not-hex".to_string();
+        assert!(
+            verify_model(&model, &malformed).is_err(),
+            "a non-hex signature field was accepted"
+        );
+    }
+
+    /// `verify_model` alone does NOT establish WHO signed; `_with_key` does.
+    ///
+    /// An attacker who can rewrite the `.sig` file can re-sign the same model
+    /// with their own key and `verify_model` will say VALID — correctly, since
+    /// it only asks "is this envelope internally consistent". This test pins
+    /// that boundary so nobody reads a green `apr pacha verify` as provenance.
+    #[test]
+    fn adversarial_2590_resigned_envelope_needs_an_expected_key_to_be_caught() {
+        let honest = SigningKey::generate();
+        let attacker = SigningKey::generate();
+        let model = vec![0x5Au8; 256];
+
+        let attacker_signature = sign_model(&model, &attacker).expect("sign");
+
+        assert!(
+            verify_model(&model, &attacker_signature).is_ok(),
+            "self-consistency check: an attacker-signed envelope IS internally valid"
+        );
+        assert!(
+            verify_model_with_key(&model, &attacker_signature, &honest.verifying_key()).is_err(),
+            "verify_model_with_key MUST reject an envelope signed by another key — \
+             this is the only call that establishes provenance"
+        );
+    }
+
+    /// Two keygen invocations must never produce the same key.
+    #[test]
+    fn adversarial_2590_keygen_never_repeats_in_a_tight_loop() {
+        use std::collections::HashSet;
+
+        const N: usize = 256;
+        let mut secrets = HashSet::new();
+        let mut publics = HashSet::new();
+        for _ in 0..N {
+            let key = SigningKey::generate();
+            secrets.insert(*key.as_bytes());
+            publics.insert(*key.verifying_key().as_bytes());
+        }
+
+        assert_eq!(secrets.len(), N, "keygen repeated a private key within {N} calls");
+        assert_eq!(publics.len(), N, "keygen repeated a public key within {N} calls");
+    }
+
+    /// A keyring must not hand back a key under a name it never stored.
+    #[test]
+    fn adversarial_2590_keyring_does_not_invent_keys() {
+        let mut keyring = Keyring::new();
+        let key = SigningKey::generate();
+        keyring.add("alice", &key.verifying_key());
+
+        assert!(keyring.get("bob").is_err(), "keyring returned a key for an unknown identity");
+        assert!(keyring.get("").is_err(), "keyring returned a key for the empty identity");
+        assert!(keyring.get("ALICE").is_err(), "keyring identity lookup must not fold case");
+
+        let empty = Keyring::new();
+        assert!(empty.default_key().is_err(), "an empty keyring must have no default key");
+    }
+}


### PR DESCRIPTION
Refs #2590. First tranche. **The surface is not done — 5 of 17 features gated, and only at the library layer.**

## The answer to the question the issue asked

#2590 asked whether crypto tests already existed and simply never ran, the way #2589 found for `pv`. They existed. **26 of them. They ran on every PR. They were green. They were testing an implementation nobody intended to ship.**

`encryption` was not a default feature of `aprender-registry`, so `cargo nextest run --workspace --lib` compiled the `not(feature = "encryption")` arm, which substituted a homebrew primitive for every real one:

| advertised | what the default build actually ran |
|---|---|
| ChaCha20 | `ks[i] = (key[i%32] + nonce[i%12] + block).wrapping_mul(i as u8 + 1)`, XORed |
| Poly1305 | a 16-byte FNV-shaped checksum whose two 8-byte halves are identical |
| Argon2id | a 10 000-round add/multiply loop over a 64-byte state |
| CSPRNG salt + nonce | `SystemTime` nanoseconds shifted by `i % 16` |

All of them returned `Ok`, and `apr pacha encrypt` printed `✓ Model encrypted successfully`. This is precisely the failure mode #2590 predicted: *"a sweep that exercises them and reports success is the weakest kind of evidence, and the one most likely to be mistaken for the strongest."*

And the second half of `17/17 UNKNOWN` has a mechanical cause: **`--features encryption` did not compile at all.** rand 0.9 dropped the `RngCore` impl on `OsRng`, so `EncryptedHeader::new` failed with `E0599`. The real ChaCha20-Poly1305 + Argon2id path had never been built on any machine, so no host could ever have verified it.

`signing` *is* a default feature, so signing/verify were running real Ed25519 — that half of the cluster was untested, not wrong.

## What this changes

- `EncryptedHeader::new` uses `rand::rng().fill_bytes`, the same handle `SigningKey::generate` already used. The encryption path compiles.
- **Every fallback primitive is deleted** — `derive_key`, `chacha_encrypt`, `chacha_decrypt`, `compute_fallback_tag`, and the timestamp salt.
- **`encryption` joins the default features**, so the shipped build and CI both exercise the real AEAD. No `.github/workflows/ci.yml` edit was needed — the tests land in the existing `--workspace --lib` run.
- Without the feature, `encrypt_model`/`decrypt_model` return `UnsupportedOperation` naming it. A build with no authenticated cipher must **refuse**, never silently downgrade.
- The pre-existing 26-test module is now `cfg(all(test, feature = "encryption"))`, so it can only ever run against the real thing.

## What this adds

23 tests — 3 falsifiers, 20 adversarial cases — plus `contracts/pacha-crypto-surface-v1.yaml` (6 proof obligations, 6 bound falsification tests, `pv validate` clean, `pv audit` no findings, all 6 test refs resolve under `--strict-test-binding`).

The sweeps are exhaustive rather than sampled, because one passing tamper offset is an anecdote:

- **every** single-bit flip at **every** byte offset of the ciphertext, header included (351 forgeries)
- **every** truncation length from 0 to `len-1`
- all **512** single-bit forgeries of a 64-byte Ed25519 signature
- a body spliced under a foreign header; appended trailing bytes; wrong Argon2id parameters; six near-miss passwords
- empty plaintext, whose tag must be no more forgeable than any other
- 256 back-to-back `keygen`s and 256 back-to-back headers, all distinct
- a two-time-pad check: `ct_a ^ ct_b` must not equal `pt_a ^ pt_b`

One test pins a boundary rather than a defect: `verify_model` establishes only that a `ModelSignature` envelope is *internally consistent*, **not who signed it**. An attacker who can rewrite the `.sig` file can re-sign the same model with their own key and `verify_model` reports VALID. Only `verify_model_with_key` establishes provenance. That is correct behaviour, and now it is written down where a green `apr pacha verify` cannot be misread as authorship.

## Mutation verification

Each mutation was grepped in **live code** before any verdict was read.

| # | mutation | engagement proof | result |
|---|---|---|---|
| 1 | restore `origin/main`'s `crypto.rs` + `Cargo.toml` verbatim | toy keystream at lines 269 and 309, both non-comment; `default = ["compression", "cli", "signing"]` | `falsify_2590_a` **RED** |
| 2 | re-inject the `wrapping_mul` keystream *inside* the encryption path | marker `MUTATION_2590_B_TOY_KEYSTREAM` present; exactly 1 non-doc `wrapping_mul(i as u8 + 1)` | `falsify_2590_b` **RED**, alone |
| 3 | re-inject the `SystemTime` salt derivation | marker `MUTATION_2590_C_TIMESTAMP_SALT` present; non-doc `seed >> (i % 16)` present | `falsify_2590_c` **RED**, alone (22 passed, 1 failed) |

Mutation 1's panic printed the fallback ciphertext, and its last 16 bytes are `163, 117, 71, 93, 42, 195, 205, 220, 163, 117, 71, 93, 42, 195, 205, 220` — the "auth tag" repeating with period 8, exactly as `tag[i] = state[i%4] >> ((i%8)*8)` implies. That is the tag standing in for Poly1305.

## Verification run

| gate | result |
|---|---|
| `cargo test -p aprender-registry --lib` | 491 passed (468 before) |
| `cargo test -p aprender-registry --tests` | 491 + 110 integration, all pass |
| `cargo test -p aprender-registry --lib --no-default-features` | fail-closed path green |
| `cargo test -p aprender-contracts --lib` | 1446 passed |
| `cargo fmt -p aprender-registry --check` | clean |
| `cargo clippy -p aprender-registry --lib -- -D warnings` | clean |
| `pv validate` / `pv audit` on the new contract | valid, no findings |
| `scripts/check_contract_test_binding.sh` | PASS |
| `scripts/check_contract_enforcement.sh` | PASS |

Argon2id at the production default (64 MiB, t=3) costs the suite ~7s in debug; the exhaustive sweeps use an explicitly-labelled cheap KDF config, since they measure whether the AEAD *rejects* bad input, which is independent of KDF hardness. No CI profile changes.

## Residual — stated as a fraction, deliberately

The cluster's 17 features are the 17 `PachaCommand` subcommands. This tranche covers **5 of 17** — `keygen`, `sign`, `verify`, `encrypt`, `decrypt` — and only at the **library** layer.

- **0 of 17 have a gated CLI path.** `crates/aprender-orchestrate/src/pacha/crypto.rs` is 420 lines and has no tests. `cmd_encrypt`/`cmd_decrypt`/`cmd_sign`/`cmd_verify` take explicit paths and are testable with tempdirs; `cmd_keygen` writes into `$HOME/.pacha`. Deferred because building `aprender-orchestrate` pulls essentially the whole workspace and the dev box is at 96% on `/`.
- **12 of 17** are registry-management verbs (`pull`, `list`, `rm`, `show`, `search`, `aliases`, `alias`, `stats`, `prune`, `pin`, `unpin`, `run`) — not crypto, untouched here.
- **`signing`'s `not(feature = "signing")` fallback is the same class of defect** — a homebrew BLAKE3 construction standing in for Ed25519. It does **not** ship (`signing` is a default feature), which is why it is not in this PR. But note honestly: the 9 signing adversarial tests here **pass against both implementations**, so they do not discriminate real Ed25519 from the fallback. They gate rejection behaviour, not algorithm identity. Fail-closing that arm is the natural follow-up.
- **`verified_hardware` is not flipped.** `docs/audits/surface_audit_clustered.csv` does not exist on this branch, so there is no field to edit. What is now true is that these 23 tests execute in the standard `workspace-test` run on the self-hosted x86-64 runner, which is the first time any host has executed the real ChaCha20-Poly1305 path.
- **No known-answer test.** The issue asked for one "where the algorithm admits one". RFC 8439 §2.8.2 gives a ChaCha20-Poly1305 KAT, but the internal `chacha_encrypt` is private and the public API interposes a random salt/nonce, so a KAT needs either a test-only seam or an RFC vector exercised through `chacha20poly1305` directly. Deferred rather than faked.

## Collision check

Touches `crates/aprender-registry/**` and one new `contracts/*.yaml` file. #2613, #2617 and #2603 touch neither. **No `.github/workflows/ci.yml` edit** — the integration-test line stays with #2617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
