### PR TITLE
fix(mcp): apr.serve vouched for a URL on a port a STRANGER was listening on (#2606)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1778 provable YAML contracts
+├── contracts/                      # 1779 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1778 contracts across inference, training, quantization, attention, FFN,
+1779 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1779 provable YAML contracts
+├── contracts/                      # 1778 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1779 contracts across inference, training, quantization, attention, FFN,
+1778 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/apr-mcp-serve-liveness-v1.yaml
+++ b/contracts/apr-mcp-serve-liveness-v1.yaml
@@ -1,0 +1,237 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-22'
+  author: PAIML Engineering
+  description: the MCP apr.serve tool may report a URL only for a port it watched accept
+    a connection while the spawned child was still alive
+  references:
+  - aprender#2606 (measured against the PUBLISHED 0.63.0 crates.io binary, sha256 2c7bc1d0eb…)
+  - aprender#2388 / PR #2415 (the argv and liveness fixes that landed on main after the 0.63.0 cut)
+  - aprender#2570 (apr tune fabricating a parameter count — same fabricated-success class)
+  lessons_learned:
+  - 'A spawn returning a pid proves a process was CREATED, not that it survived argv
+    parsing. 0.63.0 spawned `apr serve <model> --port <n>`, clap exited 2 before the
+    server was constructed, and the tool returned {"pid":3070303,"url":"http://localhost:38641"}
+    with isError ABSENT. ss -ltn showed nothing listening.'
+  - 'Annotating a fabrication is not removing it. The post-#2388 code polled for
+    liveness and correctly set ready:false when the child never bound — and still
+    emitted "url":"http://localhost:<port>" on that branch. A client reads the field
+    it asked the tool for; a truthful sibling key does not repair a false one. Make the
+    fabrication UNREPRESENTABLE: withhold the url key on every branch that did not
+    observe a connect.'
+  - 'The argv guard shipped as assert_eq!(serve_argv(m,p), vec!["serve","run",m,...]),
+    which is tautological with the implementation. It re-states the argv rather than
+    asking anything whether that argv parses, so a rename of the `run` subcommand keeps
+    it green while the tool regresses to exactly the 0.63.0 behaviour. Mutation-verified:
+    renaming run->start in BOTH the implementation and that assertion left all 14
+    aprender-mcp guards GREEN.'
+  - 'The check has to run on the surface where the DECISION is made. Only the CLI''s own
+    clap parser can answer "does apr accept this argv" — it is the surface that emitted
+    the measured rc=2. aprender-mcp cannot reach it (apr-cli depends on aprender-mcp, not
+    the reverse), so the argv falsifier lives in apr-cli.'
+  - 'A new tests/*.rs file in this repo is DARK until its name is added to the single
+    integration-test line in .github/workflows/ci.yml. Both halves of this contract are
+    therefore --lib tests, which workspace-test runs.'
+
+equations:
+  url_only_when_listening:
+    formula: 'url in payload(spawn_and_confirm(p, argv, port, t)) <=> exists s <= t such
+      that tcp_connect(127.0.0.1:port) succeeded at s AND child.try_wait() == None at s'
+    domain: p a program path, argv its arguments, port in 0..=65535, t a readiness window
+    codomain: a ToolCallResult whose single text block is a JSON object
+    invariants:
+    - port == 0 => no url (an OS-assigned port cannot be probed, so listening is never
+      observed)
+    - child exited within t => is_error == Some(true) and no url
+    - spawn failed => is_error == Some(true) and no url
+    - child alive at t but never connected => is_error == None, ready == false, no url
+    - connect succeeded with child alive => is_error == None, ready == true, url ==
+      "http://localhost:{port}"
+    - ready == true <=> url is present
+    preconditions:
+    - the liveness poll runs BEFORE the connect probe, so an unrelated process holding
+      the port cannot masquerade as the spawned daemon
+    - the connect success is re-checked against child liveness, closing the race where
+      the connect and the child's death interleave
+    postconditions:
+    - 'payload.pid is always present: the caller owns the process and must be able to
+      kill it, whether or not it ever bound'
+    - payload.port is always present as a scalar, so the attempted port is reportable
+      without being dialable by mistake
+    - the substring "http://" appears in the result of exactly the listening branch
+  argv_is_accepted_by_the_cli:
+    formula: 'Cli::try_parse_from(["apr"] ++ serve_argv(m, p)).is_ok() AND the parse
+      yields Commands::Serve{command ServeCommands::Run} with file = m and port = p'
+    domain: m a model path string, p in 1..=65535
+    codomain: the CLI's parsed command tree
+    invariants:
+    - m lands in the FILE slot, never in the subcommand slot
+    - p reaches the server launcher unchanged, across the whole u16 range
+    - parsing into `serve plan` would also parse and start nothing, so the variant is
+      asserted, not merely the absence of an error
+    preconditions:
+    - apr-cli depends on aprender-mcp, so serve_argv is callable from the parser's crate
+    postconditions:
+    - the argv the MCP tool spawns is the argv the shipped CLI accepts
+
+falsification_tests:
+- id: FALSIFY-MCP-SERVE-2606-001
+  name: live_child_that_never_binds_reports_no_url
+  prediction: 'spawn_and_confirm("sleep", ["5"], <free port>, 300ms) returns is_error
+    == None with ready == false, port == the free port, and NO url key — and its text
+    block contains no "http://" at all.'
+  test_harness: cargo test -p aprender-mcp --lib live_child_that_never_binds_reports_no_url
+  expected_output: 'test result: ok'
+  if_fails: 'The ready:false branch is emitting a URL for a port nothing is bound to —
+    aprender#2606. Mutation-verified: restoring the unconditional
+    payload["url"] = format!("http://localhost:{port}") turns this RED while the
+    pre-existing live_child_that_never_binds_reports_ready_false stays GREEN, which is
+    precisely why that older guard did not catch the shipped defect.'
+- id: FALSIFY-MCP-SERVE-2606-002
+  name: ephemeral_port_reports_no_url_and_not_ready
+  prediction: 'spawn_and_confirm with port == 0 returns is_error == None, ready ==
+    false, and no url. Port 0 is never probed, so listening is never observed.'
+  test_harness: cargo test -p aprender-mcp --lib ephemeral_port_reports_no_url_and_not_ready
+  expected_output: 'test result: ok'
+  if_fails: 'The tool is handing back "http://localhost:0" — an endpoint that cannot
+    exist — for an OS-assigned port it never learned the value of.'
+- id: FALSIFY-MCP-SERVE-2606-003
+  name: dead_child_reports_no_url
+  prediction: 'spawn_and_confirm("false", [], <free port>, 5s) returns is_error ==
+    Some(true) and its message contains no "http://".'
+  test_harness: cargo test -p aprender-mcp --lib dead_child_reports_no_url
+  expected_output: 'test result: ok'
+  if_fails: 'A URL leaked into the error path. The 0.63.0 shape was exactly this — a
+    dead child described by a reachable-looking endpoint.'
+- id: FALSIFY-MCP-SERVE-2606-004
+  name: url_appears_only_on_the_observed_listening_branch
+  prediction: 'Two identical calls differing ONLY in whether something is listening on
+    the port: the unbound one carries no url, the bound one carries ready == true and
+    url == "http://localhost:{port}". Pins url to exactly one branch from both sides.'
+  test_harness: cargo test -p aprender-mcp --lib url_appears_only_on_the_observed_listening_branch
+  expected_output: 'test result: ok'
+  if_fails: 'Either a url appeared without an observed connect (the #2606 defect), or
+    the listening branch stopped emitting one (the fix over-corrected and the tool is
+    now useless — a working server with no URL to reach it).'
+- id: FALSIFY-MCP-SERVE-2606-008
+  name: url_key_matches_ready_exhaustively_over_every_port
+  prediction: 'running_result(4242, port, ready, log) satisfies url-present == ready
+    and "http://"-in-text == ready for EVERY port in 0..=65535 and both readiness
+    values — 131072 cases, all of them, in under 2s.'
+  test_harness: cargo test -p aprender-mcp --lib url_key_matches_ready_exhaustively_over_every_port
+  expected_output: 'test result: ok'
+  if_fails: 'Some port is a special case. Spawn-based falsifiers can only sample a
+    port; this closes the domain so 0, 65535 and everything between are covered rather
+    than assumed. Discharges KANI-MCP-SERVE-2606-001 by exhaustion today.'
+- id: FALSIFY-MCP-SERVE-2606-005
+  name: falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser
+  prediction: 'Cli::try_parse_from(["apr"] ++ serve_argv("/models/…q4_k_m.apr", 38621))
+    succeeds and yields ServeCommands::Run with that file and that port.'
+  test_harness: cargo test -p apr-cli --lib falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser
+  expected_output: 'test result: ok'
+  if_fails: 'The MCP tool spawns an argv the CLI REJECTS — the measured rc=2. Two
+    mutations verified: (B1) dropping "run" from serve_argv reproduces the exact 0.63.0
+    stderr, "error: unrecognized subcommand ''/models/…q4_k_m.apr''"; (B2) renaming
+    run->start in the implementation AND in the old hard-coded-vector assertion leaves
+    all 14 aprender-mcp guards GREEN and turns only this one RED, with "error:
+    unrecognized subcommand ''start''".'
+- id: FALSIFY-MCP-SERVE-2606-006
+  name: falsify_2606_the_0_63_0_argv_is_still_rejected_by_clap
+  prediction: '["apr","serve","<model>","--port","38621"] — the exact argv the sweep
+    captured via a PATH shim — is still rejected by clap with a message naming a
+    subcommand or a Usage line.'
+  test_harness: cargo test -p apr-cli --lib falsify_2606_the_0_63_0_argv_is_still_rejected_by_clap
+  expected_output: 'test result: ok'
+  if_fails: 'A default subcommand or a positional fallback now makes the 0.63.0 argv
+    parse. That is not automatically wrong, but it silently drains -005 of meaning: the
+    defect becomes unobservable rather than fixed, and the liveness guard becomes the
+    only thing between a user and a fabricated URL. Decide deliberately; do not delete.'
+- id: FALSIFY-MCP-SERVE-2606-007
+  name: falsify_2606_serve_argv_round_trips_port_across_the_range
+  prediction: 'For port in {1, 80, 8080, 38641, 65535} the argv parses and the parsed
+    port equals the requested one.'
+  test_harness: cargo test -p apr-cli --lib falsify_2606_serve_argv_round_trips_port_across_the_range
+  expected_output: 'test result: ok'
+  if_fails: 'One failing port is an anecdote; the sweep probed 38641 alone. A flag
+    rename, a type narrowing, or a short-flag collision would show up at an edge before
+    it shows up at 8080.'
+
+proof_obligations:
+- type: invariant
+  property: apr.serve reports a URL only for a port it observed accept a connection
+    while the child was alive
+  formal: 'url in payload(r) <=> r came from the branch reached after tcp_connect(port)
+    succeeded and child.try_wait() == None'
+  applies_to: aprender_mcp::tools::serve::spawn_and_confirm, running_result
+  discharged_by: FALSIFY-MCP-SERVE-2606-001, FALSIFY-MCP-SERVE-2606-002,
+    FALSIFY-MCP-SERVE-2606-003, FALSIFY-MCP-SERVE-2606-004, FALSIFY-MCP-SERVE-2606-008
+  notes: >-
+    This is the half that survives the next argv change. It names no subcommand and
+    no flag, so it keeps its teeth however the CLI's surface moves. Discharged from
+    both sides: three branches that must NOT carry a url, and one that must.
+- type: invariant
+  property: A still-loading child is reported truthfully, not as an error and not as
+    a server
+  formal: child alive at deadline AND no connect observed => is_error == None AND
+    ready == false AND no url AND pid present
+  applies_to: aprender_mcp::tools::serve::running_result
+  discharged_by: FALSIFY-MCP-SERVE-2606-001, FALSIFY-MCP-SERVE-2606-002
+  notes: >-
+    The converse half, and a deliberate design decision rather than an oversight. A
+    multi-GB CPU model load can outlast READY_TIMEOUT; reporting isError for a healthy
+    loader would be its own false claim, and would orphan a live process the caller
+    still owns. The honest report is pid yes, url no, ready false.
+- type: invariant
+  property: The argv the MCP tool spawns is accepted by the CLI that receives it
+  formal: 'for all m, p — Cli::try_parse_from(["apr"] ++ serve_argv(m,p)) yields
+    Commands::Serve{command ServeCommands::Run} with file = m and port = p'
+  applies_to: aprender_mcp::tools::serve::serve_argv, apr_cli::Cli
+  discharged_by: FALSIFY-MCP-SERVE-2606-005, FALSIFY-MCP-SERVE-2606-007
+  notes: >-
+    Discharged against the real clap parser, not against a hard-coded vector. The
+    vector assertion is tautological with the implementation and was mutation-proven
+    blind to a coordinated rename. Any future check on this argv must run on a surface
+    that can REJECT it.
+- type: invariant
+  property: The shipped defect stays observable
+  formal: Cli::try_parse_from(["apr","serve",m,"--port",p]).is_err()
+  applies_to: apr_cli::Cli
+  discharged_by: FALSIFY-MCP-SERVE-2606-006
+  notes: >-
+    Guards the guard. If the 0.63.0 argv ever starts parsing, the positive falsifier
+    above stops distinguishing anything, and the failure would be silent.
+
+kani_harnesses:
+- id: KANI-MCP-SERVE-2606-001
+  obligation: apr.serve reports a URL only for a port it observed accept a connection
+    while the child was alive
+  property: for any port p and any ready b, running_result(pid, p, b, log) contains a
+    url key iff b, and contains the substring "http://" iff b
+  bound: 65536
+  strategy: exhaustive
+  harness: verify_url_key_matches_ready
+  status: discharged_by_exhaustion
+  notes: >-
+    running_result is a pure function of (pid, port, ready) over a finite domain of
+    131072 points, so the property is decided by enumeration rather than by model
+    checking. FALSIFY-MCP-SERVE-2606-008 runs the whole domain in under 2s. A Kani
+    harness is retained here as the escalation path for the day running_result gains
+    a non-finite input; it is NOT claimed to have been run.
+
+qa_gate:
+  id: F-MCP-SERVE-2606
+  name: apr.serve liveness and argv contract
+  checks:
+  - apr.serve emits a url key on exactly one branch — the one that observed a TCP
+    connect succeed with the child still alive
+  - Every other terminal state (spawn failure, child exit, alive-but-unbound, port 0)
+    carries no url and no "http://" substring anywhere in its text block
+  - ready == true if and only if url is present
+  - pid and port are reported on every non-error branch, so the caller can always kill
+    and always knows what was attempted
+  - serve_argv's output is parsed by the CLI's own clap parser into ServeCommands::Run
+    with the requested file and port
+  - the 0.63.0 argv is still rejected by that parser
+  pass_criteria: All eight FALSIFY-MCP-SERVE-2606 falsifiers pass, and each mechanism
+    has been mutation-verified by removing it and observing RED — with the mutation's
+    engagement proven by grepping its marker before any verdict is read

--- a/contracts/apr-mcp-serve-liveness-v1.yaml
+++ b/contracts/apr-mcp-serve-liveness-v1.yaml
@@ -1,13 +1,14 @@
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   created: '2026-08-22'
   author: PAIML Engineering
-  description: the MCP apr.serve tool may report a URL only for a port it watched accept
-    a connection while the spawned child was still alive
+  description: the MCP apr.serve tool may report a URL only for a port whose listening
+    socket is held by the child it spawned (or a descendant of it)
   references:
   - aprender#2606 (measured against the PUBLISHED 0.63.0 crates.io binary, sha256 2c7bc1d0eb…)
   - aprender#2388 / PR #2415 (the argv and liveness fixes that landed on main after the 0.63.0 cut)
   - aprender#2570 (apr tune fabricating a parameter count — same fabricated-success class)
+  - aprender#2615 (Cargo.lock [[patch.unused]] block that must never land)
   lessons_learned:
   - 'A spawn returning a pid proves a process was CREATED, not that it survived argv
     parsing. 0.63.0 spawned `apr serve <model> --port <n>`, clap exited 2 before the
@@ -32,33 +33,84 @@ metadata:
   - 'A new tests/*.rs file in this repo is DARK until its name is added to the single
     integration-test line in .github/workflows/ci.yml. Both halves of this contract are
     therefore --lib tests, which workspace-test runs.'
+  - 'v1.0.0 of this contract stated the invariant as "a port it watched accept a
+    connection while the child was still alive" — and an adversarial pass reproduced
+    the ORIGINAL fabricated-URL shape against it, because that conjunction is satisfied
+    by ANY unrelated process holding the port: the child binds nothing, the probe hits
+    the stranger''s socket, and the tool reports {"ready":true,"url":"http://localhost:
+    <port>"} for a server it did not start. The v1 test suite did not merely miss this
+    — its POSITIVE case asserted it: url_appears_only_on_the_observed_listening_branch
+    pre-bound a TcpListener, spawned `sleep`, and asserted a url came back. A test that
+    encodes the defect is worse than no test.'
+  - 'Reachability is not attribution. Tightening the claim without tightening the
+    EVIDENCE leaves the same defect behind a narrower sentence. Two mechanisms are
+    needed and each is independently load-bearing (both mutation-verified): pre-flight
+    (portable — refuse before spawning if the port already answers) and socket->pid
+    attribution (Linux — /proc/net/tcp{,6} inode INTERSECT /proc/<pid>/fd over the
+    child and its descendants). Pre-flight alone misses a stranger that arrives inside
+    the readiness window; attribution alone still reports the conflict as a quiet
+    ready:false instead of telling the caller their port is taken.'
+  - 'Where a guarantee is not portable, NARROW THE STATED CLAIM and say which one is in
+    force, rather than asserting the strong one everywhere. Socket->pid attribution
+    needs an OS interface; macOS has no /proc, and libproc/lsof are out of reach under
+    unsafe_code = "forbid" with no new dependencies. The payload therefore carries an
+    explicit `attribution` field — "child" (strong, Linux) vs "unavailable" (weak:
+    pre-flight proved the port closed before spawn, and nothing more) — so a client can
+    tell which guarantee it actually has. A platform that cannot attribute NEVER
+    returns the strong verdict.'
+  - 'Test port allocation is part of the contract''s blast radius. Once "someone else
+    holds this port" became a hard error, any test that drew a port from the kernel''s
+    ephemeral range (bind(0), release, hope) could be handed a port a sibling test
+    process had just taken — and under nextest every test is its own process, so a
+    per-process counter starting at a fixed number hands the SAME port to every test in
+    parallel. The tests draw from a private range below the ephemeral window, seeded by
+    pid, and re-draw on a pre-flight refusal a bounded number of times.'
 
 equations:
-  url_only_when_listening:
+  url_only_when_child_owns_the_port:
     formula: 'url in payload(spawn_and_confirm(p, argv, port, t)) <=> exists s <= t such
-      that tcp_connect(127.0.0.1:port) succeeded at s AND child.try_wait() == None at s'
+      that tcp_connect(127.0.0.1:port) succeeded at s AND child.try_wait() == None at s
+      AND owner_of_listening_port(port, child.pid) in {Child, Unknown}, where Child means
+      a LISTEN socket on port appears on an fd of child.pid or a transitive descendant,
+      and Unknown means this platform has no socket->pid interface at all'
     domain: p a program path, argv its arguments, port in 0..=65535, t a readiness window
     codomain: a ToolCallResult whose single text block is a JSON object
     invariants:
     - port == 0 => no url (an OS-assigned port cannot be probed, so listening is never
       observed)
+    - port != 0 AND the port already accepts connections BEFORE the spawn => is_error ==
+      Some(true), no child is spawned at all, and no url
     - child exited within t => is_error == Some(true) and no url
     - spawn failed => is_error == Some(true) and no url
     - child alive at t but never connected => is_error == None, ready == false, no url
-    - connect succeeded with child alive => is_error == None, ready == true, url ==
+    - connect succeeded with child alive but the LISTEN socket is held by some process
+      outside the child's subtree => is_error == None, ready == false, attribution ==
+      "foreign", NO url
+    - connect succeeded with child alive and the LISTEN socket on the child's own fds =>
+      is_error == None, ready == true, attribution == "child", url ==
       "http://localhost:{port}"
     - ready == true <=> url is present
+    - attribution == "child" is returned ONLY where socket->pid attribution exists; a
+      platform without it returns "unavailable" and never the strong verdict
     preconditions:
-    - the liveness poll runs BEFORE the connect probe, so an unrelated process holding
-      the port cannot masquerade as the spawned daemon
+    - the port is probed BEFORE the spawn, so a listener that predates the child can
+      never be mistaken for it — and a port that cannot be bound is refused rather than
+      handed a doomed daemon
+    - the liveness poll runs BEFORE the connect probe, so a dead child can never be
+      reported as ready
     - the connect success is re-checked against child liveness, closing the race where
       the connect and the child's death interleave
+    - attribution intersects /proc/net/tcp{,6} LISTEN inodes with /proc/<pid>/fd over
+      the child and its transitive descendants, and fails CLOSED — an unreadable table
+      or a missing LISTEN row yields Foreign, never Child
     postconditions:
     - 'payload.pid is always present: the caller owns the process and must be able to
       kill it, whether or not it ever bound'
     - payload.port is always present as a scalar, so the attempted port is reportable
       without being dialable by mistake
-    - the substring "http://" appears in the result of exactly the listening branch
+    - 'payload.attribution is always present on a non-error branch, naming the evidence
+      the verdict rests on: child | unavailable | foreign | none'
+    - the substring "http://" appears in the result of exactly the attributable branch
   argv_is_accepted_by_the_cli:
     formula: 'Cli::try_parse_from(["apr"] ++ serve_argv(m, p)).is_ok() AND the parse
       yields Commands::Serve{command ServeCommands::Run} with file = m and port = p'
@@ -104,25 +156,79 @@ falsification_tests:
   if_fails: 'A URL leaked into the error path. The 0.63.0 shape was exactly this — a
     dead child described by a reachable-looking endpoint.'
 - id: FALSIFY-MCP-SERVE-2606-004
-  name: url_appears_only_on_the_observed_listening_branch
-  prediction: 'Two identical calls differing ONLY in whether something is listening on
-    the port: the unbound one carries no url, the bound one carries ready == true and
-    url == "http://localhost:{port}". Pins url to exactly one branch from both sides.'
-  test_harness: cargo test -p aprender-mcp --lib url_appears_only_on_the_observed_listening_branch
+  name: an_unrelated_listener_on_the_port_never_produces_a_url
+  prediction: 'An unrelated TcpListener holds the port; spawn_and_confirm("sleep",
+    ["5"], that port, 500ms) returns is_error == Some(true), the message names the
+    port, and no "http://" appears anywhere. This is the verifier''s own reproduction
+    of the ORIGINAL fabricated-URL shape against the v1 fix.'
+  test_harness: cargo test -p aprender-mcp --lib an_unrelated_listener_on_the_port_never_produces_a_url
   expected_output: 'test result: ok'
-  if_fails: 'Either a url appeared without an observed connect (the #2606 defect), or
-    the listening branch stopped emitting one (the fix over-corrected and the tool is
-    now useless — a working server with no URL to reach it).'
+  if_fails: 'The tool is again reporting a URL for a server it did not start. The v1
+    gate — child alive AND something answered the port — is satisfied by any stranger
+    holding it. Mutation-verified (MUTATION-2606-M1-ENGAGED, marker grep count 1 in the
+    built test binary before any verdict was read): restoring the v1 gate turns this
+    RED with the measured payload {"attribution":"child","ready":true,
+    "url":"http://localhost:45831"} for a `sleep` child that bound nothing.'
+- id: FALSIFY-MCP-SERVE-2606-009
+  name: a_listener_that_appears_mid_window_is_not_attributed_to_the_child
+  prediction: 'Pre-flight passes (the port is free at spawn), then an unrelated
+    listener binds it inside the readiness window. On a platform with socket->pid
+    attribution the result is is_error == None, ready == false, attribution ==
+    "foreign", no url. On a platform without it, attribution != "child".'
+  test_harness: cargo test -p aprender-mcp --lib a_listener_that_appears_mid_window_is_not_attributed_to_the_child
+  expected_output: 'test result: ok'
+  if_fails: 'Pre-flight alone is being trusted. It cannot see a stranger that arrives
+    after the spawn — only attribution can. Mutation-verified: M3 (MUTATION-2606-M3-ENGAGED,
+    grep count 1) disables attribution and KEEPS pre-flight; -004 stays GREEN and this
+    one goes RED, which is exactly why both mechanisms ship.'
+- id: FALSIFY-MCP-SERVE-2606-010
+  name: live_child_that_owns_the_socket_reports_ready_true_with_url
+  prediction: 'The spawned child is this test binary re-invoked to run the ignored
+    listener_helper, which binds the port it is handed. Result: is_error == None,
+    ready == true, url == "http://localhost:{port}", and on Linux attribution ==
+    "child". The one branch that OWES a url.'
+  test_harness: cargo test -p aprender-mcp --lib live_child_that_owns_the_socket_reports_ready_true_with_url
+  expected_output: 'test result: ok'
+  if_fails: 'The fix over-corrected: a genuinely listening child gets no URL and the
+    tool is useless. This is the positive half, and it is deliberately driven by a REAL
+    child holding a REAL listening socket — the v1 positive case faked it with a
+    pre-bound listener and thereby asserted the defect.'
+- id: FALSIFY-MCP-SERVE-2606-011
+  name: classify_listener_never_attributes_a_stranger_socket_to_the_child
+  prediction: 'With a listener held by the test process and an unrelated `sleep` as the
+    nominal child, classify_listener returns ByForeignProcess on a platform with
+    attribution (and is_attributable() == false), and UnattributedAfterPreflight — never
+    ByChild — on one without.'
+  test_harness: cargo test -p aprender-mcp --lib classify_listener_never_attributes_a_stranger_socket_to_the_child
+  expected_output: 'test result: ok'
+  if_fails: 'The point where a platform verdict becomes a url decision is broken:
+    either Foreign is being turned into a url, or Unknown is being upgraded to the
+    strong ByChild claim.'
+- id: FALSIFY-MCP-SERVE-2606-012
+  name: a_listener_this_process_holds_is_attributed_to_this_process
+  prediction: 'Against a REAL kernel socket: owner_of_listening_port(port, own pid) ==
+    Child for a listener this process holds, and == Foreign for the same live listener
+    asked about an unrelated spawned process (a parent is not a descendant of its own
+    child). A port with no listener is Foreign.'
+  test_harness: cargo test -p aprender-mcp --lib tools::port_owner
+  expected_output: 'test result: ok'
+  if_fails: 'The /proc/net/tcp{,6} INTERSECT /proc/<pid>/fd mapping is wrong, which
+    would either withhold urls from working servers (Child mis-read as Foreign) or
+    restore the fabrication (Foreign mis-read as Child). The row parser is separately
+    pinned against LISTEN-vs-ESTABLISHED, wrong-port and malformed rows, and the ppid
+    parse against a comm containing spaces and parentheses.'
 - id: FALSIFY-MCP-SERVE-2606-008
-  name: url_key_matches_ready_exhaustively_over_every_port
-  prediction: 'running_result(4242, port, ready, log) satisfies url-present == ready
-    and "http://"-in-text == ready for EVERY port in 0..=65535 and both readiness
-    values — 131072 cases, all of them, in under 2s.'
-  test_harness: cargo test -p aprender-mcp --lib url_key_matches_ready_exhaustively_over_every_port
+  name: url_key_matches_attribution_exhaustively_over_every_port
+  prediction: 'running_result(4242, port, listening, log) satisfies url-present ==
+    listening.is_attributable() and "http://"-in-text == the same, and reports the
+    evidence class verbatim, for EVERY port in 0..=65535 and ALL FOUR evidence classes
+    (No, ByForeignProcess, UnattributedAfterPreflight, ByChild) — 262144 cases.'
+  test_harness: cargo test -p aprender-mcp --lib url_key_matches_attribution_exhaustively_over_every_port
   expected_output: 'test result: ok'
   if_fails: 'Some port is a special case. Spawn-based falsifiers can only sample a
     port; this closes the domain so 0, 65535 and everything between are covered rather
-    than assumed. Discharges KANI-MCP-SERVE-2606-001 by exhaustion today.'
+    than assumed. ByForeignProcess is IN the domain — that is the state the v1 fix
+    collapsed into ready:true. Discharges KANI-MCP-SERVE-2606-001 by exhaustion today.'
 - id: FALSIFY-MCP-SERVE-2606-005
   name: falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser
   prediction: 'Cli::try_parse_from(["apr"] ++ serve_argv("/models/…q4_k_m.apr", 38621))
@@ -158,17 +264,54 @@ falsification_tests:
 
 proof_obligations:
 - type: invariant
-  property: apr.serve reports a URL only for a port it observed accept a connection
-    while the child was alive
+  property: SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT — apr.serve reports a URL only for a
+    port whose listening socket is held by the child it spawned, or a descendant of it
   formal: 'url in payload(r) <=> r came from the branch reached after tcp_connect(port)
-    succeeded and child.try_wait() == None'
-  applies_to: aprender_mcp::tools::serve::spawn_and_confirm, running_result
+    succeeded, child.try_wait() == None, and a LISTEN socket on port was found on an fd
+    of the child or a transitive descendant'
+  applies_to: aprender_mcp::tools::serve::spawn_and_confirm, classify_listener,
+    running_result, aprender_mcp::tools::port_owner::owner_of_listening_port
   discharged_by: FALSIFY-MCP-SERVE-2606-001, FALSIFY-MCP-SERVE-2606-002,
-    FALSIFY-MCP-SERVE-2606-003, FALSIFY-MCP-SERVE-2606-004, FALSIFY-MCP-SERVE-2606-008
+    FALSIFY-MCP-SERVE-2606-003, FALSIFY-MCP-SERVE-2606-004, FALSIFY-MCP-SERVE-2606-008,
+    FALSIFY-MCP-SERVE-2606-009, FALSIFY-MCP-SERVE-2606-010, FALSIFY-MCP-SERVE-2606-011,
+    FALSIFY-MCP-SERVE-2606-012
   notes: >-
     This is the half that survives the next argv change. It names no subcommand and
     no flag, so it keeps its teeth however the CLI's surface moves. Discharged from
-    both sides: three branches that must NOT carry a url, and one that must.
+    both sides: five branches that must NOT carry a url — including a stranger holding
+    the port, before and during the readiness window — and one, driven by a real child
+    holding a real listening socket, that must.
+- type: invariant
+  property: Where socket->pid attribution is unavailable, the WEAKER guarantee is
+    stated rather than the stronger one asserted
+  formal: attribution_available() == false => classify_listener(port, pid) !=
+    Listening::ByChild AND payload.attribution == "unavailable" on any url-bearing
+    branch
+  applies_to: aprender_mcp::tools::port_owner::owner_of_listening_port,
+    aprender_mcp::tools::serve::classify_listener
+  discharged_by: FALSIFY-MCP-SERVE-2606-011, FALSIFY-MCP-SERVE-2606-008
+  notes: >-
+    Linux — every CI runner and every host measured in #2606 — gets the strong form.
+    macOS has no /proc, and libproc/lsof are unreachable under unsafe_code = "forbid"
+    with no new dependencies, so there the tool falls back to pre-flight alone: the
+    port was proven closed immediately before the spawn, and then began accepting
+    connections while the child was alive. A process that grabs the port inside the
+    readiness window would still be mistaken for the child there. That is a real,
+    narrower claim, labelled as such in the payload — not the strong one restated.
+- type: invariant
+  property: A port already held by another process is refused BEFORE a child is spawned
+  formal: port != 0 AND tcp_connect(127.0.0.1:port) succeeds before spawn => is_error
+    == Some(true), no process is created, and the message names the port
+  applies_to: aprender_mcp::tools::serve::spawn_and_confirm
+  discharged_by: FALSIFY-MCP-SERVE-2606-004
+  notes: >-
+    The portable half of the fix, and independently load-bearing. Mutation-verified as
+    M2 (MUTATION-2606-M2-ENGAGED, marker grep count 1): disabling ONLY pre-flight while
+    keeping attribution leaves the url correctly withheld — attribution catches it — but
+    turns FALSIFY-004 RED on the conflict report, because the caller is no longer told
+    their port is taken and is instead handed a quiet ready:false. Where the platform
+    has no attribution, this is the ONLY thing standing between a client and a
+    stranger's URL.
 - type: invariant
   property: A still-loading child is reported truthfully, not as an error and not as
     a server
@@ -203,18 +346,19 @@ proof_obligations:
 
 kani_harnesses:
 - id: KANI-MCP-SERVE-2606-001
-  obligation: apr.serve reports a URL only for a port it observed accept a connection
-    while the child was alive
-  property: for any port p and any ready b, running_result(pid, p, b, log) contains a
-    url key iff b, and contains the substring "http://" iff b
-  bound: 65536
+  obligation: SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT — apr.serve reports a URL only for a
+    port whose listening socket is held by the child it spawned
+  property: for any port p and any evidence class c, running_result(pid, p, c, log)
+    contains a url key iff c.is_attributable(), and contains the substring "http://"
+    iff the same
+  bound: 262144
   strategy: exhaustive
-  harness: verify_url_key_matches_ready
+  harness: verify_url_key_matches_attribution
   status: discharged_by_exhaustion
   notes: >-
-    running_result is a pure function of (pid, port, ready) over a finite domain of
-    131072 points, so the property is decided by enumeration rather than by model
-    checking. FALSIFY-MCP-SERVE-2606-008 runs the whole domain in under 2s. A Kani
+    running_result is a pure function of (pid, port, listening) over a finite domain of
+    262144 points, so the property is decided by enumeration rather than by model
+    checking. FALSIFY-MCP-SERVE-2606-008 runs the whole domain. A Kani
     harness is retained here as the escalation path for the day running_result gains
     a non-finite input; it is NOT claimed to have been run.
 
@@ -222,16 +366,21 @@ qa_gate:
   id: F-MCP-SERVE-2606
   name: apr.serve liveness and argv contract
   checks:
-  - apr.serve emits a url key on exactly one branch — the one that observed a TCP
-    connect succeed with the child still alive
-  - Every other terminal state (spawn failure, child exit, alive-but-unbound, port 0)
-    carries no url and no "http://" substring anywhere in its text block
+  - apr.serve emits a url key on exactly one branch — the one where a LISTEN socket on
+    the port was found on an fd of the spawned child or one of its descendants
+  - A port that already accepts connections is refused before any child is spawned, and
+    the refusal names the port (and the holding pid where the platform can say)
+  - Every other terminal state (spawn failure, child exit, alive-but-unbound, port 0,
+    stranger holding the port before OR during the window) carries no url and no
+    "http://" substring anywhere in its text block
   - ready == true if and only if url is present
+  - payload.attribution names the evidence — child | unavailable | foreign | none — and
+    "child" is never returned by a platform that cannot map a socket to a pid
   - pid and port are reported on every non-error branch, so the caller can always kill
     and always knows what was attempted
   - serve_argv's output is parsed by the CLI's own clap parser into ServeCommands::Run
     with the requested file and port
   - the 0.63.0 argv is still rejected by that parser
-  pass_criteria: All eight FALSIFY-MCP-SERVE-2606 falsifiers pass, and each mechanism
+  pass_criteria: All twelve FALSIFY-MCP-SERVE-2606 falsifiers pass, and each mechanism
     has been mutation-verified by removing it and observing RED — with the mutation's
     engagement proven by grepping its marker before any verdict is read

--- a/crates/apr-cli/src/lib_07.rs
+++ b/crates/apr-cli/src/lib_07.rs
@@ -20,4 +20,5 @@ include!("lib_verbose_inheritance_parse.rs");
 include!("lib_parse_serve.rs");
 include!("lib_dispatch_coverage.rs");
 include!("lib_dogfood_2392.rs");
+include!("lib_falsify_2606_mcp_serve_argv.rs");
 }

--- a/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
+++ b/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
@@ -1,0 +1,139 @@
+// FALSIFY-2606 — the MCP `apr.serve` argv must be accepted by the CLI's own parser.
+//
+// # Why this test is here and not in `aprender-mcp`
+//
+// The 0.63.0 dogfood sweep measured, against the published crates.io binary:
+//
+//     $ apr serve "$MODEL" --port 8080
+//     rc=2
+//     error: unrecognized subcommand '/home/noah/models/…q4_k_m.apr'
+//     Usage: apr serve [OPTIONS] <COMMAND>
+//
+// …while the MCP tool that built that argv returned `{"pid":…,"url":…}` with
+// `isError` absent. Two defects; #2388 fixed both, but the guard it left on the
+// argv half was
+//
+//     assert_eq!(serve_argv(m, p), vec!["serve", "run", m, "--port", p]);
+//
+// which is *tautological with the implementation*. It re-states the argv rather
+// than asking anything whether that argv parses. Rename `ServeCommands::Run` to
+// `Start` tomorrow and that assertion stays green while `apr.serve` regresses to
+// exactly the 0.63.0 behaviour — a child that dies at clap with rc=2.
+//
+// The only surface that can answer "does the CLI accept this?" is the CLI's own
+// clap parser, the one that produced the rc=2 above. `apr-cli` depends on
+// `aprender-mcp` (not the reverse), so the check has to live on this side of the
+// edge. It costs no subprocess, no model, and no port.
+//
+// This is a SHAPE guard on argv. The behavioural half of #2606 — that the tool
+// never reports a URL for a port it did not watch accept a connection — is
+// guarded in `aprender-mcp/src/tools/serve.rs`, and is the half that survives
+// any future argv change.
+
+/// Parse a runtime-built argv through the real `Cli` parser.
+///
+/// Mirrors `parsing.rs::parse_cli` (16 MB stack — clap's parser for 100+
+/// subcommands blows the default test-thread stack in debug builds) but takes
+/// owned `String`s, because `serve_argv` builds its argv at runtime.
+fn parse_cli_owned(args: Vec<String>) -> Result<Cli, clap::error::Error> {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || Cli::try_parse_from(args))
+        .expect("spawn thread")
+        .join()
+        .expect("join thread")
+}
+
+/// Build the argv `apr.serve` actually spawns, prefixed with argv[0].
+fn mcp_serve_argv(model: &str, port: u16) -> Vec<String> {
+    let mut argv = vec!["apr".to_string()];
+    argv.extend(aprender_mcp::tools::serve::serve_argv(model, port));
+    argv
+}
+
+/// FALSIFY-2606-A: the argv the MCP `apr.serve` tool spawns must parse.
+///
+/// RED before #2388's argv fix (`serve <model> --port N` → clap error
+/// "unrecognized subcommand"). RED again if anyone renames the subcommand
+/// without updating `serve_argv`, which the hard-coded-vector assertion in
+/// `aprender-mcp` cannot detect.
+#[test]
+fn falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser() {
+    let model = "/models/qwen2.5-coder-1.5b-instruct-q4_k_m.apr";
+    let argv = mcp_serve_argv(model, 38621);
+
+    let parsed = parse_cli_owned(argv.clone()).unwrap_or_else(|e| {
+        panic!(
+            "#2606: the MCP apr.serve tool spawns an argv the CLI REJECTS.\n\
+             argv: {argv:?}\n\
+             clap said: {e}\n\
+             This is the rc=2 the 0.63.0 sweep measured; the tool reported \
+             {{pid, url}} anyway."
+        )
+    });
+
+    // Parsing is necessary but not sufficient: it must reach the server
+    // launcher, with the model and port the caller asked for. A form that
+    // parsed into `serve plan` would also "parse" and start nothing.
+    match *parsed.command {
+        Commands::Serve {
+            command: ServeCommands::Run { ref file, port, .. },
+        } => {
+            assert_eq!(
+                file.to_string_lossy(),
+                model,
+                "model path must land in the FILE slot, not the subcommand slot"
+            );
+            assert_eq!(port, 38621, "--port must reach the server launcher");
+        }
+        ref other => panic!(
+            "#2606: argv parsed, but not into `serve run` — it would never start \
+             a server. argv: {argv:?}, parsed: {other:?}"
+        ),
+    }
+}
+
+/// FALSIFY-2606-B: the exact argv shape 0.63.0 shipped must still be rejected.
+///
+/// Pins the negative half. Without it, a future change that made `apr serve
+/// <model>` parse (e.g. a default subcommand) would silently drain FALSIFY-2606-A
+/// of meaning — the defect would become unobservable rather than fixed. If this
+/// ever goes RED it is a real decision to make, not a test to delete: the tool's
+/// liveness guard, not clap, would become the only thing standing between a user
+/// and a fabricated URL.
+#[test]
+fn falsify_2606_the_0_63_0_argv_is_still_rejected_by_clap() {
+    let model = "/models/qwen2.5-coder-1.5b-instruct-q4_k_m.apr";
+    let broken = vec![
+        "apr".to_string(),
+        "serve".to_string(),
+        model.to_string(),
+        "--port".to_string(),
+        "38621".to_string(),
+    ];
+    let err = parse_cli_owned(broken.clone())
+        .err()
+        .unwrap_or_else(|| panic!("0.63.0's argv {broken:?} unexpectedly parses now"));
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("subcommand") || rendered.contains("Usage"),
+        "expected the measured clap rejection, got: {rendered}"
+    );
+}
+
+/// FALSIFY-2606-C: the port the caller passes must survive into the parse, for
+/// the whole u16 range including the edges the sweep did not probe.
+#[test]
+fn falsify_2606_serve_argv_round_trips_port_across_the_range() {
+    for probe in [1_u16, 80, 8080, 38641, 65535] {
+        let argv = mcp_serve_argv("/models/m.gguf", probe);
+        let parsed = parse_cli_owned(argv.clone())
+            .unwrap_or_else(|e| panic!("argv {argv:?} rejected: {e}"));
+        match *parsed.command {
+            Commands::Serve {
+                command: ServeCommands::Run { port, .. },
+            } => assert_eq!(port, probe, "port {probe} must round-trip"),
+            ref other => panic!("argv {argv:?} parsed as {other:?}, not `serve run`"),
+        }
+    }
+}

--- a/crates/aprender-mcp/src/tools/mod.rs
+++ b/crates/aprender-mcp/src/tools/mod.rs
@@ -12,6 +12,7 @@
 pub mod args;
 pub mod bench;
 pub mod finetune;
+pub mod port_owner;
 pub mod qa;
 pub mod registry;
 pub mod run;

--- a/crates/aprender-mcp/src/tools/port_owner.rs
+++ b/crates/aprender-mcp/src/tools/port_owner.rs
@@ -1,0 +1,409 @@
+//! Attribute a *listening* TCP socket to the process that owns it.
+//!
+//! # Why this exists (#2606, second pass)
+//!
+//! `apr.serve` spawns a daemon and then has to answer one question honestly:
+//! *is the URL I am about to hand back reachable **because of the child I
+//! spawned**?* A TCP connect to `127.0.0.1:<port>` answers a strictly weaker
+//! question — "is **anything** listening there?" — and the two come apart in
+//! the exact case the tool exists to report on. An adversarial pass reproduced
+//! the original fabricated-URL shape against the first #2606 fix by holding
+//! the port with an unrelated process: the child never bound anything, the
+//! probe succeeded anyway, and the tool reported
+//! `{"ready":true,"url":"http://localhost:<port>"}` for a server that does not
+//! exist. A liveness check on the child does not repair that: both halves —
+//! "our child is alive" and "something answers on that port" — were true, and
+//! their conjunction still is not the claim being made.
+//!
+//! So the probe has to be tightened from *reachability* to *attribution*:
+//! the listening socket must be held by the spawned child or one of its
+//! descendants.
+//!
+//! # What is and is not portable
+//!
+//! Mapping a listening socket back to a pid needs an OS interface. On Linux
+//! `/proc/net/tcp{,6}` gives the socket inode for every listening port, and
+//! `/proc/<pid>/fd/*` gives the inodes a process holds; intersecting them is
+//! exact, needs no privileges for our own descendants, and shells out to
+//! nothing. There is no equivalent that is portable across every unix — macOS
+//! needs `libproc`/`lsof`, and neither is available here under
+//! `unsafe_code = "forbid"` with no new dependencies.
+//!
+//! This module therefore reports [`PortOwner::Unknown`] rather than guessing
+//! on platforms it cannot interrogate, and the caller degrades to a **stated,
+//! weaker** guarantee there instead of pretending to the stronger one. See
+//! `serve.rs` for how the two are kept distinguishable in the payload.
+
+/// Who holds the listening socket on a port, as far as this platform can say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortOwner {
+    /// A listening socket on the port is held by the target pid or one of its
+    /// descendants. A url naming that port is attributable to the child.
+    Child,
+    /// Something is listening (or the kernel tables say nothing at all is),
+    /// but no file descriptor belonging to the target pid or its descendants
+    /// holds a listening socket on that port. A url would name someone else's
+    /// server.
+    Foreign,
+    /// This platform cannot map a listening socket to a pid. Nothing is
+    /// claimed either way — callers must not read this as `Child`.
+    Unknown,
+}
+
+/// Attribute the listening socket on `port` to `pid` (or a descendant of it).
+///
+/// Fails **closed**: anything this platform cannot prove is [`Foreign`] on a
+/// platform that has the tables, and [`Unknown`] on one that does not. It is
+/// never [`Child`] without a matching socket inode found on one of the child's
+/// own file descriptors.
+///
+/// [`Foreign`]: PortOwner::Foreign
+/// [`Child`]: PortOwner::Child
+/// [`Unknown`]: PortOwner::Unknown
+#[must_use]
+pub fn owner_of_listening_port(port: u16, pid: u32) -> PortOwner {
+    #[cfg(target_os = "linux")]
+    {
+        linux::owner_of_listening_port(port, pid)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (port, pid);
+        PortOwner::Unknown
+    }
+}
+
+/// Every process this platform can see holding a LISTEN socket on `port`,
+/// as `(pid, comm)`.
+///
+/// Diagnostic only — the url decision is [`owner_of_listening_port`]. Naming
+/// the squatter is the difference between "port 8080 is busy" and "port 8080
+/// is held by pid 4242 (`apr`)", which is what a caller needs to unblock
+/// themselves. Empty when the platform cannot say, or when the holder belongs
+/// to another user (whose `/proc/<pid>/fd` is not readable).
+#[must_use]
+pub fn listening_pids(port: u16) -> Vec<(u32, String)> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::listening_pids(port)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = port;
+        Vec::new()
+    }
+}
+
+/// Whether this build can attribute a socket to a process at all.
+///
+/// Exposed so the tool can say *which* guarantee it is offering rather than
+/// silently offering the weaker one.
+#[must_use]
+pub const fn attribution_available() -> bool {
+    cfg!(target_os = "linux")
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::PortOwner;
+    use std::collections::HashSet;
+
+    /// TCP state code for `LISTEN` in `/proc/net/tcp` (hex, column 4).
+    const TCP_LISTEN: &str = "0A";
+
+    /// Cap on the ppid walk so a pathological (or racing) `/proc` cannot spin.
+    const MAX_PROCS: usize = 65_536;
+
+    pub fn owner_of_listening_port(port: u16, pid: u32) -> PortOwner {
+        let Some(inodes) = listening_inodes(port) else {
+            // Neither table readable: /proc is not mounted (container, chroot),
+            // so this build cannot attribute after all.
+            return PortOwner::Unknown;
+        };
+        if inodes.is_empty() {
+            // Something answered a connect but no LISTEN row exists for the
+            // port: a different netns, or a race with a closing socket.
+            // Either way it is not attributable to the child.
+            return PortOwner::Foreign;
+        }
+        for candidate in pid_and_descendants(pid) {
+            if holds_any_inode(candidate, &inodes) {
+                return PortOwner::Child;
+            }
+        }
+        PortOwner::Foreign
+    }
+
+    pub fn listening_pids(port: u16) -> Vec<(u32, String)> {
+        let Some(inodes) = listening_inodes(port) else {
+            return Vec::new();
+        };
+        if inodes.is_empty() {
+            return Vec::new();
+        }
+        let mut holders = Vec::new();
+        let Ok(entries) = std::fs::read_dir("/proc") else {
+            return holders;
+        };
+        for entry in entries.flatten().take(MAX_PROCS) {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Ok(pid) = name.parse::<u32>() else {
+                continue;
+            };
+            if holds_any_inode(pid, &inodes) {
+                let comm = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .map_or_else(|_| "?".to_string(), |c| c.trim().to_string());
+                holders.push((pid, comm));
+            }
+        }
+        holders
+    }
+
+    /// Socket inodes of every `LISTEN` socket bound to `port`, across IPv4 and
+    /// IPv6. `None` when neither table could be read.
+    fn listening_inodes(port: u16) -> Option<HashSet<u64>> {
+        let mut found = HashSet::new();
+        let mut readable = false;
+        for table in ["/proc/net/tcp", "/proc/net/tcp6"] {
+            let Ok(text) = std::fs::read_to_string(table) else {
+                continue;
+            };
+            readable = true;
+            for line in text.lines().skip(1) {
+                if let Some(inode) = listening_inode_on_port(line, port) {
+                    found.insert(inode);
+                }
+            }
+        }
+        readable.then_some(found)
+    }
+
+    /// Parse one `/proc/net/tcp{,6}` row; `Some(inode)` iff it is a `LISTEN`
+    /// socket whose local port is `port`.
+    ///
+    /// Row shape (columns are whitespace separated, addresses are hex):
+    /// `sl local_address rem_address st tx:rx tr:when retrnsmt uid timeout inode ...`
+    fn listening_inode_on_port(line: &str, port: u16) -> Option<u64> {
+        let cols: Vec<&str> = line.split_whitespace().collect();
+        // Column 9 is the inode; anything shorter is not a socket row.
+        if cols.len() < 10 {
+            return None;
+        }
+        if cols[3] != TCP_LISTEN {
+            return None;
+        }
+        let local_port_hex = cols[1].rsplit(':').next()?;
+        let local_port = u16::from_str_radix(local_port_hex, 16).ok()?;
+        if local_port != port {
+            return None;
+        }
+        cols[9].parse::<u64>().ok()
+    }
+
+    /// `pid` followed by every transitive descendant of it, from `/proc`.
+    ///
+    /// A daemon that forks (or is wrapped by a shell) still counts as ours;
+    /// nothing outside the subtree ever does.
+    fn pid_and_descendants(pid: u32) -> Vec<u32> {
+        let mut parents: Vec<(u32, u32)> = Vec::new(); // (child, parent)
+        if let Ok(entries) = std::fs::read_dir("/proc") {
+            for entry in entries.flatten().take(MAX_PROCS) {
+                let name = entry.file_name();
+                let Some(name) = name.to_str() else { continue };
+                let Ok(candidate) = name.parse::<u32>() else {
+                    continue;
+                };
+                if let Some(ppid) = parent_of(candidate) {
+                    parents.push((candidate, ppid));
+                }
+            }
+        }
+
+        let mut subtree = vec![pid];
+        let mut seen: HashSet<u32> = HashSet::from([pid]);
+        let mut cursor = 0;
+        while cursor < subtree.len() {
+            let parent = subtree[cursor];
+            cursor += 1;
+            for &(child, child_parent) in &parents {
+                if child_parent == parent && seen.insert(child) {
+                    subtree.push(child);
+                }
+            }
+        }
+        subtree
+    }
+
+    /// PPID of `pid` from `/proc/<pid>/stat`.
+    ///
+    /// The `comm` field is parenthesised and may itself contain spaces and
+    /// parentheses, so the fixed columns are counted from the LAST `)`.
+    fn parent_of(pid: u32) -> Option<u32> {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let after_comm = stat.rfind(')').map(|i| &stat[i + 1..])?;
+        // After `)`: state, ppid, ...
+        after_comm.split_whitespace().nth(1)?.parse::<u32>().ok()
+    }
+
+    /// Whether `pid` holds an open file descriptor for any of `inodes`.
+    fn holds_any_inode(pid: u32, inodes: &HashSet<u64>) -> bool {
+        let Ok(fds) = std::fs::read_dir(format!("/proc/{pid}/fd")) else {
+            return false;
+        };
+        for fd in fds.flatten() {
+            let Ok(target) = std::fs::read_link(fd.path()) else {
+                continue;
+            };
+            let target = target.to_string_lossy();
+            let Some(rest) = target.strip_prefix("socket:[") else {
+                continue;
+            };
+            let Some(digits) = rest.strip_suffix(']') else {
+                continue;
+            };
+            if digits.parse::<u64>().is_ok_and(|ino| inodes.contains(&ino)) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// A real `LISTEN` row from `/proc/net/tcp` (port 0x1F90 = 8080).
+        const LISTEN_ROW: &str = "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 \
+                                  00:00000000 00000000  1000        0 4242424 1 0000000000000000 \
+                                  100 0 0 10 0";
+        /// The same socket in `ESTABLISHED` (01) rather than `LISTEN`.
+        const ESTABLISHED_ROW: &str = "   1: 0100007F:1F90 0100007F:C000 01 00000000:00000000 \
+                                       00:00000000 00000000  1000        0 4242425 1 \
+                                       0000000000000000 20 0 0 10 -1";
+
+        #[test]
+        fn listen_row_on_the_asked_for_port_yields_its_inode() {
+            assert_eq!(listening_inode_on_port(LISTEN_ROW, 8080), Some(4_242_424));
+        }
+
+        #[test]
+        fn listen_row_on_a_different_port_is_not_matched() {
+            assert_eq!(listening_inode_on_port(LISTEN_ROW, 8081), None);
+        }
+
+        /// The state column is the difference between "a server is waiting
+        /// here" and "someone once connected here". Only the former is a
+        /// listener; matching on port alone would attribute a stale
+        /// established socket.
+        #[test]
+        fn established_row_is_not_a_listener() {
+            assert_eq!(listening_inode_on_port(ESTABLISHED_ROW, 8080), None);
+        }
+
+        #[test]
+        fn header_and_garbage_rows_are_ignored() {
+            for junk in [
+                "  sl  local_address rem_address   st tx_queue rx_queue",
+                "",
+                "   0: 0100007F:1F90 0A",
+            ] {
+                assert_eq!(listening_inode_on_port(junk, 8080), None, "junk: {junk:?}");
+            }
+        }
+
+        /// `/proc/<pid>/stat`'s `comm` is attacker-controlled: a process can
+        /// name itself `") 1 999999 ("`. Counting columns from the LAST `)`
+        /// is what keeps the ppid honest.
+        #[test]
+        fn ppid_parse_survives_a_comm_containing_spaces_and_parens() {
+            // Emulate the field layout: pid (comm) state ppid ...
+            let stat = "1234 (evil ) 1 999999 (name) S 4321 1234 1234 0 -1 4194304";
+            let after = stat.rfind(')').map(|i| &stat[i + 1..]).expect("has )");
+            let ppid: u32 = after
+                .split_whitespace()
+                .nth(1)
+                .and_then(|f| f.parse().ok())
+                .expect("ppid parses");
+            assert_eq!(ppid, 4321, "ppid must come from after the LAST )");
+        }
+
+        /// The live half: this test process holds a listening socket, so the
+        /// kernel tables plus its own fds must attribute it to itself.
+        #[test]
+        fn a_listener_this_process_holds_is_attributed_to_this_process() {
+            let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .expect("bind ephemeral port");
+            let port = listener.local_addr().expect("local_addr").port();
+            assert_eq!(
+                owner_of_listening_port(port, std::process::id()),
+                PortOwner::Child,
+                "the process that owns the socket must be recognised as owning it"
+            );
+            drop(listener);
+        }
+
+        /// The half that closes #2606's second pass: the *same* live listener,
+        /// asked about a process that did not create it, must come back
+        /// `Foreign`. A parent is not a descendant of its own child, so a
+        /// spawned `sleep` is a sound stand-in for "an unrelated process".
+        #[test]
+        fn a_listener_held_by_someone_else_is_foreign() {
+            let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .expect("bind ephemeral port");
+            let port = listener.local_addr().expect("local_addr").port();
+            let mut other = std::process::Command::new("sleep")
+                .arg("30")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn sleep");
+            assert_eq!(
+                owner_of_listening_port(port, other.id()),
+                PortOwner::Foreign,
+                "a socket held by an unrelated process must NEVER be attributed to it"
+            );
+            let _ = other.kill();
+            let _ = other.wait();
+            drop(listener);
+        }
+
+        /// Nothing listening at all is not attributable either.
+        #[test]
+        fn a_port_with_no_listener_is_foreign() {
+            let port = {
+                let l = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                    .expect("bind ephemeral port");
+                l.local_addr().expect("local_addr").port()
+            };
+            assert_eq!(
+                owner_of_listening_port(port, std::process::id()),
+                PortOwner::Foreign
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The platform gate and the resolver must agree: a build that says it
+    /// cannot attribute must never return `Child`.
+    #[test]
+    fn unavailable_attribution_never_claims_child() {
+        if !attribution_available() {
+            assert_eq!(
+                owner_of_listening_port(8080, std::process::id()),
+                PortOwner::Unknown,
+                "a platform without socket->pid tables must say Unknown, not guess"
+            );
+        }
+    }
+
+    #[test]
+    fn attribution_availability_matches_the_platform() {
+        assert_eq!(attribution_available(), cfg!(target_os = "linux"));
+    }
+}

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -25,6 +25,29 @@
 //! explicitly `ready: false` — a big model may still be loading; we report
 //! what is true rather than claiming a listening server).
 //!
+//! DOGFOOD-0.64.0 (#2606) — the published 0.63.0 binary still exhibited both
+//! defects above (the fixes landed on `main` after the 0.63.0 cut), and the
+//! sweep surfaced a third, narrower one plus a hole in how (1) was guarded:
+//!
+//! 3. `ready: false` — the "alive but not listening" branch — still emitted
+//!    `"url": "http://localhost:<port>"`. A client that reads the field it
+//!    asked for and ignores the annotation is told a URL exists for a port
+//!    nothing is bound to. [`running_result`] now emits `url` **only** on the
+//!    branch that observed a successful TCP connect with the child alive.
+//! 4. The only guard on (1) was a unit test comparing [`serve_argv`]'s output
+//!    to a hard-coded vector. That is tautological with the implementation:
+//!    it re-states the argv rather than checking anything accepts it, so a
+//!    rename of the `run` subcommand would keep it green while the tool broke
+//!    exactly as 0.63.0 did. The argv is now fed to the CLI's own clap parser
+//!    — the surface that emitted `rc=2, unrecognized subcommand` — by
+//!    `apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs`. `apr-cli` depends on
+//!    this crate, so the check lives on that side of the edge.
+//!
+//! The generalizing invariant, the one that survives the next argv change:
+//! **`apr.serve` reports a URL only for a port it watched accept a connection
+//! while the child was still alive.** A pid proves a process was created, not
+//! that it survived argv parsing.
+//!
 //! M3 shipped `notifications/cancelled` → SIGTERM → SIGKILL for `apr.run`
 //! only (see `server.rs::CancelHandle` docs: "Only `apr.run` currently
 //! honours cancellation"). A lifecycle-tracked registry for `apr.serve` —
@@ -241,21 +264,41 @@ pub fn spawn_and_confirm(
 /// `ready` distinguishes "the port accepted a connection" from "still alive
 /// but not listening yet" — the caller is told which, never told a listening
 /// server exists when none does.
+///
+/// #2606 — INVARIANT SERVE-URL-ONLY-WHEN-LISTENING. The `url` key is emitted
+/// **only** when a TCP connect to `port` succeeded while the child was still
+/// alive. `ready: false` is not a soft "probably fine": until #2606 this
+/// branch still shipped `"url": "http://localhost:<port>"`, so an MCP client
+/// that reads `url` (the field it asked for) and ignores `ready` was handed a
+/// reachable-looking endpoint that nothing was listening on — the same
+/// fabricated-success shape as the pre-#2388 `{pid, url}`, merely annotated.
+/// Withholding the key makes the fabrication unrepresentable rather than
+/// merely discouraged: there is no url to misread.
+///
+/// Still-alive-but-unbound stays a NON-error deliberately. A multi-GB model
+/// load can outlast [`READY_TIMEOUT`], the child is a real process the caller
+/// owns and must kill, and reporting `isError` for a healthy loader would be
+/// its own false claim. The honest report is: pid yes, url no, ready false.
 fn running_result(pid: u32, port: u16, ready: bool, log_path: &std::path::Path) -> ToolCallResult {
     let note = if ready {
         "server is accepting connections; kill pid via OS to stop"
     } else {
-        "process is alive but has not bound the port yet (still loading?); kill pid via OS to stop"
+        "process is alive but has not bound the port yet (still loading?); no URL is \
+         reported because nothing accepted a connection on the port; kill pid via OS to stop"
     };
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "pid": pid,
-        "url": format!("http://localhost:{port}"),
         "ready": ready,
+        "port": port,
         "stderr_log": log_path.display().to_string(),
         "note": note,
     });
+    if ready {
+        // Only reachable after a successful connect + a live-child recheck.
+        payload["url"] = serde_json::json!(format!("http://localhost:{port}"));
+    }
     let text = serde_json::to_string(&payload)
-        .unwrap_or_else(|_| format!("{{\"pid\":{pid},\"url\":\"http://localhost:{port}\"}}"));
+        .unwrap_or_else(|_| format!("{{\"pid\":{pid},\"ready\":{ready},\"port\":{port}}}"));
     ToolCallResult {
         content: vec![ContentBlock::text(text)],
         is_error: None,
@@ -496,6 +539,161 @@ mod tests {
         if let Some(log) = payload["stderr_log"].as_str() {
             let _ = std::fs::remove_file(log);
         }
+    }
+
+    // ---- DOGFOOD-0.64.0 (#2606) falsifiers -------------------------------
+    //
+    // INVARIANT SERVE-URL-ONLY-WHEN-LISTENING: `apr.serve` may put a `url` in
+    // its payload only on the branch that watched a TCP connect succeed while
+    // the child was still alive. Every other terminal state — dead child,
+    // unspawnable program, alive-but-unbound, ephemeral port — must carry NO
+    // url. This is the property that survives the next argv change: it never
+    // mentions `serve`, `run`, or any flag, so it keeps its teeth however the
+    // CLI's subcommand names move.
+
+    /// Assert the payload of a non-error result carries no reachable endpoint.
+    #[cfg(unix)]
+    fn assert_no_url(result: &ToolCallResult, ctx: &str) {
+        let text = &result.content[0].text;
+        assert!(
+            !text.contains("http://"),
+            "{ctx}: no URL may appear when nothing was observed listening, got: {text}"
+        );
+        if result.is_error.is_none() {
+            let payload = payload_of(result);
+            assert!(
+                payload.get("url").is_none(),
+                "{ctx}: `url` key must be absent, got: {payload}"
+            );
+        }
+    }
+
+    /// The #2606 defect proper: 0.63.0 (and the post-#2388 `ready:false`
+    /// branch) handed back `http://localhost:<port>` for a port nothing was
+    /// bound to. A client that reads `url` — the field it asked the tool for —
+    /// gets a working-looking endpoint that refuses every connection.
+    #[cfg(unix)]
+    #[test]
+    fn live_child_that_never_binds_reports_no_url() {
+        let port = free_port();
+        let args = vec!["5".to_string()];
+        let result = spawn_and_confirm("sleep", &args, port, Duration::from_millis(300));
+        assert_eq!(result.is_error, None, "a live child is not an error");
+        assert_no_url(&result, "alive but never bound");
+        let payload = payload_of(&result);
+        // The port is still reported — the caller needs to know which one was
+        // attempted — but as a scalar that cannot be dialled by mistake.
+        assert_eq!(payload["port"], serde_json::json!(port));
+        assert_eq!(payload["ready"], serde_json::json!(false));
+        if let Some(log) = payload["stderr_log"].as_str() {
+            let _ = std::fs::remove_file(log);
+        }
+    }
+
+    /// A dead child must not leak a URL into its error text either.
+    #[cfg(unix)]
+    #[test]
+    fn dead_child_reports_no_url() {
+        let port = free_port();
+        let result = spawn_and_confirm("false", &[], port, Duration::from_secs(5));
+        assert_eq!(result.is_error, Some(true));
+        assert_no_url(&result, "child exited immediately");
+    }
+
+    /// `port: 0` asks the OS to assign — there is no port to probe, so the
+    /// tool can prove the child survived startup and nothing more. It must
+    /// therefore never claim `ready`, and never emit `http://localhost:0`.
+    #[cfg(unix)]
+    #[test]
+    fn ephemeral_port_reports_no_url_and_not_ready() {
+        let args = vec!["5".to_string()];
+        let result = spawn_and_confirm("sleep", &args, 0, Duration::from_millis(300));
+        assert_eq!(result.is_error, None);
+        let payload = payload_of(&result);
+        assert_eq!(
+            payload["ready"],
+            serde_json::json!(false),
+            "port 0 was never probed, so readiness was never observed"
+        );
+        assert_no_url(&result, "OS-assigned port");
+        if let Some(log) = payload["stderr_log"].as_str() {
+            let _ = std::fs::remove_file(log);
+        }
+    }
+
+    /// `running_result` is a pure function of `(pid, port, ready)`, and the
+    /// `url`⇔`ready` equivalence is small enough to check EXHAUSTIVELY rather
+    /// than by sample: every one of the 65 536 ports, both readiness values.
+    /// Spawn-based falsifiers can only ever sample a port; this closes the
+    /// domain, so no port is a special case (0 and 65535 included).
+    #[test]
+    fn url_key_matches_ready_exhaustively_over_every_port() {
+        let log = std::path::Path::new("/tmp/apr-mcp-serve-exhaustive.log");
+        for port in 0..=u16::MAX {
+            for ready in [false, true] {
+                let result = running_result(4242, port, ready, log);
+                assert_eq!(result.is_error, None, "port {port}: never an error here");
+                let text = &result.content[0].text;
+                let v: serde_json::Value =
+                    serde_json::from_str(text).expect("running_result emits JSON");
+                assert_eq!(
+                    v.get("url").is_some(),
+                    ready,
+                    "port {port}, ready {ready}: `url` must be present iff ready"
+                );
+                assert_eq!(
+                    text.contains("http://"),
+                    ready,
+                    "port {port}, ready {ready}: no endpoint may appear unless ready"
+                );
+                assert_eq!(v["ready"], serde_json::json!(ready));
+                assert_eq!(v["port"], serde_json::json!(port));
+                assert_eq!(v["pid"], serde_json::json!(4242));
+            }
+        }
+    }
+
+    /// The positive half of the invariant: the ONLY combination that may
+    /// carry a url is live child + port that accepted a connection. Paired
+    /// with the three negatives above this pins `url` to exactly one branch.
+    #[cfg(unix)]
+    #[test]
+    fn url_appears_only_on_the_observed_listening_branch() {
+        // Negative: same program, same timeout, port nothing is bound to.
+        let dead_port = free_port();
+        let unbound = spawn_and_confirm(
+            "sleep",
+            &["5".to_string()],
+            dead_port,
+            Duration::from_millis(300),
+        );
+        assert_no_url(&unbound, "control: unbound port");
+        if let Some(log) = payload_of(&unbound)["stderr_log"].as_str() {
+            let _ = std::fs::remove_file(log);
+        }
+
+        // Positive: identical call, except something IS listening.
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("bind ephemeral port");
+        let bound_port = listener.local_addr().expect("local_addr").port();
+        let live = spawn_and_confirm(
+            "sleep",
+            &["5".to_string()],
+            bound_port,
+            Duration::from_millis(300),
+        );
+        assert_eq!(live.is_error, None, "got: {}", live.content[0].text);
+        let payload = payload_of(&live);
+        assert_eq!(payload["ready"], serde_json::json!(true));
+        assert_eq!(
+            payload["url"],
+            serde_json::json!(format!("http://localhost:{bound_port}")),
+            "the listening branch is the one branch that owes a url"
+        );
+        if let Some(log) = payload["stderr_log"].as_str() {
+            let _ = std::fs::remove_file(log);
+        }
+        drop(listener);
     }
 
     /// Spawning a program that does not exist is an error, not a `{pid,url}`.

--- a/crates/aprender-mcp/src/tools/serve.rs
+++ b/crates/aprender-mcp/src/tools/serve.rs
@@ -43,10 +43,53 @@
 //!    `apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs`. `apr-cli` depends on
 //!    this crate, so the check lives on that side of the edge.
 //!
+//! DOGFOOD-0.64.0 (#2606, second pass) — an adversarial review reproduced the
+//! ORIGINAL fabricated-URL shape against the fix above, and it was right to:
+//!
+//! 5. "The child is alive AND something accepted a TCP connect on that port"
+//!    is not "**our child** is listening". Both conjuncts hold when any
+//!    unrelated process happens to hold the port: the spawned child binds
+//!    nothing, the probe succeeds against the stranger's socket, and the tool
+//!    hands back `{"ready":true,"url":"http://localhost:<port>"}` for a server
+//!    it did not start and cannot vouch for. The first fix made the *claim*
+//!    narrower without making the *evidence* stronger.
+//!
+//!    Two things close it, and both are needed:
+//!
+//!    a. **Pre-flight** (portable). Before spawning, probe the port. If it
+//!       already accepts connections, no later success on it can be
+//!       attributed to a child that does not exist yet — and `apr serve run`
+//!       could not have bound it anyway. Refuse, before spawning, naming the
+//!       port.
+//!    b. **Attribution** (Linux). When the probe succeeds, require that a
+//!       LISTEN socket on that port is held by a file descriptor of the child
+//!       or one of its descendants — [`crate::tools::port_owner`], via
+//!       `/proc/net/tcp{,6}` ∩ `/proc/<pid>/fd`. A stranger that grabs the
+//!       port *during* the readiness window is caught here, which pre-flight
+//!       alone cannot do.
+//!
 //! The generalizing invariant, the one that survives the next argv change:
-//! **`apr.serve` reports a URL only for a port it watched accept a connection
-//! while the child was still alive.** A pid proves a process was created, not
-//! that it survived argv parsing.
+//!
+//! **SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT** — `apr.serve` reports a URL only
+//! when a listening socket on that port is held by the child it spawned (or a
+//! descendant of it). It names no subcommand and no flag, so it keeps its
+//! teeth however the CLI's surface moves. A pid proves a process was created,
+//! not that it survived argv parsing; a TCP connect proves *somebody* is
+//! listening, not that it is ours.
+//!
+//! **Where the guarantee is weaker, and the payload says so.** Socket→pid
+//! attribution is not portable (see [`crate::tools::port_owner`] for why: no
+//! `/proc` on macOS, and `libproc`/`lsof` are out of reach under
+//! `unsafe_code = "forbid"` with no new dependencies). On a platform that
+//! cannot attribute, the tool falls back to pre-flight alone — *the port was
+//! proven closed immediately before spawn, and then began accepting
+//! connections while our child was alive* — which is strictly weaker: a
+//! process that grabs the port inside the readiness window would still be
+//! mistaken for the child. That case is reported with
+//! `"attribution": "unavailable"` rather than dressed up as the strong
+//! guarantee, so a client can tell the two apart. On Linux — every CI runner
+//! and every measured host in #2606 — the strong form applies and the payload
+//! says `"attribution": "child"`.
 //!
 //! M3 shipped `notifications/cancelled` → SIGTERM → SIGKILL for `apr.run`
 //! only (see `server.rs::CancelHandle` docs: "Only `apr.run` currently
@@ -61,6 +104,7 @@
 #![allow(clippy::disallowed_methods)] // serde_json::json! macro expands to .unwrap() internally
 
 use crate::tools::args::{self, try_arg};
+use crate::tools::port_owner::{owner_of_listening_port, PortOwner};
 use crate::types::{ContentBlock, InputSchema, ToolCallResult, ToolDefinition};
 use std::io::Read;
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
@@ -90,6 +134,49 @@ const EPHEMERAL_PORT_WINDOW: Duration = Duration::from_secs(2);
 
 /// Bytes of the child's stderr echoed back in a failure message.
 const STDERR_TAIL_BYTES: usize = 2048;
+
+/// What the readiness loop concluded about the port, and on what evidence.
+///
+/// This is the single gate on the `url` key (#2606). It exists as an enum
+/// rather than a `bool` because "ready" was the bug: a boolean cannot
+/// distinguish *our child is listening* from *somebody is listening*, and the
+/// first fix for #2606 collapsed both into `true`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Listening {
+    /// A LISTEN socket on the port is held by the spawned child or one of its
+    /// descendants. The url is attributable. **The only strong branch.**
+    ByChild,
+    /// The port was proven closed immediately before spawn and then began
+    /// accepting connections while the child was alive, on a platform that
+    /// cannot map a socket to a pid. Reported with `attribution: unavailable`.
+    UnattributedAfterPreflight,
+    /// Something accepted a connection but the socket is NOT held by the child
+    /// or any descendant — a stranger grabbed the port inside the readiness
+    /// window. Never a url.
+    ByForeignProcess,
+    /// Nothing accepted a connection inside the readiness window.
+    No,
+}
+
+impl Listening {
+    /// Whether this branch may carry a `url`. The whole invariant, in one
+    /// place: only evidence that ties the socket to *our* child qualifies.
+    #[must_use]
+    pub const fn is_attributable(self) -> bool {
+        matches!(self, Self::ByChild | Self::UnattributedAfterPreflight)
+    }
+
+    /// Machine-readable evidence label for the payload.
+    #[must_use]
+    pub const fn attribution(self) -> &'static str {
+        match self {
+            Self::ByChild => "child",
+            Self::UnattributedAfterPreflight => "unavailable",
+            Self::ByForeignProcess => "foreign",
+            Self::No => "none",
+        }
+    }
+}
 
 /// The exact CLI form `apr.serve` shells out to.
 ///
@@ -176,7 +263,29 @@ pub fn spawn_and_confirm(
     port: u16,
     ready_timeout: Duration,
 ) -> ToolCallResult {
+    spawn_and_confirm_with_env(program, args, port, ready_timeout, &[])
+}
+
+/// [`spawn_and_confirm`] with extra environment for the child.
+///
+/// The env hook exists so the readiness/attribution contract can be exercised
+/// against a child that really does own a listening socket, without an extra
+/// binary target (`cargo test --lib`, which CI runs, does not build `[[bin]]`
+/// targets) and without mutating this process's environment.
+#[must_use]
+pub fn spawn_and_confirm_with_env(
+    program: &str,
+    args: &[String],
+    port: u16,
+    ready_timeout: Duration,
+    envs: &[(&str, String)],
+) -> ToolCallResult {
     let cmd_display = format!("{program} {}", args.join(" "));
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+
+    if let Some(conflict) = preflight_conflict(port, &addr, &cmd_display) {
+        return conflict;
+    }
 
     // The daemon outlives this call, so its stderr must not go to a pipe
     // nobody drains (a full pipe buffer would wedge the server). Route it to
@@ -188,7 +297,11 @@ pub fn spawn_and_confirm(
         Err(_) => Stdio::null(),
     };
 
-    let mut child = match Command::new(program)
+    let mut command = Command::new(program);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let mut child = match command
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -203,7 +316,6 @@ pub fn spawn_and_confirm(
     };
 
     let pid: u32 = child.id();
-    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     // Port 0 means "OS assigns" — there is nothing to probe, so the window
     // only proves the child survived startup.
     let window = if port == 0 {
@@ -213,88 +325,189 @@ pub fn spawn_and_confirm(
     };
     let deadline = Instant::now() + window;
 
+    await_readiness(
+        &mut child,
+        pid,
+        port,
+        &addr,
+        deadline,
+        &cmd_display,
+        &log_path,
+    )
+}
+
+/// Poll a live child until it dies, until the port is proven to be its own, or
+/// until the readiness window closes.
+fn await_readiness(
+    child: &mut std::process::Child,
+    pid: u32,
+    port: u16,
+    addr: &SocketAddr,
+    deadline: Instant,
+    cmd_display: &str,
+    log_path: &std::path::Path,
+) -> ToolCallResult {
     loop {
         // Liveness first: a dead child can never be ready, and checking it
         // before the connect probe stops an unrelated process that happens to
         // hold `port` from masquerading as our daemon.
         match child.try_wait() {
-            Ok(Some(status)) => {
-                let detail = read_stderr_tail(&log_path);
-                let _ = std::fs::remove_file(&log_path);
-                let code = status
-                    .code()
-                    .map_or_else(|| "signal".to_string(), |c| c.to_string());
-                return ToolCallResult::error(format!(
-                    "`{cmd_display}` exited immediately (status {code}) — no server is \
-                     listening on port {port}{detail}"
-                ));
-            }
+            Ok(Some(status)) => return exited_error(cmd_display, status, port, log_path),
             Ok(None) => {}
             Err(e) => {
-                let _ = std::fs::remove_file(&log_path);
+                let _ = std::fs::remove_file(log_path);
                 return ToolCallResult::error(format!("failed to poll `{cmd_display}`: {e}"));
             }
         }
 
-        if port != 0 && TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT).is_ok() {
+        if port != 0 && TcpStream::connect_timeout(addr, CONNECT_TIMEOUT).is_ok() {
             // Re-check liveness: the connect could have raced a dying child.
             if let Ok(Some(status)) = child.try_wait() {
-                let detail = read_stderr_tail(&log_path);
-                let _ = std::fs::remove_file(&log_path);
-                let code = status
-                    .code()
-                    .map_or_else(|| "signal".to_string(), |c| c.to_string());
-                return ToolCallResult::error(format!(
-                    "`{cmd_display}` exited immediately (status {code}) — no server is \
-                     listening on port {port}{detail}"
-                ));
+                return exited_error(cmd_display, status, port, log_path);
             }
-            return running_result(pid, port, true, &log_path);
+            // #2606 (second pass), (5b) ATTRIBUTION. A successful connect only
+            // proves SOMEBODY is listening. Require the socket to be held by
+            // our child (or a descendant) before naming a url after it.
+            return running_result(pid, port, classify_listener(port, pid), log_path);
         }
 
         if Instant::now() >= deadline {
-            return running_result(pid, port, false, &log_path);
+            return running_result(pid, port, Listening::No, log_path);
         }
         std::thread::sleep(READY_POLL);
     }
 }
 
+/// #2606 (second pass), (5a) PRE-FLIGHT — refuse a port that is already taken,
+/// BEFORE spawning anything.
+///
+/// If the port already accepts connections there is no child yet to own it, so
+/// every later probe on it is unattributable by construction — and
+/// `apr serve run` could not have bound it anyway. This is the portable half of
+/// the fix: on a platform with no socket→pid interface it is the only thing
+/// standing between a client and a stranger's URL.
+fn preflight_conflict(port: u16, addr: &SocketAddr, cmd_display: &str) -> Option<ToolCallResult> {
+    if port == 0 || TcpStream::connect_timeout(addr, CONNECT_TIMEOUT).is_err() {
+        return None;
+    }
+    // Name the squatter when the platform can: "port 8080 is busy" leaves the
+    // caller stuck, "held by pid 4242 (apr)" does not.
+    let holders = crate::tools::port_owner::listening_pids(port);
+    let held_by = if holders.is_empty() {
+        String::new()
+    } else {
+        let list: Vec<String> = holders
+            .iter()
+            .map(|(pid, comm)| format!("pid {pid} ({comm})"))
+            .collect();
+        format!(" (held by {})", list.join(", "))
+    };
+    Some(ToolCallResult::error(format!(
+        "port {port} is already accepting connections BEFORE `{cmd_display}` was \
+         spawned{held_by} — another process holds it. Refusing to start a server that \
+         cannot bind it, and refusing to report a URL for a listener this tool did \
+         not start."
+    )))
+}
+
+/// The child died inside the readiness window: report the status and the tail
+/// of its own stderr, which is what turns "it didn't work" into "unrecognized
+/// subcommand".
+fn exited_error(
+    cmd_display: &str,
+    status: std::process::ExitStatus,
+    port: u16,
+    log_path: &std::path::Path,
+) -> ToolCallResult {
+    let detail = read_stderr_tail(log_path);
+    let _ = std::fs::remove_file(log_path);
+    let code = status
+        .code()
+        .map_or_else(|| "signal".to_string(), |c| c.to_string());
+    ToolCallResult::error(format!(
+        "`{cmd_display}` exited immediately (status {code}) — no server is listening on \
+         port {port}{detail}"
+    ))
+}
+
+/// Turn a successful connect into the evidence class it actually supports.
+///
+/// Pure decision, kept out of the loop so it can be reasoned about (and
+/// mutated) on its own: `Unknown` from a platform without socket→pid tables
+/// must NOT become `ByChild`, and `Foreign` must NOT become a url.
+fn classify_listener(port: u16, pid: u32) -> Listening {
+    match owner_of_listening_port(port, pid) {
+        PortOwner::Child => Listening::ByChild,
+        PortOwner::Foreign => Listening::ByForeignProcess,
+        // Pre-flight already proved the port was closed when we spawned, so
+        // this is the best a non-attributing platform can honestly claim.
+        PortOwner::Unknown => Listening::UnattributedAfterPreflight,
+    }
+}
+
 /// Build the non-error payload for a child that is still running.
 ///
-/// `ready` distinguishes "the port accepted a connection" from "still alive
-/// but not listening yet" — the caller is told which, never told a listening
-/// server exists when none does.
+/// `listening` carries both the verdict and the EVIDENCE it rests on, and is
+/// the sole gate on the `url` key.
 ///
-/// #2606 — INVARIANT SERVE-URL-ONLY-WHEN-LISTENING. The `url` key is emitted
-/// **only** when a TCP connect to `port` succeeded while the child was still
-/// alive. `ready: false` is not a soft "probably fine": until #2606 this
-/// branch still shipped `"url": "http://localhost:<port>"`, so an MCP client
-/// that reads `url` (the field it asked for) and ignores `ready` was handed a
-/// reachable-looking endpoint that nothing was listening on — the same
-/// fabricated-success shape as the pre-#2388 `{pid, url}`, merely annotated.
-/// Withholding the key makes the fabrication unrepresentable rather than
-/// merely discouraged: there is no url to misread.
+/// #2606 — INVARIANT SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT. `url` is emitted
+/// only for [`Listening::ByChild`] — a LISTEN socket on `port` held by the
+/// spawned child or a descendant — or, on a platform that cannot map a socket
+/// to a pid at all, for [`Listening::UnattributedAfterPreflight`], which is
+/// flagged as such in the payload (`attribution: "unavailable"`) instead of
+/// being passed off as the strong guarantee.
+///
+/// Two fabrications are excluded, and the second is the one the first #2606
+/// fix missed. (i) Until #2388/#2606 the alive-but-unbound branch still
+/// shipped `"url": "http://localhost:<port>"`, so a client reading the field
+/// it asked for got an endpoint nothing was listening on. (ii) Gating on
+/// "child alive AND something answered the port" still fabricated whenever an
+/// unrelated process held the port: the url named a stranger's server. Both
+/// are now unrepresentable — there is no url to misread on either branch.
 ///
 /// Still-alive-but-unbound stays a NON-error deliberately. A multi-GB model
 /// load can outlast [`READY_TIMEOUT`], the child is a real process the caller
 /// owns and must kill, and reporting `isError` for a healthy loader would be
 /// its own false claim. The honest report is: pid yes, url no, ready false.
-fn running_result(pid: u32, port: u16, ready: bool, log_path: &std::path::Path) -> ToolCallResult {
-    let note = if ready {
-        "server is accepting connections; kill pid via OS to stop"
-    } else {
-        "process is alive but has not bound the port yet (still loading?); no URL is \
-         reported because nothing accepted a connection on the port; kill pid via OS to stop"
+fn running_result(
+    pid: u32,
+    port: u16,
+    listening: Listening,
+    log_path: &std::path::Path,
+) -> ToolCallResult {
+    let ready = listening.is_attributable();
+    let note = match listening {
+        Listening::ByChild => {
+            "server is accepting connections and the listening socket is held by the \
+             spawned process; kill pid via OS to stop"
+        }
+        Listening::UnattributedAfterPreflight => {
+            "the port was closed before spawn and is now accepting connections while the \
+             child is alive, but this platform cannot map a socket to a pid, so the \
+             listener is NOT proven to be the spawned process; kill pid via OS to stop"
+        }
+        Listening::ByForeignProcess => {
+            "a process OTHER than the one just spawned holds the listening socket on this \
+             port; no URL is reported because it would name someone else's server; \
+             kill pid via OS to stop"
+        }
+        Listening::No => {
+            "process is alive but has not bound the port yet (still loading?); no URL is \
+             reported because nothing accepted a connection on the port; kill pid via OS to stop"
+        }
     };
     let mut payload = serde_json::json!({
         "pid": pid,
         "ready": ready,
         "port": port,
+        "attribution": listening.attribution(),
         "stderr_log": log_path.display().to_string(),
         "note": note,
     });
     if ready {
-        // Only reachable after a successful connect + a live-child recheck.
+        // Only reachable when the listening socket was tied to this child, or
+        // (on a platform that cannot tie it) when pre-flight proved the port
+        // was closed before this child existed.
         payload["url"] = serde_json::json!(format!("http://localhost:{port}"));
     }
     let text = serde_json::to_string(&payload)
@@ -355,6 +568,7 @@ crate::register_mcp_tool!(
 #[allow(clippy::disallowed_methods)] // serde_json::json! expands to code that hits unwrap()
 mod tests {
     use super::*;
+    use crate::tools::port_owner::attribution_available;
 
     #[test]
     fn definition_has_correct_name_and_required_field() {
@@ -419,14 +633,123 @@ mod tests {
         assert_ne!(argv[1], "/models/qwen.gguf");
     }
 
-    /// Pick a port nothing is listening on. Binding and immediately dropping
-    /// leaves the port free with high probability, which is enough for a test
-    /// whose assertion is about the child, not the port.
+    /// Pick a port nothing is listening on, and that nothing is likely to
+    /// grab before the test spawns.
+    ///
+    /// Deliberately NOT `bind(0)`: that draws from the kernel's ephemeral
+    /// range, so a port handed out here and released can be re-issued moments
+    /// later to any *other* concurrent `bind(0)` — including one in a sibling
+    /// test, or another crate's test binary on the same machine. Since #2606's
+    /// second pass, a port that turns out to be held by a stranger is a hard
+    /// error (that is the fix), so that race would surface as a flake in tests
+    /// about something else entirely. Walking a private range above the
+    /// ephemeral window, and proving each candidate binds, removes it.
+    /// Low end of the private test range. Above the privileged ports, below
+    /// the kernel's ephemeral window (32768–60999) so no `bind(0)` anywhere on
+    /// the machine can be handed the same number.
+    #[cfg(unix)]
+    const TEST_PORT_BASE: u16 = 10_000;
+    /// Width of the private range.
+    #[cfg(unix)]
+    const TEST_PORT_SPAN: u16 = 22_000;
+
     #[cfg(unix)]
     fn free_port() -> u16 {
-        let l = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
-            .expect("bind ephemeral port");
-        l.local_addr().expect("local_addr").port()
+        use std::sync::atomic::{AtomicU16, Ordering};
+        static NEXT: AtomicU16 = AtomicU16::new(0);
+
+        // Start each PROCESS at a different offset. Under nextest every test
+        // is its own process, so a counter that always started at the same
+        // number would hand the identical port to every test running in
+        // parallel — and since #2606's second pass a port held by a stranger
+        // is a hard error, that collision would surface as a flake in tests
+        // about something else. The pid spreads them out; the bind check
+        // below still proves each candidate is actually free.
+        let seed = u16::try_from(std::process::id() % u32::from(TEST_PORT_SPAN))
+            .unwrap_or_else(|_| unreachable!("modulo TEST_PORT_SPAN fits in u16"));
+        let _ = NEXT.compare_exchange(0, seed.max(1), Ordering::Relaxed, Ordering::Relaxed);
+
+        for _ in 0..256 {
+            let offset = NEXT.fetch_add(1, Ordering::Relaxed) % TEST_PORT_SPAN;
+            let port = TEST_PORT_BASE + offset;
+            // A successful bind proves the port is free right now; dropping
+            // the listener releases it for the test's own child to take.
+            if std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port)).is_ok() {
+                return port;
+            }
+        }
+        panic!("no free port in the private test range");
+    }
+
+    /// Run `body` on a port nothing else holds, retrying if the machine
+    /// disagrees.
+    ///
+    /// Between `free_port`'s bind check and the spawn there is a window in
+    /// which any other process on the box can take the port; the tests below
+    /// are about the tool's behaviour, not about winning that race. A
+    /// pre-flight conflict therefore means the test's PRECONDITION failed, so
+    /// re-draw a port — but only a bounded number of times, and only for that
+    /// one distinctive message. A tool that refuses every port still fails,
+    /// loudly: the retry cannot turn a real regression green.
+    #[cfg(unix)]
+    fn on_exclusive_port<F>(body: F) -> (u16, ToolCallResult)
+    where
+        F: Fn(u16) -> ToolCallResult,
+    {
+        let mut last = String::new();
+        for _ in 0..8 {
+            let port = free_port();
+            let result = body(port);
+            if !result.content[0]
+                .text
+                .contains("already accepting connections BEFORE")
+            {
+                return (port, result);
+            }
+            last.clone_from(&result.content[0].text);
+        }
+        panic!("8 ports in a row were reported as already held; last: {last}");
+    }
+
+    /// Environment key the re-entrant [`listener_helper`] reads its port from.
+    const LISTEN_PORT_ENV: &str = "APR_MCP_SERVE_TEST_LISTEN_PORT";
+
+    /// Ignored by every normal run; invoked ONLY as a child of
+    /// `live_child_that_owns_the_socket_reports_ready_true_with_url`, where it
+    /// plays the part of `apr serve run`: bind the port it is handed, hold it,
+    /// and wait to be killed. Without a real listening child there is no
+    /// honest way to exercise the one branch that may emit a url.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "helper process for live_child_that_owns_the_socket_reports_ready_true_with_url"]
+    fn listener_helper() {
+        let Ok(raw) = std::env::var(LISTEN_PORT_ENV) else {
+            // Run without the env var (e.g. `--include-ignored`): no-op.
+            return;
+        };
+        let port: u16 = raw.parse().expect("port env var is a u16");
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port))
+            .expect("helper binds the port it was handed");
+        // Bounded, so a failed kill cannot leave the port held forever.
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        drop(listener);
+    }
+
+    /// libtest's `--exact` takes the path WITHOUT the crate name.
+    #[cfg(unix)]
+    fn helper_test_path() -> String {
+        let module = module_path!()
+            .split_once("::")
+            .map_or(module_path!(), |(_crate_name, rest)| rest);
+        format!("{module}::listener_helper")
+    }
+
+    #[cfg(unix)]
+    fn kill_pid(pid: u64) {
+        let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
     }
 
     #[cfg(unix)]
@@ -441,8 +764,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn child_that_exits_immediately_is_reported_as_error() {
-        let port = free_port();
-        let result = spawn_and_confirm("false", &[], port, Duration::from_secs(5));
+        let (port, result) =
+            on_exclusive_port(|port| spawn_and_confirm("false", &[], port, Duration::from_secs(5)));
         assert_eq!(
             result.is_error,
             Some(true),
@@ -465,12 +788,12 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn dead_child_error_carries_its_stderr_and_exit_status() {
-        let port = free_port();
         let args = vec![
             "-c".to_string(),
             "echo 'unrecognized subcommand' >&2; exit 2".to_string(),
         ];
-        let result = spawn_and_confirm("sh", &args, port, Duration::from_secs(5));
+        let (_port, result) =
+            on_exclusive_port(|port| spawn_and_confirm("sh", &args, port, Duration::from_secs(5)));
         assert_eq!(result.is_error, Some(true));
         let msg = &result.content[0].text;
         assert!(
@@ -483,24 +806,60 @@ mod tests {
         );
     }
 
-    /// Success path: a live child plus a port that accepts connections is the
-    /// only combination that may report `ready: true`.
+    /// Success path: a live child that OWNS a listening socket on the port.
+    ///
+    /// The child is this very test binary, re-invoked to run the `#[ignore]`d
+    /// [`listener_helper`] below, which binds the port it is handed and holds
+    /// it. That makes the listening socket genuinely the spawned process's —
+    /// the one and only case that may carry a url. Nothing portable lets a
+    /// shell builtin listen on a TCP port, and a helper `[[bin]]` would not be
+    /// built by `cargo test --lib` (the form CI runs), so re-entering the test
+    /// harness is what keeps this branch reachable from a `--lib` test.
     #[cfg(unix)]
     #[test]
-    fn live_child_with_bound_port_reports_ready_true() {
-        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
-            .expect("bind ephemeral port");
-        let port = listener.local_addr().expect("local_addr").port();
-        let args = vec!["5".to_string()];
-        let result = spawn_and_confirm("sleep", &args, port, Duration::from_secs(5));
+    fn live_child_that_owns_the_socket_reports_ready_true_with_url() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let args = vec![
+            "--exact".to_string(),
+            helper_test_path(),
+            "--ignored".to_string(),
+            "--nocapture".to_string(),
+            "--test-threads".to_string(),
+            "1".to_string(),
+        ];
+        // The helper reads its port from its own environment, set only for
+        // the child — this process's environment is never mutated.
+        let (port, result) = on_exclusive_port(|port| {
+            spawn_and_confirm_with_env(
+                &exe.to_string_lossy(),
+                &args,
+                port,
+                Duration::from_secs(20),
+                &[(LISTEN_PORT_ENV, port.to_string())],
+            )
+        });
+        // Reap the helper BEFORE asserting: a panic here would otherwise leave
+        // it holding the port, poisoning later runs on the same machine.
+        if let Some(pid) = payload_of(&result)["pid"].as_u64() {
+            kill_pid(pid);
+        }
         assert_eq!(result.is_error, None, "got: {}", result.content[0].text);
         let payload = payload_of(&result);
         assert_eq!(payload["ready"], serde_json::json!(true));
         assert_eq!(
             payload["url"],
-            serde_json::json!(format!("http://localhost:{port}"))
+            serde_json::json!(format!("http://localhost:{port}")),
+            "a child that owns the listening socket is the branch that owes a url"
         );
-        assert!(payload["pid"].as_u64().is_some_and(|p| p > 0));
+        if attribution_available() {
+            assert_eq!(
+                payload["attribution"],
+                serde_json::json!("child"),
+                "on Linux the url must rest on socket->pid attribution, not on the \
+                 weaker pre-flight fallback"
+            );
+        }
+        assert!(payload["pid"].as_u64().is_some_and(|pid| pid > 0));
         // The log path handed to the client must actually exist.
         let log = payload["stderr_log"]
             .as_str()
@@ -510,7 +869,6 @@ mod tests {
             "stderr_log {log} must exist for a running daemon"
         );
         let _ = std::fs::remove_file(log);
-        drop(listener);
     }
 
     /// A live child that never binds is neither a failure nor a running
@@ -519,9 +877,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn live_child_that_never_binds_reports_ready_false() {
-        let port = free_port();
         let args = vec!["5".to_string()];
-        let result = spawn_and_confirm("sleep", &args, port, Duration::from_millis(300));
+        let (_port, result) = on_exclusive_port(|port| {
+            spawn_and_confirm("sleep", &args, port, Duration::from_millis(300))
+        });
         assert_eq!(result.is_error, None);
         let payload = payload_of(&result);
         assert_eq!(
@@ -543,13 +902,19 @@ mod tests {
 
     // ---- DOGFOOD-0.64.0 (#2606) falsifiers -------------------------------
     //
-    // INVARIANT SERVE-URL-ONLY-WHEN-LISTENING: `apr.serve` may put a `url` in
-    // its payload only on the branch that watched a TCP connect succeed while
-    // the child was still alive. Every other terminal state — dead child,
-    // unspawnable program, alive-but-unbound, ephemeral port — must carry NO
-    // url. This is the property that survives the next argv change: it never
-    // mentions `serve`, `run`, or any flag, so it keeps its teeth however the
-    // CLI's subcommand names move.
+    // INVARIANT SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT: `apr.serve` may put a
+    // `url` in its payload only when a LISTEN socket on that port is held by
+    // the child it spawned (or a descendant). Every other terminal state —
+    // dead child, unspawnable program, alive-but-unbound, ephemeral port, and
+    // *a stranger holding the port* — must carry NO url. This is the property
+    // that survives the next argv change: it never mentions `serve`, `run`, or
+    // any flag, so it keeps its teeth however the CLI's subcommand names move.
+    //
+    // The first #2606 fix stated the weaker "child alive AND something
+    // accepted a connect", which an unrelated listener satisfies — see
+    // `an_unrelated_listener_on_the_port_never_produces_a_url`. Where a
+    // platform cannot attribute a socket to a pid, the tests below narrow to
+    // what it does guarantee rather than assert a claim the code cannot make.
 
     /// Assert the payload of a non-error result carries no reachable endpoint.
     #[cfg(unix)]
@@ -575,9 +940,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn live_child_that_never_binds_reports_no_url() {
-        let port = free_port();
         let args = vec!["5".to_string()];
-        let result = spawn_and_confirm("sleep", &args, port, Duration::from_millis(300));
+        let (port, result) = on_exclusive_port(|port| {
+            spawn_and_confirm("sleep", &args, port, Duration::from_millis(300))
+        });
         assert_eq!(result.is_error, None, "a live child is not an error");
         assert_no_url(&result, "alive but never bound");
         let payload = payload_of(&result);
@@ -594,8 +960,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn dead_child_reports_no_url() {
-        let port = free_port();
-        let result = spawn_and_confirm("false", &[], port, Duration::from_secs(5));
+        let (_port, result) =
+            on_exclusive_port(|port| spawn_and_confirm("false", &[], port, Duration::from_secs(5)));
         assert_eq!(result.is_error, Some(true));
         assert_no_url(&result, "child exited immediately");
     }
@@ -621,75 +987,215 @@ mod tests {
         }
     }
 
-    /// `running_result` is a pure function of `(pid, port, ready)`, and the
-    /// `url`⇔`ready` equivalence is small enough to check EXHAUSTIVELY rather
-    /// than by sample: every one of the 65 536 ports, both readiness values.
-    /// Spawn-based falsifiers can only ever sample a port; this closes the
-    /// domain, so no port is a special case (0 and 65535 included).
+    /// `running_result` is a pure function of `(pid, port, listening)`, and
+    /// the `url`⇔attribution equivalence is small enough to check
+    /// EXHAUSTIVELY rather than by sample: every one of the 65 536 ports, all
+    /// four evidence classes. Spawn-based falsifiers can only ever sample a
+    /// port; this closes the domain, so no port is a special case (0 and 65535
+    /// included).
+    ///
+    /// Crucially, `ByForeignProcess` — "the port answers, but the socket is
+    /// somebody else's" — is in the domain. That is the state the first #2606
+    /// fix collapsed into `ready: true`, and here it must carry no url at any
+    /// port.
     #[test]
-    fn url_key_matches_ready_exhaustively_over_every_port() {
+    fn url_key_matches_attribution_exhaustively_over_every_port() {
         let log = std::path::Path::new("/tmp/apr-mcp-serve-exhaustive.log");
         for port in 0..=u16::MAX {
-            for ready in [false, true] {
-                let result = running_result(4242, port, ready, log);
+            for listening in [
+                Listening::No,
+                Listening::ByForeignProcess,
+                Listening::UnattributedAfterPreflight,
+                Listening::ByChild,
+            ] {
+                let expect_url = matches!(
+                    listening,
+                    Listening::ByChild | Listening::UnattributedAfterPreflight
+                );
+                let result = running_result(4242, port, listening, log);
                 assert_eq!(result.is_error, None, "port {port}: never an error here");
                 let text = &result.content[0].text;
                 let v: serde_json::Value =
                     serde_json::from_str(text).expect("running_result emits JSON");
                 assert_eq!(
                     v.get("url").is_some(),
-                    ready,
-                    "port {port}, ready {ready}: `url` must be present iff ready"
+                    expect_url,
+                    "port {port}, {listening:?}: `url` must be present iff the listener \
+                     is attributable to the spawned child"
                 );
                 assert_eq!(
                     text.contains("http://"),
-                    ready,
-                    "port {port}, ready {ready}: no endpoint may appear unless ready"
+                    expect_url,
+                    "port {port}, {listening:?}: no endpoint may appear otherwise"
                 );
-                assert_eq!(v["ready"], serde_json::json!(ready));
+                assert_eq!(v["ready"], serde_json::json!(expect_url));
                 assert_eq!(v["port"], serde_json::json!(port));
                 assert_eq!(v["pid"], serde_json::json!(4242));
+                assert_eq!(
+                    v["attribution"],
+                    serde_json::json!(listening.attribution()),
+                    "port {port}, {listening:?}: the evidence class must be reported, so a \
+                     client can tell the strong guarantee from the weak one"
+                );
             }
         }
     }
 
-    /// The positive half of the invariant: the ONLY combination that may
-    /// carry a url is live child + port that accepted a connection. Paired
-    /// with the three negatives above this pins `url` to exactly one branch.
+    /// The evidence classes and the url gate must not drift apart: `ByChild`
+    /// is the only class that is BOTH attributable and labelled `child`.
+    #[test]
+    fn only_child_owned_evidence_carries_the_strong_label() {
+        assert!(Listening::ByChild.is_attributable());
+        assert_eq!(Listening::ByChild.attribution(), "child");
+        assert!(!Listening::ByForeignProcess.is_attributable());
+        assert!(!Listening::No.is_attributable());
+        // The weak branch may carry a url, but must never be mislabelled as
+        // the strong one.
+        assert!(Listening::UnattributedAfterPreflight.is_attributable());
+        assert_ne!(
+            Listening::UnattributedAfterPreflight.attribution(),
+            "child",
+            "the fallback must not masquerade as socket->pid attribution"
+        );
+    }
+
+    /// `classify_listener` is the point where a platform verdict becomes a url
+    /// decision. `Foreign` must never become a url, and `Unknown` must never
+    /// become the strong `ByChild` claim.
     #[cfg(unix)]
     #[test]
-    fn url_appears_only_on_the_observed_listening_branch() {
-        // Negative: same program, same timeout, port nothing is bound to.
-        let dead_port = free_port();
-        let unbound = spawn_and_confirm(
-            "sleep",
-            &["5".to_string()],
-            dead_port,
-            Duration::from_millis(300),
-        );
-        assert_no_url(&unbound, "control: unbound port");
-        if let Some(log) = payload_of(&unbound)["stderr_log"].as_str() {
-            let _ = std::fs::remove_file(log);
-        }
-
-        // Positive: identical call, except something IS listening.
+    fn classify_listener_never_attributes_a_stranger_socket_to_the_child() {
         let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .expect("bind ephemeral port");
-        let bound_port = listener.local_addr().expect("local_addr").port();
-        let live = spawn_and_confirm(
+        let port = listener.local_addr().expect("local_addr").port();
+        let mut stranger = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let verdict = classify_listener(port, stranger.id());
+        let _ = stranger.kill();
+        let _ = stranger.wait();
+        drop(listener);
+
+        if attribution_available() {
+            assert_eq!(
+                verdict,
+                Listening::ByForeignProcess,
+                "a socket held by an unrelated process must not be classified as the child's"
+            );
+            assert!(
+                !verdict.is_attributable(),
+                "and therefore must not be allowed to carry a url"
+            );
+        } else {
+            assert_eq!(
+                verdict,
+                Listening::UnattributedAfterPreflight,
+                "a platform that cannot attribute must say so, never claim ByChild"
+            );
+            assert_ne!(verdict, Listening::ByChild);
+        }
+    }
+
+    /// **The #2606 second-pass falsifier — the verifier's own reproduction.**
+    ///
+    /// An unrelated process holds the port; the spawned child binds nothing
+    /// and never will. The first #2606 fix reported
+    /// `{"ready":true,"url":"http://localhost:<port>"}` here, because its gate
+    /// was "child alive AND *something* accepted a connect" — a stranger's
+    /// listener satisfies both conjuncts. This is byte-for-byte the
+    /// fabricated-URL shape #2606 was filed about, merely reached by a
+    /// different route.
+    ///
+    /// RED against the previous implementation; the whole point of the second
+    /// pass.
+    #[cfg(unix)]
+    #[test]
+    fn an_unrelated_listener_on_the_port_never_produces_a_url() {
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+
+        // `sleep` stands in for a daemon that dies at clap, or hangs loading,
+        // or otherwise never binds: exactly the 0.63.0 child.
+        let result = spawn_and_confirm(
             "sleep",
             &["5".to_string()],
-            bound_port,
-            Duration::from_millis(300),
+            port,
+            Duration::from_millis(500),
         );
-        assert_eq!(live.is_error, None, "got: {}", live.content[0].text);
-        let payload = payload_of(&live);
-        assert_eq!(payload["ready"], serde_json::json!(true));
+
+        assert_no_url(&result, "a stranger holds the port");
         assert_eq!(
-            payload["url"],
-            serde_json::json!(format!("http://localhost:{bound_port}")),
-            "the listening branch is the one branch that owes a url"
+            result.is_error,
+            Some(true),
+            "a port already held by someone else is a conflict the caller must be told \
+             about, not a server; got: {}",
+            result.content[0].text
         );
+        assert!(
+            result.content[0].text.contains(&port.to_string()),
+            "the conflict must name the port, got: {}",
+            result.content[0].text
+        );
+        drop(listener);
+    }
+
+    /// The same class, but with the stranger arriving *inside* the readiness
+    /// window rather than before it — the case pre-flight alone cannot see.
+    /// Only socket→pid attribution catches this, so on a platform without it
+    /// the assertion narrows to what that platform actually guarantees.
+    #[cfg(unix)]
+    #[test]
+    fn a_listener_that_appears_mid_window_is_not_attributed_to_the_child() {
+        // The stranger must arrive AFTER pre-flight, which is the whole
+        // point of this case. If the machine is loaded enough that it lands
+        // first, pre-flight refuses and the attempt is re-drawn on a fresh
+        // port rather than asserted on — the precondition failed, not the
+        // tool. Eight refusals in a row still fail loudly.
+        let mut attempt = 0;
+        let (result, listener) = loop {
+            attempt += 1;
+            assert!(attempt <= 8, "pre-flight refused 8 ports in a row");
+            let port = free_port();
+            let handle = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(200));
+                std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port)).ok()
+            });
+            let result =
+                spawn_and_confirm("sleep", &["5".to_string()], port, Duration::from_secs(3));
+            let listener = handle.join().ok().flatten();
+            if !result.content[0]
+                .text
+                .contains("already accepting connections BEFORE")
+            {
+                break (result, listener);
+            }
+            drop(listener);
+        };
+
+        let payload = payload_of(&result);
+        if attribution_available() {
+            assert_no_url(&result, "stranger bound the port mid-window");
+            assert_eq!(
+                payload["attribution"],
+                serde_json::json!("foreign"),
+                "the socket belongs to the test process, not the spawned child; got: {payload}"
+            );
+            assert_eq!(payload["ready"], serde_json::json!(false));
+        } else {
+            // Documented weaker guarantee: pre-flight passed and the port
+            // later answered, so this platform cannot tell whose it is. It
+            // must at least refuse the strong label.
+            assert_ne!(
+                payload["attribution"],
+                serde_json::json!("child"),
+                "a platform without attribution must not claim it; got: {payload}"
+            );
+        }
         if let Some(log) = payload["stderr_log"].as_str() {
             let _ = std::fs::remove_file(log);
         }
@@ -700,13 +1206,14 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn unspawnable_program_reports_error() {
-        let port = free_port();
-        let result = spawn_and_confirm(
-            "apr-does-not-exist-9c1f",
-            &[],
-            port,
-            Duration::from_millis(200),
-        );
+        let (_port, result) = on_exclusive_port(|port| {
+            spawn_and_confirm(
+                "apr-does-not-exist-9c1f",
+                &[],
+                port,
+                Duration::from_millis(200),
+            )
+        });
         assert_eq!(result.is_error, Some(true));
         assert!(result.content[0].text.contains("failed to spawn"));
     }


### PR DESCRIPTION
Refs #2606 (P0). **Second pass — an adversarial verifier reproduced the original
defect against the first fix on this branch. That is now closed.**

## What the verifier found, and why it was right

The first fix gated `url` on *"our child is alive AND something accepted a TCP
connect on that port"*. That conjunction is satisfied by **any** unrelated
process holding the port: the spawned child binds nothing, the probe succeeds
against the stranger's socket, and the tool reports

```json
{"pid":2043970,"port":45831,"ready":true,"url":"http://localhost:45831","attribution":"child"}
```

for a server it did not start — byte-for-byte the #2606 shape, reached by a
different route. Reachability is not attribution: the *claim* was narrowed
without the *evidence* being strengthened.

**The v1 test suite did not merely miss this — its positive case asserted it.**
`url_appears_only_on_the_observed_listening_branch` pre-bound a `TcpListener`,
spawned `sleep`, and asserted a url came back. A test that encodes the defect is
worse than no test; it is deleted.

## What now stands behind a url

Two mechanisms, each independently load-bearing (both mutation-verified below):

| | Mechanism | Portable? | Catches |
|---|---|---|---|
| **5a** | **Pre-flight** — probe the port *before* spawning; if it already answers, refuse without creating a process, naming the port and (where the platform can say) the holding pid + comm | yes | a stranger that predates the child |
| **5b** | **Attribution** — on a successful connect, require a LISTEN socket on that port on an fd of the child *or a transitive descendant*: `/proc/net/tcp{,6}` inodes ∩ `/proc/<pid>/fd`, in the new `tools::port_owner` | Linux | a stranger that arrives *inside* the readiness window |

`ready: bool` was itself part of the bug — a boolean cannot distinguish "our
child is listening" from "somebody is listening". It is now an evidence class,
`ByChild | UnattributedAfterPreflight | ByForeignProcess | No`, and `url` is
gated on it in exactly one place. Attribution fails **closed**: an unreadable
table or a missing LISTEN row yields `Foreign`, never `Child`.

## Where the guarantee is weaker, the payload says so

Socket→pid attribution needs an OS interface. macOS has no `/proc`, and
`libproc`/`lsof` are out of reach under `unsafe_code = "forbid"` with no new
dependencies. **So the stated invariant is narrowed rather than overclaimed**:
the payload carries `attribution` — `"child"` (strong; Linux, i.e. every CI
runner and every host measured in #2606) vs `"unavailable"` (weak: pre-flight
proved the port closed immediately before spawn, and nothing more). A platform
that cannot attribute never returns the strong verdict.

**SERVE-URL-ONLY-WHEN-LISTENING → SERVE-URL-ONLY-WHEN-CHILD-OWNS-PORT.**

## Falsifiers (all `--lib`, so `workspace-test` runs them)

| Crate | Test |
|---|---|
| aprender-mcp | `an_unrelated_listener_on_the_port_never_produces_a_url` ← the verifier's repro |
| aprender-mcp | `a_listener_that_appears_mid_window_is_not_attributed_to_the_child` |
| aprender-mcp | `live_child_that_owns_the_socket_reports_ready_true_with_url` |
| aprender-mcp | `classify_listener_never_attributes_a_stranger_socket_to_the_child` |
| aprender-mcp | `port_owner`: real-socket attribution both ways, LISTEN-vs-ESTABLISHED rows, comm with spaces/parens |
| aprender-mcp | `url_key_matches_attribution_exhaustively_over_every_port` — 65 536 ports × 4 evidence classes |
| aprender-mcp | `live_child_that_never_binds_reports_no_url`, `dead_child_reports_no_url`, `ephemeral_port_reports_no_url_and_not_ready` |
| apr-cli | the three `falsify_2606_*` argv parser tests (unchanged) |

The positive branch is driven by a **real child holding a real listening
socket**: the test binary re-invoked to run an `#[ignore]`d `listener_helper`. A
`[[bin]]` helper would not be built by `cargo test --lib`, which is what CI runs.

## Mutation verification — engagement proven before any verdict was read

Each marker was grepped out of the **built** test binary
(`strings -a … | grep -c` == 1) *before* the suite ran, and re-run against the
**final refactored** code, since the old proof does not transfer:

| Mutation | Marker count | Result |
|---|---|---|
| **FINAL-M1** — both mechanisms reverted to the v1 gate | 1 | **3 RED**, reproducing `{"attribution":"child","ready":true,"url":"http://localhost:45831"}` for a `sleep` child that bound nothing |
| **FINAL-M2** — pre-flight OFF, attribution ON | 1 | **1 RED**: url still correctly withheld (`attribution: "foreign"`), but the caller is no longer told their port is taken |
| **FINAL-M3** — attribution OFF, pre-flight ON | 1 | **2 RED**: the mid-window stranger is attributed to the child again |

Neither mechanism is redundant. Restored: 139 passed, 0 failed, **0**
`MUTATION-2606` markers left in the binary.

## Test port allocation is part of the blast radius

Once "someone else holds this port" is a hard error, a test that draws a port
from the kernel's ephemeral range (`bind(0)`, release, hope) can be handed a port
a sibling test process just took — and **under nextest every test is its own
process**, so a per-process counter starting at a fixed number hands the *same*
port to every test in parallel. Ports now come from a private range below the
ephemeral window, seeded by pid, with a bounded re-draw on a pre-flight refusal.
Verified 6× `cargo test` and 4× `cargo nextest run --profile ci`, all green.

## Contract

`contracts/apr-mcp-serve-liveness-v1.yaml` → **v2.0.0**. `pv validate` clean;
`pv score` 0.47 with **Falsify 1.00** (Kani dimension dilutes as obligations were
added). Twelve falsifiers, and the v1 lesson recorded verbatim.

Complexity: the added pre-flight was extracted (`preflight_conflict`,
`exited_error`, `await_readiness`) so both halves of the spawn path are pmat
**A-**, better than the single function on `main`.

## ⚠️ README.md is deliberately NOT touched — see #2630

`check_readme_claims.sh` will be **RED on this PR, and that is CORRECT.** Six
open PRs each add exactly one contract and four of them independently bump the
same three hardcoded README figures 1778 → 1779. Every one is individually
correct and they are mutually exclusive — only one can ever merge green, and it
reds the other five. The integration branch that folds these PRs sets the figure
**once**, from a real measurement, after they are all merged together.

**Please do not "helpfully" re-add the bump here.** The contract is the
deliverable and it stays.

`Cargo.lock` is left at `origin/main`: an ancestor `.cargo/config.toml` injects
an 11-entry `[[patch.unused]]` block that must never land (#2615).
`.github/` is untouched — #2617 owns the integration-test line in `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
