### PR TITLE
fix(release): three more places read the facade pin with a line regex, and one of them WRITES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,6 +855,20 @@ jobs:
       # facade resolves its upstream from the REGISTRY, so publishing it first
       # yields a crate that cannot compile for anyone -- while inside this tree
       # it resolves through `path` and looks perfectly fine. Case table first.
+      # aprender#2635: the cascade-coverage gate below resolves each facade's
+      # upstream pin through scripts/lib/facade_pin.py, which used `tomllib` --
+      # stdlib only since 3.11. It was verified on a 3.13 dev box; THIS RUNNER
+      # HOST is 3.10.12 (these `run: bash` steps execute on the host, not in the
+      # sovereign-ci container), so the helper died at import, printed nothing,
+      # and R3 -- the rule stopping a facade from publishing before its upstream
+      # -- had nothing to check. The class is a release gate carrying an
+      # interpreter assumption never checked against the machine it runs on.
+      # Runs BEFORE the gates that depend on those helpers, so a floor violation
+      # reports as itself rather than as a mystery inert scan. Case table first.
+      - name: Min-Python case table
+        run: bash scripts/check_python_helpers_min_version.sh --self-test
+      - name: Every gate's python helper must run on the fleet's minimum Python
+        run: bash scripts/check_python_helpers_min_version.sh
       - name: Cascade-coverage case table
         run: bash scripts/check_cascade_covers_all_crates.sh --self-test
       - name: The release cascade must cover and order every publishable crate

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -47,17 +47,32 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # not listed: a fourth facade added later is picked up without editing this file,
 # and the signpost facade (no `upstream` line at all) is skipped by the same rule
 # that makes it publishable at any point in the cascade.
+# aprender#2628, FOURTH INSTANCE — and the only one on the WRITE side.
+#
+# This enumeration used `grep -q '^upstream *=.*version *= *"'`, which matches the
+# INLINE spelling only. Cargo treats the multi-line `[dependencies.upstream]`
+# table as IDENTICAL, and a manifest written that way vanished from this list.
+# The consequence is worse than a missed check, because BOTH the writer and its
+# own validator read this function: `set_facade_pins` never rewrote the file,
+# `--check` never inspected it, and `--check` then reported rc=0 "all consistent"
+# with a stale pin. Ask what the loop iterates, and whether the defect removes
+# items from it.
+#
+# Reading now goes through scripts/lib/facade_pin.py, which parses the manifest
+# as TOML. See that file for why tomllib rather than `cargo metadata`.
 facade_pinned_manifests() {  # root
     local f
     for f in "$1"/crates/facades/*/Cargo.toml; do
         [ -f "$f" ] || continue
-        grep -q '^upstream *=.*version *= *"' "$f" && printf '%s\n' "$f"
+        if [ -n "$(facade_pin "$f")" ]; then
+            printf '%s\n' "$f"
+        fi
     done
     return 0
 }
 
 facade_pin() {  # manifest
-    sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "$1" | head -1
+    python3 "$REPO_ROOT/scripts/lib/facade_pin.py" read "$1"
 }
 
 # The facades' own package version — the one that must NOT move.
@@ -76,7 +91,13 @@ set_facade_pins() {  # root new_version
     local f n=0
     while IFS= read -r f; do
         [ -n "$f" ] || continue
-        sed -i -E "s|^(upstream *=.*version *= *\")[^\"]*(\".*)$|\1$2\2|" "$f"
+        # Both spellings (#2628). The enumeration was taught to SEE the
+        # multi-line table before this was taught to REWRITE it; self-test row 8
+        # caught that half-fix, which is exactly what the row exists for.
+        python3 "$REPO_ROOT/scripts/lib/facade_pin.py" write "$f" "$2" || {
+            printf 'bump-version: no upstream pin rewritten in %s\n' "$f" >&2
+            return 1
+        }
         n=$((n + 1))
     done < <(facade_pinned_manifests "$1")
     printf '%s\n' "$n"
@@ -151,8 +172,46 @@ if [ "${1:-}" = "--self-test" ]; then
         printf 'FAIL  row 6 re-running the bump changed the file again\n'; fails=1
     fi
 
+    # rows 7-8 — aprender#2628, the falsifier for the defect this file had.
+    # The multi-line dependency table cargo treats as IDENTICAL to the inline
+    # form. The old grep enumeration could not SEE it (row 7), and after that was
+    # fixed the old sed still could not REWRITE it (row 8) -- row 8 caught that
+    # half-fix on the first run.
+    mkdir -p "$TD/crates/facades/multiline"
+    printf '[package]\nname = "multiline"\nversion = "0.4.0"\n\n[dependencies.upstream]\npath = "../../aprender-contracts"\nversion = "0.63.0"\npackage = "aprender-contracts"\n' \
+        > "$TD/crates/facades/multiline/Cargo.toml"
+    # Row 7 must exercise the ENUMERATION, not the reader — those are different
+    # functions and it was the enumeration that was blind. An earlier version of
+    # this row called facade_pin directly and stayed GREEN under a mutation that
+    # reverted the enumeration to its grep, i.e. it did not test what its label
+    # claimed.
+    # NOTE the here-string. `facade_pinned_manifests "$TD" | grep -q ...` returns
+    # 141 under `set -o pipefail` even when grep MATCHES: grep -q exits on the
+    # first hit, the producer takes SIGPIPE, and pipefail hands the pipeline the
+    # producer's status. It is input-size dependent, so it goes green on a
+    # one-line fixture and red on a two-line one. Capture first, then match.
+    _enum="$(facade_pinned_manifests "$TD")"
+    if grep -q '/multiline/Cargo.toml$' <<< "$_enum"; then
+        printf 'ok    row 7 a multi-line [dependencies.upstream] table is ENUMERATED (#2628)\n'
+    else
+        printf 'FAIL  row 7 a multi-line table is invisible -- it would be neither bumped nor\n'
+        printf '      checked, and --check would report ok with a stale pin\n'; fails=1
+    fi
+    set_facade_pins "$TD" 0.64.0 >/dev/null
+    if grep -q 'version = "0.64.0"' "$TD/crates/facades/multiline/Cargo.toml"; then
+        printf 'ok    row 8 the multi-line pin is actually REWRITTEN by the bump\n'
+    else
+        printf 'FAIL  row 8 the multi-line pin was enumerated but not rewritten\n'; fails=1
+    fi
+    if grep -q 'package = "aprender-contracts"' "$TD/crates/facades/multiline/Cargo.toml" \
+       && grep -q 'path = "../../aprender-contracts"' "$TD/crates/facades/multiline/Cargo.toml"; then
+        printf 'ok    row 9 the multi-line rewrite left path and package intact\n'
+    else
+        printf 'FAIL  row 9 the multi-line rewrite damaged a sibling key\n'; fails=1
+    fi
+
     [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
-    printf '\nSELF-TEST PASSED (6/6)\n'
+    printf '\nSELF-TEST PASSED (9/9)\n'
     exit 0
 fi
 

--- a/scripts/check_cascade_covers_all_crates.sh
+++ b/scripts/check_cascade_covers_all_crates.sh
@@ -83,11 +83,18 @@ facade_edges() {
     local dir
     for dir in "$1"/crates/facades/*/; do
         [ -f "${dir}Cargo.toml" ] || continue
-        local up
-        up=$(sed -n 's/^upstream *=.*package *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1)
+        # aprender#2628, FIFTH INSTANCE. These were two line-anchored seds
+        # matching only the INLINE `upstream = { ... }` spelling. Cargo treats the
+        # multi-line `[dependencies.upstream]` table as IDENTICAL, so a facade
+        # written that way produced NO EDGE here — it would appear to impose no
+        # publish-ordering constraint at all, which is the opposite of the truth
+        # and exactly what this function exists to establish. Resolved through
+        # scripts/lib/facade_pin.py, which parses the manifest as TOML.
+        local up pin
+        up=$(python3 "$REPO_ROOT/scripts/lib/facade_pin.py" package "${dir}Cargo.toml")
         [ -n "$up" ] || continue
-        sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1 \
-            | grep -q . || continue
+        pin=$(python3 "$REPO_ROOT/scripts/lib/facade_pin.py" read "${dir}Cargo.toml")
+        [ -n "$pin" ] || continue
         printf '%s\t%s\n' "$(basename "$dir")" "$up"
     done
 }
@@ -173,9 +180,14 @@ if [ "${1:-}" = "--self-test" ]; then
     # A miniature repo: two upstreams, one facade that pins one of them, one
     # signpost facade with no upstream at all.
     mkdir -p "$TD/repo/crates/facades/face" "$TD/repo/crates/facades/signpost"
-    printf 'upstream = { path = "../../up", version = "1.2.3", package = "up" }\n' \
+    # aprender#2628: this fixture used to write `upstream = { ... }` at TOP LEVEL,
+    # with no [dependencies] header. That is not a valid cargo manifest — only the
+    # old line-based sed could accept it, so the fixture silently encoded the
+    # parser's looseness rather than a real facade. Now it is a manifest cargo
+    # would actually resolve, and `row 6` below drives the multi-line spelling.
+    printf '[package]\nname = "face"\nversion = "0.4.0"\n\n[dependencies]\nupstream = { path = "../../up", version = "1.2.3", package = "up" }\n' \
         > "$TD/repo/crates/facades/face/Cargo.toml"
-    printf '[package]\nname = "signpost"\n' \
+    printf '[package]\nname = "signpost"\nversion = "0.4.0"\n# NO [dependencies].\n' \
         > "$TD/repo/crates/facades/signpost/Cargo.toml"
     printf 'up\nother\nface\nsignpost\n' | sort -u > "$TD/uni_good"
 

--- a/scripts/check_facade_compat.sh
+++ b/scripts/check_facade_compat.sh
@@ -355,10 +355,62 @@ printf -- '\n--- PUBLISH ORDER: what building here does NOT prove --------------
 # compile for a real consumer no matter how green this script is -- which is
 # exactly the failure an adversarial review found, and exactly what building
 # through the path dep hides.
+# aprender#2628, SECOND INSTANCE. This loop used to read the pin with
+#     awk -F'"' '/^upstream *=/{...}'
+# and then treat "no match" as "no pinned upstream version" -- printing `ok` and
+# SKIPPING the comparison. That awk matches only the INLINE spelling, so writing
+# the identical dependency as a multi-line table
+#     [dependencies.upstream]
+#     path = "..."
+#     version = "0.63.0"
+#     package = "aprender-contracts"
+# -- which cargo treats as IDENTICAL -- silently disarmed R3. MEASURED:
+#     inline  -> ARMED (pin=0.63.0), compared against the workspace version
+#     multi   -> "ok  no pinned upstream version", comparison never runs
+# R3 is the rule that keeps a facade's pin tracking the version published from
+# THIS tree, so disarming it publishes a facade pinned to an OLDER upstream --
+# a crate that, in this script's own words, "cannot compile for a real consumer
+# no matter how green this script is".
+#
+# Fixed by asking `cargo metadata`, which is the authority on what a manifest
+# MEANS. That also makes the empty case SOUND rather than merely tolerated:
+# cargo cannot fail to parse a manifest it has already accepted, so "no upstream"
+# is now a real answer (the lib-only signpost facade) instead of a parse failure
+# wearing the same clothes.
+facade_pin_of() {
+    cargo metadata --format-version 1 --no-deps --manifest-path "$1" 2>/dev/null \
+      | PKG="$2" python3 -c '
+import json, os, sys
+try:
+    meta = json.load(sys.stdin)
+except Exception:
+    sys.exit(3)                      # unparseable: NOT the same as "no upstream"
+want = os.environ["PKG"]
+for p in meta.get("packages", []):
+    if p.get("name") != want:
+        continue
+    for d in p.get("dependencies", []):
+        if d.get("rename") == "upstream":
+            print((d.get("req") or "").lstrip("^~=v ").strip())
+            sys.exit(0)
+    sys.exit(0)                      # package found, genuinely no upstream
+sys.exit(3)                          # package not found: also not an answer
+'
+}
+
 for pkg in provable-contracts provable-contracts-macros provable-contracts-cli; do
-    up_ver=$(awk -F'"' '/^upstream *=/{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.[0-9]+\.[0-9]+$/){print $i; exit}}' \
-        "crates/facades/$pkg/Cargo.toml" 2>/dev/null)
-    [ -n "$up_ver" ] || { printf 'ok    %s: no pinned upstream version\n' "$pkg"; continue; }
+    up_ver=$(facade_pin_of "crates/facades/$pkg/Cargo.toml" "$pkg"); meta_rc=$?
+    if [ "$meta_rc" -ne 0 ]; then
+        printf 'FAIL  %s: could not resolve its manifest via cargo metadata, so the\n' "$pkg"
+        printf '      upstream pin could not be checked at all. Refusing to report ok\n'
+        printf '      for a question this guard did not answer (aprender#2628).\n'
+        rc=1
+        continue
+    fi
+    # NOTE: no parentheses in this printf -- bashrs SC1028 mis-attributes them to
+    # the preceding [ ] test even though they are single-quoted in a separate
+    # command after ||, and the shell-lint ratchet counts errors, not intent.
+    [ -n "$up_ver" ] || { printf 'ok    %s: no pinned upstream version -- cargo resolved none\n' "$pkg"; continue; }
     if [ "$up_ver" = "$WS_VER" ]; then
         printf 'ok    %s: upstream pinned to the workspace version (%s)\n' "$pkg" "$up_ver"
     else
@@ -388,9 +440,19 @@ done
 # The row is kept, inverted, as a REGRESSION DETECTOR. A dependency reappearing
 # on this crate would silently restore the blocker, and a deleted check would
 # not notice.
-cli_ver=$(awk -F'"' '/^upstream *=/{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.[0-9]+\.[0-9]+$/){print $i; exit}}' \
-    crates/facades/provable-contracts-cli/Cargo.toml 2>/dev/null)
-if [ -z "$cli_ver" ]; then
+# aprender#2628, THIRD INSTANCE -- and the most consequential, because this row
+# is INVERTED: empty means "ok, no dependency", so a parse failure reads as the
+# PASSING answer. This row exists to notice a dependency REAPPEARING; with the
+# old awk it could not notice one that reappeared in multi-line table form, i.e.
+# it was blind to exactly the regression it was written to detect. Resolved via
+# cargo metadata, and an unresolvable manifest now FAILS instead of passing.
+cli_ver=$(facade_pin_of crates/facades/provable-contracts-cli/Cargo.toml provable-contracts-cli); cli_rc=$?
+if [ "$cli_rc" -ne 0 ]; then
+    printf 'FAIL  provable-contracts-cli: cargo metadata could not resolve its manifest,\n'
+    printf '      so "has no upstream dependency" was never actually established. This row\n'
+    printf '      is a regression detector; an unanswered question is not a pass (#2628).\n'
+    rc=1
+elif [ -z "$cli_ver" ]; then
     printf 'ok    provable-contracts-cli has NO upstream pin -- it is a lib-only signpost\n'
     printf '      with zero dependencies, so it is publishable at ANY point in the\n'
     printf '      cascade. The bin-only-0.63.0 STAGE blocker (#2553) is dissolved, not\n'

--- a/scripts/check_facade_order_gate.sh
+++ b/scripts/check_facade_order_gate.sh
@@ -129,6 +129,31 @@ for c in provable-contracts provable-contracts-macros; do
   else fail "$c resolved NO upstream in-tree — the gate would return READY (#2628)"; fi
 done
 
+# --- ROW 6: the SAME class in check_facade_compat.sh's R3 (aprender#2628) -----
+# R3 keeps a facade's upstream pin tracking the version published from THIS tree.
+# It had the identical fail-open shape: an awk over the inline spelling, with
+# "no match" printing `ok` and skipping the comparison. Pin it here so the class
+# cannot come back in either script.
+COMPAT="$REPO_ROOT/scripts/check_facade_compat.sh"
+if [ ! -f "$COMPAT" ]; then
+  fail "check_facade_compat.sh not found — R3 coverage unverified"
+else
+  if grep -q "facade_pin_of" "$COMPAT"; then
+    pass "check_facade_compat.sh R3 resolves its pin via cargo metadata, not a line regex"
+  else
+    fail "check_facade_compat.sh R3 no longer uses facade_pin_of — if it went back to a line-shaped regex, a multi-line dependency table disarms it silently (#2628)"
+  fi
+  # Strip comments before scanning: this guard must measure CODE, not the prose
+  # that DOCUMENTS the defect. Without this it matches the very comment explaining
+  # the fix and can never go green -- the same "the pattern hit a comment quoting
+  # the literal" trap that wasted a mutation run earlier today, inverted.
+  if sed 's/#.*//' "$COMPAT" | grep -qE "awk[^|]*/\^upstream \*=/"; then
+    fail "check_facade_compat.sh still extracts the upstream pin with an awk over '^upstream =' — that matches only the inline spelling (#2628)"
+  else
+    pass "check_facade_compat.sh has no line-regex extraction of the upstream pin"
+  fi
+fi
+
 echo
 if [ "$rc" -eq 0 ]; then
   echo "PASS: the facade order gate arms on every spelling cargo accepts, and"

--- a/scripts/check_python_helpers_min_version.sh
+++ b/scripts/check_python_helpers_min_version.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# Every python helper on a release-gate path must run under the MINIMUM Python
+# the fleet provides -- not merely under the one on the box where it was written.
+#
+# aprender#2635. scripts/lib/facade_pin.py was written and verified on a dev box
+# running python 3.13 and used `tomllib`, which entered the stdlib in 3.11. The
+# CI runner host runs 3.10.12. On the runner every invocation died with
+# ModuleNotFoundError, the helper printed NOTHING, facade_edges() produced no
+# ordering edges, and R3 -- the rule that stops a facade being published before
+# its upstream -- had nothing left to check. The cascade-coverage case table
+# caught it because it asserts a REJECTION; the live scan next to it would have
+# reported "ok R3 nothing to order" and gone quietly inert.
+#
+# The class is not "tomllib is 3.11+". It is a release gate carrying an
+# INTERPRETER ASSUMPTION that was never checked against the machine the gate runs
+# on -- the same family as the apr-binary rule already in this programme: the
+# thing that ran is not the thing that was reasoned about.
+#
+# WHAT THIS GATE CAN AND CANNOT KNOW, stated plainly because a gate that implies
+# coverage it does not have is the same defect one level up:
+#
+#   RULE A (static, host-independent, exact everywhere).  Every import in every
+#   helper is extracted with `ast` -- never by importing the file -- and checked
+#   against a table of when each module entered the stdlib. This runs identically
+#   on a 3.13 dev box and on a 3.10 runner, so it does not depend on the very
+#   thing it is auditing. It is what makes this gate meaningful when it happens
+#   to execute on a NEWER interpreter than the floor.
+#
+#   RULE B (dynamic, exact only for the interpreter actually present).  Every
+#   helper is byte-compiled and every import resolved with importlib.find_spec
+#   under `python3` AS THIS HOST RESOLVES IT. Where the gate runs on the runner
+#   this is exact coverage of the real target. Where it runs on a newer box it
+#   proves less, and the gate SAYS SO in its output rather than implying the
+#   floor was tested.
+#
+# The universe is derived, not listed. It is scripts/lib/*.py -- the directory
+# that exists only to serve gate scripts -- plus every `scripts/**.py` path
+# literal named by any shell script that a workflow names. Path LITERALS, not
+# `python3 <path>` invocations: a helper reached through a shell variable
+# (`P="$REPO_ROOT/scripts/lib/x.py"; python3 "$P"`) drops out of an
+# invocation-shaped scan, and a universe assembled from the wrong side is the
+# recurring way a guard ends up iterating fewer items than it claims.
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# The minimum Python the fleet provides. MEASURED, not assumed: the self-hosted
+# runner host that executes the `run: bash scripts/...` steps in ci.yml is
+# Ubuntu 22.04, whose /usr/bin/python3 is 3.10.12. Those steps run on the HOST,
+# not in the sovereign-ci container (which has no python3 at all -- irrelevant
+# here, and not something to "fix"). Raise this only when every host is raised.
+PY_FLOOR_MAJOR=3
+PY_FLOOR_MINOR=10
+
+# module<TAB>major<TAB>minor -- the release the module entered the stdlib.
+# Only entries ABOVE the floor can ever fire; the rest document the boundary.
+# aprender#2635: `tomllib` is the row that was missing when it mattered.
+# A function rather than a multi-line string: bashrs cannot parse the latter
+# (SC1078), and a guard whose own linter cannot read it is not maintainable.
+stdlib_since() {
+    printf 'tomllib\t3\t11\n'
+    printf 'dbm.sqlite3\t3\t13\n'
+    printf 'graphlib\t3\t9\n'
+    printf 'zoneinfo\t3\t9\n'
+}
+
+floor_str() { printf '%s.%s' "$PY_FLOOR_MAJOR" "$PY_FLOOR_MINOR"; }
+
+# --------------------------------------------------------------------------
+# Universe.
+gate_shell_scripts() {  # root -- scripts a workflow actually names
+    local root="$1"
+    if [ -d "$root/.github/workflows" ]; then
+        grep -rhoE 'scripts/[A-Za-z0-9_./-]+\.sh' "$root/.github/workflows" 2>/dev/null | sort -u
+    fi
+}
+
+py_universe() {  # root
+    local root="$1" rel
+    {
+        # 1. the shared gate-helper directory, in full.
+        if [ -d "$root/scripts/lib" ]; then
+            find "$root/scripts/lib" -maxdepth 1 -name '*.py' -printf 'scripts/lib/%f\n' 2>/dev/null
+        fi
+        # 2. every scripts/**.py named by a shell script a workflow names.
+        while IFS= read -r rel; do
+            [ -n "$rel" ] || continue
+            [ -f "$root/$rel" ] || continue
+            grep -ohE 'scripts/[A-Za-z0-9_./-]+\.py' "$root/$rel" 2>/dev/null
+        done < <(gate_shell_scripts "$root")
+    } | sort -u | while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        [ -f "$root/$rel" ] && printf '%s\n' "$rel"
+    done
+}
+
+# --------------------------------------------------------------------------
+# RULE A: static, host-independent.
+rule_a() {  # root  -> 0 ok, 1 violation
+    local root="$1" rc=0 rel line mod kind since_major since_minor row found
+    local marked_shown=0
+    while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        local imports
+        imports="$(python3 "$root/scripts/lib/py_imports.py" "$root/$rel" 2>&1)"
+        if [ $? -ne 0 ]; then
+            printf 'FAIL  A %s: could not be parsed\n%s\n' "$rel" "$imports"
+            rc=1
+            continue
+        fi
+        while IFS=$'\t' read -r line mod kind; do
+            [ -n "$mod" ] || continue
+            found=""
+            while IFS=$'\t' read -r row since_major since_minor; do
+                [ -n "$row" ] || continue
+                [ "$row" = "$mod" ] || continue
+                found=1
+                if [ "$since_major" -gt "$PY_FLOOR_MAJOR" ] \
+                   || { [ "$since_major" -eq "$PY_FLOOR_MAJOR" ] \
+                        && [ "$since_minor" -gt "$PY_FLOOR_MINOR" ]; }; then
+                    if [ "$kind" = "marked" ]; then
+                        printf 'note  A %s:%s imports %s (stdlib %s.%s) -- EXCUSED by an\n' \
+                            "$rel" "$line" "$mod" "$since_major" "$since_minor"
+                        printf '        explicit `# min-python-ok` marker. The import must be\n'
+                        printf '        guarded; it is named here so the excuse is never silent.\n'
+                        marked_shown=$((marked_shown + 1))
+                    else
+                        printf 'FAIL  A %s:%s imports %s, which entered the stdlib in %s.%s.\n' \
+                            "$rel" "$line" "$mod" "$since_major" "$since_minor"
+                        printf '        The fleet floor is python %s. On a floor host this helper\n' "$(floor_str)"
+                        printf '        dies at import, prints nothing, and the gate that reads it\n'
+                        printf '        goes inert instead of red.\n'
+                        rc=1
+                    fi
+                fi
+            done < <(stdlib_since)
+            : "$found"
+        done <<< "$imports"
+    done < <(py_universe "$root")
+    return "$rc"
+}
+
+# --------------------------------------------------------------------------
+# RULE B: dynamic, under python3 as THIS host resolves it.
+rule_b() {  # root  -> 0 ok, 1 violation
+    local root="$1" rc=0 rel out
+    while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        out="$(python3 "$root/scripts/lib/py_can_run.py" "$root/$rel" 2>&1)"
+        if [ -n "$out" ]; then
+            printf 'FAIL  B %s under python3 %s on this host:\n' \
+                "$rel" "$(python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null)"
+            printf '%s\n' "$out" | sed 's/^/        /'
+            rc=1
+        fi
+    done < <(py_universe "$root")
+    return "$rc"
+}
+
+# --------------------------------------------------------------------------
+# Self-test.
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    TD="$(mktemp -d)" || exit 1
+    case "$TD" in /tmp/*|/var/folders/*) : ;; *) printf 'bad tmp\n'; exit 1 ;; esac
+    trap 'rm -rf "${TD:?}"' EXIT
+
+    mkfix() {  # name -- build a miniature repo at $TD/$name
+        local r="$TD/$1"
+        mkdir -p "$r/.github/workflows" "$r/scripts/lib"
+        printf 'jobs:\n  g:\n    steps:\n      - run: bash scripts/check_thing.sh\n' \
+            > "$r/.github/workflows/ci.yml"
+        printf '#!/usr/bin/env bash\npython3 "$REPO_ROOT/scripts/lib/helper.py" read\n' \
+            > "$r/scripts/check_thing.sh"
+        cp "$REPO_ROOT/scripts/lib/py_imports.py" "$r/scripts/lib/py_imports.py"
+        printf '%s' "$r"
+    }
+
+    row() {  # label want_rc root needle
+        local label="$1" want="$2" root="$3" needle="$4" out rc
+        out="$(rule_a "$root" 2>&1)"; rc=$?
+        if [ "$rc" != "$want" ]; then
+            printf 'FAIL  %s: exit %s, expected %s\n%s\n' "$label" "$rc" "$want" "$out"
+            fails=1; return
+        fi
+        if [ -n "$needle" ] && ! grep -q -- "$needle" <<< "$out"; then
+            printf 'FAIL  %s: exit %s as expected but did not name %s\n%s\n' \
+                "$label" "$rc" "$needle" "$out"
+            fails=1; return
+        fi
+        printf 'ok    %s\n' "$label"
+    }
+
+    # Row 1 CONTROL. Without a passing case every row below is satisfied by a
+    # checker that fails unconditionally.
+    R="$(mkfix control)"
+    printf 'import os\nimport re\nimport sys\n' > "$R/scripts/lib/helper.py"
+    row 'row 1 a helper importing only ancient stdlib passes' 0 "$R" ''
+
+    # Row 2 THE DEFECT, reproduced: the exact #2635 import.
+    R="$(mkfix tomllib)"
+    printf 'import sys\nimport tomllib\n' > "$R/scripts/lib/helper.py"
+    row 'row 2 `import tomllib` in a gate helper is REJECTED' 1 "$R" 'tomllib'
+
+    # Row 3 the other spelling of the same import.
+    R="$(mkfix fromform)"
+    printf 'from tomllib import load\n' > "$R/scripts/lib/helper.py"
+    row 'row 3 `from tomllib import ...` is REJECTED too' 1 "$R" 'tomllib'
+
+    # Row 4 a nested import is still an import. The first draft of the extractor
+    # looked only at module level, which would have missed exactly this.
+    R="$(mkfix nested)"
+    printf 'def f():\n    import tomllib\n    return tomllib\n' > "$R/scripts/lib/helper.py"
+    row 'row 4 an import nested inside a function is REJECTED' 1 "$R" 'tomllib'
+
+    # Row 5 the declared-intent marker excuses the line it is on...
+    R="$(mkfix marked)"
+    printf 'try:\n    import tomllib  # min-python-ok\nexcept ImportError:\n    tomllib = None\n' \
+        > "$R/scripts/lib/helper.py"
+    row 'row 5 a guarded import carrying the marker is allowed' 0 "$R" 'EXCUSED'
+
+    # Row 6 ...and ONLY the line it is on. An escape hatch that leaks to the
+    # rest of the file is a worse defect than the one it excuses.
+    R="$(mkfix marked_leak)"
+    printf 'import tomllib  # min-python-ok\nimport dbm.sqlite3\n' > "$R/scripts/lib/helper.py"
+    row 'row 6 the marker does NOT excuse a different unmarked import' 1 "$R" 'dbm.sqlite3'
+
+    # Row 7 THE UNIVERSE. A helper reached only through a shell VARIABLE must
+    # still be scanned -- an invocation-shaped scan would drop it, and the gate
+    # would pass while never looking at the file carrying the defect.
+    R="$(mkfix viavar)"
+    printf 'import os\n' > "$R/scripts/lib/helper.py"
+    printf '#!/usr/bin/env bash\nP="$REPO_ROOT/scripts/other.py"\npython3 "$P"\n' \
+        > "$R/scripts/check_thing.sh"
+    printf 'import tomllib\n' > "$R/scripts/other.py"
+    row 'row 7 a helper reached via a shell variable is still in the universe' 1 "$R" 'scripts/other.py'
+
+    # Row 8 scope. A .py that no gate-wired script names is NOT this gate's
+    # business -- research scripts legitimately import torch. A gate that fails
+    # on files it does not govern gets disabled, which is how coverage dies.
+    R="$(mkfix outofscope)"
+    printf 'import os\n' > "$R/scripts/lib/helper.py"
+    printf 'import tomllib\n' > "$R/scripts/research_only.py"
+    row 'row 8 a .py no gate-wired script names is out of scope' 0 "$R" ''
+
+    # Row 9 VACUITY in the universe. A gate over zero files reports success.
+    R="$(mkfix empty)"
+    rm -f "$R/scripts/lib/helper.py" "$R/scripts/lib/py_imports.py" "$R/scripts/check_thing.sh"
+    _u="$(py_universe "$R")"
+    if [ -z "$_u" ]; then
+        printf 'ok    row 9 an empty universe is detectable (main scan rejects it)\n'
+    else
+        printf 'FAIL  row 9 py_universe invented %s files for an empty tree\n' \
+            "$(printf '%s\n' "$_u" | wc -l)"
+        fails=1
+    fi
+
+    # Row 10 the universe over the REAL tree is non-empty and contains the file
+    # this whole ticket is about. A case table that only ever runs on fixtures
+    # cannot notice that the real scan stopped finding anything.
+    _u="$(py_universe "$REPO_ROOT")"
+    if grep -qx 'scripts/lib/facade_pin.py' <<< "$_u"; then
+        printf 'ok    row 10 the real universe contains scripts/lib/facade_pin.py (%s files)\n' \
+            "$(printf '%s\n' "$_u" | wc -l | tr -d ' ')"
+    else
+        printf 'FAIL  row 10 the real universe does NOT contain scripts/lib/facade_pin.py\n'
+        fails=1
+    fi
+
+    [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
+    printf '\nSELF-TEST PASSED (10/10)\n'
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+printf '=== python helpers on release-gate paths must run on the fleet floor ===\n\n'
+
+HOST_PY="$(python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null)"
+if [ -z "$HOST_PY" ]; then
+    printf 'FAIL  no python3 on PATH -- every helper below is unrunnable here\n'
+    exit 1
+fi
+printf 'declared fleet floor : python %s\n' "$(floor_str)"
+printf 'this host`s python3  : python %s (%s)\n' "$HOST_PY" "$(command -v python3)"
+
+UNIVERSE="$(py_universe "$REPO_ROOT")"
+if [ -z "$UNIVERSE" ]; then
+    printf '\nFAIL  the helper universe is EMPTY -- the ENUMERATION is broken, and a\n'
+    printf '      gate over zero files reports success on a broken tree.\n'
+    exit 1
+fi
+printf 'helpers in scope     : %s\n\n' "$(printf '%s\n' "$UNIVERSE" | wc -l | tr -d ' ')"
+
+RC=0
+if rule_a "$REPO_ROOT"; then
+    printf 'ok    A no helper imports a stdlib module newer than python %s\n' "$(floor_str)"
+else
+    RC=1
+fi
+
+if rule_b "$REPO_ROOT"; then
+    printf 'ok    B every helper compiles and resolves its imports under python %s\n' "$HOST_PY"
+else
+    RC=1
+fi
+
+# Say exactly what was and was not observed. The floor is what matters; this
+# host is only sometimes at it.
+HOST_MINOR="${HOST_PY#*.}"
+printf '\ncoverage: '
+if [ "$HOST_MINOR" -lt "$PY_FLOOR_MINOR" ]; then
+    printf 'this host (%s) is BELOW the declared floor (%s).\n' "$HOST_PY" "$(floor_str)"
+    printf '          The floor declaration is wrong for a machine that runs these gates.\n'
+    RC=1
+elif [ "$HOST_MINOR" -eq "$PY_FLOOR_MINOR" ]; then
+    printf 'rule B ran ON the floor interpreter (python %s), so the\n' "$HOST_PY"
+    printf '          dynamic half is EXACT coverage of the real target.\n'
+else
+    printf 'rule B ran on python %s, ABOVE the floor (%s). It therefore\n' \
+        "$HOST_PY" "$(floor_str)"
+    printf '          proves these helpers run HERE, NOT that they run on the floor.\n'
+    printf '          Only rule A -- which is host-independent -- covers the floor from\n'
+    printf '          this host. This is stated rather than implied on purpose: the\n'
+    printf '          defect being guarded was exactly a floor claim made from a\n'
+    printf '          newer interpreter.\n'
+fi
+
+exit "$RC"

--- a/scripts/lib/facade_pin.py
+++ b/scripts/lib/facade_pin.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Read or rewrite a facade's `upstream` version pin, in every spelling cargo accepts.
+
+aprender#2628. The shell used a line-anchored regex that matched only the INLINE
+form:
+
+    upstream = { path = "...", version = "0.63.0", package = "aprender-contracts" }
+
+Cargo treats the multi-line table as IDENTICAL:
+
+    [dependencies.upstream]
+    path = "..."
+    version = "0.63.0"
+    package = "aprender-contracts"
+
+A manifest written that way was invisible to the enumeration, so `set_facade_pins`
+never rewrote it AND `--check` never inspected it -- and `--check` then reported
+rc=0 "all consistent" with a stale pin. The writer and its own validator shared
+one blind spot.
+
+Reading uses tomllib (authoritative about TOML structure, and unlike
+`cargo metadata` it does not require a resolvable workspace, so the --self-test
+fixtures still work). Writing is a targeted text edit so comments and formatting
+survive -- round-tripping through a TOML writer would reformat the manifest.
+
+  read    <manifest>            -> prints the version, or nothing if no upstream
+                                   exit 0; exit 3 if the file could not be parsed
+  package <manifest>            -> prints the upstream's real package name
+                                   (the `package = ` rename target), or nothing
+  write   <manifest> <version>  -> exit 0 if rewritten, 1 if no pin was found
+"""
+import re
+import sys
+import tomllib
+
+
+def read_pin(path):
+    with open(path, "rb") as fh:
+        m = tomllib.load(fh)
+    for table in ("dependencies", "dev-dependencies", "build-dependencies"):
+        dep = m.get(table, {}).get("upstream")
+        if isinstance(dep, dict) and dep.get("version"):
+            return dep["version"]
+        if isinstance(dep, str):
+            return dep
+    return None
+
+
+def read_package(path):
+    """The real crate the `upstream` rename points at, for ordering-graph edges."""
+    with open(path, "rb") as fh:
+        m = tomllib.load(fh)
+    for table in ("dependencies", "dev-dependencies", "build-dependencies"):
+        dep = m.get(table, {}).get("upstream")
+        if isinstance(dep, dict):
+            return dep.get("package") or "upstream"
+    return None
+
+
+def write_pin(path, new):
+    src = open(path).read()
+
+    # 1. inline table on one line
+    out, n = re.subn(
+        r'(?m)^(upstream\s*=\s*\{[^}\n]*?version\s*=\s*")[^"]*(")',
+        lambda mo: mo.group(1) + new + mo.group(2),
+        src,
+    )
+    if n:
+        open(path, "w").write(out)
+        return n
+
+    # 2. the version key inside a [...dependencies.upstream] table, scoped to
+    #    that table so no other section's `version` is touched.
+    lines = src.splitlines(keepends=True)
+    inside = False
+    done = 0
+    for i, ln in enumerate(lines):
+        head = re.match(r"\s*\[([^\]]+)\]\s*$", ln)
+        if head:
+            name = head.group(1).strip()
+            inside = name.split(".")[-1] == "upstream" and "dependencies" in name
+            continue
+        if inside:
+            mo = re.match(r'(\s*version\s*=\s*")[^"]*(".*?)(\r?\n?)$', ln)
+            if mo:
+                lines[i] = mo.group(1) + new + mo.group(2) + (mo.group(3) or "\n")
+                done += 1
+    if done:
+        open(path, "w").write("".join(lines))
+    return done
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    mode, path = argv[1], argv[2]
+    if mode == "read":
+        try:
+            pin = read_pin(path)
+        except Exception:
+            return 3
+        if pin:
+            print(pin)
+        return 0
+    if mode == "package":
+        try:
+            pkg = read_package(path)
+        except Exception:
+            return 3
+        if pkg:
+            print(pkg)
+        return 0
+    if mode == "write":
+        if len(argv) < 4:
+            return 2
+        return 0 if write_pin(path, argv[3]) else 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/facade_pin.py
+++ b/scripts/lib/facade_pin.py
@@ -18,27 +18,233 @@ never rewrote it AND `--check` never inspected it -- and `--check` then reported
 rc=0 "all consistent" with a stale pin. The writer and its own validator shared
 one blind spot.
 
-Reading uses tomllib (authoritative about TOML structure, and unlike
-`cargo metadata` it does not require a resolvable workspace, so the --self-test
-fixtures still work). Writing is a targeted text edit so comments and formatting
-survive -- round-tripping through a TOML writer would reformat the manifest.
+aprender#2635 -- WHY THERE IS A HAND PARSER HERE, AND WHY THAT IS THE NARROW CHOICE.
+
+The first fix read the manifest with `tomllib`. `tomllib` entered the stdlib in
+3.11. The dev box where it was verified runs 3.13; the CI runner host runs
+3.10.12, so on the runner every invocation died with ModuleNotFoundError, this
+module printed NOTHING, `facade_edges()` produced NO ordering edges, and R3 --
+the rule that stops a facade publishing before its upstream -- had nothing left
+to check. The case table caught it; the live scan would have gone quietly inert,
+which is the exact fail-open this file exists to prevent.
+
+`cargo metadata` remains rejected for the reason recorded in the first fix: it
+needs a RESOLVABLE workspace, and the --self-test fixtures deliberately are not
+one, so it makes the guard unable to run against its own case table.
+
+A tomllib-then-tomli-then-hand-parser chain was rejected too. `tomli` is not
+guaranteed on the runner, and more importantly a chain means the branch taken
+depends on the host: the 3.13 dev box would exercise one parser and the 3.10
+runner another, so "verified here" would not transfer to "works there" -- which
+is precisely the defect being fixed, one level down. ONE parser runs everywhere.
+
+The cost is that this parser is not a general TOML implementation, and it is not
+trying to be. It resolves ONE construct: a dependency named or renamed
+`upstream`, and its `version`, under the three top-level dependency tables, in
+the spellings cargo accepts. Everything else in the file is skipped, not
+interpreted. Two things keep that honest:
+
+  * `--self-test` drives a must-match / must-not-match case table (below).
+  * where `tomllib` IS importable -- this dev box, the 3.11+ hosts -- the
+    self-test additionally runs it as a DIFFERENTIAL ORACLE over every real
+    manifest in the tree and requires the two to agree. tomllib is thus still
+    the authority on TOML, but only at TEST time; no runtime path imports it,
+    so no host runs code another host did not.
+
+Writing stays a targeted text edit so comments and formatting survive --
+round-tripping through a TOML writer would reformat the manifest.
 
   read    <manifest>            -> prints the version, or nothing if no upstream
-                                   exit 0; exit 3 if the file could not be parsed
+                                   exit 0; exit 3 if the file could not be read
   package <manifest>            -> prints the upstream's real package name
                                    (the `package = ` rename target), or nothing
   write   <manifest> <version>  -> exit 0 if rewritten, 1 if no pin was found
+  --self-test                   -> case table + differential oracle
 """
+import os
 import re
 import sys
-import tomllib
+
+# The three dependency tables cargo resolves from the registry. Target-specific
+# tables (`[target.'cfg(unix)'.dependencies]`) are deliberately NOT included:
+# the tomllib version this replaces did not read them either, and a facade does
+# not pin its upstream per-target. `_split_key` keeps them out by construction
+# rather than by luck -- a target table's key path has four components, not two.
+DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+# A bare or quoted TOML key, optionally dotted.
+_KEY = r"(?:\"[^\"]*\"|'[^']*'|[A-Za-z0-9_-]+)"
+_KV = re.compile(r"^\s*(" + _KEY + r"(?:\s*\.\s*" + _KEY + r")*)\s*=\s*(.*)$")
+
+_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "\\": "\\", '"': '"'}
+
+
+def _consume_in_string(line, i, quote, out):
+    """Copy one character from inside a string. -> (next_i, quote_or_None)."""
+    ch = line[i]
+    # Escapes are only special in a basic (double-quoted) string.
+    if quote == '"' and ch == "\\" and i + 1 < len(line):
+        out.append(ch)
+        out.append(line[i + 1])
+        return i + 2, quote
+    out.append(ch)
+    return i + 1, (None if ch == quote else quote)
+
+
+def _strip_comment(line):
+    """Drop a trailing `#` comment, but not a `#` inside a string."""
+    out = []
+    quote = None
+    i = 0
+    n = len(line)
+    while i < n:
+        if quote is not None:
+            i, quote = _consume_in_string(line, i, quote, out)
+            continue
+        ch = line[i]
+        if ch == "#":
+            break
+        if ch in "\"'":
+            quote = ch
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _split_key(text):
+    """Split a dotted TOML key into components, honouring quoting.
+
+    `target."cfg(unix)".dependencies` -> ['target', 'cfg(unix)', 'dependencies'],
+    so a target table can never be mistaken for a top-level dependency table.
+    """
+    parts = []
+    cur = []
+    quote = None
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if quote:
+            if ch == quote:
+                quote = None
+            else:
+                cur.append(ch)
+            i += 1
+            continue
+        if ch in "\"'":
+            quote = ch
+            i += 1
+            continue
+        if ch == ".":
+            parts.append("".join(cur).strip())
+            cur = []
+            i += 1
+            continue
+        cur.append(ch)
+        i += 1
+    parts.append("".join(cur).strip())
+    return parts
+
+
+def _unquote(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        inner = value[1:-1]
+        if value[0] == '"':
+            inner = re.sub(
+                r"\\(.)", lambda mo: _ESCAPES.get(mo.group(1), mo.group(1)), inner
+            )
+        return inner
+    return value
+
+
+# One `key = value` pair inside an inline table.
+_INLINE_PAIR = re.compile(
+    r"(?:^|,)\s*(" + _KEY + r")\s*=\s*"
+    r"(\"(?:[^\"\\]|\\.)*\"|'[^']*'|\[[^\]]*\]|[^,}]+)"
+)
+
+
+def _parse_value(text):
+    """A dependency's value: an inline table -> dict, a bare string -> str.
+
+    TOML 1.0 forbids a newline inside an inline table, so `{ ... }` is always
+    complete on the line it opens on. That is a guarantee of the format, not an
+    assumption about how these manifests happen to be written.
+    """
+    text = text.strip()
+    if text.startswith("{"):
+        body = text[1 : text.rindex("}")] if "}" in text else text[1:]
+        table = {}
+        for mo in _INLINE_PAIR.finditer(body):
+            table[_unquote(mo.group(1))] = _unquote(mo.group(2))
+        return table
+    if text[:1] in "\"'":
+        return _unquote(text)
+    return None
+
+
+def _header_path(line):
+    """The table path a header line opens, or None if the line is not a header."""
+    if line.startswith("[["):
+        # An array-of-tables header. Never a dependency table we read; return a
+        # path that cannot match so the keys that follow are ignored.
+        return ["\x00array-of-tables"]
+    if line.startswith("[") and line.endswith("]"):
+        return _split_key(line[1:-1])
+    return None
+
+
+def _dep_slot(full):
+    """-> (dep_table, key) if `full` addresses the upstream dependency, else None.
+
+    key is None for `[dependencies] upstream = ...` (the whole value) and
+    'version'/'package' for `[dependencies.upstream] version = ...`.
+    """
+    if len(full) < 2 or full[0] not in DEP_TABLES or full[1] != "upstream":
+        return None
+    if len(full) == 2:
+        return (full[0], None)
+    if len(full) == 3 and full[2] in ("version", "package"):
+        return (full[0], full[2])
+    return None
+
+
+def _record(found, full, raw):
+    slot = _dep_slot(full)
+    if slot is None:
+        return
+    dep_table, key = slot
+    if key is None:
+        found.setdefault(dep_table, _parse_value(raw))
+        return
+    current = found.setdefault(dep_table, {})
+    if isinstance(current, dict):
+        current[key] = _unquote(raw)
+
+
+def parse_upstream(path):
+    """-> {dep_table: value} for the `upstream` dependency, value str or dict."""
+    found = {}
+    table = []
+    with open(path, encoding="utf-8") as fh:
+        for raw in fh:
+            line = _strip_comment(raw).strip()
+            if not line:
+                continue
+            head = _header_path(line)
+            if head is not None:
+                table = head
+                continue
+            mo = _KV.match(line)
+            if mo:
+                _record(found, table + _split_key(mo.group(1)), mo.group(2))
+    return found
 
 
 def read_pin(path):
-    with open(path, "rb") as fh:
-        m = tomllib.load(fh)
-    for table in ("dependencies", "dev-dependencies", "build-dependencies"):
-        dep = m.get(table, {}).get("upstream")
+    deps = parse_upstream(path)
+    for table in DEP_TABLES:
+        dep = deps.get(table)
         if isinstance(dep, dict) and dep.get("version"):
             return dep["version"]
         if isinstance(dep, str):
@@ -48,10 +254,9 @@ def read_pin(path):
 
 def read_package(path):
     """The real crate the `upstream` rename points at, for ordering-graph edges."""
-    with open(path, "rb") as fh:
-        m = tomllib.load(fh)
-    for table in ("dependencies", "dev-dependencies", "build-dependencies"):
-        dep = m.get(table, {}).get("upstream")
+    deps = parse_upstream(path)
+    for table in DEP_TABLES:
+        dep = deps.get(table)
         if isinstance(dep, dict):
             return dep.get("package") or "upstream"
     return None
@@ -91,32 +296,313 @@ def write_pin(path, new):
     return done
 
 
+# ---------------------------------------------------------------------------
+# Case table. Each row is (label, manifest text, expected read_pin,
+# expected read_package). The must-NOT-match rows matter as much as the
+# must-match ones: a parser that answers "0.1.0" to everything passes every
+# positive row on its own.
+CASES = [
+    (
+        "inline table, the original spelling",
+        '[package]\nname = "f"\n\n[dependencies]\n'
+        'upstream = { path = "../up", version = "1.2.3", package = "up" }\n',
+        "1.2.3",
+        "up",
+    ),
+    (
+        "multi-line [dependencies.upstream] table -- the #2628 defect",
+        '[package]\nname = "f"\n\n[dependencies.upstream]\n'
+        'path = "../up"\nversion = "1.2.3"\npackage = "up"\n',
+        "1.2.3",
+        "up",
+    ),
+    (
+        "multi-line table, keys in the other order",
+        '[dependencies.upstream]\npackage = "up"\nversion = "9.9.9"\n',
+        "9.9.9",
+        "up",
+    ),
+    (
+        "bare string version",
+        '[dependencies]\nupstream = "4.5.6"\n',
+        "4.5.6",
+        None,
+    ),
+    (
+        "no rename: package defaults to the dependency name",
+        '[dependencies]\nupstream = { version = "1.0.0" }\n',
+        "1.0.0",
+        "upstream",
+    ),
+    (
+        "dev-dependencies is read too",
+        '[dev-dependencies]\nupstream = { version = "2.0.0", package = "up" }\n',
+        "2.0.0",
+        "up",
+    ),
+    (
+        "build-dependencies is read too",
+        '[build-dependencies.upstream]\nversion = "3.0.0"\npackage = "up"\n',
+        "3.0.0",
+        "up",
+    ),
+    (
+        "dependencies wins over dev-dependencies",
+        '[dependencies]\nupstream = { version = "1.0.0", package = "a" }\n'
+        '[dev-dependencies]\nupstream = { version = "2.0.0", package = "b" }\n',
+        "1.0.0",
+        "a",
+    ),
+    (
+        "quoted key name",
+        '[dependencies]\n"upstream" = { version = "1.4.0", package = "up" }\n',
+        "1.4.0",
+        "up",
+    ),
+    (
+        "extra whitespace everywhere",
+        "[ dependencies ]\n   upstream   =   { version   =   '1.5.0' }\n",
+        "1.5.0",
+        "upstream",
+    ),
+    (
+        "trailing comment after the inline table",
+        '[dependencies]\nupstream = { version = "1.6.0" }  # pinned by bump-version\n',
+        "1.6.0",
+        "upstream",
+    ),
+    (
+        "a `#` inside a string is not a comment",
+        '[dependencies]\nupstream = { version = "1.7.0", package = "up#x" }\n',
+        "1.7.0",
+        "up#x",
+    ),
+    # ---- must NOT match ----
+    (
+        "NO-MATCH a commented-out pin is not a pin",
+        '[dependencies]\n# upstream = { version = "1.2.3" }\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH path-only dependency has no registry pin, but does name a package",
+        '[dependencies]\nupstream = { path = "../up", package = "up" }\n',
+        None,
+        "up",
+    ),
+    (
+        "NO-MATCH a different dependency named similarly",
+        '[dependencies]\nupstream-extra = { version = "1.2.3" }\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH a serde dependency is not the upstream",
+        '[dependencies]\nserde = { version = "1.0", features = ["derive"] }\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH `upstream` under a non-dependency table",
+        '[package.metadata]\nupstream = "1.2.3"\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH a target-specific table is not a top-level dependency table",
+        '[target."cfg(unix)".dependencies]\nupstream = { version = "1.2.3" }\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH the version key of a NEIGHBOURING table does not leak in",
+        '[dependencies.upstream]\npath = "../up"\npackage = "up"\n'
+        '\n[dependencies.other]\nversion = "8.8.8"\n',
+        None,
+        "up",
+    ),
+    (
+        "NO-MATCH `[package] version` is not the pin",
+        '[package]\nname = "f"\nversion = "0.4.0"\n',
+        None,
+        None,
+    ),
+    (
+        "NO-MATCH a manifest with no dependencies at all",
+        '[package]\nname = "signpost"\nversion = "0.4.0"\n',
+        None,
+        None,
+    ),
+]
+
+
+WRITE_CASES = (
+    (
+        "write round-trips the inline spelling",
+        '[dependencies]\nupstream = { path = "../up", version = "1.2.3", package = "up" }\n',
+    ),
+    (
+        "write round-trips the multi-line spelling",
+        '[dependencies.upstream]\npath = "../up"\nversion = "1.2.3"\npackage = "up"\n',
+    ),
+)
+
+
+def _write(path, text):
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _check_read_cases(path):
+    """The must-match / must-not-match table. -> number of failures."""
+    fails = 0
+    for label, text, want_pin, want_pkg in CASES:
+        _write(path, text)
+        got_pin, got_pkg = read_pin(path), read_package(path)
+        if got_pin != want_pin or got_pkg != want_pkg:
+            print(
+                "FAIL  %s\n      pin: got %r want %r\n      pkg: got %r want %r"
+                % (label, got_pin, want_pin, got_pkg, want_pkg)
+            )
+            fails += 1
+        else:
+            print("ok    %s" % label)
+    return fails
+
+
+def _check_write_cases(path):
+    """A writer that edits a spelling the reader cannot see is the #2628 shape."""
+    fails = 0
+    for label, text in WRITE_CASES:
+        _write(path, text)
+        n = write_pin(path, "7.7.7")
+        got = read_pin(path)
+        if not n or got != "7.7.7":
+            print("FAIL  %s: wrote %r, read back %r" % (label, n, got))
+            fails += 1
+        else:
+            print("ok    %s" % label)
+    return fails
+
+
+def _oracle_pin(tomllib, path):
+    """read_pin's answer, computed by tomllib instead. None if unparsable."""
+    with open(path, "rb") as fh:
+        try:
+            doc = tomllib.load(fh)
+        except tomllib.TOMLDecodeError:
+            return None, False
+    for table in DEP_TABLES:
+        dep = doc.get(table, {}).get("upstream")
+        if isinstance(dep, dict) and dep.get("version"):
+            return dep["version"], True
+        if isinstance(dep, str):
+            return dep, True
+    return None, True
+
+
+def _compare_to_oracle(tomllib, subjects):
+    """subjects: iterable of (label, path). -> (failures, compared)."""
+    fails = 0
+    checked = 0
+    for label, real in subjects:
+        oracle, parsed = _oracle_pin(tomllib, real)
+        if not parsed:
+            continue
+        mine = read_pin(real)
+        if mine != oracle:
+            print(
+                "FAIL  oracle disagrees on %s: hand %r tomllib %r"
+                % (label, mine, oracle)
+            )
+            fails += 1
+        checked += 1
+    return fails, checked
+
+
+def _real_manifests(root):
+    for dirpath, _dirs, files in os.walk(os.path.join(root, "crates")):
+        if "Cargo.toml" in files:
+            yield os.path.join(dirpath, "Cargo.toml")
+
+
+def _check_oracle(path):
+    """Differential oracle: where tomllib exists it is the authority on TOML.
+
+    Runs at TEST time only. No runtime path imports it, so a 3.10 host and a
+    3.13 host execute the same resolver -- which is the point of aprender#2635.
+    """
+    try:
+        import tomllib  # min-python-ok
+    except ImportError:
+        print(
+            "note  tomllib absent (python %d.%d) -- differential oracle SKIPPED "
+            "on this host; the case table above still ran"
+            % (sys.version_info[0], sys.version_info[1])
+        )
+        return 0
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    fails = 0
+    checked = 0
+    for label, text, _p, _k in CASES:
+        _write(path, text)
+        f, c = _compare_to_oracle(tomllib, [(label, path)])
+        fails += f
+        checked += c
+    f, c = _compare_to_oracle(tomllib, ((m, m) for m in _real_manifests(root)))
+    fails += f
+    checked += c
+    print("ok    differential oracle: hand parser == tomllib on %d manifests" % checked)
+    return fails
+
+
+def _self_test():
+    import tempfile
+
+    path = os.path.join(tempfile.mkdtemp(), "Cargo.toml")
+    fails = _check_read_cases(path)
+    fails += _check_write_cases(path)
+
+    # Vacuity: a parser returning None for everything satisfies every NO-MATCH
+    # row, so the table must carry enough must-MATCH rows to exclude that.
+    if len([c for c in CASES if c[2] is not None]) < 5:
+        print("FAIL  the case table has too few must-MATCH rows to be falsifying")
+        fails += 1
+
+    fails += _check_oracle(path)
+
+    if fails:
+        print("\nSELF-TEST FAILED (%d)" % fails)
+        return 1
+    print("\nSELF-TEST PASSED (%d rows)" % (len(CASES) + len(WRITE_CASES)))
+    return 0
+
+
+def _emit(resolver, path):
+    """Print what `resolver` finds, or nothing. exit 3 if the file is unreadable."""
+    try:
+        value = resolver(path)
+    except OSError:
+        return 3
+    if value:
+        print(value)
+    return 0
+
+
 def main(argv):
+    if len(argv) >= 2 and argv[1] == "--self-test":
+        return _self_test()
     if len(argv) < 3:
         print(__doc__, file=sys.stderr)
         return 2
     mode, path = argv[1], argv[2]
-    if mode == "read":
-        try:
-            pin = read_pin(path)
-        except Exception:
-            return 3
-        if pin:
-            print(pin)
-        return 0
-    if mode == "package":
-        try:
-            pkg = read_package(path)
-        except Exception:
-            return 3
-        if pkg:
-            print(pkg)
-        return 0
-    if mode == "write":
-        if len(argv) < 4:
-            return 2
-        return 0 if write_pin(path, argv[3]) else 1
-    return 2
+    readers = {"read": read_pin, "package": read_package}
+    if mode in readers:
+        return _emit(readers[mode], path)
+    if mode != "write" or len(argv) < 4:
+        return 2
+    return 0 if write_pin(path, argv[3]) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/lib/py_can_run.py
+++ b/scripts/lib/py_can_run.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Can this helper actually load under the interpreter running me right now?
+
+aprender#2635, the dynamic half of scripts/check_python_helpers_min_version.sh.
+Two questions, both answered WITHOUT executing the file under audit:
+
+  1. does it compile?            (the builtin `compile`, so syntax newer than this
+                                  interpreter is a hard failure, not a surprise
+                                  at gate time)
+  2. does every module it imports RESOLVE?  (`importlib.util.find_spec`, which
+                                  locates a module without importing it, so a
+                                  helper with side effects is never run)
+
+Imports carrying the `# min-python-ok` marker are skipped -- those are declared
+guarded imports, and the shell gate prints each one so the excuse is visible.
+
+Prints one `MISSING <line> <module>` per unresolvable import, or `SYNTAX <msg>`,
+and exits 1 if anything failed. Silent + exit 0 means the helper loads here.
+"""
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import py_imports  # noqa: E402  (needs the path insert above)
+
+
+def _resolves(module):
+    """Is `module` importable here? find_spec locates without importing."""
+    try:
+        return importlib.util.find_spec(module.split(".")[0]) is not None
+    except (ImportError, ValueError, AttributeError):
+        return False
+
+
+def _compiles(path):
+    """-> None if the file parses under this interpreter, else the message."""
+    try:
+        with open(path, "rb") as fh:
+            compile(fh.read(), path, "exec")
+    except (SyntaxError, ValueError) as exc:
+        return str(exc).strip()
+    return None
+
+
+def check(path):
+    syntax = _compiles(path)
+    if syntax is not None:
+        return ["SYNTAX %s" % syntax]
+
+    # A helper may import a sibling helper; resolve from its own directory the
+    # way the interpreter will when it is actually invoked.
+    here = os.path.dirname(os.path.abspath(path))
+    if here not in sys.path:
+        sys.path.insert(0, here)
+
+    return [
+        "MISSING %d %s" % (lineno, mod)
+        for lineno, mod, kind in py_imports.imports(path)
+        if kind != "marked" and not _resolves(mod)
+    ]
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    rc = 0
+    for path in argv[1:]:
+        for problem in check(path):
+            print(problem)
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/py_imports.py
+++ b/scripts/lib/py_imports.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""List the modules a python file imports, without executing it.
+
+aprender#2635. Used by scripts/check_python_helpers_min_version.sh to decide
+whether a helper on a release-gate path can run under the minimum Python the
+fleet provides.
+
+Parsing with `ast` rather than importing the file matters twice over: importing
+would run module-level code (a gate helper must never be executed just to be
+audited), and it would answer only for the interpreter doing the auditing --
+which is the whole defect being guarded against.
+
+Each import is printed as:
+
+    <line>\t<module>\t<marked|plain>
+
+`module` is the dotted name as written. `marked` means the source line carries
+the `# min-python-ok` declared-intent marker, i.e. the author asserts the import
+is guarded (inside a try/except ImportError) or otherwise cannot run at gate
+time. The gate prints every marked line rather than hiding it.
+
+Only `ast` and `sys` are used, both stdlib since forever, so this file cannot
+itself become the thing that fails to load on an old interpreter.
+"""
+import ast
+import sys
+
+MARKER = "# min-python-ok"
+
+
+def _module_names(node):
+    """The dotted module names this node imports; [] if none, None if not an import."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        # `from . import x` has no module; a relative import cannot be a
+        # stdlib module, so it is not interesting here.
+        if node.level or not node.module:
+            return []
+        return [node.module]
+    return None
+
+
+def _line_kind(lines, lineno):
+    """'marked' if the source line carries the declared-intent marker."""
+    text = lines[lineno - 1] if 0 < lineno <= len(lines) else ""
+    return "marked" if MARKER in text else "plain"
+
+
+def imports(path):
+    with open(path, "rb") as fh:
+        src = fh.read()
+    lines = src.decode("utf-8", "replace").splitlines()
+    out = []
+    # ast.walk, not tree.body: an import nested inside a function or a
+    # try/except is still an import that runs at gate time.
+    for node in ast.walk(ast.parse(src, filename=path)):
+        names = _module_names(node)
+        if not names:
+            continue
+        lineno = getattr(node, "lineno", 0)
+        kind = _line_kind(lines, lineno)
+        out.extend((lineno, name, kind) for name in names)
+    return sorted(set(out))
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    rc = 0
+    for path in argv[1:]:
+        try:
+            rows = imports(path)
+        except (OSError, SyntaxError) as exc:
+            print("ERROR\t%s\t%s" % (path, exc), file=sys.stderr)
+            rc = 1
+            continue
+        for lineno, name, kind in rows:
+            print("%d\t%s\t%s" % (lineno, name, kind))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Refs #2628, #2629.

#2628 was filed for **one** fail-open gate. Fixing it and pointing the new guard at its
siblings found **four more instances of the same shape, all in the release path** — and one of
them is on the *write* side.

## The class

Cargo accepts two spellings of the same dependency, and `cargo metadata` returns the identical
result for both:

```toml
upstream = { path = "…", version = "0.63.0", package = "aprender-contracts" }
```
```toml
[dependencies.upstream]
path = "…"
version = "0.63.0"
package = "aprender-contracts"
```

Every line-anchored regex in the release path understood only the first, and each treated
*"no match"* as *"there is nothing here"* — the **passing** answer.

## The instances, worst first

**1. `bump-version.sh` — the only one that WRITES.** `facade_pinned_manifests()` chose which
manifests carry a pin with `grep -q '^upstream *=.*version *= *"'`. A multi-line manifest
vanished from that list, so `set_facade_pins` never rewrote it **and `--check` never inspected
it** — both read the same function. `--check` then reported `rc=0` "all consistent" over a
stale pin. *The writer and its own validator shared one blind spot.*

**2. `check_cascade_covers_all_crates.sh::facade_edges`** builds the R3 publish-**ordering**
graph. Measured, old sed + one multi-line manifest:

| | R3 edges | exit |
|---|---|---|
| mutant | **1** | rc=0 |
| fixed | **2** | rc=0 |

It does not fail — it silently establishes one fewer ordering constraint, and that constraint
is what stops a facade publishing before its upstream.

**3 & 4. `check_facade_compat.sh`** R3 (pin == workspace version) and the inverted signpost row,
where an empty read *is* the passing answer, so a parse failure reads as success.

## A commit I had silently lost

3 and 4 were committed on the #2629 branch and **never pushed** — I held the push to keep CI off
the merge queue, and the batch then folded the branch at its *pushed* state. The work was
dropped without a trace. I found it only because a grep for the old pattern still matched on
`main`. Recovered here and verified against `main` before re-applying.

## One helper

`scripts/lib/facade_pin.py` — `read` / `package` / `write`, parsing the manifest as TOML.

**tomllib rather than `cargo metadata`, deliberately.** The question is purely structural, and
cargo needs a *resolvable workspace* — which the self-test fixtures are not. Using cargo made
`bump-version` rows 1–2 fail on fixtures that are perfectly valid TOML: a real defect traded for
a guard that cannot run. Writing stays a targeted text edit so comments and formatting survive.

## A fixture defect the change surfaced

`check_cascade_covers_all_crates.sh` wrote `upstream = { … }` at **top level with no
`[dependencies]` header** — not a valid cargo manifest. Only the old line-based sed could accept
it, so the fixture encoded the parser's looseness rather than a real facade.

## Mutation-verified, engagement grep-proved before any verdict was read

| mutation | result |
|---|---|
| enumeration → `grep` | rows 7 **and** 8 RED |
| `facade_edges` → sed | 1 edge instead of 2 |
| R3 → awk | order-gate names the line-regex extraction |
| byte-identical no-op | GREEN throughout |

**Three self-inflicted defects the new rows caught, each on first run** — recorded because
catching them is the point:

- **Row 8 caught a half-fix**: I taught the enumeration to *see* the multi-line table but not
  the writer to *rewrite* it.
- **Row 7 did not test what its label claimed**: it called the reader directly and stayed GREEN
  under a mutation that reverted the enumeration.
- `facade_pinned_manifests "$TD" | grep -q …` returned **141 despite grep matching** — SIGPIPE
  plus `pipefail`. Input-size dependent, so green on a one-line fixture and red on a two-line
  one. Capture first, match a here-string.

## Gates

bashrs **0 errors** on all four scripts. Self-tests: `bump-version` 9/9, `cascade-covers` 7/7,
`facade-compat` 8/8, `facade-order-gate` 10/10. `bump-version.sh --check` rc=0.
