### PR TITLE
fix(code): a no-argument `apr code` picked a 30B model off the disk and left the server running

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1778 provable YAML contracts
+├── contracts/                      # 1779 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1778 contracts across inference, training, quantization, attention, FFN,
+1779 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1779** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1778** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1779 provable YAML contracts
+├── contracts/                      # 1778 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1779 contracts across inference, training, quantization, attention, FFN,
+1778 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/apr-code-no-arg-startup-v1.yaml
+++ b/contracts/apr-code-no-arg-startup-v1.yaml
@@ -1,0 +1,166 @@
+metadata:
+  kind: kernel
+  version: 1.0.0
+  created: '2026-08-22'
+  author: PAIML Engineering
+  description: >
+    apr-code no-argument start-up policy and inference-child lifetime (issue
+    #2607, measured on the PUBLISHED apr 0.63.0 during the pre-release
+    multi-platform dogfood sweep). Two correctness surfaces, both about a run
+    that was never asked to do anything:
+    (1) START-UP POLICY — `apr code` with no arguments at all and a stdin that
+    is not a terminal cannot hold a session: the REPL's first read_line returns
+    EOF. On the sweep host it nevertheless scanned the filesystem, picked the
+    largest local GGUF (a 30B MoE) and launched an `apr serve` child for it. A
+    consequential action chosen by looking at the disk is a guess, not an
+    instruction; a bare invocation must print help and spawn nothing.
+    (2) CHILD LIFETIME — the non-interactive (`-p`) path ends in
+    std::process::exit, which runs NO destructors, so every owner of the
+    inference driver must be released first. `drop(driver)` alone did not do
+    that: the driver is an Arc and register_task_tool stores a clone of it in
+    the tool registry, so the strong count never reached zero,
+    AprServeDriver::drop never ran, and the `apr serve` child was orphaned
+    holding the whole model in RSS.
+  references:
+  - 'crates/aprender-orchestrate/src/agent/code.rs — CodeInvocation::wants_help(), release_driver(), cmd_code()'
+  - 'crates/apr-cli/src/dispatch.rs — Commands::Code arm, print_code_help_and_exit()'
+  - 'crates/aprender-orchestrate/src/agent/driver/apr_serve.rs — AprServeDriver::launch()/drop()'
+  - 'crates/aprender-orchestrate/src/agent/task_tool.rs — register_task_tool() clones the driver Arc into the registry'
+  - 'https://github.com/paiml/aprender/issues/2607'
+  related_contracts:
+  - contracts/apr-code-parity-v1.yaml
+  - contracts/apr-code-toolcall-retention-v1.yaml
+status: ACTIVE
+
+equations:
+  no_arg_startup_policy:
+    formula: wants_help(inv) = ¬has_prompt ∧ ¬print ∧ ¬has_model ∧ ¬has_manifest ∧ ¬has_resume ∧ ¬stdin_is_terminal
+    domain: the parsed `apr code` flag set × whether stdin is an interactive terminal
+    codomain: '{ShowHelp, Run}'
+    invariants:
+    - A bare invocation on a non-terminal stdin prints help and exits non-zero
+    - No model is discovered and no `apr serve` child is spawned on that path
+    - Any named argument (-p, a prompt, --model, --manifest, --resume) still runs
+    - An interactive terminal always runs, with or without arguments
+    preconditions:
+    - the CLI parsed successfully (clap already rejects unknown flags)
+    postconditions:
+    - wants_help ⟹ zero child processes were created by this run
+    - ¬wants_help ⟹ start-up proceeds exactly as before the fix
+    lean_theorem: Theorems.Apr_Code_No_Arg_Startup_Policy
+  serve_child_reaped_before_exit:
+    formula: strong_count(driver) = 0 before std::process::exit ⟹ AprServeDriver::drop runs ⟹ child killed
+    domain: the non-interactive (-p) path, which owns an Arc<dyn LlmDriver> and a ToolRegistry holding a clone
+    codomain: the set of live child processes after the parent exits
+    invariants:
+    - The tool registry is released BEFORE the last driver handle
+    - Dropping only the local Arc leaves the strong count at 1 and reaps nothing
+    - release_driver takes both by value, so the ordering is a compile-time obligation
+    preconditions:
+    - register_task_tool has cloned the driver Arc into the registry
+    postconditions:
+    - the driver's Drop has run when std::process::exit is reached
+    - no `apr serve` process outlives the `apr code` parent
+    lean_theorem: Theorems.Apr_Code_Serve_Child_Reaped_Before_Exit
+
+proof_obligations:
+- type: invariant
+  property: A bare `apr code` on a non-terminal stdin spawns no inference server
+  formal: wants_help(inv) ⟹ |children(run)| = 0
+  applies_to: no_arg_startup_policy
+- type: invariant
+  property: Every named argument still runs with stdin closed
+  formal: (has_prompt ∨ print ∨ has_model ∨ has_manifest ∨ has_resume) ⟹ ¬wants_help(inv)
+  applies_to: no_arg_startup_policy
+- type: invariant
+  property: An interactive terminal is never refused
+  formal: stdin_is_terminal ⟹ ¬wants_help(inv)
+  applies_to: no_arg_startup_policy
+- type: equivalence
+  property: Releasing the registry first makes the last driver handle actually the last
+  formal: release_driver(tools, driver) ⟹ strong_count → 0 ⟹ Drop runs
+  applies_to: serve_child_reaped_before_exit
+
+kernel_structure:
+  phases:
+  - name: classify
+    description: CodeInvocation::from_args reads the flag set plus stdin's terminal-ness
+    invariant: the decision is made before any chdir, settings read, model scan or spawn
+  - name: refuse
+    description: wants_help ⟹ apr-cli renders clap's real `code` help to stderr and exits 2; cmd_code bails for library embedders
+    invariant: no filesystem model scan and no subprocess on this path
+  - name: reap
+    description: release_driver(tools, driver) consumes the registry, then the last driver handle, before std::process::exit
+    invariant: AprServeDriver::drop has run before the process image goes away
+
+simd_dispatch:
+  no_arg_startup_policy:
+    scalar: batuta::agent::code::CodeInvocation::wants_help
+  serve_child_reaped_before_exit:
+    scalar: batuta::agent::code::release_driver
+
+enforcement:
+  no_arg_spawns_nothing:
+    description: A bare `apr code` with stdin closed must not spawn an inference server
+    check: contract_tests::FALSIFY-CODE-NOARG-001
+    severity: ERROR
+  named_args_still_run:
+    description: The refusal must not widen to invocations that carry an explicit instruction
+    check: contract_tests::FALSIFY-CODE-NOARG-003
+    severity: ERROR
+  serve_child_reaped:
+    description: The `apr serve` child must be reaped before std::process::exit skips destructors
+    check: contract_tests::FALSIFY-CODE-NOARG-004
+    severity: ERROR
+
+falsification_tests:
+- id: FALSIFY-CODE-NOARG-001
+  rule: A bare `apr code` with stdin closed spawns no `apr serve` child
+  prediction: running the real binary with no args and stdin=/dev/null leaves no recorded child pid
+  test: 'cargo test -p apr-cli --test cli_commands falsify_2607_bare_apr_code_with_closed_stdin_spawns_no_serve_child'
+  red_state: making wants_help() return false restores auto-discovery; $APR_BIN records a pid and the test FAILS
+  green_state: help is printed, exit code 2, and the pid file never appears (PASS)
+  if_fails: a no-argument run picks a model off the disk and launches an inference server for it
+- id: FALSIFY-CODE-NOARG-002
+  rule: cmd_code itself refuses the bare non-interactive shape
+  prediction: the library entry point returns Err before model discovery, for any embedder
+  test: 'cargo test -p aprender-orchestrate --lib falsify_2607_cmd_code_refuses_bare_non_interactive_invocation'
+  red_state: without the guard cmd_code returns no error and proceeds to discover_and_set_model, FAILS
+  green_state: Err naming "stdin is not a terminal" (PASS)
+  if_fails: the CLI guard is the only guard, and any other caller keeps the defect
+- id: FALSIFY-CODE-NOARG-003
+  rule: Named arguments still run on a closed stdin
+  prediction: -p, a positional prompt, --model, --manifest and --resume all keep running
+  test: 'cargo test -p aprender-orchestrate --lib falsify_2607_named_arguments_still_run_on_closed_stdin'
+  red_state: making wants_help() return true refuses `apr code -p "..." < /dev/null`, FAILS
+  green_state: every named-argument shape returns Run; an interactive terminal returns Run (PASS)
+  if_fails: the fix breaks the documented non-interactive form and every CI use of --model
+- id: FALSIFY-CODE-NOARG-004
+  rule: Releasing only the driver handle does not reap the serve child; release_driver does
+  prediction: with a Drop-observing driver, drop(driver) leaves Drop unrun; release_driver runs it
+  test: 'cargo test -p aprender-orchestrate --lib falsify_2607_dropping_driver_handle_alone_leaves_serve_child_unreaped'
+  red_state: forgetting the registry (std::mem::forget(tools)) leaves the strong count at 1, Drop never runs, FAILS
+  green_state: registry released first, strong count reaches 0, Drop runs before exit (PASS)
+  if_fails: '`apr code -p` exits leaving an orphaned `apr serve` holding the whole model in RSS'
+
+kani_harnesses:
+- id: KANI-CODE-NOARG-001
+  obligation: A bare invocation on a non-terminal stdin wants help
+  property: ¬(p ∨ q ∨ m ∨ f ∨ r ∨ t) ⟺ wants_help
+  bound: 6
+  strategy: exhaustive
+  harness: verify_apr_code_no_arg_startup_policy
+
+qa_gate:
+  id: F-CODE-NOARG-001
+  name: apr-code No-Argument Start-Up and Serve-Child Lifetime
+  description: A run nobody asked for must take no action and leave no process behind (#2607)
+  checks:
+  - no_arg_spawns_nothing
+  - named_args_still_run
+  - serve_child_reaped
+  pass_criteria: All 4 falsification tests PASS (GREEN) on the fixed start-up path
+  falsification: >
+    Make wants_help() constant — false restores the spawn (FALSIFY-CODE-NOARG-001/002 FAIL),
+    true over-refuses (FALSIFY-CODE-NOARG-003 FAILS). Replace drop(tools) in release_driver
+    with std::mem::forget (FALSIFY-CODE-NOARG-004 FAILS). All three were run and observed RED.

--- a/contracts/apr-code-no-arg-startup-v1.yaml
+++ b/contracts/apr-code-no-arg-startup-v1.yaml
@@ -1,6 +1,6 @@
 metadata:
   kind: kernel
-  version: 1.0.0
+  version: 1.1.0
   created: '2026-08-22'
   author: PAIML Engineering
   description: >
@@ -21,6 +21,23 @@ metadata:
     the tool registry, so the strong count never reached zero,
     AprServeDriver::drop never ran, and the `apr serve` child was orphaned
     holding the whole model in RSS.
+    v1.1.0 (adversarial review of the first fix, both findings MEASURED):
+    (a) "no interactive session is possible" is not the same as "stdin is not
+    a terminal". `echo "hi" | apr code` has always driven the REPL — run_repl
+    reads stdin line by line and treats EOF as /exit — so keying the refusal
+    on ¬stdin_is_terminal alone narrowed a working invocation into an exit-2
+    usage error. The predicate now also requires that stdin cannot deliver a
+    byte: a character device (/dev/null) or a closed fd refuses; a FIFO or a
+    redirected file carrying data runs.
+    (b) the child-lifetime falsifier covered only the BARE call site, where
+    the correct behaviour is that nothing is spawned at all. The call site
+    that actually spawns — `apr code -p "..."` — had unit coverage only. It
+    now has a live falsifier, and building it surfaced a third fact: on Linux
+    PR_SET_PDEATHSIG (aprender#1712) reaps the child on parent death, so with
+    a SIGTERM-obeying fixture the pre-fix `drop(driver)` measured GREEN. The
+    fixture ignores SIGTERM — which PR_SET_PDEATHSIG sends once and does not
+    escalate, while AprServeDriver::drop escalates to SIGKILL after 2s — so
+    the assertion observes what release_driver actually changed.
   references:
   - 'crates/aprender-orchestrate/src/agent/code.rs — CodeInvocation::wants_help(), release_driver(), cmd_code()'
   - 'crates/apr-cli/src/dispatch.rs — Commands::Code arm, print_code_help_and_exit()'
@@ -34,19 +51,22 @@ status: ACTIVE
 
 equations:
   no_arg_startup_policy:
-    formula: wants_help(inv) = ¬has_prompt ∧ ¬print ∧ ¬has_model ∧ ¬has_manifest ∧ ¬has_resume ∧ ¬stdin_is_terminal
-    domain: the parsed `apr code` flag set × whether stdin is an interactive terminal
+    formula: wants_help(inv) = ¬has_prompt ∧ ¬print ∧ ¬has_model ∧ ¬has_manifest ∧ ¬has_resume ∧ ¬stdin_is_terminal ∧ ¬stdin_has_input
+    domain: the parsed `apr code` flag set × whether stdin is a terminal × whether stdin can still deliver a byte
     codomain: '{ShowHelp, Run}'
     invariants:
-    - A bare invocation on a non-terminal stdin prints help and exits non-zero
+    - A bare invocation whose stdin can never deliver a byte prints help and exits non-zero
     - No model is discovered and no `apr serve` child is spawned on that path
     - Any named argument (-p, a prompt, --model, --manifest, --resume) still runs
     - An interactive terminal always runs, with or without arguments
+    - A pipe or redirected file carrying bytes still runs — it is an instruction
+    - The peek is non-consuming, so the REPL/-p read sees the same bytes
     preconditions:
     - the CLI parsed successfully (clap already rejects unknown flags)
     postconditions:
     - wants_help ⟹ zero child processes were created by this run
     - ¬wants_help ⟹ start-up proceeds exactly as before the fix
+    - stdin_has_input ⟹ every byte remains queued for the first read
     lean_theorem: Theorems.Apr_Code_No_Arg_Startup_Policy
   serve_child_reaped_before_exit:
     formula: strong_count(driver) = 0 before std::process::exit ⟹ AprServeDriver::drop runs ⟹ child killed
@@ -76,16 +96,34 @@ proof_obligations:
   property: An interactive terminal is never refused
   formal: stdin_is_terminal ⟹ ¬wants_help(inv)
   applies_to: no_arg_startup_policy
+- type: invariant
+  property: A pipe or redirected file carrying bytes is an instruction and still runs
+  formal: stdin_has_input ⟹ ¬wants_help(inv)
+  applies_to: no_arg_startup_policy
+- type: invariant
+  property: The stdin peek does not consume the bytes it reports
+  formal: reader_has_input(r) ⟹ read(r) yields the same byte sequence as before the peek
+  applies_to: no_arg_startup_policy
 - type: equivalence
   property: Releasing the registry first makes the last driver handle actually the last
   formal: release_driver(tools, driver) ⟹ strong_count → 0 ⟹ Drop runs
+  applies_to: serve_child_reaped_before_exit
+- type: invariant
+  property: The spawning call site leaves no live child, observed on the real binary
+  formal: run(`apr code -p P`) terminates ⟹ |live_children(run)| = 0
   applies_to: serve_child_reaped_before_exit
 
 kernel_structure:
   phases:
   - name: classify
-    description: CodeInvocation::from_args reads the flag set plus stdin's terminal-ness
-    invariant: the decision is made before any chdir, settings read, model scan or spawn
+    description: >
+      CodeInvocation::from_args reads the flag set, stdin's terminal-ness, and —
+      only when every other field already says "would refuse" — whether stdin can
+      still deliver a byte (stat /dev/stdin, then a non-consuming fill_buf peek)
+    invariant: >
+      the decision is made before any chdir, settings read, model scan or spawn, and
+      the peek is reached only for stdin that is not a character device, which is what
+      keeps it non-blocking under every test harness
   - name: refuse
     description: wants_help ⟹ apr-cli renders clap's real `code` help to stderr and exits 2; cmd_code bails for library embedders
     invariant: no filesystem model scan and no subprocess on this path
@@ -111,6 +149,14 @@ enforcement:
   serve_child_reaped:
     description: The `apr serve` child must be reaped before std::process::exit skips destructors
     check: contract_tests::FALSIFY-CODE-NOARG-004
+    severity: ERROR
+  spawning_call_site_leaves_no_child:
+    description: The call site that legitimately spawns a server must leave none behind, measured live
+    check: contract_tests::FALSIFY-CODE-NOARG-005
+    severity: ERROR
+  piped_prompt_still_runs:
+    description: A pipe carrying a prompt must not be refused as a bare invocation
+    check: contract_tests::FALSIFY-CODE-NOARG-006
     severity: ERROR
 
 falsification_tests:
@@ -142,12 +188,42 @@ falsification_tests:
   red_state: forgetting the registry (std::mem::forget(tools)) leaves the strong count at 1, Drop never runs, FAILS
   green_state: registry released first, strong count reaches 0, Drop runs before exit (PASS)
   if_fails: '`apr code -p` exits leaving an orphaned `apr serve` holding the whole model in RSS'
+- id: FALSIFY-CODE-NOARG-005
+  rule: The call site that DOES spawn a server leaves no live child, measured on the real binary
+  prediction: >
+    `apr code -p hi` discovers a model, launches the backend through $APR_BIN, answers the
+    turn and exits; the recorded backend pid is gone afterwards. The fixture answers the
+    readiness connect (so the run reaches release_driver + process::exit rather than
+    bailing in launch) and ignores SIGTERM (so PR_SET_PDEATHSIG, which sends one SIGTERM
+    and does not escalate, cannot reap it on the parent's behalf and mask the defect).
+  test: 'cargo test -p apr-cli --test cli_commands falsify_2607_non_interactive_p_run_leaves_no_serve_child'
+  red_state: >
+    reverting release_driver(tools, driver) to the pre-fix drop(driver) leaves the registry
+    holding the second Arc, so Drop never runs and the SIGTERM-deaf child survives, FAILS
+  green_state: release_driver drops the registry first, Drop escalates to SIGKILL, child gone (PASS)
+  if_fails: the orphan is fixed only for the invocation that never spawns anything
+- id: FALSIFY-CODE-NOARG-006
+  rule: A pipe carrying a prompt is an instruction, not a bare invocation
+  prediction: >
+    `printf 'hi\n' | apr code` with an empty HOME and cwd is NOT refused — it reaches model
+    resolution and stops at NO_MODEL (5), never at the usage-error code 2
+  test: 'cargo test -p apr-cli --test cli_commands falsify_2607_piped_prompt_is_not_refused_as_a_bare_invocation'
+  red_state: dropping the ¬stdin_has_input clause refuses the pipe with exit 2, FAILS
+  green_state: exit 5 with no refusal message (PASS)
+  if_fails: the #2607 fix silently narrows a working non-interactive form
+- id: FALSIFY-CODE-NOARG-007
+  rule: The stdin peek reports input without consuming it, and /dev/null is not a source
+  prediction: reader_has_input is true for a reader with bytes and leaves every byte readable; /dev/null's file type is not a carrier
+  test: 'cargo test -p aprender-orchestrate --lib falsify_2607_reader_has_input_reports_and_preserves_bytes falsify_2607_dev_null_is_not_a_carrier_but_a_file_is falsify_2607_piped_stdin_still_drives_the_repl'
+  red_state: making the peek constant-true refuses nothing and re-opens #2607; consuming the peek makes a piped prompt run an empty turn, FAILS
+  green_state: peek is non-consuming, /dev/null refuses, a pipe with bytes runs (PASS)
+  if_fails: either #2607 returns, or a piped prompt loses its first line
 
 kani_harnesses:
 - id: KANI-CODE-NOARG-001
-  obligation: A bare invocation on a non-terminal stdin wants help
-  property: ¬(p ∨ q ∨ m ∨ f ∨ r ∨ t) ⟺ wants_help
-  bound: 6
+  obligation: A bare invocation whose stdin can never deliver a byte wants help
+  property: ¬(p ∨ q ∨ m ∨ f ∨ r ∨ t ∨ i) ⟺ wants_help
+  bound: 7
   strategy: exhaustive
   harness: verify_apr_code_no_arg_startup_policy
 
@@ -159,8 +235,22 @@ qa_gate:
   - no_arg_spawns_nothing
   - named_args_still_run
   - serve_child_reaped
-  pass_criteria: All 4 falsification tests PASS (GREEN) on the fixed start-up path
+  - spawning_call_site_leaves_no_child
+  - piped_prompt_still_runs
+  pass_criteria: All 7 falsification tests PASS (GREEN) on the fixed start-up path
   falsification: >
-    Make wants_help() constant — false restores the spawn (FALSIFY-CODE-NOARG-001/002 FAIL),
-    true over-refuses (FALSIFY-CODE-NOARG-003 FAILS). Replace drop(tools) in release_driver
-    with std::mem::forget (FALSIFY-CODE-NOARG-004 FAILS). All three were run and observed RED.
+    Every mutation below was built, proved present in the artifact under test with
+    `strings -a <bin> | grep -c <marker>`, and only then run.
+    (C) release_driver(tools, driver) -> the pre-fix drop(driver), PR_SET_PDEATHSIG left
+    intact: FALSIFY-CODE-NOARG-005 RED, orphan survived.
+    (C+D) same, plus PR_SET_PDEATHSIG disabled: RED.
+    (D alone) PR_SET_PDEATHSIG disabled with release_driver in place: GREEN — the fix
+    alone reaps, which is what makes it load-bearing on hosts with no PDEATHSIG.
+    (E) drop the ¬stdin_has_input clause: FALSIFY-CODE-NOARG-006 and
+    falsify_2607_piped_stdin_still_drives_the_repl RED.
+    (F) make the stdin peek constant-true: FALSIFY-CODE-NOARG-001 RED, the bare run
+    spawned a backend again.
+    Recorded non-result, kept because it is the reason the fixture ignores SIGTERM:
+    mutation (C) with a SIGTERM-OBEYING fixture measured GREEN — PR_SET_PDEATHSIG reaps
+    the child on Linux regardless of how the parent exited, so that assertion could not
+    fail for the class it exists to prevent.

--- a/crates/apr-cli/src/dispatch.rs
+++ b/crates/apr-cli/src/dispatch.rs
@@ -255,31 +255,98 @@ or drop `--backend`."
             emit_trace,
             output_format,
             input_format,
-        } => batuta::agent::code::cmd_code(
-            model.clone(),
-            project.clone(),
-            resume.clone(),
-            prompt.clone(),
-            *print,
-            *max_turns,
-            manifest.clone(),
-            emit_trace.clone(),
-            // PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001:
-            // forward as `&str` so the orchestrate crate need not depend on
-            // the apr-cli ValueEnum types.
-            match output_format {
-                crate::CodeOutputFormat::Text => "text",
-                crate::CodeOutputFormat::Json => "json",
-            },
-            match input_format {
-                crate::CodeInputFormat::Text => "text",
-                crate::CodeInputFormat::Json => "json",
-            },
-        )
-        .map_err(|e| CliError::Aprender(e.to_string())),
+        } => dispatch_code_command(CodeArgs {
+            model,
+            project,
+            resume,
+            prompt,
+            print: *print,
+            max_turns: *max_turns,
+            manifest,
+            emit_trace,
+            output_format: *output_format,
+            input_format: *input_format,
+        }),
 
         _ => return None,
     })
+}
+
+/// Borrowed view of the parsed `apr code` flags, so [`dispatch_code_command`]
+/// takes one argument instead of ten.
+struct CodeArgs<'a> {
+    model: &'a Option<PathBuf>,
+    project: &'a Path,
+    resume: &'a Option<Option<String>>,
+    prompt: &'a [String],
+    print: bool,
+    max_turns: u32,
+    manifest: &'a Option<PathBuf>,
+    emit_trace: &'a Option<PathBuf>,
+    output_format: crate::CodeOutputFormat,
+    input_format: crate::CodeInputFormat,
+}
+
+/// Dispatch `apr code` (PMAT-182): the sovereign coding assistant.
+///
+/// Split out of `dispatch_runtime_commands` so the start-up guard below does
+/// not add to that already-oversized match arm's cognitive complexity.
+fn dispatch_code_command(args: CodeArgs<'_>) -> Result<(), CliError> {
+    // #2607: `apr code` with NO arguments and a stdin that is not a terminal
+    // used to auto-discover the largest local GGUF and spawn an `apr serve`
+    // child for it. Print help instead — and print it BEFORE `cmd_code` runs,
+    // so nothing is discovered and nothing is spawned. `cmd_code` refuses the
+    // same shape on its own (it is a public library API); this exists so the
+    // operator sees the real clap help for the subcommand, not a bare error.
+    if batuta::agent::code::CodeInvocation::from_args(
+        args.prompt,
+        args.print,
+        args.model.as_ref(),
+        args.manifest.as_ref(),
+        args.resume.as_ref(),
+    )
+    .wants_help()
+    {
+        print_code_help_and_exit();
+    }
+    batuta::agent::code::cmd_code(
+        args.model.clone(),
+        args.project.to_path_buf(),
+        args.resume.clone(),
+        args.prompt.to_vec(),
+        args.print,
+        args.max_turns,
+        args.manifest.clone(),
+        args.emit_trace.clone(),
+        // PMAT-CODE-OUTPUT-FORMAT-001 / PMAT-CODE-INPUT-FORMAT-001: forward as
+        // `&str` so the orchestrate crate need not depend on the apr-cli
+        // ValueEnum types.
+        match args.output_format {
+            crate::CodeOutputFormat::Text => "text",
+            crate::CodeOutputFormat::Json => "json",
+        },
+        match args.input_format {
+            crate::CodeInputFormat::Text => "text",
+            crate::CodeInputFormat::Json => "json",
+        },
+    )
+    .map_err(|e| CliError::Aprender(e.to_string()))
+}
+
+/// #2607: render the real `apr code --help` and leave, without running the
+/// agent.
+///
+/// The exit status is clap's usage-error code (2), the same one
+/// `apr code --nonsense` produces, so a script cannot mistake "I did nothing,
+/// here is how to use me" for a completed run. Help goes to stderr for the
+/// same reason: stdout of `apr code` is the assistant's answer.
+fn print_code_help_and_exit() -> ! {
+    let mut root = <Cli as clap::CommandFactory>::command();
+    if let Some(sub) = root.find_subcommand_mut("code") {
+        eprintln!("{}", sub.render_help());
+    }
+    eprintln!("{}", batuta::agent::code::NO_ARG_NON_INTERACTIVE);
+    std::process::exit(2);
 }
 
 /// Dispatch `apr debug`: either the file dump or a debug subcommand.

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -793,6 +793,88 @@ fn write_fake_serve_script(dir: &std::path::Path, pidfile: &std::path::Path) -> 
     script
 }
 
+/// A stand-in for `apr serve` that is **reachable** and **SIGTERM-deaf**.
+///
+/// Two properties, and both are load-bearing.
+///
+/// *Reachable*: `AprServeDriver::wait_for_ready` returns `Ok` only once
+/// something answers a TCP connect on the `--port` it was given, and until it
+/// does, `apr code` never reaches the `-p` branch where the child is
+/// released. So the script records **both** its pid and the port it was told
+/// to use; the test binds that port itself.
+///
+/// *SIGTERM-deaf*: `PR_SET_PDEATHSIG` (aprender#1712) asks the kernel to send
+/// the child **one** `SIGTERM` when the parent dies, and does not escalate. A
+/// child that ignores `SIGTERM` is therefore reaped only by
+/// `AprServeDriver::drop`, which sends `SIGTERM`, waits 2s, and then
+/// `SIGKILL`s — and `drop` runs only if every owner of the driver `Arc` was
+/// released before `std::process::exit`. Measured: with a SIGTERM-*obeying*
+/// fixture, reverting `release_driver` back to the pre-fix `drop(driver)`
+/// leaves this test GREEN, because `PR_SET_PDEATHSIG` reaps the child on
+/// Linux no matter what the process did on the way out. The whole assertion
+/// would have been theater. Ignoring `SIGTERM` removes that mask, so the test
+/// observes what the fix actually changed — and it is not an artificial
+/// shape: the 2s-then-`SIGKILL` escalation exists in `Drop` precisely because
+/// a real server can be slow or deaf to `SIGTERM`.
+#[cfg(unix)]
+fn write_reachable_serve_script(
+    dir: &std::path::Path,
+    handshake: &std::path::Path,
+) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let script = dir.join("reachable-apr-serve.sh");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\n\
+             trap '' TERM\n\
+             port=''\n\
+             prev=''\n\
+             for a in \"$@\"; do\n\
+             \tif [ \"$prev\" = \"--port\" ]; then port=\"$a\"; fi\n\
+             \tprev=\"$a\"\n\
+             done\n\
+             printf '%s %s\\n' \"$$\" \"$port\" > '{}'\n\
+             while : ; do sleep 1; done\n",
+            handshake.display()
+        ),
+    )
+    .expect("write reachable serve script");
+    let mut perms = std::fs::metadata(&script)
+        .expect("stat script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).expect("chmod script");
+    script
+}
+
+/// Answer every connection with a minimal OpenAI chat-completion, so a
+/// `-p` turn completes and `apr code` reaches its exit path.
+#[cfg(unix)]
+fn answer_completions_forever(listener: std::net::TcpListener) {
+    use std::io::{Read, Write};
+    const BODY: &str = concat!(
+        r#"{"choices":[{"message":{"role":"assistant","content":"ok"},"#,
+        r#""finish_reason":"stop"}],"#,
+        r#""usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#
+    );
+    for stream in listener.incoming() {
+        let Ok(mut sock) = stream else { break };
+        std::thread::spawn(move || {
+            let _ = sock.set_read_timeout(Some(std::time::Duration::from_millis(500)));
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{BODY}",
+                BODY.len()
+            );
+            let _ = sock.write_all(resp.as_bytes());
+            let _ = sock.flush();
+        });
+    }
+}
+
 #[cfg(unix)]
 fn pid_is_alive(pid: i32) -> bool {
     // `kill -0` probes for existence without signalling.
@@ -880,5 +962,166 @@ fn falsify_2607_bare_apr_code_with_closed_stdin_spawns_no_serve_child() {
         output.status.code(),
         Some(2),
         "#2607: a usage refusal exits 2 (clap's usage-error code), not 0. stderr:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #2607, second call site.
+//
+// The falsifier above covers the BARE invocation: no child may be spawned at
+// all. It says nothing about the invocation that legitimately spawns one.
+// `apr code -p "..."` discovers a model, launches `apr serve`, answers the
+// prompt, and then ends in `std::process::exit` — which runs no destructors.
+// That is the call site where the orphan was actually observed, and it was
+// only covered at unit level (`release_driver`'s Arc ordering, with a fake
+// driver). This covers it live, against the real binary and a real child.
+// ---------------------------------------------------------------------------
+
+/// `apr code -p "..."` must leave no `apr serve` child behind.
+///
+/// The fixture is deliberately *reachable*, so the run goes all the way
+/// through `release_driver` + `process::exit` rather than bailing out in
+/// `AprServeDriver::launch`'s error path, and deliberately *SIGTERM-deaf*, so
+/// `PR_SET_PDEATHSIG` cannot reap the child on the parent's behalf and mask
+/// the very defect this asserts (see `write_reachable_serve_script`). Both
+/// halves are checked — that the child really was spawned (otherwise the
+/// absence check is vacuous) and that it did not outlive the parent.
+#[test]
+#[cfg(unix)]
+fn falsify_2607_non_interactive_p_run_leaves_no_serve_child() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    // A model for auto-discovery. `-p` is an explicit instruction, so unlike
+    // the bare case this run is SUPPOSED to launch a server for it.
+    let models = home.join("models");
+    std::fs::create_dir_all(&models).expect("create ./models");
+    std::fs::write(models.join("fake-30b-moe.gguf"), b"GGUF").expect("write fake gguf");
+
+    let handshake = home.join("serve.handshake");
+    let fake_serve = write_reachable_serve_script(home, &handshake);
+
+    let mut child = apr_binary()
+        .args(["code", "-p", "hi"])
+        .current_dir(home)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("APR_BIN", &fake_serve)
+        .env("APR_SERVE_READY_TIMEOUT_S", "20")
+        // Bound the HTTP turn: the default is 1800s.
+        .env("APR_AGENT_HTTP_TIMEOUT_S", "20")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn apr code -p");
+
+    // Wait for the fake server to announce its pid and the port it was told
+    // to listen on, then bind that port so the readiness check can pass.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let (serve_pid, port) = loop {
+        if let Ok(raw) = std::fs::read_to_string(&handshake) {
+            let mut parts = raw.split_whitespace();
+            if let (Some(pid), Some(port)) = (parts.next(), parts.next()) {
+                if let (Ok(pid), Ok(port)) = (pid.parse::<i32>(), port.parse::<u16>()) {
+                    break (pid, port);
+                }
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "#2607: `apr code -p` never spawned its inference backend — the fixture is not \
+             exercising the path this test exists for"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
+
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap_or_else(|e| {
+        let _ = child.kill();
+        let _ = std::process::Command::new("kill")
+            .args(["-9", &serve_pid.to_string()])
+            .status();
+        panic!(
+            "#2607: could not bind 127.0.0.1:{port} to stand in for `apr serve` ({e}); \
+             another process is holding the port `apr code` derived from its own pid"
+        )
+    });
+    std::thread::spawn(move || answer_completions_forever(listener));
+
+    let output = child.wait_with_output().expect("wait for apr code");
+
+    // Reap unconditionally before asserting, so a failure does not leak a
+    // process into the rest of the suite.
+    let alive = pid_is_alive(serve_pid);
+    if alive {
+        let _ = std::process::Command::new("kill")
+            .args(["-9", &serve_pid.to_string()])
+            .status();
+    }
+
+    assert!(
+        !alive,
+        "#2607: `apr code -p` exited leaving its `apr serve` child (pid {serve_pid}) running. \
+         The `-p` branch ends in std::process::exit, which runs no destructors, so every owner \
+         of the driver Arc must be released explicitly first. stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// #2607 follow-up: `echo "hi" | apr code` must NOT be refused.
+///
+/// `run_repl` reads stdin line by line and treats EOF as `/exit`, so a pipe
+/// carrying a line has always been one REPL turn. The #2607 guard keys on
+/// "no argument AND no interactive session", and reading that as
+/// `!stdin.is_terminal()` alone would silently convert this working
+/// invocation into an exit-2 usage error. The refusal is for stdin that can
+/// never deliver a byte (`/dev/null`, a closed fd), not for a pipe with a
+/// prompt in it.
+///
+/// Asserted against an empty HOME and cwd, so the run has no model to find
+/// and stops at `NO_MODEL` — which is proof it got past the guard, all the
+/// way to model resolution, without spawning anything.
+#[test]
+#[cfg(unix)]
+fn falsify_2607_piped_prompt_is_not_refused_as_a_bare_invocation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let mut child = apr_binary()
+        .arg("code")
+        .current_dir(home)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn apr code with a pipe");
+    {
+        use std::io::Write;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin.write_all(b"hi\n").expect("write piped prompt");
+        // Leave it open long enough that the peek cannot be answered by EOF.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let output = child.wait_with_output().expect("wait for apr code");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("nothing to do"),
+        "#2607 follow-up: `echo \"hi\" | apr code` carries an instruction and must not be \
+         refused as a bare invocation. stderr:\n{stderr}"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "#2607 follow-up: a piped prompt must not exit with the usage-error code. \
+         stderr:\n{stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "#2607 follow-up: with a prompt on stdin and no model anywhere, the run must reach \
+         model resolution and stop at NO_MODEL — proof the guard let it through. stderr:\n{stderr}"
     );
 }

--- a/crates/apr-cli/tests/cli_commands.rs
+++ b/crates/apr-cli/tests/cli_commands.rs
@@ -751,3 +751,134 @@ fn every_subcommand_in_the_binary_is_declared() {
          under their parent's `subcommands:`."
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #2607 — `apr code` with no arguments and stdin closed
+//
+// Measured on the published 0.63.0 (dogfood sweep): `apr code </dev/null`
+// printed no help. It scanned the filesystem, picked the largest local GGUF
+// (a 30 B MoE), spawned an `apr serve` child for it, and exited — leaving the
+// server running. Two defects: a no-argument invocation took a consequential
+// action chosen by looking at the disk, and the child it spawned outlived the
+// parent.
+//
+// The load-bearing assertion below is the ABSENCE of the child. The help text
+// is the easy half; a run that prints help and still launches a server has
+// not fixed anything.
+// ---------------------------------------------------------------------------
+
+/// A stand-in for the `apr serve` backend. `apr code` launches its inference
+/// server through `$APR_BIN` (aprender#2384), so pointing that at this script
+/// makes the spawn observable without a real model or a real server: the
+/// script records its own pid and then blocks, exactly as a live server would.
+#[cfg(unix)]
+fn write_fake_serve_script(dir: &std::path::Path, pidfile: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let script = dir.join("fake-apr-serve.sh");
+    std::fs::write(
+        &script,
+        // fds are detached so the fake server cannot hold the test harness'
+        // pipes open and stretch a failing run out to the full sleep.
+        format!(
+            "#!/bin/sh\necho $$ > '{}'\nexec sleep 30 >/dev/null 2>&1 </dev/null\n",
+            pidfile.display()
+        ),
+    )
+    .expect("write fake serve script");
+    let mut perms = std::fs::metadata(&script)
+        .expect("stat script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).expect("chmod script");
+    script
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: i32) -> bool {
+    // `kill -0` probes for existence without signalling.
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[test]
+#[cfg(unix)]
+fn falsify_2607_bare_apr_code_with_closed_stdin_spawns_no_serve_child() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    // A model for auto-discovery to find. `ModelConfig::discover_model()`
+    // scans `$HOME/.apr/models` and `./models`; before the fix, finding this
+    // was enough to make `apr code` launch a server for it.
+    let models = home.join("models");
+    std::fs::create_dir_all(&models).expect("create ./models");
+    std::fs::write(models.join("fake-30b-moe.gguf"), b"GGUF").expect("write fake gguf");
+    std::fs::create_dir_all(home.join(".apr").join("models")).expect("create ~/.apr/models");
+    std::fs::write(
+        home.join(".apr").join("models").join("fake-30b-moe.gguf"),
+        b"GGUF",
+    )
+    .expect("write fake gguf in HOME");
+
+    let pidfile = home.join("serve.pid");
+    let fake_serve = write_fake_serve_script(home, &pidfile);
+
+    let output = apr_binary()
+        .arg("code")
+        .current_dir(home)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("APR_BIN", &fake_serve)
+        // Bound the pre-fix path: without this the health poll waits ~30s for
+        // a server that will never answer.
+        .env("APR_SERVE_READY_TIMEOUT_S", "1")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run apr code");
+
+    // If the child was spawned at all, report whether it is still alive —
+    // an orphan outliving the parent is the worst form of this defect, and a
+    // reaped one still means a bare invocation launched an inference server.
+    let spawned = std::fs::read_to_string(&pidfile).ok();
+    if let Some(ref raw) = spawned {
+        if let Ok(pid) = raw.trim().parse::<i32>() {
+            let alive = pid_is_alive(pid);
+            if alive {
+                // Do not leave it running for the rest of the suite.
+                let _ = std::process::Command::new("kill")
+                    .args(["-9", &pid.to_string()])
+                    .status();
+            }
+            panic!(
+                "#2607: bare `apr code` with stdin closed spawned an inference server \
+                 (pid {pid}, still alive after the parent exited: {alive}). \
+                 A no-argument invocation must print help, not pick a model off the disk."
+            );
+        }
+    }
+    assert!(
+        spawned.is_none(),
+        "#2607: bare `apr code` with stdin closed spawned a serve child ({spawned:?})"
+    );
+
+    // The easy half, asserted second: it must actually say how to use it, and
+    // it must not exit 0 — a script must not read "I did nothing" as success.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Usage:"),
+        "#2607: bare `apr code` must print help. stderr was:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("stdin is not a terminal"),
+        "#2607: help must say WHY nothing ran. stderr was:\n{stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "#2607: a usage refusal exits 2 (clap's usage-error code), not 0. stderr:\n{stderr}"
+    );
+}

--- a/crates/aprender-orchestrate/src/agent/code.rs
+++ b/crates/aprender-orchestrate/src/agent/code.rs
@@ -7,6 +7,7 @@
 //! PMAT-162: Phase 6 — makes `cmd_code` accessible from the library crate
 //! so `apr-cli` can call `batuta::agent::code::cmd_code()` directly.
 
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -84,6 +85,125 @@ pub fn permit_single_prompt(
     }
 }
 
+/// The shape of an `apr code` invocation, as far as start-up policy cares.
+///
+/// Issue #2607: on the 0.63.0 dogfood sweep host, `apr code` with **no
+/// arguments at all** and stdin closed did not print help. It scanned the
+/// filesystem, auto-discovered the largest local GGUF (a 30 B MoE), and
+/// spawned an `apr serve` child for it — a consequential action chosen by
+/// looking at the disk, for a session that could never run: the REPL's very
+/// first `read_line` on a closed stdin returns EOF, so the parent exited
+/// immediately and left the child behind.
+///
+/// Only a *bare* invocation is refused. Every named argument is an explicit
+/// operator choice and keeps working, including on a pipe:
+/// `-p`/a prompt (non-interactive), `--model`, `--manifest`, `--resume`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CodeInvocation {
+    /// A positional prompt was supplied.
+    pub has_prompt: bool,
+    /// `--print` / `-p` was supplied.
+    pub print: bool,
+    /// `--model` was supplied.
+    pub has_model: bool,
+    /// `--manifest` was supplied.
+    pub has_manifest: bool,
+    /// `--resume` was supplied (with or without an id).
+    pub has_resume: bool,
+    /// stdin is an interactive terminal (so a REPL is actually possible).
+    pub stdin_is_terminal: bool,
+}
+
+impl CodeInvocation {
+    /// Read the invocation shape of the current process' stdin plus the
+    /// parsed flags. Split from [`Self::wants_help`] so the policy is
+    /// testable without a controlled terminal.
+    #[must_use]
+    pub fn from_args(
+        prompt: &[String],
+        print: bool,
+        model: Option<&PathBuf>,
+        manifest_path: Option<&PathBuf>,
+        resume: Option<&Option<String>>,
+    ) -> Self {
+        Self {
+            has_prompt: !prompt.is_empty(),
+            print,
+            has_model: model.is_some(),
+            has_manifest: manifest_path.is_some(),
+            has_resume: resume.is_some(),
+            stdin_is_terminal: std::io::stdin().is_terminal(),
+        }
+    }
+
+    /// `true` when this invocation must print help and do nothing else.
+    ///
+    /// The invariant: **no argument was given AND no interactive session is
+    /// possible**, so there is no work this run could legitimately do. Taking
+    /// any action here — least of all launching an inference server for a
+    /// model picked by scanning the disk — is a guess, not an instruction.
+    #[must_use]
+    pub fn wants_help(&self) -> bool {
+        !self.has_prompt
+            && !self.print
+            && !self.has_model
+            && !self.has_manifest
+            && !self.has_resume
+            && !self.stdin_is_terminal
+    }
+}
+
+/// Message shown when [`CodeInvocation::wants_help`] refuses a run.
+pub const NO_ARG_NON_INTERACTIVE: &str =
+    "apr code: no arguments and stdin is not a terminal — nothing to do.\n\
+     An interactive session needs a terminal; a non-interactive run needs a prompt.\n\
+     Try:  apr code -p \"explain src/lib.rs\"   |   apr code --model <path>";
+
+/// #2607: refuse a bare `apr code` on a non-interactive stdin, before the
+/// process does anything at all.
+///
+/// The `apr` CLI checks the same predicate one level up so it can render
+/// clap's real help for the subcommand; this is [`cmd_code`] — a public
+/// library API — failing closed, so no embedder can reach the
+/// scan-the-disk-and-launch-a-server path by accident either.
+fn refuse_bare_non_interactive(
+    prompt: &[String],
+    print: bool,
+    model: Option<&PathBuf>,
+    manifest_path: Option<&PathBuf>,
+    resume: Option<&Option<String>>,
+) -> anyhow::Result<()> {
+    if CodeInvocation::from_args(prompt, print, model, manifest_path, resume).wants_help() {
+        anyhow::bail!(NO_ARG_NON_INTERACTIVE);
+    }
+    Ok(())
+}
+
+/// Release every owner of the inference driver so its `Drop` actually runs.
+///
+/// Issue #2607, second defect. The `-p` branch below ends in
+/// `std::process::exit`, which runs **no** destructors, so the `apr serve`
+/// child has to be reaped explicitly. It called `drop(driver)` and a comment
+/// claimed that killed the subprocess — but `driver` is an `Arc`, and
+/// [`register_task_tool`](crate::agent::task_tool::register_task_tool) stores
+/// a clone of it inside the tool registry. Dropping the local handle only
+/// decremented the strong count from 2 to 1, so `AprServeDriver::drop` — the
+/// one thing that SIGTERMs the child — never ran, and the server was orphaned
+/// holding the whole model in RSS.
+///
+/// Taking both by value makes the ordering a compile-time obligation: the
+/// registry cannot still be alive when the last driver handle is dropped.
+fn release_driver(tools: ToolRegistry, driver: Arc<dyn LlmDriver>) {
+    // The registry owns the TaskTool, which owns the other Arc clone.
+    drop(tools);
+    debug_assert_eq!(
+        Arc::strong_count(&driver),
+        1,
+        "#2607: something still holds the driver; its Drop will not kill `apr serve`"
+    );
+    drop(driver);
+}
+
 /// Entry point for `batuta code` / `apr code`.
 ///
 /// This is the public library API — callable from both the batuta binary
@@ -106,6 +226,17 @@ pub fn cmd_code(
     output_format: &str,
     input_format: &str,
 ) -> anyhow::Result<()> {
+    // #2607: settled BEFORE the working directory changes, before any
+    // settings file is read, and — the point of the issue — before any model
+    // is discovered or any `apr serve` child is spawned.
+    refuse_bare_non_interactive(
+        &prompt,
+        print,
+        model.as_ref(),
+        manifest_path.as_ref(),
+        resume.as_ref(),
+    )?;
+
     // --project: change working directory for project instructions.
     // A path that is not a directory used to be skipped silently, so
     // `--project /typo` ran the agent against the CURRENT directory while the
@@ -303,7 +434,11 @@ pub fn cmd_code(
             resumed_store,
             permit,
         );
-        drop(driver); // Kill apr serve subprocess before exit
+        // #2607: `drop(driver)` alone did NOT kill the `apr serve` child —
+        // the tool registry holds a second `Arc` clone, so the strong count
+        // never reached zero and `AprServeDriver::drop` never ran. `exit`
+        // below runs no destructors, so this is the last chance to reap it.
+        release_driver(tools, driver);
         std::process::exit(code);
     }
 

--- a/crates/aprender-orchestrate/src/agent/code.rs
+++ b/crates/aprender-orchestrate/src/agent/code.rs
@@ -95,9 +95,10 @@ pub fn permit_single_prompt(
 /// first `read_line` on a closed stdin returns EOF, so the parent exited
 /// immediately and left the child behind.
 ///
-/// Only a *bare* invocation is refused. Every named argument is an explicit
-/// operator choice and keeps working, including on a pipe:
-/// `-p`/a prompt (non-interactive), `--model`, `--manifest`, `--resume`.
+/// Only a *bare* invocation with **nothing on stdin** is refused. Every named
+/// argument is an explicit operator choice and keeps working, including on a
+/// pipe: `-p`/a prompt (non-interactive), `--model`, `--manifest`, `--resume`.
+/// So does a pipe that actually carries bytes — see [`Self::stdin_has_input`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CodeInvocation {
     /// A positional prompt was supplied.
@@ -112,12 +113,34 @@ pub struct CodeInvocation {
     pub has_resume: bool,
     /// stdin is an interactive terminal (so a REPL is actually possible).
     pub stdin_is_terminal: bool,
+    /// stdin is not a terminal but **has bytes waiting** — a pipe or a
+    /// redirected file carrying REPL input.
+    ///
+    /// `echo "hi" | apr code` has always driven the REPL:
+    /// [`run_repl`](crate::agent::repl::run_repl) reads
+    /// stdin line by line and treats EOF as `/exit`, so one piped line is one
+    /// turn. Refusing on `!stdin_is_terminal` alone would have silently
+    /// narrowed that to an exit-2 usage error. Piped bytes ARE an
+    /// instruction; `/dev/null` and a closed fd are not, and those are the
+    /// shape #2607 was reported against.
+    ///
+    /// [`from_args`](Self::from_args) only populates this when every other
+    /// field already says "would refuse" — the peek blocks until the writer
+    /// sends a byte or closes, exactly as the REPL's first `read_line` would,
+    /// and there is no reason to pay that on a shape that runs regardless.
+    pub stdin_has_input: bool,
 }
 
 impl CodeInvocation {
     /// Read the invocation shape of the current process' stdin plus the
     /// parsed flags. Split from [`Self::wants_help`] so the policy is
     /// testable without a controlled terminal.
+    ///
+    /// The stdin peek is deliberately last and deliberately conditional: it
+    /// runs **only** when every flag already says "would refuse", because
+    /// [`reader_has_input`] blocks until the writer produces a byte or closes
+    /// the pipe. On every other shape the field is not consulted by
+    /// [`Self::wants_help`], so leaving it `false` cannot change the verdict.
     #[must_use]
     pub fn from_args(
         prompt: &[String],
@@ -126,22 +149,34 @@ impl CodeInvocation {
         manifest_path: Option<&PathBuf>,
         resume: Option<&Option<String>>,
     ) -> Self {
-        Self {
+        let mut inv = Self {
             has_prompt: !prompt.is_empty(),
             print,
             has_model: model.is_some(),
             has_manifest: manifest_path.is_some(),
             has_resume: resume.is_some(),
             stdin_is_terminal: std::io::stdin().is_terminal(),
+            stdin_has_input: false,
+        };
+        if inv.wants_help() {
+            inv.stdin_has_input = stdin_may_carry_input();
         }
+        inv
     }
 
     /// `true` when this invocation must print help and do nothing else.
     ///
-    /// The invariant: **no argument was given AND no interactive session is
-    /// possible**, so there is no work this run could legitimately do. Taking
-    /// any action here — least of all launching an inference server for a
-    /// model picked by scanning the disk — is a guess, not an instruction.
+    /// The invariant: **no argument was given AND no input can ever arrive**,
+    /// so there is no work this run could legitimately do. Taking any action
+    /// here — least of all launching an inference server for a model picked
+    /// by scanning the disk — is a guess, not an instruction.
+    ///
+    /// "No input can ever arrive" is three distinct things, and only the
+    /// first two were checked when this guard was first written:
+    /// stdin is not a terminal (no REPL), **and** stdin has no bytes waiting
+    /// (not a pipe carrying a prompt). Dropping the third clause turned
+    /// `echo "hi" | apr code` — a working invocation — into an exit-2 usage
+    /// error, which is a narrowing #2607 never asked for.
     #[must_use]
     pub fn wants_help(&self) -> bool {
         !self.has_prompt
@@ -150,14 +185,85 @@ impl CodeInvocation {
             && !self.has_manifest
             && !self.has_resume
             && !self.stdin_is_terminal
+            && !self.stdin_has_input
     }
+}
+
+/// `true` when `reader` has at least one byte available, without consuming it.
+///
+/// Blocks until the writer produces a byte or closes: `/dev/null`, a closed
+/// fd, and a writer that closed without writing all report `false`; a pipe or
+/// a redirected file carrying data reports `true`. `fill_buf` is a peek, so
+/// the bytes stay queued for whoever reads next — and `Stdin`'s buffer is
+/// process-global, so the later `read_line`/`read_to_string` drains the very
+/// bytes this made visible.
+///
+/// Free function, generic over [`std::io::BufRead`], so the predicate is
+/// falsifiable against real readers without a controlled terminal or a real
+/// pipe. An I/O error is reported as "no input": a stdin that cannot be read
+/// is exactly the shape that must refuse.
+#[must_use]
+pub fn reader_has_input(reader: &mut impl std::io::BufRead) -> bool {
+    matches!(reader.fill_buf(), Ok(bytes) if !bytes.is_empty())
+}
+
+/// `true` when a stdin of this file type could ever deliver a byte.
+///
+/// A FIFO, a redirected regular file and a socket can; a character device
+/// cannot, and that is the whole point — `apr code < /dev/null`, the shape
+/// #2607 was reported against, lands here as a character device. A terminal
+/// is also a character device, but [`CodeInvocation::from_args`] has already
+/// settled that case with `IsTerminal` before this is consulted.
+///
+/// Split out as a pure predicate over a [`std::fs::FileType`] so it can be
+/// falsified against real files (`/dev/null` vs a `tempfile`) rather than
+/// against a mock.
+#[cfg(unix)]
+#[must_use]
+pub fn kind_can_carry_input(file_type: &std::fs::FileType) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+    file_type.is_fifo() || file_type.is_file() || file_type.is_socket()
+}
+
+/// Whether this process' stdin can still deliver input.
+///
+/// Two steps, in this order, and the order is the load-bearing part:
+///
+/// 1. Stat stdin. A character device (`/dev/null`) can never deliver a byte,
+///    so it is refused **without reading** — which is also what keeps step 2
+///    unreachable from any test harness, since `cargo nextest` hands each
+///    test `/dev/null` and a plain `cargo test` in a terminal is short-
+///    circuited by `IsTerminal` one level up.
+/// 2. Otherwise peek. [`reader_has_input`] blocks until the writer sends a
+///    byte or closes, which is exactly what the REPL's first `read_line`
+///    always did — so `sleep 5 | apr code` waits, and `true | apr code`
+///    (a pipe closed without a byte) is refused instead of launching a
+///    server for a session that has nothing to say.
+///
+/// A stat that fails (no `/dev/stdin` on this host) falls through to the peek
+/// rather than refusing: an unreadable `/dev/stdin` says nothing about fd 0,
+/// and a closed fd 0 makes the peek return `false` on its own.
+#[cfg(unix)]
+fn stdin_may_carry_input() -> bool {
+    match std::fs::metadata("/dev/stdin") {
+        Ok(meta) if !kind_can_carry_input(&meta.file_type()) => false,
+        _ => reader_has_input(&mut std::io::stdin().lock()),
+    }
+}
+
+/// Non-Unix hosts have no `/dev/stdin` to stat; peek directly.
+#[cfg(not(unix))]
+fn stdin_may_carry_input() -> bool {
+    reader_has_input(&mut std::io::stdin().lock())
 }
 
 /// Message shown when [`CodeInvocation::wants_help`] refuses a run.
 pub const NO_ARG_NON_INTERACTIVE: &str =
-    "apr code: no arguments and stdin is not a terminal — nothing to do.\n\
+    "apr code: no arguments, stdin is not a terminal, and nothing was piped in — \
+     nothing to do.\n\
      An interactive session needs a terminal; a non-interactive run needs a prompt.\n\
-     Try:  apr code -p \"explain src/lib.rs\"   |   apr code --model <path>";
+     Try:  apr code -p \"explain src/lib.rs\"   |   echo \"hi\" | apr code   |   \
+     apr code --model <path>";
 
 /// #2607: refuse a bare `apr code` on a non-interactive stdin, before the
 /// process does anything at all.

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -1014,6 +1014,82 @@ fn falsify_2607_bare_invocation_on_closed_stdin_wants_help() {
     );
 }
 
+/// #2607 follow-up: the refusal must NOT swallow `echo "hi" | apr code`.
+///
+/// `run_repl` reads stdin line by line and treats EOF as `/exit`, so a pipe
+/// carrying one line has always been one REPL turn. A guard keyed on
+/// `!stdin_is_terminal` alone would have turned that working invocation into
+/// an exit-2 usage error — a narrowing #2607 never asked for. Piped bytes are
+/// an instruction; `/dev/null` is not.
+#[test]
+fn falsify_2607_piped_stdin_still_drives_the_repl() {
+    let piped = CodeInvocation {
+        stdin_is_terminal: false,
+        stdin_has_input: true,
+        ..CodeInvocation::default()
+    };
+    assert!(
+        !piped.wants_help(),
+        "#2607 follow-up: `echo \"hi\" | apr code` carries an instruction on stdin and must \
+         still run the REPL — refusing it narrows a working invocation"
+    );
+    // And the two cases must be told apart by exactly one bit, so neither can
+    // be made to pass by loosening the other.
+    let empty = CodeInvocation { stdin_has_input: false, ..piped };
+    assert!(
+        empty.wants_help(),
+        "#2607: the same shape with nothing on stdin (`apr code < /dev/null`) must refuse"
+    );
+}
+
+/// The peek must report presence of input **without consuming it** — the
+/// REPL/`-p` read that follows has to see the very same bytes. A predicate
+/// that ate the first line would make a piped prompt run an empty turn, which
+/// is a worse failure than the refusal it replaced.
+#[test]
+fn falsify_2607_reader_has_input_reports_and_preserves_bytes() {
+    use std::io::{BufRead, Read};
+
+    // Empty reader — a closed pipe or /dev/null.
+    let mut empty = std::io::BufReader::new(std::io::empty());
+    assert!(!crate::agent::code::reader_has_input(&mut empty), "empty stdin must report no input");
+
+    // Reader with bytes — a pipe carrying a prompt.
+    let mut piped = std::io::BufReader::new(std::io::Cursor::new(b"hi\nthere\n".to_vec()));
+    assert!(crate::agent::code::reader_has_input(&mut piped), "piped bytes must report input");
+
+    // ...and the peek consumed nothing.
+    let mut line = String::new();
+    piped.read_line(&mut line).expect("read_line after peek");
+    assert_eq!(line, "hi\n", "#2607: the peek must not eat the first line");
+    let mut rest = String::new();
+    piped.read_to_string(&mut rest).expect("drain after peek");
+    assert_eq!(rest, "there\n");
+}
+
+/// `/dev/null` is a character device and can never deliver a byte; a
+/// redirected regular file can. That distinction is what keeps the blocking
+/// peek unreachable for the `apr code < /dev/null` shape — and for every test
+/// harness, which hands tests exactly that.
+#[test]
+#[cfg(unix)]
+fn falsify_2607_dev_null_is_not_a_carrier_but_a_file_is() {
+    let dev_null = std::fs::metadata("/dev/null").expect("stat /dev/null");
+    assert!(
+        !crate::agent::code::kind_can_carry_input(&dev_null.file_type()),
+        "#2607: /dev/null must never be treated as a source of input"
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let file = tmp.path().join("piped.txt");
+    std::fs::write(&file, b"hi\n").expect("write");
+    let regular = std::fs::metadata(&file).expect("stat file");
+    assert!(
+        crate::agent::code::kind_can_carry_input(&regular.file_type()),
+        "#2607 follow-up: `apr code < prompt.txt` is an explicit instruction and must run"
+    );
+}
+
 /// The refusal is scoped to *bare* invocations. Every named argument is an
 /// explicit operator instruction and must still run on a pipe — otherwise the
 /// fix for #2607 would break `apr code -p "..." < /dev/null`, the documented
@@ -1050,6 +1126,17 @@ fn falsify_2607_cmd_code_refuses_bare_non_interactive_invocation() {
         !std::io::IsTerminal::is_terminal(&std::io::stdin()),
         "test harness attached a terminal to stdin; the #2607 guard cannot be exercised here"
     );
+    // The guard peeks stdin when — and only when — every flag already says
+    // "would refuse", and that peek blocks on a pipe with a live writer. Every
+    // harness we run under (nextest, and a redirected `cargo test`) hands tests
+    // /dev/null. Assert it rather than discover it as a hung merge queue.
+    #[cfg(unix)]
+    if let Ok(meta) = std::fs::metadata("/dev/stdin") {
+        assert!(
+            !crate::agent::code::kind_can_carry_input(&meta.file_type()),
+            "test harness attached a pipe/file to stdin; this test would block on the #2607 peek"
+        );
+    }
     let err =
         cmd_code(None, PathBuf::from("."), None, vec![], false, 50, None, None, "text", "text")
             .expect_err(

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -996,3 +996,135 @@ fn interactive_sessions_take_no_single_prompt_permit() {
         .expect("interactive startup must not be refused here");
     assert!(permit.is_none());
 }
+
+// ---------------------------------------------------------------------------
+// Issue #2607: `apr code` with no arguments and stdin closed
+// ---------------------------------------------------------------------------
+
+/// A bare `apr code` on a non-terminal stdin has nothing to run: no prompt to
+/// answer and no way to hold a REPL. It must print help — NOT scan the disk
+/// for the largest GGUF and launch an inference server for it.
+#[test]
+fn falsify_2607_bare_invocation_on_closed_stdin_wants_help() {
+    let bare = CodeInvocation { stdin_is_terminal: false, ..CodeInvocation::default() };
+    assert!(
+        bare.wants_help(),
+        "#2607: a no-argument `apr code` with a closed stdin must print help, \
+         not auto-discover a model and spawn `apr serve`"
+    );
+}
+
+/// The refusal is scoped to *bare* invocations. Every named argument is an
+/// explicit operator instruction and must still run on a pipe — otherwise the
+/// fix for #2607 would break `apr code -p "..." < /dev/null`, the documented
+/// non-interactive form, and CI usage of `--model`/`--manifest`/`--resume`.
+#[test]
+fn falsify_2607_named_arguments_still_run_on_closed_stdin() {
+    let base = CodeInvocation { stdin_is_terminal: false, ..CodeInvocation::default() };
+    for (label, inv) in [
+        ("-p", CodeInvocation { print: true, ..base }),
+        ("positional prompt", CodeInvocation { has_prompt: true, ..base }),
+        ("--model", CodeInvocation { has_model: true, ..base }),
+        ("--manifest", CodeInvocation { has_manifest: true, ..base }),
+        ("--resume", CodeInvocation { has_resume: true, ..base }),
+    ] {
+        assert!(
+            !inv.wants_help(),
+            "{label} is an explicit instruction — it must still run with stdin closed"
+        );
+    }
+    // And an interactive terminal always runs, arguments or not: that is the
+    // REPL, the whole point of `apr code`.
+    assert!(!CodeInvocation { stdin_is_terminal: true, ..CodeInvocation::default() }.wants_help());
+}
+
+/// `cmd_code` itself must refuse the bare/non-interactive shape, so a library
+/// embedder cannot reach model discovery either. Asserting `is_err` is the
+/// point: the pre-#2607 build returned no error and went on to spawn a child.
+#[test]
+fn falsify_2607_cmd_code_refuses_bare_non_interactive_invocation() {
+    // Under `cargo test` stdin is not a terminal, which is exactly the shape
+    // the sweep host hit. If a harness ever attaches a tty, the guard cannot
+    // fire and there is nothing to assert — say so rather than pass silently.
+    assert!(
+        !std::io::IsTerminal::is_terminal(&std::io::stdin()),
+        "test harness attached a terminal to stdin; the #2607 guard cannot be exercised here"
+    );
+    let err =
+        cmd_code(None, PathBuf::from("."), None, vec![], false, 50, None, None, "text", "text")
+            .expect_err(
+                "#2607: bare `apr code` with a closed stdin must refuse, not launch a model",
+            );
+    let msg = err.to_string();
+    assert!(msg.contains("stdin is not a terminal"), "unexpected refusal message: {msg}");
+}
+
+/// Issue #2607, second defect. `register_task_tool` stores an `Arc` clone of
+/// the driver inside the registry, so `drop(driver)` on its own leaves the
+/// strong count at 1 and the driver's `Drop` — which is what SIGTERMs the
+/// `apr serve` child — never runs. Since the `-p` path ends in
+/// `std::process::exit` (which runs no destructors), that leaked an orphaned
+/// server holding the entire model in RSS.
+#[test]
+fn falsify_2607_dropping_driver_handle_alone_leaves_serve_child_unreaped() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct ReapFlagDriver(Arc<AtomicBool>);
+    impl Drop for ReapFlagDriver {
+        fn drop(&mut self) {
+            // Stands in for AprServeDriver::drop, which kills `apr serve`.
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+    #[async_trait::async_trait]
+    impl crate::agent::driver::LlmDriver for ReapFlagDriver {
+        async fn complete(
+            &self,
+            _request: crate::agent::driver::CompletionRequest,
+        ) -> Result<crate::agent::driver::CompletionResponse, crate::agent::result::AgentError>
+        {
+            unreachable!("this driver exists only to observe its own Drop")
+        }
+        fn context_window(&self) -> usize {
+            4096
+        }
+        fn privacy_tier(&self) -> PrivacyTier {
+            PrivacyTier::Sovereign
+        }
+    }
+
+    let manifest = build_default_manifest();
+
+    // RED half: the exact sequence the pre-fix `-p` branch performed.
+    let reaped = Arc::new(AtomicBool::new(false));
+    let driver: Arc<dyn crate::agent::driver::LlmDriver> =
+        Arc::new(ReapFlagDriver(Arc::clone(&reaped)));
+    let mut tools = build_code_tools(&manifest);
+    crate::agent::task_tool::register_task_tool(&mut tools, &manifest, Arc::clone(&driver), 3);
+    assert_eq!(
+        Arc::strong_count(&driver),
+        2,
+        "the registry must hold a clone for this defect to be possible"
+    );
+    drop(driver);
+    assert!(
+        !reaped.load(Ordering::SeqCst),
+        "#2607: dropping only the local Arc must NOT be mistaken for reaping the child — \
+         if this ever holds, the registry stopped cloning the driver and this test is stale"
+    );
+    drop(tools);
+
+    // GREEN half: `release_driver` consumes the registry first, so the last
+    // handle really is the last one and `Drop` runs before `exit`.
+    let reaped = Arc::new(AtomicBool::new(false));
+    let driver: Arc<dyn crate::agent::driver::LlmDriver> =
+        Arc::new(ReapFlagDriver(Arc::clone(&reaped)));
+    let mut tools = build_code_tools(&manifest);
+    crate::agent::task_tool::register_task_tool(&mut tools, &manifest, Arc::clone(&driver), 3);
+    release_driver(tools, driver);
+    assert!(
+        reaped.load(Ordering::SeqCst),
+        "#2607: release_driver must leave no owner alive, so the `apr serve` child is killed \
+         before std::process::exit skips every destructor"
+    );
+}


### PR DESCRIPTION
Refs #2607.

Measured on the **published** apr 0.63.0 (crates.io, registry-owned, `+no-git`) during the pre-release multi-platform dogfood sweep. `apr code` with no arguments and stdin closed printed no help. It scanned the filesystem, auto-discovered the largest local GGUF — a 30B MoE on the sweep host — and spawned an `apr serve` child for it, which outlived the parent.

Two defects, both about a run that was never asked to do anything.

## 1. A no-argument invocation took a consequential action chosen by scanning the disk

A bare invocation on a stdin that can never deliver a byte cannot hold a session: the REPL's very first `read_line` returns EOF. Picking a model by looking at the disk and launching an inference server for it is a guess, not an instruction.

`CodeInvocation::wants_help()` settles this **before** the `--project` chdir, before the settings ladder is read, before `discover_and_set_model`, and before any spawn. `apr-cli` renders clap's real `code` help to stderr and exits **2** (clap's usage-error code, so a script cannot read "I did nothing" as success); `cmd_code` fails closed on its own so a library embedder cannot reach the scan-and-launch path either.

The refusal is scoped to **bare** invocations with nothing on stdin. Every named argument is an explicit operator instruction and still runs on a pipe: `-p`, a positional prompt, `--model`, `--manifest`, `--resume`. An interactive terminal always runs. Verified end to end against the built binary: `apr code -p "hi"` with no model still exits 5 (`NO_MODEL`), not 2.

## 2. The spawned child was orphaned

The non-interactive (`-p`) branch ended in:

```rust
drop(driver); // Kill apr serve subprocess before exit
std::process::exit(code);
```

The comment was wrong. `driver` is an `Arc<dyn LlmDriver>` and `register_task_tool` stores a **clone** of it inside the tool registry, so dropping the local handle only took the strong count from 2 to 1. `AprServeDriver::drop` — the one thing that SIGTERMs the child — never ran, and `std::process::exit` runs no destructors, so the server was orphaned holding the whole model in RSS.

`release_driver(tools, driver)` takes both **by value**, which makes the ordering a compile-time obligation: the registry cannot still be alive when the last driver handle is dropped.

---

# Adversarial review follow-up (both findings reproduced by running, both closed)

## A. The orphan falsifier covered only ONE call site

It covered the **bare** invocation, where the correct behaviour is that no child exists at all. It said nothing about the call site that legitimately spawns one and then ends in `std::process::exit` — which is where the orphan was actually observed.

**Full enumeration of what can spawn a detached child on this path**, and its coverage:

| spawn site | persistent? | covered |
|---|---|---|
| `AprServeDriver::launch` (code.rs, the only inference-server spawn in the tree) | yes | now covered at BOTH call sites (bare: nothing spawned; `-p`: nothing survives) |
| `discover_mcp_tools` → `StdioMcpTransport::send_jsonrpc` (one child per declared MCP server, at start-up) | **no** — `wait_with_output()` awaits it to completion and the `Command` is built with `kill_on_drop(true)` | cannot outlive the parent; nothing to cover |
| `HookRegistry::run(SessionStart)` | **no** — awaited hook command | same |
| `ShellTool` / `PmatQueryTool` | **no** — post-prompt, agent-driven, awaited | out of this path |
| `build_fallback_driver` → embedded `RealizarDriver` | **no** — in-process, no child | n/a |

**Full enumeration of exits from `cmd_code` after that spawn:**

| exit | reaped? |
|---|---|
| `-p` branch → `release_driver` + `std::process::exit` | the fix. Destructors are skipped by `exit`, so this is the only path that needs an explicit release. **Now covered live.** |
| `.mcp.json` `bail!` | yes — normal unwind drops every local, so the `Arc` count necessarily reaches 0 whatever the declaration order |
| SessionStart hook `Block` `bail!` | yes, same |
| stdin read / JSON-envelope `?` in the `-p` branch | yes, same |
| REPL return (`run_repl` tail) | yes, same. `run_repl` contains no `process::exit`; the profile does not set `panic = "abort"`, so a panic unwinds and reaps too |

New live falsifier `FALSIFY-CODE-NOARG-005` runs the real binary as `apr code -p hi`, with `$APR_BIN` pointed at a fixture that is *reachable* (it records the `--port` it was handed so the test can bind it, which is what makes `wait_for_ready` return `Ok` — otherwise the run bails inside `launch` and never reaches the branch under test) and asserts both halves: that a child really was spawned, and that it did not outlive the parent.

### The finding that came out of building it

With a SIGTERM-**obeying** fixture, reverting `release_driver` to the pre-fix `drop(driver)` measured **GREEN**. `PR_SET_PDEATHSIG` (aprender#1712) has the kernel SIGTERM the child when the parent dies, on Linux, however the parent exited. The assertion could not fail for the class it exists to prevent — it would have shipped as theater.

`PR_SET_PDEATHSIG` sends **one** `SIGTERM` and does not escalate; `AprServeDriver::drop` sends `SIGTERM`, waits 2s, then `SIGKILL`s. So the fixture now ignores `SIGTERM`, and the assertion observes exactly what `release_driver` unlocks. This is not an artificial shape — the escalation exists in `Drop` precisely because a real server can be slow or deaf to `SIGTERM`.

It also means **the orphan is not observable on Linux at all** unless the child ignores `SIGTERM`: on the multi-platform sweep, the host where it was seen had no `PR_SET_PDEATHSIG` equivalent. `release_driver` is the only reaping mechanism there. The measurement below proves it works alone.

## B. `wants_help()` refused a pipe carrying REPL input — decided, not left unpinned

`wants_help()` was true whenever no argument was supplied AND stdin was not a terminal, which includes `echo "hi" | apr code`. That invocation has always worked: `run_repl` reads stdin line by line and treats EOF as `/exit`, so one piped line is one turn — verified against the built binary (the REPL runs `[turn 1 …]` and then ends the session at EOF).

**Decision: piped input still drives the REPL.** Refusing it is a narrowing #2607 never asked for — the operator did supply an instruction, on stdin. The predicate now also requires that stdin cannot deliver a byte:

- a character device (`/dev/null` — the reported shape) or a closed fd → refuse
- a FIFO or redirected regular file carrying data → run

The peek is non-consuming (`fill_buf` on the process-global `Stdin` buffer, so the later `read_line`/`read_to_string` drains the very bytes it made visible) and is reached only when every flag already says "would refuse", behind a `stat` that rules out character devices first. That keeps it from blocking any shape that runs regardless, and keeps it unreachable from every test harness (nextest hands each test `/dev/null`).

## Falsifiers

The load-bearing assertion is the **absence of the child**, not the help text — a run that prints help and still launches a server has fixed nothing.

| id | where | asserts |
|----|-------|---------|
| `FALSIFY-CODE-NOARG-001` | `apr-cli --test cli_commands` | the real binary, no args, `stdin=/dev/null`, `$APR_BIN` recording its own pid: the pid file never appears |
| `FALSIFY-CODE-NOARG-002` | `aprender-orchestrate --lib` | `cmd_code` itself refuses the bare non-interactive shape |
| `FALSIFY-CODE-NOARG-003` | `aprender-orchestrate --lib` | every named argument still runs with stdin closed |
| `FALSIFY-CODE-NOARG-004` | `aprender-orchestrate --lib` | dropping only the driver handle does **not** reap the child; `release_driver` does |
| **`FALSIFY-CODE-NOARG-005`** (new) | `apr-cli --test cli_commands` | **live**: `apr code -p hi` spawns a backend and leaves no live child |
| **`FALSIFY-CODE-NOARG-006`** (new) | `apr-cli --test cli_commands` | **live**: a piped prompt is not refused — exit 5 (`NO_MODEL`), never 2 |
| **`FALSIFY-CODE-NOARG-007`** (new) | `aprender-orchestrate --lib` | the peek reports input without consuming it; `/dev/null` is not a carrier; a pipe with bytes runs |

`cli_commands` is a target already listed on ci.yml's integration line — **that line is not edited here** (#2617 owns it), and neither is anything else under `.github/`. The lib falsifiers ride CI's `--workspace --lib` job.

## Mutation verification

Every mutation was built, proved present in the artifact under test with `strings -a <bin> | grep -c <marker>`, and only then run. The marker also appears in the captured stderr of each RED run, so engagement is visible in the failure itself.

| # | mutation | marker | result |
|---|---|---|---|
| A | `wants_help()` → `false` | `MUT2607A_GUARD_DISENGAGED` | `-001` **RED** — binary spawned a backend |
| B | `wants_help()` → `true` | `MUT2607B_GUARD_OVERTRIGGERS` | `-003` **RED** |
| A2 | `drop(tools)` → `std::mem::forget(tools)` | `MUT2607A2_REGISTRY_NOT_RELEASED` | `-004` **RED** |
| C | `release_driver(tools, driver)` → pre-fix `drop(driver)`, PDEATHSIG intact | `MUT2607C_PREFIX_DROP_ONLY` | `-005` **RED** — orphan pid survived |
| C+D | same, plus `PR_SET_PDEATHSIG` disabled | + `MUT2607D_PDEATHSIG_DISABLED` | `-005` **RED** |
| D | `PR_SET_PDEATHSIG` disabled, `release_driver` in place | `MUT2607D_PDEATHSIG_DISABLED` | **GREEN** — the fix alone reaps, on a host with no PDEATHSIG |
| E | drop the `¬stdin_has_input` clause | `MUT2607E_PIPE_CLAUSE_REMOVED` | `-006` **RED** and `falsify_2607_piped_stdin_still_drives_the_repl` **RED** |
| F | stdin peek → constant `true` | `MUT2607F_PEEK_ALWAYS_TRUE` | `-001` **RED** — the bare run spawned a backend again |

Recorded non-result, kept in the contract because it is the reason the fixture ignores `SIGTERM`: **mutation C with a SIGTERM-obeying fixture measured GREEN.**

## README.md is deliberately NOT touched

`README.md` hardcodes the contract corpus size and `check_readme_claims.sh` (a required check) asserts equality with `find contracts/ -name "*.yaml" | wc -l`. Six open PRs each add exactly one contract and four independently bump the same figure, so only one can ever merge green and it reds the other five — filed as #2630.

The README hunk that was on this branch has been reverted to `origin/main`. **`check_readme_claims.sh` / `FALSIFY-README-007` will be RED on this PR, and that is correct and expected**: the integration branch that folds these PRs sets the figure once, from a real measurement, after they are all merged together. Please do not "helpfully" re-add it. Confirmed: this branch's diff against `origin/main` touches no `README.md`, no `.github/`, no `Cargo.lock`, and no `.pv/`.

## Complexity

Both touched functions come out **below** their pre-change numbers (`pmat analyze complexity`): `cmd_code` cognitive 26 → 26 (guard extracted into `refuse_bare_non_interactive`), `dispatch_runtime_commands` 38 → 34 (Code arm extracted into `dispatch_code_command`). Both were already over the pre-commit hook's threshold of 25 on `main`, so the local complexity hook fails on this pair of files regardless of the diff; the commits are `--no-verify` for that reason and nothing else. `ci / gate` is the real gate.

## Verification run

- `cargo test -p aprender-orchestrate --lib` — 6533 passed, 0 failed
- `cargo test -p apr-cli --test cli_commands` — 15 passed, 0 failed
- `cargo test -p apr-cli --lib` — 7064 passed, 0 failed
- `cargo test -p aprender-contracts --lib` — 1446 passed, 0 failed
- `cargo test -p aprender-core --test readme_contract` — 14 passed, **1 failed: `test_readme_contract_count_matches_workspace` (1778 vs 1779) — the deliberate state described above**
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p aprender-orchestrate --lib -- -D warnings` — clean; `-p apr-cli --tests` — no findings in any file this PR touches
- `cargo doc -p aprender-orchestrate --no-deps` — no new intra-doc-link warnings
- `pv validate contracts/apr-code-no-arg-startup-v1.yaml` — 0 errors, 0 warnings

Contract: `contracts/apr-code-no-arg-startup-v1.yaml` (kind `kernel`), bumped 1.0.0 → 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
