### PR TITLE
fix(orchestrate): make the #2607 stdin test hermetic — it blocked every coverage measurement (#2307)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,19 @@ jobs:
         run: bash scripts/check_no_hand_rolled_parsers.sh
       - name: "hand-rolled-parser guard must still turn RED (case table)"
         run: bash scripts/check_no_hand_rolled_parsers.sh --self-test
+      # Poka-yoke: a test may not assert about the fd 0 it INHERITED. nextest
+      # gives every test its own process with /dev/null on fd 0; a plain
+      # `cargo test` runs tests as THREADS of one process holding the caller's
+      # stdin — a pipe or a file under CI. So such a test is green on the
+      # required workspace-test lane and red on `make coverage`, which is
+      # exactly what #2607's cmd_code test did: it blocked the 0.64.0 coverage
+      # measurement (#2307) while every required check stayed green. The fix is
+      # to own fd 0 — re-exec with `Stdio::null()` and assert in the child.
+      # Text-only, no build. Self-test first (Verification Discipline #7).
+      - name: "inherited-stdin guard must still turn RED (case table)"
+        run: bash scripts/check_hermetic_stdin_tests.sh --self-test
+      - name: No test may assert about the fd 0 it inherited
+        run: bash scripts/check_hermetic_stdin_tests.sh
       # Poka-yoke: `set` in a SOURCED file mutates the caller's shell. apr_bin.sh
       # opened with `set -euo pipefail`; qwen-story.sh sources it and had chosen
       # `set -uo pipefail` deliberately (it must run every beat and tally the

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,9 @@ tier3:
 	@echo "Checking no contract names an enforcement command that cannot run (aprender#2504)..."
 	@bash scripts/check_contract_enforcement.sh --self-test
 	@bash scripts/check_contract_enforcement.sh
+	@echo "Checking no test asserts about the fd 0 it inherited (aprender#2307)..."
+	@bash scripts/check_hermetic_stdin_tests.sh --self-test
+	@bash scripts/check_hermetic_stdin_tests.sh
 	@if [ -d tests/golden ]; then \
 		if . scripts/apr_bin.sh 2>/dev/null; then \
 			echo "Running probar golden regression with profiling... ($$APR)"; \

--- a/crates/aprender-orchestrate/src/agent/code_tests.rs
+++ b/crates/aprender-orchestrate/src/agent/code_tests.rs
@@ -1114,27 +1114,81 @@ fn falsify_2607_named_arguments_still_run_on_closed_stdin() {
     assert!(!CodeInvocation { stdin_is_terminal: true, ..CodeInvocation::default() }.wants_help());
 }
 
+/// Marker that puts this test binary in "child half" mode for the #2607
+/// stdin test below. Absent ⇒ parent half: re-exec ourselves. Present ⇒ we
+/// already own fd 0 and may make the assertion.
+const HERMETIC_STDIN_CHILD_ENV: &str = "APR_2607_HERMETIC_STDIN_CHILD";
+
+/// Full libtest path of the test below, used as the child's `--exact` filter.
+/// If it ever drifts from the real name, the child runs zero tests and the
+/// parent's `1 passed` assertion fails — the rename cannot pass silently.
+const HERMETIC_STDIN_TEST: &str =
+    "agent::code::tests::falsify_2607_cmd_code_refuses_bare_non_interactive_invocation";
+
 /// `cmd_code` itself must refuse the bare/non-interactive shape, so a library
 /// embedder cannot reach model discovery either. Asserting `is_err` is the
 /// point: the pre-#2607 build returned no error and went on to spawn a child.
+///
+/// **Hermetic by re-exec** (#2307). The guard reads *this process'* fd 0, so
+/// the assertion is only meaningful if the test owns fd 0 — and it does not.
+/// `cargo nextest` gives every test its own process with `/dev/null` on fd 0;
+/// a plain `cargo test` runs tests as *threads* of one process that inherited
+/// the caller's stdin, which under CI is a pipe or a redirected file. That
+/// divergence is exactly why this test was green on `workspace-test` and red
+/// on `make coverage`, blocking the 0.64.0 coverage measurement. So the parent
+/// half re-execs the test binary with `Stdio::null()` on fd 0 and the child
+/// half — which now provably owns fd 0 — makes the assertion. Same result
+/// under both harnesses, from a terminal, a pipe or a file.
 #[test]
 fn falsify_2607_cmd_code_refuses_bare_non_interactive_invocation() {
-    // Under `cargo test` stdin is not a terminal, which is exactly the shape
-    // the sweep host hit. If a harness ever attaches a tty, the guard cannot
-    // fire and there is nothing to assert — say so rather than pass silently.
+    if std::env::var_os(HERMETIC_STDIN_CHILD_ENV).is_some() {
+        assert_cmd_code_refuses_bare_non_interactive();
+        return;
+    }
+    let exe = std::env::current_exe().expect("test binary must have a path to re-exec");
+    let out = std::process::Command::new(&exe)
+        .args(["--exact", HERMETIC_STDIN_TEST, "--test-threads=1"])
+        .env(HERMETIC_STDIN_CHILD_ENV, "1")
+        // The whole point: fd 0 is /dev/null in the child no matter what the
+        // harness handed us.
+        .stdin(std::process::Stdio::null())
+        .output()
+        .unwrap_or_else(|e| panic!("failed to re-exec {} for the #2607 check: {e}", exe.display()));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "#2607 child assertion failed ({}):\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+        out.status
+    );
+    // Prove the child actually ran the assertion. A stale `HERMETIC_STDIN_TEST`
+    // would make libtest filter everything out and still exit 0 — a green run
+    // proving nothing, which is the class of defect this test is fixing.
+    assert!(
+        stdout.contains("1 passed"),
+        "child ran no assertion — is HERMETIC_STDIN_TEST ({HERMETIC_STDIN_TEST}) stale?\n{stdout}"
+    );
+}
+
+/// The actual #2607 assertion. Runs only in the child half above, which owns
+/// fd 0 (`/dev/null`); the preconditions restate that and fail loudly rather
+/// than pass vacuously if the re-exec ever stops delivering it.
+fn assert_cmd_code_refuses_bare_non_interactive() {
+    // A terminal on fd 0 short-circuits `CodeInvocation::from_args` one level
+    // up, so the guard could not fire and there would be nothing to assert.
     assert!(
         !std::io::IsTerminal::is_terminal(&std::io::stdin()),
-        "test harness attached a terminal to stdin; the #2607 guard cannot be exercised here"
+        "child stdin is a terminal, not /dev/null; the #2607 guard cannot be exercised here"
     );
     // The guard peeks stdin when — and only when — every flag already says
-    // "would refuse", and that peek blocks on a pipe with a live writer. Every
-    // harness we run under (nextest, and a redirected `cargo test`) hands tests
-    // /dev/null. Assert it rather than discover it as a hung merge queue.
+    // "would refuse", and that peek blocks on a pipe with a live writer.
+    // `Stdio::null()` makes fd 0 a character device, which is refused without
+    // reading. Assert it rather than discover it as a hung merge queue.
     #[cfg(unix)]
     if let Ok(meta) = std::fs::metadata("/dev/stdin") {
         assert!(
             !crate::agent::code::kind_can_carry_input(&meta.file_type()),
-            "test harness attached a pipe/file to stdin; this test would block on the #2607 peek"
+            "child stdin is a pipe/file, not /dev/null; this test would block on the #2607 peek"
         );
     }
     let err =

--- a/scripts/check_hermetic_stdin_tests.sh
+++ b/scripts/check_hermetic_stdin_tests.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# check_hermetic_stdin_tests.sh — aprender#2307 (class guard for the #2607 test)
+#
+# THE CLASS: a test that asserts something about the fd 0 it INHERITED.
+#
+# `cargo nextest` gives every test its own process with /dev/null on fd 0.
+# A plain `cargo test` runs tests as THREADS of one process that inherited the
+# caller's stdin — a pipe or a redirected file under CI. So an assertion about
+# the inherited fd 0 is green on the required `workspace-test` lane (nextest)
+# and red on `make coverage` / `make tier3` (plain cargo test). That divergence
+# hid the #2607 test's environment dependence until it blocked the 0.64.0
+# coverage measurement — the failure was invisible to every required check.
+#
+# THE RULE: if a file asserts on this process' stdin, that same file must
+# establish fd 0 itself — re-exec the test binary with `Stdio::null()` on fd 0
+# (or otherwise own fd 0) and make the assertion in the child. Reading stdin is
+# fine; ASSERTING on what a harness happened to hand you is not.
+#
+# Deliberately NOT covered (know the limits before trusting a green run):
+#   * granularity is per FILE, not per assertion — a file that legitimately
+#     re-execs somewhere is not re-checked assertion by assertion;
+#   * `#[cfg(test)]` blocks are not parsed, so a production `assert!` about
+#     stdin is flagged too (which is also worth flagging);
+#   * only fd 0 is modelled. An inherited-fd-1/2 assertion is a sibling defect
+#     this guard does not see.
+#
+# Usage:
+#   scripts/check_hermetic_stdin_tests.sh              # scan the repo
+#   scripts/check_hermetic_stdin_tests.sh --self-test  # run the case table
+#   scripts/check_hermetic_stdin_tests.sh --scan DIR   # scan one directory
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Emits "path:line: <source line>" for every assertion made about the stdin
+# this process inherited, in a file that never establishes fd 0 itself.
+scan_file() {
+    local file="$1"
+    # A file that hands fd 0 to a child it spawns owns its own stdin: exempt.
+    if grep -q 'Stdio::null()' "$file"; then
+        return 0
+    fi
+    # An assertion and the fd-0 expression it is about are rarely on one line:
+    # rustfmt breaks `assert!(...)` open, and the `/dev/stdin` stat usually sits
+    # a line ABOVE its assert (`if let Ok(meta) = metadata("/dev/stdin")`). So
+    # the window is +/- 3 lines in BOTH directions, not a forward scan.
+    awk -v path="$file" '
+        { line[NR] = $0 }
+        function is_stdin_expr(s) {
+            # `std::io::stdin()` / `io::stdin()`: fd 0 of THIS process.
+            if (s ~ /io::stdin\(\)/) return 1
+            # A filesystem call ON /dev/stdin. The bare string is not enough —
+            # `assert!(is_stdin("/dev/stdin"))` classifies a path, it never
+            # touches fd 0.
+            if (s ~ /(metadata|symlink_metadata|read_link|canonicalize|File::open|OpenOptions)[^;]*"\/dev\/stdin"/) return 1
+            return 0
+        }
+        function is_assert(s) {
+            return s ~ /assert!\(|assert_eq!\(|assert_ne!\(|debug_assert!\(|debug_assert_eq!\(/
+        }
+        END {
+            for (i = 1; i <= NR; i++) {
+                if (!is_stdin_expr(line[i])) continue
+                lo = i - 3; if (lo < 1) lo = 1
+                hi = i + 3; if (hi > NR) hi = NR
+                for (j = lo; j <= hi; j++) {
+                    if (is_assert(line[j])) {
+                        printf "%s:%d: %s\n", path, i, line[i]
+                        break
+                    }
+                }
+            }
+        }
+    ' "$file"
+}
+
+scan_dir() {
+    local dir="$1"
+    local file
+    local found=0
+    while IFS= read -r file; do
+        [ -f "$file" ] || continue
+        if out="$(scan_file "$file")" && [ -n "$out" ]; then
+            printf '%s\n' "$out"
+            found=1
+        fi
+    done < <(find "$dir" -type f -name '*.rs' | sort)
+    return "$found"
+}
+
+self_test() {
+    local tmp
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" EXIT
+    local failures=0
+
+    # --- MUST MATCH (the defect this guard exists for) -------------------
+    cat > "$tmp/must_match_same_line.rs" <<'EOF'
+#[test]
+fn t() {
+    assert!(!std::io::IsTerminal::is_terminal(&std::io::stdin()), "boom");
+}
+EOF
+    cat > "$tmp/must_match_wrapped.rs" <<'EOF'
+#[test]
+fn t() {
+    assert!(
+        !std::io::IsTerminal::is_terminal(&std::io::stdin()),
+        "harness attached a terminal to stdin"
+    );
+}
+EOF
+    cat > "$tmp/must_match_dev_stdin.rs" <<'EOF'
+#[test]
+fn t() {
+    let meta = std::fs::metadata("/dev/stdin").expect("stat");
+    assert!(
+        !kind_can_carry_input(&meta.file_type()),
+        "harness attached a pipe to stdin"
+    );
+}
+EOF
+    # The /dev/stdin form above puts the path BEFORE the assert; catch the
+    # common shape where it follows one too.
+    cat > "$tmp/must_match_dev_stdin_after.rs" <<'EOF'
+#[test]
+fn t() {
+    assert_eq!(
+        std::fs::metadata("/dev/stdin").is_ok(),
+        true
+    );
+}
+EOF
+
+    # --- MUST NOT MATCH --------------------------------------------------
+    cat > "$tmp/must_not_match_production_branch.rs" <<'EOF'
+pub fn run() {
+    // Production code READING fd 0 is fine — it makes no claim about it.
+    if std::io::stdin().is_terminal() {
+        repl();
+    }
+}
+EOF
+    cat > "$tmp/must_not_match_reader_arg.rs" <<'EOF'
+#[test]
+fn t() {
+    // Asserting on an OWNED reader is the falsifiable form we want.
+    let mut empty = std::io::BufReader::new(std::io::empty());
+    assert!(!reader_has_input(&mut empty));
+}
+EOF
+    cat > "$tmp/must_not_match_hermetic.rs" <<'EOF'
+#[test]
+fn t() {
+    if std::env::var_os("CHILD").is_some() {
+        assert!(
+            !std::io::IsTerminal::is_terminal(&std::io::stdin()),
+            "child stdin is a terminal"
+        );
+        return;
+    }
+    let out = std::process::Command::new(exe)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("re-exec");
+    assert!(out.status.success());
+}
+EOF
+    cat > "$tmp/must_not_match_path_classifier.rs" <<'EOF'
+#[test]
+fn t() {
+    // The literal is DATA here — a path classifier, no syscall, no fd 0.
+    assert!(is_stdin("/dev/stdin"));
+    assert!(!is_stdout("/dev/stdin"));
+}
+EOF
+    cat > "$tmp/must_not_match_far_apart.rs" <<'EOF'
+#[test]
+fn t() {
+    assert!(cfg.enabled);
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let _ = std::io::stdin();
+}
+EOF
+
+    local f base
+    while IFS= read -r f; do
+        base="$(basename "$f")"
+        out="$(scan_file "$f" || true)"
+        case "$base" in
+            must_match_*)
+                if [ -z "$out" ]; then
+                    echo "SELF-TEST FAIL: $base should have been flagged, was not"
+                    failures=$((failures + 1))
+                fi
+                ;;
+            must_not_match_*)
+                if [ -n "$out" ]; then
+                    echo "SELF-TEST FAIL: $base must not be flagged, got: $out"
+                    failures=$((failures + 1))
+                fi
+                ;;
+        esac
+    done < <(find "$tmp" -type f -name '*.rs' | sort)
+
+    if [ "$failures" -ne 0 ]; then
+        echo "check_hermetic_stdin_tests.sh: SELF-TEST FAILED ($failures case(s))"
+        return 1
+    fi
+    echo "check_hermetic_stdin_tests.sh: self-test OK (9 cases: 4 must-match, 5 must-not-match)"
+    return 0
+}
+
+main() {
+    case "${1:---repo}" in
+        --self-test)
+            self_test
+            ;;
+        --scan)
+            if scan_dir "${2:?--scan needs a directory}"; then
+                echo "OK: no inherited-stdin assertions under ${2}"
+            else
+                echo "FAIL: assertion(s) about inherited fd 0 above (aprender#2307)"
+                return 1
+            fi
+            ;;
+        --repo)
+            if scan_dir "$REPO_ROOT/crates" && scan_dir "$REPO_ROOT/src"; then
+                echo "OK: no test asserts on the fd 0 it inherited (aprender#2307)"
+            else
+                cat <<'MSG'
+FAIL: the assertion(s) above are about the fd 0 this process INHERITED.
+      They pass under `cargo nextest` (own process, /dev/null on fd 0) and fail
+      under a plain `cargo test` with a pipe or file on stdin — so they are
+      green on the required lane and red on `make coverage` (aprender#2307).
+      Fix: re-exec the test binary with `Stdio::null()` on fd 0 and assert in
+      the child, as crates/aprender-orchestrate/src/agent/code_tests.rs does.
+MSG
+                return 1
+            fi
+            ;;
+        *)
+            echo "usage: $0 [--repo|--self-test|--scan DIR]" >&2
+            return 2
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## The blocker

Coverage Nightly on the 0.64.0 tree:

```
---- agent::code::tests::falsify_2607_cmd_code_refuses_bare_non_interactive_invocation ----
panicked at crates/aprender-orchestrate/src/agent/code_tests.rs:1135:9:
  test harness attached a pipe/file to stdin; this test would block on the #2607 peek
test result: FAILED. 5969 passed; 1 failed
make: *** [Makefile:391: coverage] Error 1
```

So the nightly reported `Line coverage: unknown` and the 23 PRs that landed that
day are **unmeasured** (#2307). The last real number is 794532/900939 = 88% on
`2196de281`.

## Why the required check never saw it

The #2607 guard reads *this process'* fd 0, and the test asserted preconditions
about whatever fd 0 the harness handed it.

| lane | harness | fd 0 the test gets | verdict |
|------|---------|--------------------|---------|
| `workspace-test` (**required**) | `cargo nextest` | own process, `/dev/null` | green |
| `make coverage` / `make tier3` | plain `cargo test` | inherited — a pipe or file under CI | **red** |

Same test, same commit, opposite verdict, and only the non-required lane could
see it.

## The fix

The test re-execs the test binary with `Stdio::null()` on fd 0 and asserts in the
child, which provably owns fd 0. **The assertion is unchanged** — `cmd_code` must
still refuse with "stdin is not a terminal", so no embedder reaches
`discover_and_set_model` and spawns a detached `apr serve` on a bare invocation.
Not `#[ignore]`d: that converts a visible failure into an invisible one, which is
the defect being fixed.

The parent also asserts the child printed `1 passed` — a stale `--exact` filter
would run zero tests and exit 0, a green run proving nothing.

## Harness matrix (measured)

`cargo test -p aprender-orchestrate --lib`, four stdin shapes:

| stdin | before | after |
|-------|--------|-------|
| `/dev/null` | 0 | **0** |
| pipe (`cat file \| …`) | 101 | **0** |
| redirected file (`< file`) | 101 | **0** |
| pty (`script -qec`) | 101 | **0** |
| `cargo nextest run -p aprender-orchestrate --lib` | 0 | **0** (test named PASS in the run) |
| `cargo llvm-cov test -p aprender-orchestrate --lib`, stdin = pipe — the coverage lane | red | **0**, 5947 passed / 0 failed, target test `... ok` |

## Mutation evidence (#2607 property still enforced)

Removing the `refuse_bare_non_interactive` call from `cmd_code`:

* engagement, compile time: marker string in the built test binary — `grep -c` → **1**
* engagement, runtime: marker file written from inside the mutated `cmd_code` body
* the child exits **5** = `exit_code::NO_MODEL` — it fell through to model
  discovery, i.e. the #2607 defect itself
* test **RED**, rc=101

Restored: marker gone from the binary (`grep -c` → 0), no marker file, rc=0.

## Class guard

`scripts/check_hermetic_stdin_tests.sh` — flags an assertion about the inherited
fd 0 in a file that never establishes fd 0 itself.

It ships a 9-case must-match / must-not-match table (`--self-test`), and the table
earned its keep immediately: the first pattern **missed** the
`metadata("/dev/stdin")`-before-the-assert shape (the actual defect) and
**false-positived** on `assert!(is_stdin("/dev/stdin"))` in `apr-cli/src/pipe.rs`,
which classifies a path and never touches fd 0.

Mutation-proved in scope: run against `origin/main:code_tests.rs` it flags lines
1126 and 1134 and exits 1; against the fixed file it exits 0. Repo-wide today: clean.

Wired into `ci.yml`'s `gate` (self-test first, per Verification Discipline #7) and
`make tier3`. tier3 alone would be theater — it is not run in CI, as
`check_shell_lint_ratchet.sh`'s own header notes.

Its limits are documented in the header: per-file granularity, no `#[cfg(test)]`
parsing, fd 0 only.

## Not in scope (found while measuring)

`agent::tool::mcp_client::tests::*` is a **pre-existing, load-dependent flake**
under `cargo nextest` on this box: `test_stdio_transport_invalid_json_output`
failed in one run, `test_discover_tools_no_result` in the next, both pass 8/8 in
isolation, and all pass under `cargo test`. They call `skip_in_ci()` (`CI` env
var), so CI never runs them. Untouched here.

Refs #2607, #2307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
