### PR TITLE
fix(release): the facade order gate returned READY for a manifest it could not parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,6 +690,14 @@ jobs:
         run: bash scripts/check_facade_compat.sh --self-test
       - name: provable-contracts 0.3.1 code still compiles against the facades
         run: bash scripts/check_facade_compat.sh
+      # aprender#2628: check_facade_compat.sh proves the facades COMPILE and are
+      # shaped right; it does not touch the cascade's publish-ORDER gate. That
+      # gate read its requirement with a line-shaped sed and returned READY when
+      # it could not parse one, so rewriting a dependency into the equivalent
+      # multi-line table -- which cargo treats as IDENTICAL -- disarmed it
+      # silently and the cascade would upload a facade before its upstream.
+      - name: The cascade's facade order gate arms on every spelling cargo accepts
+        run: bash scripts/check_facade_order_gate.sh
       # aprender#2558: nothing detected two crates declaring the same `[[bin]]
       # name`. FOUR things claimed `pv` -- the crates.io pipe viewer, /usr/bin/pv,
       # aprender-contracts-cli and the provable-contracts-cli facade -- all

--- a/scripts/cascade-publish.sh
+++ b/scripts/cascade-publish.sh
@@ -159,13 +159,86 @@ version_live() {
 # A crate with no `upstream =` line (the lib-only signpost facade, which has no
 # dependencies at all) is ready by construction — that independence is stated in
 # its manifest and is what makes it publishable at any point in the cascade.
+# WHICH FACADES MUST HAVE AN UPSTREAM (aprender#2628).
+#
+# The previous implementation read the requirement with a line-shaped `sed` and
+# treated "I could not parse one" as "there is none to order against" -- it
+# returned READY. MEASURED: `cargo` accepts the inline and the multi-line
+# dependency table as IDENTICAL (`cargo metadata` returns the same
+# `('aprender-contracts','upstream','^0.63.0')` for both), while the sed parses
+# only the inline spelling. So rewriting
+#
+#   upstream = { path = "...", version = "0.63.0", package = "aprender-contracts" }
+# as
+#   [dependencies.upstream]
+#   path = "..."
+#   version = "0.63.0"
+#   package = "aprender-contracts"
+#
+# -- a semantically null edit that `cargo add` itself can produce and that no
+# reviewer would flag -- silently DISARMED this gate, and the cascade would
+# upload a facade before its upstream: a crate nobody can compile, on an
+# append-only registry.
+#
+# Two changes close it, and the second matters more than the first:
+#   1. Resolve the requirement with `cargo metadata`, the authority on what a
+#      manifest MEANS, instead of a regex over one of its spellings.
+#   2. Assert POSITIVELY. Absence of evidence must not read as evidence of
+#      absence: a facade named here that resolves to no upstream is a FAILURE,
+#      not a pass. `provable-contracts-cli` is deliberately absent from the list
+#      -- it is the lib-only signpost facade with no [dependencies] at all, which
+#      check_facade_compat.sh row R3 enforces from the other direction.
+FACADE_EXPECTS_UPSTREAM="provable-contracts provable-contracts-macros"
+
+# Resolve a facade's upstream (name and required version) from cargo itself.
+# Echoes "<name> <version>" or nothing. The dependency is identified by its
+# RENAME (`upstream`), which is how the manifest refers to it, so this does not
+# depend on the dependency's spelling or position in the file.
+facade_upstream_of() {
+  local manifest=$1 pkg=$2
+  cargo metadata --format-version 1 --no-deps --manifest-path "$manifest" 2>/dev/null \
+    | PKG="$pkg" python3 -c '
+import json, os, sys
+try:
+    meta = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+want = os.environ["PKG"]
+for p in meta.get("packages", []):
+    if p.get("name") != want:
+        continue
+    for d in p.get("dependencies", []):
+        if d.get("rename") == "upstream":
+            req = (d.get("req") or "").lstrip("^~=v ").strip()
+            if d.get("name") and req:
+                print(d["name"], req)
+            sys.exit(0)
+' 2>/dev/null
+}
+
 facade_upstream_ready() {
-  local crate=$1 manifest=${MANIFEST[$1]:-} up_name up_ver
+  local crate=$1 manifest=${MANIFEST[$1]:-} resolved up_name up_ver expected=0
   [ -n "$manifest" ] || return 0
-  up_name=$(sed -n 's/^upstream *=.*package *= *"\([^"]*\)".*/\1/p' "$manifest" 2>/dev/null | head -1)
-  up_ver=$(sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "$manifest" 2>/dev/null | head -1)
-  # No upstream requirement -> nothing to order against.
-  [ -n "$up_name" ] && [ -n "$up_ver" ] || return 0
+
+  case " $FACADE_EXPECTS_UPSTREAM " in *" $crate "*) expected=1 ;; esac
+
+  resolved=$(facade_upstream_of "$manifest" "$crate")
+  up_name=${resolved%% *}
+  up_ver=${resolved##* }
+
+  if [ -z "$resolved" ] || [ -z "$up_name" ] || [ -z "$up_ver" ]; then
+    if [ "$expected" -eq 1 ]; then
+      # The gate could not answer the question it exists to answer. Refuse.
+      echo "ORDER-FAIL ($crate is declared to require an upstream, but cargo"
+      echo "            resolved none from $manifest -- refusing to publish"
+      echo "            rather than assuming there is nothing to order against;"
+      echo "            see aprender#2628)"
+      return 1
+    fi
+    # Not expected to have one (the lib-only signpost facade): ready by design.
+    return 0
+  fi
+
   if version_live "$up_name" "$up_ver"; then
     return 0
   fi

--- a/scripts/check_facade_order_gate.sh
+++ b/scripts/check_facade_order_gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# The cascade's facade ORDER gate must arm on every spelling cargo accepts.
+#
+# WHY THIS GUARD EXISTS (aprender#2628)
+# -------------------------------------
+# `facade_upstream_ready` in scripts/cascade-publish.sh decides whether a
+# crates.io compatibility facade may be uploaded yet. A facade resolves its
+# upstream FROM THE REGISTRY, so publishing it first yields a crate that cannot
+# compile for anyone -- on an append-only registry.
+#
+# The original implementation read the requirement with a line-shaped `sed` and
+# returned READY when it could not parse one. MEASURED: cargo treats the inline
+# and multi-line dependency tables as identical, the sed understands only the
+# inline one, and so a semantically null reformat DISARMED the gate silently.
+#
+# This guard is the falsifier for that class: it exercises the REAL functions
+# (extracted from cascade-publish.sh, never re-implemented -- if they are
+# renamed or deleted, extraction fails and this guard fails) against both
+# spellings plus the two boundary cases.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CASCADE="$REPO_ROOT/scripts/cascade-publish.sh"
+echo "=== cascade facade order gate (check_facade_order_gate.sh) ==="
+
+[ -f "$CASCADE" ] || { echo "FAIL: $CASCADE not found"; exit 1; }
+
+# Extract the two functions under test. Re-implementing them here would test a
+# copy, which is the defect this repo keeps filing (see #2585).
+WORK=$(mktemp -d)
+# SEC011: never let the trap loose on an unvalidated path. `set -e` would catch
+# a failing mktemp, but the cleanup must be safe on its own terms rather than
+# relying on that.
+case "$WORK" in
+  /tmp/*|/var/folders/*) : ;;
+  *) echo "FAIL: mktemp -d returned an unexpected path '$WORK'; refusing to clean up"; exit 1 ;;
+esac
+trap 'rm -rf "${WORK:?}"' EXIT
+sed -n '/^facade_upstream_of() {/,/^}/p'   "$CASCADE" >  "$WORK/fns.sh"
+sed -n '/^FACADE_EXPECTS_UPSTREAM=/p'      "$CASCADE" >> "$WORK/fns.sh"
+for fn in facade_upstream_of FACADE_EXPECTS_UPSTREAM; do
+  grep -q "$fn" "$WORK/fns.sh" || { echo "FAIL: could not extract '$fn' from cascade-publish.sh"; exit 1; }
+done
+# shellcheck disable=SC1091
+. "$WORK/fns.sh"
+
+# NOTE on the `|| true` on every facade_upstream_of call below: under
+# `set -e`, a resolver whose last command legitimately evaluates false (e.g. a
+# `[ -n "$x" ] && echo`) makes the enclosing assignment fail and KILLS this
+# script mid-run -- it then exits non-zero having printed no FAIL line at all.
+# That was observed while mutation-testing this very guard: the pre-#2628 sed
+# resolver returns non-zero for a manifest it cannot parse, and the guard died
+# after row 1 instead of reporting rows 2-8. A guard that fails without a
+# diagnostic is the defect this repo keeps filing, so the failure of a resolver
+# is captured as DATA (an empty string) and judged by the row, never by set -e.
+rc=0
+pass() { printf 'ok    %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; rc=1; }
+
+# Build a throwaway two-crate workspace: one upstream, one facade. The facade's
+# dependency spelling is the variable under test.
+mk_case() {
+  local dir=$1 spelling=$2
+  mkdir -p "$dir/up/src" "$dir/facade/src"
+  cat > "$dir/Cargo.toml" <<EOF
+[workspace]
+members = ["up", "facade"]
+resolver = "2"
+EOF
+  cat > "$dir/up/Cargo.toml" <<EOF
+[package]
+name = "gate-upstream"
+version = "0.63.0"
+edition = "2021"
+EOF
+  : > "$dir/up/src/lib.rs"
+  {
+    printf '[package]\nname = "gate-facade"\nversion = "0.4.0"\nedition = "2021"\n\n'
+    case "$spelling" in
+      inline) printf '[dependencies]\nupstream = { path = "../up", version = "0.63.0", package = "gate-upstream" }\n' ;;
+      multi)  printf '[dependencies.upstream]\npath = "../up"\nversion = "0.63.0"\npackage = "gate-upstream"\n' ;;
+      none)   : ;;
+    esac
+  } > "$dir/facade/Cargo.toml"
+  : > "$dir/facade/src/lib.rs"
+}
+
+# --- ROW 1/2: both spellings cargo accepts must RESOLVE identically ----------
+for spelling in inline multi; do
+  d="$WORK/$spelling"; mk_case "$d" "$spelling"
+  got=$(facade_upstream_of "$d/facade/Cargo.toml" "gate-facade" || true)
+  if [ "$got" = "gate-upstream 0.63.0" ]; then
+    pass "'$spelling' dependency spelling resolves to: $got"
+  else
+    fail "'$spelling' dependency spelling resolved to '<$got>', expected 'gate-upstream 0.63.0' (#2628)"
+  fi
+done
+
+# --- ROW 3: a facade with genuinely no upstream resolves to nothing ----------
+d="$WORK/none"; mk_case "$d" none
+got=$(facade_upstream_of "$d/facade/Cargo.toml" "gate-facade" || true)
+if [ -z "$got" ]; then
+  pass "a facade with no dependencies resolves to no upstream"
+else
+  fail "a facade with no dependencies resolved '<$got>', expected nothing"
+fi
+
+# --- ROW 4: the EXPECTATION list is the thing that makes row 3 safe ----------
+# Row 3 alone is satisfied by a resolver that always returns nothing -- which is
+# exactly the #2628 defect. What excludes that outcome is the positive list.
+for c in provable-contracts provable-contracts-macros; do
+  case " $FACADE_EXPECTS_UPSTREAM " in
+    *" $c "*) pass "$c is declared to REQUIRE an upstream" ;;
+    *)        fail "$c is missing from FACADE_EXPECTS_UPSTREAM — an unparseable manifest would read as READY (#2628)" ;;
+  esac
+done
+case " $FACADE_EXPECTS_UPSTREAM " in
+  *" provable-contracts-cli "*)
+    fail "provable-contracts-cli must NOT be in FACADE_EXPECTS_UPSTREAM — it is the lib-only signpost facade with no dependencies (check_facade_compat.sh R3)" ;;
+  *) pass "provable-contracts-cli is correctly exempt (signpost facade, no dependencies)" ;;
+esac
+
+# --- ROW 5: the real facades in this tree must still resolve -----------------
+for c in provable-contracts provable-contracts-macros; do
+  m="$REPO_ROOT/crates/facades/$c/Cargo.toml"
+  if [ ! -f "$m" ]; then fail "$c manifest missing at $m"; continue; fi
+  got=$(facade_upstream_of "$m" "$c" || true)
+  if [ -n "$got" ]; then pass "$c resolves its upstream in-tree: $got"
+  else fail "$c resolved NO upstream in-tree — the gate would return READY (#2628)"; fi
+done
+
+echo
+if [ "$rc" -eq 0 ]; then
+  echo "PASS: the facade order gate arms on every spelling cargo accepts, and"
+  echo "      cannot be disarmed by a manifest it fails to parse."
+else
+  echo "FAILED: the cascade could publish a facade before its upstream."
+fi
+exit "$rc"


### PR DESCRIPTION
Closes #2628.

## The gate that could not fail

`facade_upstream_ready` in `scripts/cascade-publish.sh` is what stops the release cascade
uploading a crates.io compatibility facade before its upstream. That ordering is not
cosmetic: a facade resolves `aprender-contracts*` **from the registry**, so publishing it
first yields a crate that **cannot compile for anyone** — on an append-only registry, so it
can be yanked but never withdrawn.

The script is explicit that this is a mechanism, not a hope:

> *"Being last makes the order LIKELY; `facade_upstream_ready` below makes it TRUE."*

It did not. The requirement was read with a line-shaped `sed`, and the "nothing to order
against" branch `return 0` — **READY**. So a manifest the `sed` could not parse silently
disarmed the gate.

## Measured

`cargo` treats the inline and multi-line dependency tables as identical —
`cargo metadata --no-deps` returns the same `('aprender-contracts','upstream','^0.63.0')`
for both. The `sed` understands only one:

| spelling | gate verdict |
|---|---|
| `upstream = { path = "…", version = "0.63.0", package = "…" }` | ARMED |
| `[dependencies.upstream]` + `path`/`version`/`package` lines | **READY, though an upstream exists** |

That reformat is semantically null, `cargo add` can produce it, and no reviewer would flag it.

## What made it dangerous rather than merely fragile

The gate returns READY for `provable-contracts-cli` today and **that is correct** — it is the
lib-only signpost facade with no `[dependencies]` at all, which `check_facade_compat.sh` row
R3 enforces from the other direction. So *"no upstream by design"* and *"an upstream exists
and I failed to parse it"* took the **same silent path**. There was no observable difference
between the gate working and the gate being off.

## Fix

1. Resolve with **`cargo metadata`** — the authority on what a manifest *means* — keyed on the
   dependency's **rename** (`upstream`), so it no longer depends on spelling or position.
2. **Assert positively.** `FACADE_EXPECTS_UPSTREAM` names the facades that must have one; a
   facade on that list resolving to none is now `ORDER-FAIL`. Absence of evidence must not read
   as evidence of absence.

New guard `scripts/check_facade_order_gate.sh`, wired into `guard-runner-labels`. It
**extracts the real functions** from `cascade-publish.sh` rather than re-implementing them — a
copy is the same defect one iteration later (#2585) — and fails if extraction fails.

## Mutation-verified both directions

Engagement grep-proved before any verdict was read, and re-verified after each change to the
guard itself (an old proof does not transfer across a change to the thing proving it):

| mutation | result |
|---|---|
| restore the pre-fix `sed` resolver | rc=1 — `FAIL 'multi' … resolved to '<>'` |
| drop `provable-contracts` from the expectation list | rc=1, naming it |
| byte-identical no-op | rc=0, PASS |

All reverted; `grep -c MUTANT` is 0.

## A defect this guard found in itself

The first mutation run exited 1 having printed **no FAIL line at all**. Under `set -e`, a
resolver whose last command evaluates false makes the enclosing assignment fail and kills the
script mid-run — so it reported failure without a diagnostic, exactly like
`check_facade_compat.sh:212` discarding its cargo output. Resolver failure is now captured as
data and judged by the row.

bashrs 0 errors — SEC011 on the cleanup trap fixed by validating the `mktemp` path before
arming it, not by suppressing the rule.

## Sequencing

Touches `ci.yml` only by **adding a step** to `guard-runner-labels`. It does **not** touch the
integration-test line that #2617 owns, and shares no file with #2613.
