### PR TITLE
fix(dogfood): ONE runner — merge both hardenings, then GATE the rule that had been rediscovered five times (#2640)

### DIFF
--- a/.claude/skills/apr-dogfood/SKILL.md
+++ b/.claude/skills/apr-dogfood/SKILL.md
@@ -18,7 +18,22 @@ description: Dogfood the aprender release surface — derive every interface fro
 `F-COV-*`, `F-CHAOS-*`, `F-DIFF-*`, `F-WORKTREE-HEAD-001`, `F-EXPORT-ROUNDTRIP-001`,
 `F-VALIDATE-QUALITY-001`, `F-RUN-EXIT-SANITY-001`, `F-7B-INFERENCE-001`,
 `F-APR-INFERENCE-PARITY-001`)
-**Absorbs**: `dogfood.sh` release-gate protocol, `invariance.py` transport gate
+**Defers to** (v3.1, aprender#2640 — this line used to read "**Absorbs**: `dogfood.sh`
+release-gate protocol", and "absorbs" is the wrong verb: it invited a second copy
+and the runner promptly grew one):
+`scripts/dogfood.sh` is the ONE fleet release-gate protocol and
+`.claude/skills/dogfood/SKILL.md` is its ONE prose. This skill layers aprender's
+surface-coverage ledger ON TOP of it and must not restate a gate the runner owns.
+The `invariance.py` transport gate likewise belongs to the runner
+(`scripts/invariance.py`), not to this file.
+
+Three documents describe overlapping release work; each owns exactly one scope:
+
+| skill | scope | source of truth for |
+|---|---|---|
+| `dogfood` | ANY Rust crate in the fleet | the generic pre-release protocol, `scripts/dogfood.sh` |
+| `apr-dogfood` (this file) | this repo's shipped surface | gate coverage against the surface ledger |
+| `pre-release` | `apr-cli` only | the crates.io publish gates |
 **New**: Phase 2 (coverage ledger), Phase 5 (fleet hardware matrix), the mutation registry
 
 **Contracts**:

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -1,0 +1,789 @@
+---
+name: dogfood
+description: Sovereign-stack PRE-RELEASE protocol. Run this BEFORE generating a GitHub or crates.io release of any Rust crate in the fleet (copia, forjar, pmat, trueno, aprender, …). It runs every local release gate (fmt, clippy, tests, ≥95% coverage, cargo-deny, provable contracts) through the deterministic tools — pv, bashrs, pmat — verifies the release's CLI/HTTP/MCP interfaces against the spawned binary — including a DERIVED, SIMULTANEOUS cross-transport invariance check that invokes the same verb through every declared transport while all of them are live and requires byte-identical results, does a publish dry-run, and DOGFOODS the crate by using its own release binary on real data. Then it requires the MANDATORY clean-room gate and gives a go/no-go verdict with a receipt. Use when the user says "dogfood", "pre-release", "release checklist", "ready to publish/release", "cut a release", or asks whether a crate is release-ready.
+---
+
+# dogfood — pre-release protocol
+
+The gate that stands between "CI is green" and `cargo publish`. It codifies the
+sovereign quality bar (CLAUDE.md) into one repeatable, evidence-producing protocol.
+
+**Toyota way, non-negotiable:** any RED gate STOPS the release. Fix the *root cause*
+in the crate — never `--no-verify`, never `--skip`, never lower a floor to pass.
+
+## There is exactly one of everything here
+
+This file and `scripts/dogfood.sh` are the ONLY copies of the protocol, and both
+live in the aprender repo, in git, reachable by CI and by `git diff`.
+
+They did not used to be. Until #2640 the runner existed twice — once here and once
+at `~/.claude/skills/dogfood/dogfood.sh` — and the two had silently diverged in nine
+places. Every one was a real hardening the other copy lacked, so *neither copy was
+safe to delete and neither was safe to trust*
+(`docs/audits/dogfood-divergence-2640.md`). The user-scope path is now a ~50-line
+shim that `exec`s this runner; `scripts/check_dogfood_shim.sh` keeps it one, and
+`scripts/check_verifier_pinning.sh` keeps the merged hardenings honest. If you find
+yourself about to copy either file somewhere, read that triage first.
+
+## Run it
+
+From (or pointing at) the crate repo:
+
+```bash
+bash <aprender>/scripts/dogfood.sh [REPO_DIR]   # defaults to $PWD
+# ~/.claude/skills/dogfood/dogfood.sh still works: it is a shim onto the above.
+```
+
+### A crate's own release gates are DECLARED, never copied in
+
+A repo that has written its own release guards declares them in its `Cargo.toml`,
+beside `[package.metadata.transports]`, and the runner discovers and runs each one
+with its own row in the receipt:
+
+```toml
+[package.metadata.dogfood]
+gates = ["scripts/check_multiplatform_dogfood.sh", "scripts/check_verifier_pinning.sh"]
+```
+
+This is the anti-duplication rule applied to the runner itself. Without it, the way
+to get a repo-specific gate into the protocol is to edit the protocol — which is how
+it acquired a second copy of itself in the first place.
+
+Both vacuity guards are hard FAILs, not SKIPs: a declared script that does not exist
+is a *deleted* gate, and a missing or empty `gates` list is a clean sweep over an
+empty set — the signature failure this protocol exists to refuse, reappearing one
+layer up at discovery.
+
+`DOGFOOD_GATES_ONLY=1` runs only that section, for exercising discovery without a
+full sweep. It can never print GO; a partial run is not a verdict.
+
+It writes a receipt to `<repo>/.dogfood/receipt-<ts>.json` and exits `0` = GO,
+`1` = NO-GO. On NO-GO it prints every red gate with its note before the verdict —
+a verdict that says only "a gate failed" makes the reader hunt for it, and the
+hunt is where bypasses start. Report the verdict and the failing gate(s) to the
+user; do not proceed to release on a NO-GO.
+
+It creates three artefact dirs in the repo — `.dogfood/` (receipts), `.pmat/`
+(the context index CB-200 cannot run without) and `.pv/` (pv's lint cache). They
+are excluded from the `git-clean` check because the protocol creates them; add
+all three to the crate's `.gitignore`.
+
+## What it checks (and why each matters)
+
+1. **git-clean** — uncommitted work must be committed before a tag points at it.
+2. **version-unpublished** — the `Cargo.toml` version is not already on crates.io
+   (crates.io versions are immutable; a re-publish fails). Bump first if it is.
+3. **changelog** — `CHANGELOG.md` has an entry for this version.
+4. **fmt / clippy / test** — `cargo fmt --check`, `clippy -D warnings` (pedantic),
+   the full test suite. Clean-room-published crates gate the binary behind the
+   `cli` feature, so those run with `--features cli`.
+5. **coverage** — `make coverage-check` (the ≥95% whole-crate floor).
+6. **security** — `cargo deny check advisories`.
+7. **contracts** — `make contracts`, where the crate has one. It runs what this
+   protocol cannot generically replicate: the Lean (L4) proofs and the
+   falsification suites. **It is not the authority on the pv layer** — 7b/7b′/7b″
+   run `pv` directly so the exit codes are ours. Its recipe is also checked
+   statically for laundered exit codes (**contracts-exit-integrity**, 7e).
+
+   The earlier text here claimed `make contracts` runs "`pv validate` + `lean
+   lean/*.lean` + `pv proof-status --binding` + the falsification suites". That
+   was true of copia and false of the repo the skill was most often pointed at:
+   rmedia has no `lean/` directory, its recipe never invokes `proof-status`, and
+   it contains no falsification suite. A protocol description that does not
+   match the repo is the same defect as a gate that does not run.
+
+7a. **deterministic-tools** — `pv`, `bashrs`, `pmat` and `probador` must be
+   INSTALLED. Their absence is a **NO-GO**, not a WARN.
+
+   These are the verifiers the protocol is built on, and they are *deterministic*:
+   the same input yields the same verdict on any machine, unlike reading a diff
+   and forming an opinion. A release verified by tools that were not installed is
+   an unverified release that prints GO.
+
+   This used to WARN, contradicting this file's own rule that "a WARN in a
+   release protocol is a step everybody learns to walk past". On 2026-08-16
+   `pv validate` was run across forjar's contracts for the first time and **six
+   had never passed it** — including the one `forjar prove` maps into its own
+   `N/N proofs passed` line. Nothing had run the validator, so nothing knew.
+
+7b. **pv-contracts** — every `contracts/*.yaml` validated individually, behind a
+   **positive control**: a deliberately malformed contract is validated first and
+   must be REJECTED. If `pv validate` accepts it, "N contracts valid" is a count
+   of files, not a verdict, and the gate says so instead of reporting green.
+   A `contracts/` directory that yields *zero* validatable files is a FAIL: a
+   glob matching nothing passes vacuously. `binding.yaml` is excluded by name —
+   it is a binding registry, not a contract.
+
+   **Never replace this loop with `pv lint <FILE>`.** Verified three ways in
+   pv 0.49.0, all exit 0 printing `Result: PASS`: on a contract `pv validate`
+   rejects, on `binding.yaml`, and **on a path that does not exist**. `pv lint`
+   reads directories; handed a file it lints zero contracts and calls it a pass.
+
+7b′. **pv-lint** — `pv lint <DIR>` (directory form only), the 8-gate schema
+   sweep: duplicate ids, dangling refs, reverse coverage, composition. Errors
+   gate; its warnings do not.
+
+7b″. **pv-bindings** — `pv verify-bindings <binding> --crate-name <crate>`, run
+   from the crate root. This answers a question nothing else in the protocol
+   asks: does every binding name a symbol that **exists**? `pv proof-status
+   --binding` does not — pointed at
+   `ThisFunctionDoesNotExistAnywhere::nope` it printed `Bindings 2/2` and exited
+   0. It counts entries; it does not resolve them.
+
+   Ghost findings are **REPORT, not FAIL**, and the reason is written down so it
+   can be re-armed. pv 0.49.0 misses `pub(super) fn` (rmedia's `apply_loudnorm`
+   is reported a ghost and is real at
+   `crates/rmedia-core/src/audio_cleanup/normalize.rs:27`) and private `async fn`
+   in a `[[bin]]` module — copia's **only** ghost, `deliver_local`, is real at
+   `src/bin/copia/incremental.rs:330`. It also matches prose-qualified
+   `function:` fields literally (`all_entries (slug field)`) and is module-blind:
+   a binding with the right function name under a module that does not exist
+   verifies clean. Making it blocking today would be permanent red on false
+   positives, and a permanently red gate gets bypassed for substance. What DOES
+   fail here is the tool producing **no verification line at all** — an unrun
+   verifier is not a clean one. Enforce R1–R4 meanwhile with a crate-local linter
+   (rmedia's `scripts/lint-contract-bindings.sh` is the reference; it is stricter
+   than pv on module-path awareness and `pub(super)` visibility).
+
+7c. **bashrs** — gated on the rules that are trustworthy, reporting the rest.
+   `SEC*`/`DET*`/`IDEM*` findings **FAIL** the release: SEC011 caught a real
+   unguarded `rm -rf "$tmp"` in a forjar resource this week. `SC1020/SC1035/SC1140`
+   are *reported but not gating* — they fire inside string literals
+   (paiml/bashrs#226, still OPEN in 6.66.2; even `echo "done"` trips SC1035), and
+   gating on them would make this unpassable. An unpassable gate trains people to
+   bypass the whole protocol, so the suppression is deliberate, narrow, and
+   carries the issue number to be re-armed against.
+
+   **A clean bashrs result has three causes and only one of them is "the shell is
+   clean."** So the gate proves the other two are false before believing it:
+
+   - **Positive control.** A sentinel script carrying a known `DET002` is linted
+     first and must be flagged. Cost 83 ms. Watched fail: with `bashrs` shadowed
+     by `#!/bin/sh exit 0`, the gate reported *POSITIVE CONTROL FAILED … do not
+     read a clean result as clean* instead of "0 errors".
+   - **The scan receipt.** bashrs prints `Linted N file(s): …` on **stderr**, and
+     the gate asserts N equals the count it enumerated itself with `git ls-files`.
+     Without it a repo-root `.bashrsignore` silently zeroes the gate: verified,
+     `bashrs lint --level error sub/bad.sh` on a file containing `DET002` printed
+     `Skipped: sub/bad.sh` and **exited 0 with no receipt at all**. `--no-ignore`
+     restores the finding (exit 2) and is mandatory. The receipt is only emitted
+     for N≥2, so a known-clean sentinel is appended to the argv — otherwise a
+     one-script crate has no receipt to assert.
+   - **No pipeline, no `xargs`.** `xargs bashrs lint` remaps any exit in 1..125
+     to **123**, so errors and warnings become indistinguishable. argv is built
+     with a read loop.
+
+   Exit codes are overloaded and must not be read as a ladder: `0` = nothing at
+   or above `--level` **or** everything was ignored; `1` = warnings **or** "No
+   lintable files found"; `2` = errors **or** the path does not exist. Only the
+   receipt disambiguates. `--level` drives the exit code, not `--fail-on` —
+   verified, `--fail-on error` on a warning-only file still exits 1.
+
+   **Not covered, and named rather than implied:** GitHub Actions `run:` blocks
+   (bashrs parses a whole workflow YAML as bash — pointed at rmedia's `ci.yml` it
+   flagged `SC1020: Missing space before closing ]` on line 29, which is
+   `branches: [main, master]`), and DET/SEC inside Makefile *recipes* (filename
+   dispatches the rule set; identical content named `Makefile` gets MAKE001-020
+   and loses DET002/SEC008/SEC015). Covering `run:` blocks needs a real
+   extractor. That is work, not coverage.
+
+7d. **cli-surface / transport-decl / transport-absence / interface-parity** —
+   RELEASE INTERFACE VERIFICATION (CLI / HTTP / MCP).
+
+   **cli-surface** enumerates the subcommands the release binary *advertises in
+   its own `--help`*, then requires each to answer `--help` with exit 0. It
+   catches a release shipping a subcommand that panics, was renamed, or is listed
+   but unimplemented — a CLI claiming a surface it does not have. The surface is
+   read from the artifact, so it cannot drift the way a hand-written fixture
+   does. (forjar: 159 advertised subcommands, all answering.)
+
+   **transport-decl** — every interface the release ships is DECLARED in
+   `Cargo.toml`, versioned with the code it describes:
+
+   ```toml
+   [package.metadata.transports]
+   cli  = { e2e = "e2e_cli_t" }
+   mcp  = { e2e = "e2e_mcp_stdio_t", features = ["mcp"] }
+   http = { e2e = "e2e_http_serve_t", features = ["http", "lua"] }
+   ```
+
+   No declaration is a **FAIL**, not a skip. It is one line per transport, and it
+   converts "we have no HTTP surface" from an assumption into an enforced fact.
+
+   **transport-absence** — the binary must not advertise an `mcp`/`serve`/`http`
+   subcommand that no declaration covers. An undeclared transport is an
+   unverified one, and this makes adding one without declaring it a failure.
+
+   **interface-parity** — each declared transport's e2e target is run **by name**:
+   `cargo test -p <crate> --features <f> --test <target>`. Three properties, and
+   each has been watched fail:
+
+   1. **The target exists and its features are enabled.** Naming it with `--test`
+      is load-bearing: `cargo test --test e2e_http_t` without the feature is
+      `error: target 'e2e_http_t' … requires the features: 'http'`, **exit 101**,
+      while a bare `cargo test` exits 0 and does not mention the target once.
+      Naming it converts absence into a hard error; not naming it is a
+      gate-shaped silence.
+   2. **It spawns the shipped binary.** The target's source must reference
+      `CARGO_BIN_EXE_`. A parity suite that calls the library cannot see
+      reachability — rmedia's four-way transport-parity suite was **GREEN for the
+      whole period `mcp::serve_stdio` and `http::serve` had no caller from
+      `main.rs`** (GH-247). The transports agreed with each other perfectly and
+      were unreachable from the process entry point. Agreement cannot falsify
+      reachability; that is this file's own "a test you author cannot falsify a
+      premise you hold", with the unexamined premise being *the transport is
+      wired up*.
+   3. **It actually runs tests.** `test result: ok. 0 passed` is a vacuous pass
+      and FAILs.
+
+7d′. **transport-invariance — every transport LIVE AT ONCE, verbs DERIVED**
+
+   `interface-parity` proves each transport is reachable and green *in its own
+   e2e*. Necessary, and not sufficient: three transports can each pass their own
+   test file and still disagree about what a verb **returns**, because nothing
+   compares them — each e2e only ever sees its own surface.
+
+   This gate invokes the **same verb through every declared transport while all
+   of them are standing**, and requires byte-identical results.
+
+   **DERIVED, never hand-written.** The verb list comes from the *binary*, via
+   the `list` command the crate declares. A hand-written probe tests the verbs
+   someone remembered; a derived one tests the surface that actually shipped,
+   and grows when the surface grows. The gate FAILs when the binary lists
+   nothing — a parity check over an empty surface is vacuously true, the same
+   defect as a registry that silently empties.
+
+   **SIMULTANEOUS, never sequential.** One transport at a time cannot
+   distinguish *"they agree"* from *"they share a process-global that only one
+   of them may hold at a time"*. All of them up together is the configuration a
+   real client fleet produces, and the one that surfaces a shared listener, a
+   shared lock, or a runtime that tolerates a single owner.
+
+   It also asserts the agreed payload **parses as JSON** — two transports
+   returning identically-wrong bytes must not pass.
+
+   Declare it beside `[package.metadata.transports]`:
+
+   ```toml
+   [package.metadata.unified_surface]
+   list  = "verb list"                                    # one name per line
+   cli   = "verb call {verb} --json {params}"
+   http  = { serve = "verb serve --port {port}", path = "/v1/verbs/{verb}" }
+   probe = { verb = "validate", params = "{\"path\":\"forjar.yaml\"}" }
+   ```
+
+   `probe` must name a verb that is **safe to invoke repeatedly and has no side
+   effects** — the gate calls it once per transport, every run.
+
+   Absent declaration → SKIP. Declaration present but `invariance.py` missing →
+   **FAIL**, not SKIP: a gate that cannot run has not passed.
+
+### Never dogfood by hand
+
+**The protocol runs the binary. You do not.**
+
+Manual verification — a hand-typed `curl`, a binary path you picked yourself, a
+list of endpoints you remembered — is not a cheap version of this gate. It is a
+different activity with a worse failure mode, because it silently tests
+*something other than the artifact*.
+
+Observed 2026-08-22, while building the very surface this gate checks: a manual
+dogfood of a new HTTP transport reported `unrecognized subcommand 'serve'` and
+appeared to prove the feature broken. The feature was fine. The binary at
+`<repo>/target/debug/<crate>` was four minutes stale, because this workstation
+sets cargo's target directory globally and the real output was under
+`/mnt/nvme-raid0/targets/`. The e2e suite passed throughout — it uses
+`CARGO_BIN_EXE_`, which cannot be stale.
+
+`$BINPATH` here comes from `cargo build --message-format=json`'s own
+`executable` field for exactly this reason: it is the artifact cargo just
+produced, wherever cargo chose to put it. A path you type is a guess about where
+that is.
+
+So if you find yourself starting a server and curling it to check something,
+that is a signal the **declaration is missing**, not that the gate is
+unnecessary. Add `[package.metadata.unified_surface]` and let the protocol do it
+— derived, simultaneous, and against the binary that will actually ship.
+
+
+   **What the e2e target must assert** (the gate enforces that it exists, spawns
+   the artifact and passes; what it checks is the crate's job). The reference
+   implementation is rmedia — `crates/rmedia-cli/src/verbs/conformance.rs` plus
+   `tests/e2e_mcp_stdio_t.rs` and `tests/e2e_http_serve_t.rs`:
+
+   - **Surface equality** — the name sets from all transports (CLI leaf walk of
+     the *derived* clap tree, MCP `tools/list`, HTTP `GET /v1/verbs`) are equal
+     to each other and to a committed manifest that is **generated from the
+     registry**, not maintained beside it. Docs as a projection make drift
+     unrepresentable.
+   - **One green verb through every transport, diffed as bytes** — with the MCP
+     and HTTP params *derived from the CLI argv through the adapter*, so it
+     compares adapters rather than three hand-written inputs that happen to agree.
+   - **One red input through every transport** — same error class, each
+     transport's own code (exit 2 / JSON-RPC -32602 / HTTP 400), no invented values.
+   - **Lifecycle** — readiness read from the child (never `sleep`), SIGTERM
+     exits 0, port released.
+
+   **probador-suite** runs `probador test` where the crate configures it
+   (`probar.toml`, or a `jugar-probar` dependency). Missing *configuration* is a
+   SKIP with its reason; a missing *tool* is already a NO-GO above.
+
+   ### probar/probador: what it gates, and the gap
+
+   **probador 1.0.3 cannot verify a CLI, HTTP or MCP interface today.** It is
+   "Playwright-Compatible Testing for WASM + TUI Applications". Its subcommands
+   are `test, record, report, coverage, init, config, serve, build, watch,
+   playbook, comply, av-sync, audio, video, animation, stress, llm` — none of
+   which drives another process's CLI, an arbitrary HTTP endpoint, or a JSON-RPC
+   server. Specifically, verified in the source:
+
+   - `serve` is a **dev server for the WASM app under test** (axum
+     `extract::ws`, hot reload, COOP/COEP) — it hosts a page; it is not an HTTP
+     client.
+   - `llm` **is** a real HTTP client and `llm bench --start <cmd>` even has the
+     right shape, but the protocol is hardwired: `crates/probar/src/llm/client.rs`
+     builds `{base_url}/v1/chat/completions` and POSTs a typed `ChatRequest`.
+     There is no way to say "POST /v1/&lt;verb&gt; with this body and diff the bytes".
+   - **MCP is inert**: `jsonrpc` appears in exactly two files, both
+     `generated_contracts.rs`, and the generated `contract_jsonrpc_framing!`
+     macros have **zero call sites** in `probar` or `probar-cli`. It carries the
+     vocabulary, not the capability.
+   - `probador comply` is **vacuous off-WASM**: on a plain 4-line Rust CLI crate
+     with no WASM, no HTML and no browser it scored **8/10**, passing "Custom
+     elements tested", "Threading modes tested", "WASM size limit". Gating on
+     that would be precisely the defect this protocol exists to catch, so it is
+     not gated.
+
+   So probador's honest contribution to a Rust CLI release is its own suite where
+   a crate configures it, and **nothing** for CLI/HTTP/MCP parity. That is why
+   7d is built on cargo, which is already present, and why there is no `probador
+   interface` invocation in `dogfood.sh` — writing one would be a step that reads
+   as a pass without verifying anything.
+
+   **The gap, as work rather than coverage.** For probar to become the home of
+   this gate it needs five capabilities it does not have: (1) a process-under-test
+   driver — spawn an arbitrary binary with argv/env/cwd and capture stdout,
+   stderr and exit code separately (generalising `llm bench --start`);
+   (2) a stdio JSON-RPC client with initialize / tools-list / tools-call as
+   first-class ops (the `mcp-protocol-v1` contract macros it already carries are
+   the schema for exactly this); (3) a general HTTP client — arbitrary
+   method/path/body/headers with raw-byte capture, i.e. `llm/client.rs` with the
+   hardcoded path and typed body lifted out; (4) readiness and lifecycle
+   primitives — ephemeral port, readiness line read from the child, real SIGTERM,
+   assert exit 0 and port release; (5) a cross-transport diff assertion. (1)+(4)
+   would also fix `comply`'s vacuity, since C001 "Code execution verified" is the
+   same *did it actually run* question. A plausible surface is
+   `probador interface --manifest probador.interface.toml`, hosted by the existing
+   `playbook` state machine. Until then, this section states what is missing
+   rather than implying it is covered.
+
+   The previous gate here was `probar run`: wrong binary (`probador`), and `run`
+   is not a subcommand. `command -v probar` therefore failed and it WARNed on
+   every release. **A verifier that has never executed is indistinguishable from
+   one that passes** — which is the defect this entire skill exists to prevent,
+   sitting inside the skill itself.
+
+7e. **contracts-exit-integrity** — the `contracts:` recipe is inspected for
+   laundered exit codes *before* its GREEN is believed. A POSIX `for` loop exits
+   with its **last iteration's** status, so
+
+   ```make
+   contracts:
+   	@for c in contracts/*.yaml; do pv validate "$$c"; done
+   	pv lint contracts/binding.yaml 2>/dev/null || true
+   ```
+
+   reports whatever the alphabetically-last contract did. That is rmedia's actual
+   recipe, and running its body against rmedia's real contracts **exits 0 with 17
+   of 47 contracts failing validation** — because the last name in the glob,
+   `visual-quality-v1.yaml`, passes. The largest false green found in this fleet.
+   The second line is dead twice over (`pv lint` on a FILE passes over zero
+   contracts, and `|| true` would swallow it anyway). The correct shape is
+   copia's: `do pv validate "$$c" || exit 1; done`.
+
+7f. **pmat-verify / pmat-comply** — `pmat comply check` runs 155 checks and **its
+   exit code cannot see a skip**. Measured on a clean tiny crate:
+   `{"pass":26,"warn":13,"fail":0,"skip":116}`, `"is_compliant": true`, exit 0 —
+   and **three of those 116 skipped checks carry `"severity": "Error"`**.
+   `--strict` does not help; it only adds a warnings tri-state, in which skips
+   appear nowhere.
+
+   The sharpest case is **CB-200 (TDG Grade Gate)**. In a fresh `git clone` with
+   no `.pmat/` it reports *Skip: "Not measured: no .pmat/context.db … Run `pmat
+   query \"x\"` to create the index."* Measured on rmedia: fresh clone
+   `{"fail":3,"skip":95}` with CB-200 = Skip; after **one** `pmat query`,
+   `{"fail":4,"skip":93}` with CB-200 = **Fail — "24 function(s) below minimum
+   grade A"**. The green was the index's absence, not the tree's quality.
+
+   So the gate **builds the index first**, then treats CB-200 `Skip` and `Fail`
+   as equally NO-GO — unmeasured is not a pass — and REPORTS the rest. The rest
+   stays non-gating because 17 further checks want state a release checkout
+   structurally cannot have (a gitignored `.pmat-work/` ticket dir, a *sibling*
+   `../provable-contracts/proof-status.json`, a ledger), which is genuinely a
+   property of the workstation
+   (paiml/paiml-mcp-agent-toolkit#1008). CB-200 is not in that category: it is
+   fixable with one command, so it is gated. The old handling failed both ways —
+   it piped comply into `python3`, so the number recorded was the *python stage's*
+   result and comply's own exit code was lost, and it marked the outcome WARN.
+8. **publish-dry-run** — `cargo publish --dry-run` packages cleanly (env
+   `CARGO_REGISTRY_TOKEN` is unset so a stale token can't mask a real auth setup).
+9. **dogfood-use** — THE dogfood step: the tool exercises its own generated
+   artifacts against **real external tools and real on-disk shapes**, and fails
+   if reality disagrees with what the code assumes.
+
+   **Prefer a native subcommand over a shell script.** If the crate exposes one
+   (`forjar dogfood`), run that — it lives with the code, is versioned with it,
+   is itself unit-tested, and can enumerate its own surface exhaustively. Fall
+   back to `scripts/dogfood-use.sh` only for crates that have no native gate yet.
+
+   **A missing dogfood capability is a NO-GO, not a WARN.** A released tool
+   nobody actually ran is not dogfooded, and a WARN in a release protocol is a
+   step everybody learns to walk past.
+10. **clean-room** — marked MANUAL because it runs on the intel CI box and is heavy.
+    It is a **HARD release gate**: no `cargo publish` for any Sovereign AI Stack
+    crate without it. Run it yourself before releasing:
+    `make -C ~/src/infra/machines/clean-room clean-room-<crate>`.
+
+## What dogfooding has to do — and why tests do not replace it
+
+**A test you author cannot falsify a premise you hold.** forjar shipped three
+releases in two days, each fixing the previous, and every one had passed 12,904
+unit tests, a five-gate clean room and a 19-check CI run:
+
+| release | bug | why the tests missed it |
+|---|---|---|
+| 1.13.0 | `backup_sync` read rclone's `--combined` status characters inverted, so files that were NOT backed up left the coverage denominator — a backup missing data reported *higher* coverage than one with everything | the test stub emitted whichever characters the author believed in, so it could never disagree |
+| 1.13.2 | `disk_budget` required both `CACHEDIR.TAG` and `.rustc_info.json`; across a real 4.6 TB tree **zero of sixteen** marker-bearing dirs had the pair, so the reaper matched nothing and went inert at 94% used | the fixture had both markers because the author believed both were present |
+
+Both are the same failure: the fixture and the code shared an author, so it was
+confirmed rather than tested. Only the real tool and real data can break that
+loop. So a dogfood exercise must:
+
+- **invoke the real external tool** the code depends on (`rclone check` itself,
+  not a stub of it) and assert on its actual output;
+- **build the on-disk shapes that really occur**, taken from a machine, not from
+  what the layout is assumed to be;
+- **fail when the tool is absent** rather than skipping — a dogfood run that
+  quietly skips the real dependency proves nothing;
+- **use the interpreter production uses** (forjar executes with `bash`; checking
+  emitted scripts under `sh` tests a configuration that never runs);
+- **be exhaustive over the surface**, so a new feature cannot land with no
+  coverage. `forjar dogfood` matches every `ResourceType` with no wildcard arm:
+  a new type fails to compile until its coverage is declared, and
+  `NotApplicable` requires a written reason. That is the property that stops the
+  gate going quiet — the previous `dogfood-use.sh` covered only `file`
+  resources and still returned GO while two new resource types shipped broken.
+
+### Verifying the gate is real
+
+A gate nobody has seen fail is not evidence. For each bug class it claims to
+cover, apply the bug as a **named mutation** and confirm the gate turns RED,
+then restore and confirm GREEN. Record both in the PR. forjar's:
+
+```
+both-markers cargo rule   -> FAIL disk_budget: repo target root NOT detected
+inverted rclone +/-       -> FAIL backup_sync: counter keyed on wrong character
+```
+
+**This applies to the protocol's own gates.** Every gate in `dogfood.sh` was run
+against a fixture crate at full GREEN (`VERDICT: GO`, exit 0), then mutated one
+at a time; the tree was restored after each and re-confirmed GREEN. 2026-08-16
+ledger — mutation → the gate that turned RED:
+
+| mutation | gate | what it printed |
+|---|---|---|
+| `det002-timestamp` (add `$(date +%s%N)` to a script) | bashrs | 1 SEC/DET/IDEM error(s) over 3 file(s): DET002 |
+| `bashrsignore+real-finding` (`.bashrsignore='*.sh'` hiding that DET002) | bashrs | *still* FAILs — `--no-ignore` is load-bearing |
+| `bashrs-partial-scan` (stub silently lints 2 of 4 files, exit 0) | bashrs | NO SCAN RECEIPT: expected `Linted 4 file(s)`, got `Linted 2 file(s)` |
+| `bashrs-noop-shadow` (`#!/bin/sh exit 0` on PATH) | bashrs | POSITIVE CONTROL FAILED … do not read a clean result as clean |
+| `contract-schema-break` (rename a required key) | pv-contracts, pv-lint | 1 checked, FAILED: hash-integrity-v1.yaml / `Summary: 1 errors` |
+| `pv-noop-shadow` | pv-contracts | POSITIVE CONTROL FAILED: `pv validate` accepted a malformed contract |
+| `ghost-binding` (point a binding at a nonexistent fn) | pv-bindings | REPORT `0/1 verified; 1 ghost(s)` — by design, see 7b″ |
+| `unreadable-binding` (corrupt `binding.yaml`) | pv-bindings | FAIL: produced no verification line — an unrun verifier is not a clean one |
+| `laundered-for-loop` (drop `\|\| exit 1`) | contracts-exit-integrity | recipe launders its exit code: a for-loop with no `\|\| exit` |
+| `or-true-swallow` (append `\|\| true`) | contracts-exit-integrity | `\|\| true` swallows a real failure |
+| `pmat-index-absent` (`rm -rf .pmat`, `pmat query` stubbed out) | pmat-comply | CB-200 is UNMEASURED, not passing |
+| `drop-transports-table` | transport-decl | no `[package.metadata.transports]` … an undeclared transport is an unverified one |
+| `undeclare-http` (binary still ships `serve`) | transport-absence | binary advertises undeclared transport surface: serve(→http) |
+| `library-only-e2e` (e2e calls the lib, not the binary) | interface-parity | e2e never references `CARGO_BIN_EXE_` — exercises the library, not the release artifact |
+| `unmet-required-features` (drop `features=["http"]`) | interface-parity | http(exit=101) |
+| `vacuous-zero-test-e2e` (target compiles, runs no tests) | interface-parity | target ran 0 tests — a vacuous pass |
+| `render-compact-over-http` (one transport pretty, one compact) | transport-invariance | `validate` differs between cli and http — verified against forjar 2026-08-22 |
+| `empty-verb-list` (binary lists no verbs) | transport-invariance | the binary lists NO verbs — a parity check over an empty surface is vacuous |
+| `delete-invariance.py` | transport-invariance | invariance.py missing — a gate that cannot run is not a SKIP |
+| `advertised-but-unusable` (list `diag` in `--help`, don't implement it) | cli-surface | advertised but unusable: diag (of 2 checked) |
+
+Two negatives worth keeping, because "did not go red" is also a finding:
+a duplicate contract id is a pv **warning**, not an error, so pv-lint stays
+green on it; and `.bashrsignore` alone over *clean* scripts stays green, which
+is correct — it is only dangerous when it hides a real finding, which is what
+the mutation above tests.
+
+### The gate that crashed instead of running
+
+`dogfood.sh` referenced `$BINPATH` in the renacer gate ~100 lines **before** the
+release binary was built. Under `set -u` that is a fatal abort, not a skipped
+gate. Reproduced on a crate with a `renacer.toml` (trueno has one, and renacer
+is installed): `dogfood.sh: line 181: BINPATH: unbound variable`, **exit 1** —
+the same exit code this script uses for NO-GO. It never reached the contracts
+step, the dogfood step, or the receipt, and a crashed protocol was
+indistinguishable from a considered verdict. The build now happens once, near
+the top, and records its own `release-binary` gate.
+
+Two smaller versions of the same disease, also fixed: the note extractor printed
+raw ANSI (`(B[m`) instead of the failure, and the crate's feature detection
+matched `cli = { e2e = … }` inside `[package.metadata.transports]`, running every
+gate with `--features cli` against a crate that has no such feature.
+
+### Status vocabulary
+
+`PASS` / `FAIL` / `SKIP` / `REPORT` / `MANUAL`. **`SKIP` must record the
+enumeration that found nothing** ("0 files from: `git ls-files '*.sh' …`"), so
+*no subject* can be told apart from *did not look*. **`REPORT` is a measurement
+that is deliberately not gating, and must carry both the number and the upstream
+issue it waits on** — a REPORT with no issue number is a WARN wearing a costume.
+Do not add new `WARN`s: a WARN in a release protocol is a step everybody learns
+to walk past.
+
+### Legacy: the `scripts/dogfood-use.sh` contract
+
+For crates without a native gate. The script receives `$BIN` (the built release
+binary) and `$WORK` (a scratch dir) and exits non-zero if the tool misbehaves on
+real input — e.g. copia round-trips its own source tree through sync + bisync +
+hub and asserts byte-identity. Migrate these to native subcommands over time.
+
+## Gaps this protocol did not catch (pmat 3.32.0) — now required checks
+
+Every item below is a defect that survived a green CI, ~20,000 passing tests and
+a NO-GO receipt that named neither. They are listed as *checks to run*, not
+advice, because each was invisible to the version of this protocol that produced
+that receipt.
+
+**1. A gate that cannot fail is not a gate — prove it fails.**
+`make coverage` ended with
+
+    if [ -n "$COV_PCT" ] && [ below threshold ]; then fail; else PASS; fi
+
+so an EMPTY percentage — a broken instrumentation run, a changed summary format,
+anything that stops `TOTAL` parsing — took the else branch and printed
+`✅ Coverage % meets threshold 95%` at exit 0. The test run above it was
+`|| true`, so a failing suite reached the same place. **Grep every gate for the
+shape `[ -n "$X" ] && [ …bad… ]`, and for `|| true` on the step that produces the
+measurement.** An unmeasured value must FAIL, and must say which of the two
+states it is in.
+
+**2. A gate nobody runs is decoration — check it is WIRED, not merely present.**
+Two falsification gates lived in the Makefile and in `tests/all.rs`. Both were
+referenced **zero times** in any workflow, because every CI leg runs
+`cargo test --lib` and they are integration targets. Run
+`grep -c "<gate-target>" .github/workflows/` for each `make` gate. Then check it
+is *blocking*: a job that reports but is not in a required context (directly or
+via an aggregator's `needs:`) cannot stop a merge. Adding a gate that reports and
+cannot block reproduces the exact defect the gate detects.
+
+**3. A checker that measured nothing must not report success.**
+Assert a floor on the population inside the checker itself — `assert!(checked >
+1000)` in a repo with thousands of the thing being checked. Silence from a broken
+walk is byte-identical to silence from a clean tree.
+
+**4. A harness must not report the developer's shell.**
+`run()` scrubbed `CARGO*`, `RUSTC*` and `PMAT_CONFIG` and never touched
+`RUST_LOG`, so `--quiet` read as a no-op on ~43 commands with RUST_LOG unset and
+as effective with it exported. Third instance of that class in one file — the
+other two are `NO_COLOR=1` (turned ~40 `--color` flags into false no-ops) and a
+nested `cargo check` under `cargo test` that made the harness *manufacture the
+defect it claimed to detect*. **Scrub the environment, then let a flag that needs
+one DECLARE it per-flag.** Never set it globally: the variable that makes
+`--quiet` observable makes `--verbose` inert.
+
+**5. Regenerate generated artifacts AFTER merging, never before.**
+A committed ledger that counts every test in the tree is stale the moment the
+base branch adds one. Regenerating and then merging produced a red PR that looked
+like real breakage twice.
+
+**6. Verify a constraint before repeating it.**
+"PRs touching `.github/workflows/*` need a web-UI merge click — the token lacks
+`workflow` scope" was carried for an entire session and was FALSE: the token had
+the scope and the remote was SSH, which bypasses token scopes entirely. The
+evidence — a successful push of workflow edits — was already in the transcript.
+`gh auth status` and `git remote get-url origin` take one second between them.
+
+**7. Read the file back after a scripted edit, and never `grep -c` a binary.**
+A `python -c` inside double quotes let the shell execute backticks in a comment
+and silently blank two words. `grep -c pattern <binary>` does not count matches —
+use `grep -ac`. Both produce a confident, wrong "done".
+
+**8. An external oracle is the point — comparing a tool to its own report proves
+nothing.** `analyze clippy` reported `total_diagnostics: 0` on a crate
+`cargo clippy` gives 76 warnings for, because the count was taken AFTER a
+confidence filter. No unit test could catch it: the fixture and the code share an
+author. The dogfood check that catches it runs **real cargo clippy** and compares.
+
+## Adoption state (2026-08-16) — the baselines, stated rather than hidden
+
+Both crates measured today are **NO-GO**, and that is the gates working:
+
+- **copia 0.2.0** — RED on `version-unpublished` (0.2.0 is already on crates.io;
+  bump it) and on `transport-decl` (a 7-subcommand CLI that has never declared
+  its interfaces). Everything else green: 11 contracts valid, `pv lint` 0 errors,
+  bashrs 2 files linted with the receipt confirmed, CB-200 measured and passing,
+  `contracts:` recipe propagates failure, dogfood-use round-trips L1/L2/L3.
+  `pv-bindings` REPORTs 14/15 with one ghost, which is a pv false positive
+  (see 7b″).
+- **rmedia** — measured read-only today, RED on four: `pv-contracts` (**17 of 47**
+  contracts have never passed `pv validate`); `contracts-exit-integrity` (its
+  `contracts:` recipe is exactly the laundered `for` loop above);
+  `bashrs` (13 files linted, receipt confirmed, gating findings **DET002 ×2,
+  SEC010 ×11, SEC011 ×1** — `scripts/bench-whisper-e2e.sh:83,89` is
+  `START_NS=$(date +%s%N)` in a benchmark, a defensible use and precisely why
+  this wants a dated baseline rather than a blanket block; 82 SC10xx suppressed
+  as #226 and 150 further parse-noise errors reported but not gating); and
+  `pmat-comply` (CB-200: 24 functions below grade A). Its interface work is the
+  reference implementation for 7d and is already done — it needs the declaration.
+
+Record a dated baseline in the crate rather than weakening a gate. A baseline may
+only shrink.
+
+### 9. A gate that is green here and red on the runner measured a different thing
+
+Not a flaky gate — a gate whose CONTROL differs between environments. pmat's
+flag-efficacy sweep was green on the workstation and red in CI, reporting
+`analyze coverage-improve --fast` as a flag that "parses but changes nothing".
+The flag is wired (`perfection_score/calculator.rs:212,297,316`). The runner's
+corpus has no Makefile, so the command exits 1 with an empty stdout **before any
+flag is read**, and the flagged run reproduced the baseline byte for byte
+because both had already failed. The gate was accusing working code.
+
+The general rule, which belongs in any differential harness:
+
+> A baseline that exited non-zero **and rendered nothing** is not a control.
+> Every flag compared against it reproduces it exactly.
+
+Note both conjuncts. Keying on the exit code alone excuses every no-op flag on
+every failing quality gate — `quality-gate`, `analyze lint-hotspot` and `enforce
+extreme` all exit 1 while printing a full report, and that is their healthy
+outcome. pmat had this guard on its two-value probe path and not on its boolean
+path, so the rule lived in one of the two places that needed it; the fix moved it
+into the single function both paths validate their baseline through.
+
+**So: run the release gates in the CI environment before believing them, and
+when a gate fires, reproduce the finding by hand before filing it.** A local
+green is evidence about the local corpus, not about the gate.
+
+### 9b. `cargo test --lib` does not run doctests, and the clean room does
+
+Two doc comments in pmat 3.32.0 contained prose indented by four spaces. Markdown
+reads an indented block as a code block and rustdoc COMPILES a code block as
+Rust, so both were doctests, and both failed:
+
+```
+src/cli_exit.rs:75                 error: expected one of `!` or `::`, found `:`
+src/services/unrun_tests/mod.rs:154 error: unknown start of token: \u{2014}
+```
+
+Every local check in that session was `cargo test --lib`, which excludes
+doctests entirely, so the defects were green locally and red in the clean room's
+B3 gate. Neither block was ever meant to be executable; both are now fenced
+```` ```text ````.
+
+**Run `cargo test --doc` before a release, not only `--lib`.** And note this
+compounds with the coverage note elsewhere in this file: `make coverage[-broad]`
+also uses `--lib`, so a doctest is unmeasured there too.
+
+### 10. `cargo deny check advisories` is only as wide as RustSec
+
+`advisories ok` answers "is anything in my tree **listed in RustSec**" — not "is
+anything in my tree known-vulnerable". Measured in pmat 3.32.0: cargo-deny
+printed `no crate matched advisory criteria / advisories ok` while thrift 0.17.0
+sat in the tree (`parquet 57.3.1` <- `aprender-db`) carrying CVE-2026-43868
+(medium, CVSS 5.3, patched 0.23.0). RustSec's db, pulled the same day with 1,208
+advisories, had **no thrift entry at all**; GitHub's Advisory Database did.
+
+The protocol now runs a `security-2nd-source` check against
+`gh api "repos/{owner}/{repo}/dependabot/alerts" --paginate` — an independent
+database, which is the entire point. FAIL on high/critical, WARN otherwise, and
+WARN when `gh` is missing, because a source that did not run is not a source
+that found nothing.
+
+## 11. FLEET dogfood — the release binary against real repositories
+
+**Every gate above tests pmat against fixtures pmat's own authors wrote**, so
+the fixture and the code share an author and confirm each other. That is the
+loop this whole protocol exists to break, and it was still unbroken at the top
+of 3.32.0.
+
+So: `cargo install --path . --root <scratch>` the release tree, and run that
+binary against **every repo in the sovereign stack**. The roster is the one
+`~/src/infra/machines/clean-room/Makefile` declares — aprender, whisper-apr,
+forjar, depyler, bashrs, duende, rmedia, copia, pepita, pzsh, cohete, pforge.
+They span 10 to 60,980 files of code nobody wrote to make pmat look good.
+
+Harness: `scripts/../fleet-dogfood.sh` in this skill directory, one repo per
+invocation.
+
+**Install to a SCRATCH root, never over `~/.cargo/bin`.** And use the built
+artifact for pmat's own gates: the installed `pmat` and the release tree both
+print `3.32.0` while being different commits, and in this cycle that difference
+ran the OLD CB-200 against the new tree and produced a false NO-GO. Only the
+`commit:` line in `--version` distinguishes them.
+
+**Two kinds of finding, and conflating them is the failure mode:**
+
+| | meaning | ticket goes to |
+|---|---|---|
+| `PMAT-DEFECT` | pmat crashed, hung, emitted unparseable JSON, or reported success having measured nothing | pmat |
+| `REPO-FINDING` | pmat worked and found real debt in the target | that repo |
+
+Conflating them files a tool's own bugs as other people's debt. **One
+consolidated ticket per repo**, never one per finding — a maintainer opening six
+issues from an automated sweep closes all six unread. **Reproduce every
+PMAT-DEFECT by hand before filing.** If a repo is clean, file nothing and say so:
+this must not manufacture work.
+
+## 12. TRANSPORT PARITY — ask the same question three ways
+
+A CLI-only sweep proves nothing about the other transports. This project's
+history records **24 MCP-vs-CLI contradictions in a single round**, and the
+3.32.0 surface audit found that of the 16 tools the shipped binary actually
+serves over MCP, **zero** had a top-tier coverage row while the 18 it does not
+serve scored higher. The tested surface and the served surface were nearly
+disjoint.
+
+Harness: `transport-parity.sh` in this skill directory. For each repo it asks
+one question over **CLI, MCP stdio and HTTP** and compares the answers. The
+finding it produces is not "a transport is broken" — it is **"the transports
+DISAGREE"**, which is worse, because each looks correct alone.
+
+Two traps, both hit on the first run:
+
+* **Get the tool schema right.** The MCP tools take `paths` (an array), not
+  `project_path`. Calling them wrongly yields `-32602 Validation error`, which
+  reads exactly like a defect. The harness now classifies any JSON-RPC error as
+  a HARNESS fault, because the first run produced three confident phantom
+  findings that way.
+* **A missing HTTP build is SKIPPED and said so**, never silently passed.
+
+## 13. All three transports must be in the DEFAULT build
+
+`mcp-http` was opt-in, so `cargo install pmat` produced a binary whose
+`serve --help` read `[HTTP NOT COMPILED IN this build]` — while the crate
+description said "(CLI, MCP, HTTP)". Two of three were true by default.
+
+A transport nobody can reach without knowing a flag name is close to a transport
+that does not ship, and it cannot be dogfooded by anyone who has not been told
+the flag. As of 3.32.0 `mcp-http` is in `default`. **If a release moves it back
+out, the description must move with it.**
+
+## On GO — the release (only after clean-room is also green)
+
+1. `git tag vX.Y.Z && git push origin vX.Y.Z` (or the repo's release workflow).
+2. `env -u CARGO_REGISTRY_TOKEN cargo publish` from a box with valid crates.io
+   credentials (lambda-labs/intel). If the tag-triggered release workflow is
+   flaky, publishing manually is the sanctioned fallback.
+3. Create the GitHub release from the tag (binaries via the release workflow).
+4. Attach the dogfood receipt to the release notes as the pre-release evidence.
+
+## On NO-GO
+
+Stop. Report the failing gate + its note. Fix the root cause in the owning crate
+(five-whys), commit, re-run `dogfood`. Never release on a NO-GO.

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -31,8 +31,15 @@ From (or pointing at) the crate repo:
 
 ```bash
 bash <aprender>/scripts/dogfood.sh [REPO_DIR]   # defaults to $PWD
+cd <aprender> && bash scripts/dogfood.sh ../other-crate   # the relative form works too
 # ~/.claude/skills/dogfood/dogfood.sh still works: it is a shim onto the above.
 ```
+
+The relative form is the fleet path, and it is gated (PART 3 of
+`scripts/check_verifier_pinning.sh`). It briefly was not: `SKILL_DIR` was resolved
+after the runner had already `cd`-ed into the target repo, so a relative
+`${BASH_SOURCE[0]}` pointed at the wrong tree and the fail-closed pin library was
+"missing" — exit 2 before any gate ran, while the absolute form kept working.
 
 ### A crate's own release gates are DECLARED, never copied in
 

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -19,6 +19,24 @@ effort: high          # MACS F4: pinned for reproducible cost/behavior - gates a
 - Uncommitted changes: !`git status --short | wc -l`
 - Test count: !`cargo test -p apr-cli --lib 2>&1 | grep 'test result' | tail -1`
 
+## Three documents, three scopes — and only one of them is the fleet protocol
+
+Written down because three skills describe overlapping release work and the
+duplication is harder to see in prose than in code: nothing runs it, and no diff
+surfaces it (aprender#2640, D6).
+
+| skill | scope | source of truth for |
+|---|---|---|
+| `dogfood` (`.claude/skills/dogfood/SKILL.md`) | ANY Rust crate in the fleet | the generic pre-release protocol and `scripts/dogfood.sh` |
+| `apr-dogfood` | this repo's shipped surface | gate coverage against the surface ledger |
+| `pre-release` (this file) | `apr-cli` only | the crates.io publish gates below |
+
+**Do not restate a gate that lives in another of the three.** If a gate here also
+belongs to the fleet protocol, it belongs in `scripts/dogfood.sh` and this file
+should reference it — that is exactly how the runner came to exist twice.
+
+Run all independent gates in parallel where possible.
+
 ## Your Task
 
 Run the apr-cli pre-release QA checklist below. This checklist was derived from 5 historical release failures (CB-510, PMAT-262, GH-342, GH-343, GH-344/345) using Five-Whys root cause analysis on git history.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,23 @@ jobs:
       # correct everywhere else). Run the table; do not re-read the regex.
       - name: "`apr`-pinning guard must still turn RED (case table + surfaces)"
         run: bash scripts/check_apr_bin_pinned.sh --self-test
+      # Poka-yoke: Cargo.lock was 15 days stale on main (last touched 2026-08-01,
+      # manifests changed 08-10 and 08-11). Every CI job runs cargo WITHOUT
+      # --locked, so cargo rewrote the lock in place and stayed green; the only
+      # jobs that pass --locked are in binary-release.yml, i.e. the RELEASE path,
+      # which was broken on main. Resolution only, no build, ~1s.
+      #
+      # THIS STEP RUNS BEFORE EVERY STEP IN THIS JOB THAT INVOKES CARGO. It was
+      # placed after them, and the verifier-pinning step below cargo-builds pv
+      # (through scripts/pv_bin.sh) without --locked -- so a stale lock was
+      # silently repaired in the workspace before the guard whose entire purpose
+      # is to notice it ever looked. The guard could not have failed. The
+      # pinning guard now also snapshots and restores Cargo.lock and FAILS if
+      # the build moved it, so the two are independent.
+      - name: Cargo.lock must match the manifests
+        run: bash scripts/check_lockfile_current.sh
+      - name: "lockfile guard must still turn RED (case table)"
+        run: bash scripts/check_lockfile_current.sh --self-test
       # #2640: the SAME defect class as the two steps above, one level up. The
       # dogfood release runner existed as two 1170-line copies whose divergence
       # was, in every hunk, a pin for a release verifier that one copy had and
@@ -538,15 +555,6 @@ jobs:
         run: |
           cargo install bashrs --locked --quiet || true
           bash scripts/check_shell_lint_ratchet.sh
-      # Poka-yoke: Cargo.lock was 15 days stale on main (last touched 2026-08-01,
-      # manifests changed 08-10 and 08-11). Every CI job runs cargo WITHOUT
-      # --locked, so cargo rewrote the lock in place and stayed green; the only
-      # jobs that pass --locked are in binary-release.yml, i.e. the RELEASE path,
-      # which was broken on main. Resolution only, no build, ~1s.
-      - name: Cargo.lock must match the manifests
-        run: bash scripts/check_lockfile_current.sh
-      - name: "lockfile guard must still turn RED (case table)"
-        run: bash scripts/check_lockfile_current.sh --self-test
       # Poka-yoke: nextest IGNORES an unknown config key with a warning instead
       # of failing. `slow-warning = "60s"` is not a nextest key, so profile.ci
       # had no per-test timeout and a hung run died at the job's 85-minute

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,21 @@ jobs:
       # correct everywhere else). Run the table; do not re-read the regex.
       - name: "`apr`-pinning guard must still turn RED (case table + surfaces)"
         run: bash scripts/check_apr_bin_pinned.sh --self-test
+      # #2640: the SAME defect class as the two steps above, one level up. The
+      # dogfood release runner existed as two 1170-line copies whose divergence
+      # was, in every hunk, a pin for a release verifier that one copy had and
+      # the other did not. This guard scans the merged runner for a bare
+      # pv/pmat/apr AND exercises both pins against a poisoned PATH -- presence
+      # of `PMAT_BIN` proves nothing about which binary the gate ends up running.
+      # It found `pmat analyze reachability` bare in BOTH copies on its first run.
+      - name: The release runner must not resolve a verifier through PATH
+        run: bash scripts/check_verifier_pinning.sh
+      # One runner, one prose, and the user-scope copy stays a <=70-line shim
+      # that fails CLOSED. The cap lives here, in the repo on protected main;
+      # the file it caps lives at user scope, where it could otherwise raise its
+      # own ceiling.
+      - name: One dogfood runner, and the user-scope copy is a gated shim
+        run: bash scripts/check_dogfood_shim.sh
       # deny.toml is 7.2 KB of licence / banned-crate / source-allowlist policy
       # that ran in NO workflow -- only `make deny`, which is not a prerequisite
       # of any tier, so nothing but a human typing it ever invoked it. Meanwhile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,6 +539,28 @@ include = [
     "crates/aprender-core/README.md",
 ]
 
+# This crate's OWN release gates, DISCOVERED by scripts/dogfood.sh rather than
+# copied into it (#2640). The runner reads this list, runs each script, and gives
+# each one its own row in the release receipt. Declaring the list here — beside
+# [package.metadata.transports], versioned with the code it guards — is what
+# stops the runner from growing a second copy of itself to hold repo-specific
+# gates. A missing script FAILs; so does an empty list.
+#
+# scripts/dogfood_surfaces.sh is deliberately NOT here, and the reason is
+# ordering, not cost. Discovery runs early, before the runner has built the
+# release artifact; dogfood_surfaces.sh enumerates 29 binary targets from BUILT
+# binaries, so declaring it here would make the cheap repo-local guards wait on
+# a 27-crate build and would build the workspace twice per run. It stays where
+# it is, driven by .claude/skills/dogfood/SKILL.md at release time against the
+# artifact this runner produces. Move it here the day discovery gains an
+# after-the-binary phase.
+[package.metadata.dogfood]
+gates = [
+    "scripts/check_multiplatform_dogfood.sh",
+    "scripts/check_verifier_pinning.sh",
+    "scripts/check_dogfood_shim.sh",
+]
+
 [[bin]]
 name = "apr"
 path = "src/bin/apr.rs"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1790** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1791** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1790 provable YAML contracts
+├── contracts/                      # 1791 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1790 contracts across inference, training, quantization, attention, FFN,
+1791 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/dogfood-runner-unification-v1.yaml
+++ b/contracts/dogfood-runner-unification-v1.yaml
@@ -1,0 +1,282 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-23'
+  author: PAIML Engineering
+  references:
+  - 'docs/audits/dogfood-divergence-2640.md — the required triage: 9 hunks, 62 changed lines, ALL classified hardening-port, zero drift-discard'
+  - 'scripts/dogfood.sh — the one canonical runner (aprender#2640)'
+  - 'scripts/verifier_pin.sh — THE verifier-pinning rule, stated once, plus the two pins'
+  - 'scripts/check_verifier_pinning.sh — the gate: static scan + behavioural probe of both pins'
+  - 'scripts/check_dogfood_shim.sh — the gate: one runner, one prose, and the user-scope copy stays a gated shim'
+  - 'scripts/.dogfood-shim-reference.sh — the reviewed text of the user-scope shim'
+  - '.claude/skills/dogfood/SKILL.md — the one canonical prose, with an explicit `name:` (#2332)'
+  - 'aprender#2361 — a user-scope skill shadowed the repo one; hardening it edited a file that never ran'
+  description: >
+    The dogfood pre-release protocol existed as TWO 1170-line copies, one in this
+    repo and one at ~/.claude/skills/dogfood/. They shared all gate names and had
+    diverged in nine places; every hunk was a real, measured hardening the other
+    copy lacked, so neither was safe to delete and neither was safe to trust.
+
+    This contract holds the post-merge invariants. Its subject is not "the runner
+    works" — it is "there is exactly one runner, it carries BOTH hardenings, the
+    hardenings BEHAVE rather than merely being present, and a repo's own release
+    gates are DISCOVERED rather than copied into the runner."
+
+    The organising rule is the one #2640 found had been rediscovered five separate
+    times (PMAT_BIN, scripts/pv_bin.sh, scripts/apr_bin.sh, aprender#2384,
+    APR-BENCH-RFC-001): a gate that decides a release must not resolve its verifier
+    through PATH. Five rediscoveries is the evidence that a rule merely stated is
+    documentation. It ships here as an obligation with a named mutation.
+
+equations:
+  single_runner:
+    formula: |
+      R = { p in git ls-files : basename(p) == "dogfood.sh" }
+      REQUIRE: |R| == 1 AND R == { "scripts/dogfood.sh" }
+    domain: tracked paths in the aprender working tree
+    codomain: bool
+    invariants:
+    - 'Exactly one tracked dogfood.sh. Two copies is the defect state; zero is a deleted protocol.'
+    - 'It lives in the repo, not at user scope: git-tracked, PR-reviewed, CI-reachable and diffable are the four properties whose absence produced #2361.'
+
+  verifier_pinning:
+    formula: |
+      V = { pv, pmat, apr }          -- exactly the tools this repo PINS
+      S = { scripts/dogfood.sh, scripts/verifier_pin.sh }
+      bare(f) = { t in V : t appears in COMMAND POSITION in f
+                           after comments and quoted spans are removed }
+      REQUIRE: union over f in S of bare(f) == {}
+    domain: shell source of the release runner and its pin library
+    codomain: set of unpinned verifier tokens (must be empty)
+    invariants:
+    - 'A mention inside a comment or a string is NOT an invocation — the runner must stay able to describe its own rule.'
+    - 'bashrs and probador are deliberately OUT of V: no pin exists for them, and the rule''s second clause is "where the repo does not pin, REPORT". Adding them would demand a pin that does not exist.'
+    - 'The tokeniser ships a must-match / must-not-match case table (--self-test) because the apr-invocation patterns in this repo were wrong five times and every one was caught by a table, none by review.'
+
+  pin_behaviour:
+    formula: |
+      let stale be an executable named `pmat` FIRST on PATH
+      let built be the artifact cargo produced for the crate under test
+      verifier_pin_pmat("pmat",  built) = built     -- self-referential case
+      verifier_pin_pmat("other", built) = "pmat"    -- PATH is correct elsewhere
+      verifier_pin_pmat("pmat",  "")    = "pmat"    -- never fabricate a pin
+      let decoy be an executable named `pv` FIRST on PATH
+      verifier_pin_pv() = P  with  P != decoy  and  P executable
+    domain: the two pin functions in scripts/verifier_pin.sh
+    codomain: resolved verifier paths
+    invariants:
+    - 'Presence of PMAT_BIN in the source proves nothing about which binary the gate runs. The pins are EXERCISED against a poisoned PATH.'
+    - 'Measured, 2026-08-22, releasing pmat 3.32.0: installed 3.32.0 commit 8134bb373 vs built 3.32.0 commit 7a7409e03. BOTH PRINT 3.32.0 — only the commit differs, and nothing in the receipt showed it.'
+    - 'Measured: PATH pv 0.49.0 vs in-tree 0.63.0 disagreed on the release-deciding gate — strict-test-binding 253 refs / 51 missing stale vs 371 / 27 at HEAD.'
+
+  gate_discovery:
+    formula: |
+      G = Cargo.toml [package.metadata.dogfood].gates
+      REQUIRE: G is a non-empty list of strings
+      forall g in G: exists(g) AND run(g) is reported as its OWN receipt row
+      absent(G) or G == []  =>  FAIL
+      declared g with not exists(g)  =>  FAIL   (never SKIP)
+    domain: the crate manifest of the crate under test
+    codomain: one receipt row per declared gate, plus one aggregate row
+    invariants:
+    - 'Reuses the mechanism the runner already implements for [package.metadata.transports]; nothing new is invented.'
+    - 'A declared script that does not exist is a DELETED gate, not an absent requirement. SKIP would make deletion the cheapest way to silence a guard.'
+    - 'A clean sweep over an empty gate set is this protocol''s signature failure, reappearing one layer up at discovery. Both vacuity cases are hard FAILs.'
+    - 'Each gate gets its own row: rolling them into one aggregate is how a red gate hides behind a green neighbour.'
+
+  shim_is_a_shim:
+    formula: |
+      let U = ~/.claude/skills/dogfood/dogfood.sh
+      exists(U) => lines(U) <= 70
+                   AND gate_names(U) == {}
+                   AND U is byte-identical to scripts/.dogfood-shim-reference.sh
+                   AND run(U with the aprender checkout ABSENT) exits != 0
+                       AND names the REVISIT TRIGGER
+    domain: the user-scope copy, if the host has one
+    codomain: bool
+    invariants:
+    - 'The CAP lives in the repo, on protected main; the FILE it caps lives at user scope. Any state the author writes and the gate reads can be moved in the same commit — so it is deliberately not co-located.'
+    - '70 is chosen, not guessed: the shim is 49 lines, of which 32 are rationale. The smallest gate in the protocol is ~12 lines with its rationale plus a call site, so re-inlining even ONE gate spends the whole headroom.'
+    - 'Fail-closed is BEHAVIOURAL, not textual: the shim is actually run with the checkout absent.'
+    - 'REVISIT TRIGGER: the first time dogfood is invoked on a crate whose own repo is checked out but aprender is NOT. That is the signal infra-canonical has become correct — move the protocol, do not restore a local copy.'
+
+  single_prose:
+    formula: |
+      exists(.claude/skills/dogfood/SKILL.md)
+      AND it declares `name: dogfood` EXPLICITLY
+      AND not exists(~/.claude/skills/dogfood/SKILL.md)
+    domain: skill definitions visible to a session
+    codomain: bool
+    invariants:
+    - 'A user-scope skill WINS over a repo one. Without the explicit name: the repo skill is named after its directory, collides, and never appears in the session listing (#2332).'
+    - 'Duplication moved from executable to prose is HARDER to detect, because nothing runs it and no diff surfaces it.'
+
+falsification_tests:
+- id: F-DOG1-001
+  rule: single canonical runner
+  prediction: 'git ls-files yields exactly one dogfood.sh, at scripts/dogfood.sh'
+  test: 'bash scripts/check_dogfood_shim.sh   # row 1'
+  if_fails: 'a second runner exists — the #2640 defect state has returned'
+  mutation: 'add a second tracked dogfood.sh anywhere in the tree; row 1 must turn RED'
+
+- id: F-DOG1-002
+  rule: no verifier resolved through PATH
+  prediction: 'no bare pv/pmat/apr in command position in the runner or its pin library'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 1'
+  if_fails: 'a release gate would be measured with whatever binary PATH happens to offer'
+  mutation: 'reintroduce a bare `pmat` call (gate pmat-verify pmat verify --format json); PART 1 must turn RED'
+
+- id: F-DOG1-003
+  rule: the tokeniser is right before its verdict means anything
+  prediction: 'nine must-flag forms are all reported; ten must-not-flag forms are all accepted'
+  test: 'bash scripts/check_verifier_pinning.sh --self-test'
+  if_fails: 'the scan is either blind or noisy, and PART 1''s green says nothing'
+  mutation: 'remove "if" from the OPENERS set; the `if pv validate x` row must stop being flagged and the table must turn RED'
+
+- id: F-DOG1-004
+  rule: the PMAT_BIN hardening BEHAVES
+  prediction: 'with a stale pmat first on PATH and the crate under test named pmat, the pin resolves to the BUILT artifact'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2, rows 1-3'
+  if_fails: 'the gate that decides a pmat release measures a different build than the one shipping'
+  mutation: 'delete the `if [ "$verifier_pin_crate" = "pmat" ]` branch from verifier_pin_pmat; PART 2 row 1 must turn RED'
+
+- id: F-DOG1-005
+  rule: the pv pin BEHAVES
+  prediction: 'with a decoy pv first on PATH, the resolved PV is not the decoy'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2, row 4'
+  if_fails: 'contract validation — the release-deciding gate — runs on an unknown pv'
+  mutation: 'replace the pv_bin.sh source with PV=$(command -v pv); PART 2 row 4 must turn RED'
+
+- id: F-DOG1-006
+  rule: a declared gate that does not exist FAILS
+  prediction: 'a path in [package.metadata.dogfood].gates with no file behind it produces a FAIL row, never a SKIP'
+  test: 'DOGFOOD_GATES_ONLY=1 bash scripts/dogfood.sh'
+  if_fails: 'deleting a guard becomes the cheapest way to make it stop complaining'
+  mutation: 'add "scripts/check_this_does_not_exist.sh" to the gates list; a declared:* row must turn RED and the run must exit 1'
+
+- id: F-DOG1-007
+  rule: an empty or absent declaration FAILS
+  prediction: 'gates = [] and a missing [package.metadata.dogfood] both produce a FAIL'
+  test: 'DOGFOOD_GATES_ONLY=1 bash scripts/dogfood.sh'
+  if_fails: 'a clean sweep over an empty gate set reports GO'
+  mutation: 'set gates = [], then delete the block entirely; both must turn dogfood-gates RED'
+
+- id: F-DOG1-008
+  rule: the user-scope copy stays a shim
+  prediction: 'the user-scope dogfood.sh is <= 70 lines, invokes no gate, and is byte-identical to the reviewed reference'
+  test: 'bash scripts/check_dogfood_shim.sh   # rows 3a-3d'
+  if_fails: 'the shadow is re-forming, and hardening the repo will again edit a file that never runs'
+  mutation: 'append `mark pv-contracts PASS "ported back"` to the user-scope shim; rows 3b and 3d must turn RED'
+
+- id: F-DOG1-009
+  rule: the shim fails CLOSED
+  prediction: 'with the aprender checkout absent the shim exits non-zero and names the REVISIT TRIGGER'
+  test: 'bash scripts/check_dogfood_shim.sh   # row 3c'
+  if_fails: 'the shim degrades to something local, which is the shadow with extra steps'
+  mutation: 'replace the shim body with `exit 0`, then with a mute `exit 2`; row 3c must turn RED for both'
+
+- id: F-DOG1-010
+  rule: one prose, and it is the reviewed one
+  prediction: '.claude/skills/dogfood/SKILL.md exists with an explicit `name: dogfood`, and no user-scope SKILL.md shadows it'
+  test: 'bash scripts/check_dogfood_shim.sh   # rows 2 and 4'
+  if_fails: 'the repo skill never appears in the session listing and edits to it change nothing that runs (#2332/#2361)'
+  mutation: 'delete the `name:` line from the repo SKILL.md, and restore a user-scope SKILL.md; rows 2 and 4 must turn RED'
+
+proof_obligations:
+- type: invariant
+  property: 'Exactly one tracked dogfood.sh exists, at scripts/dogfood.sh (F-DOG1-001)'
+  formal: '|{ p in git ls-files : basename(p) = "dogfood.sh" }| = 1'
+- type: invariant
+  property: 'No verifier in V = {pv, pmat, apr} appears in command position unpinned in the runner or its pin library (F-DOG1-002)'
+  formal: 'forall f in S, bare(f) = {}'
+- type: soundness
+  property: 'The bare-invocation tokeniser flags every must-flag form and no must-not-flag form (F-DOG1-003)'
+  formal: 'flag(must_flag) = must_flag and flag(must_not_flag) = {}'
+- type: determinism
+  property: 'The PMAT_BIN pin selects the built artifact when the crate under test is pmat, and PATH otherwise (F-DOG1-004)'
+  formal: 'verifier_pin_pmat("pmat", b) = b for executable b; verifier_pin_pmat(c, b) = "pmat" for c != "pmat"'
+- type: determinism
+  property: 'The pv pin never resolves to a PATH pv (F-DOG1-005)'
+  formal: 'verifier_pin_pv() != command -v pv, given a decoy first on PATH'
+- type: completeness
+  property: 'Every declared gate produces exactly one receipt row, and a declared-but-missing script produces FAIL (F-DOG1-006)'
+  formal: 'forall g in G, exists exactly one row(g); not exists(g) => row(g) = FAIL'
+- type: bound
+  property: 'An absent or empty gate declaration is a FAIL, never a vacuous pass (F-DOG1-007)'
+  formal: 'G = {} or G undefined => dogfood-gates = FAIL'
+- type: bound
+  property: 'The user-scope shim is at most 70 lines, invokes no gate, and matches the reviewed reference byte for byte (F-DOG1-008)'
+  formal: 'lines(U) <= 70 and gate_names(U) = {} and U = reference'
+- type: safety
+  property: 'The shim fails closed and loudly when the canonical checkout is absent (F-DOG1-009)'
+  formal: 'exit(U | no checkout) != 0 and "REVISIT TRIGGER" in stderr(U)'
+- type: invariant
+  property: 'Exactly one prose description of the protocol is reachable, and it is the repo copy (F-DOG1-010)'
+  formal: 'exists(repo SKILL.md with explicit name) and not exists(user-scope SKILL.md)'
+
+kani_harnesses:
+# Declared, NOT written. These are shell guards over shell source; there is no
+# Rust surface for Kani to model-check, and inventing one would be theatre. The
+# harnesses name the three obligations that WOULD be model-checkable if the
+# pin resolution moved into Rust (which `apr dogfood` would do — explicitly out
+# of scope for #2640, because porting before unifying means porting twice).
+- id: KH-DOG1-001
+  obligation: verifier_pinning
+  property: no_verifier_token_reaches_execution_unpinned
+  bound: 4
+- id: KH-DOG1-002
+  obligation: pin_behaviour
+  property: pin_selection_is_independent_of_path_contents
+  bound: 4
+- id: KH-DOG1-003
+  obligation: gate_discovery
+  property: empty_or_missing_gate_set_is_never_a_pass
+  bound: 4
+
+qa_gate:
+  id: F-DOG1-GATE-001
+  name: one dogfood runner, both hardenings, and the rule enforced
+  description: >
+    The organising gate for aprender#2640. It is not enough that the merged runner
+    CONTAINS both hardenings — the triage that justified the merge established that
+    each copy independently gained one, so a merge that carried them forward as
+    inert text would satisfy a presence check and lose the property. Every
+    obligation here is therefore either a structural uniqueness claim or a
+    behavioural probe under a poisoned PATH.
+  checks:
+  - single_runner
+  - verifier_pinning_static
+  - verifier_pinning_case_table
+  - pmat_pin_behaviour
+  - pv_pin_behaviour
+  - gate_discovery_runs_each
+  - gate_discovery_vacuity
+  - shim_shape
+  - shim_fails_closed
+  - single_prose
+  pass_criteria: >
+    scripts/check_verifier_pinning.sh exits 0 AND scripts/check_dogfood_shim.sh exits 0
+    AND `DOGFOOD_GATES_ONLY=1 scripts/dogfood.sh` gives every declared gate its own
+    receipt row. A RED here is NO-GO independent of every other gate being green: a
+    release verified by an unknown binary is an unverified release that says GO.
+
+verification_summary:
+  total_obligations: 10
+  proven: 0
+  tested: 10
+  status: proposed
+  notes: >
+    All ten obligations are TESTED by two committed guards, both wired into CI and
+    both declared in [package.metadata.dogfood] so the release runner itself runs
+    them. Each carries a named mutation that was OBSERVED turning it RED on
+    2026-08-23, with the unmutated tree observed GREEN first (discrimination).
+
+    Nothing here is PROVEN in the L4/L5 sense and the count says so. These are shell
+    guards over shell source; the honest ladder position is L3.
+
+    Note what the guard found on its first run, before any mutation: `pmat analyze
+    reachability` was invoked BARE in BOTH copies of the runner. The copy that
+    INVENTED the PMAT_BIN hardening had never applied it there, because the
+    subcommand landed after the hardening did. That is the argument for the gate in
+    one line — the rule's own author missed a site, and only a mechanical sweep of
+    the whole file noticed.

--- a/contracts/dogfood-runner-unification-v1.yaml
+++ b/contracts/dogfood-runner-unification-v1.yaml
@@ -43,15 +43,55 @@ equations:
     formula: |
       V = { pv, pmat, apr }          -- exactly the tools this repo PINS
       S = { scripts/dogfood.sh, scripts/verifier_pin.sh }
-      bare(f) = { t in V : t appears in COMMAND POSITION in f
-                           after comments and quoted spans are removed }
-      REQUIRE: union over f in S of bare(f) == {}
-    domain: shell source of the release runner and its pin library
+          UNION Cargo.toml [package.metadata.dogfood].gates
+      unpinned(f) = { t in V :  t is in COMMAND POSITION in f
+                             OR t is the subject of a PATH PROBE in f
+                             OR t is a literal word of a `for … in` list in f }
+                    where INERT text is removed first: comments,
+                    single-quoted spans, double-quoted literal text, and DATA
+                    heredoc bodies -- but NOT `$( … )` / backticks, which are
+                    command position even inside double quotes, and NOT a
+                    heredoc body whose introducing command is a shell.
+      REQUIRE: union over f in S of unpinned(f) == {}
+    domain: shell source of the release runner, its pin library, and every gate the runner DISCOVERS and EXECUTES
     codomain: set of unpinned verifier tokens (must be empty)
     invariants:
     - 'A mention inside a comment or a string is NOT an invocation — the runner must stay able to describe its own rule.'
+    - 'A command substitution IS command position even inside double quotes. `mark deterministic-tools PASS "… pmat $(pmat --version …)"` was live in the runner — the one row whose job is to say WHICH pmat measured the release named a pmat off PATH — and the first version of the scanner collapsed the whole quoted span to a placeholder and reported the file clean.'
+    - 'A PATH PROBE (`command -v pmat`, `type -aP pv`) does not run the tool and still decides whether a gate runs, against PATH rather than against the pin. The runner gated its entire pmat section on `command -v pmat`, so releasing pmat with no pmat on PATH would have skipped every pmat gate while the pin sat resolved and unused.'
+    - 'A verifier NAME in a `for … in` word list is a call site whose command word is a variable (`for t in bashrs pmat probador; do command -v "$t"`), invisible to any command-position scan.'
+    - 'S is DERIVED from the manifest, not hardcoded: the runner executes every declared gate with `bash "$dg_path"` inside the release verdict, so a declared gate resolving a verifier through PATH decides the release with an unknown binary exactly as directly as the runner would. An empty derivation is a FAIL, not a pass.'
     - 'bashrs and probador are deliberately OUT of V: no pin exists for them, and the rule''s second clause is "where the repo does not pin, REPORT". Adding them would demand a pin that does not exist.'
     - 'The tokeniser ships a must-match / must-not-match case table (--self-test) because the apr-invocation patterns in this repo were wrong five times and every one was caught by a table, none by review.'
+
+  pin_is_used:
+    formula: |
+      let call_pmat = first line of the runner invoking verifier_pin_pmat
+      let call_pv   = first line of the runner invoking verifier_pin_pv
+      let use_pmat  = first line of the runner referencing $PMAT_BIN
+      let use_pv    = first line of the runner referencing $PV
+      REQUIRE: call_pmat exists AND use_pmat exists AND call_pmat < use_pmat
+      REQUIRE: call_pv   exists AND use_pv   exists AND call_pv   < use_pv
+      REQUIRE: the runner contains no assignment PMAT_BIN=<non-empty>
+               and no assignment PV=<non-empty>   (only verifier_pin.sh decides)
+    domain: scripts/dogfood.sh
+    codomain: bool
+    invariants:
+    - 'PRESENCE IS NOT USE. Replacing the `verifier_pin_pmat "$CRATE" "$BINPATH"` call site with `PMAT_BIN=pmat` sends every pmat gate back through PATH, and a bare-token scan stays GREEN on it — an assignment is not an invocation, and the scanner is right about that. So the call site is asserted separately.'
+    - 'The ORDER matters as much as the presence: a pin called after its first use reads an unset variable, which under `set -u` is a crash and without it is an empty command.'
+    - 'Empty initialisation (PV="") stays legal — the runner sets it so an unpinned repo leaves PV unmistakably unset.'
+
+  fleet_path:
+    formula: |
+      SKILL_DIR must be resolved from ${BASH_SOURCE[0]} BEFORE `cd "$REPO_DIR"`
+      REQUIRE: run(`bash scripts/dogfood.sh <other-crate>`) does not exit 2
+               AND reaches the declared-gate section
+    domain: invocation forms of the runner
+    codomain: bool
+    invariants:
+    - 'This runner exists to be pointed at OTHER repos, by the relative path its own Usage line documents. `${BASH_SOURCE[0]}` is whatever the caller typed, so resolving it after the `cd` looks for this skill''s helpers inside the TARGET repo.'
+    - 'That was harmless while the helpers were optional. #2640 made verifier_pin.sh load-bearing and fail-closed, and the runner then refused to start on every relative invocation: measured rc=2 relative, rc=0 absolute, against a fixture crate.'
+    - 'Absolute invocation kept working, which is exactly why nothing noticed. A guard that only exercises the convenient form is not exercising the fleet path.'
 
   pin_behaviour:
     formula: |
@@ -128,10 +168,10 @@ falsification_tests:
 
 - id: F-DOG1-003
   rule: the tokeniser is right before its verdict means anything
-  prediction: 'nine must-flag forms are all reported; ten must-not-flag forms are all accepted'
+  prediction: '18 must-flag forms are all reported; 14 must-not-flag forms are all accepted; a DATA heredoc is inert and a `bash <<EOF` heredoc is not'
   test: 'bash scripts/check_verifier_pinning.sh --self-test'
   if_fails: 'the scan is either blind or noisy, and PART 1''s green says nothing'
-  mutation: 'remove "if" from the OPENERS set; the `if pv validate x` row must stop being flagged and the table must turn RED'
+  mutation: 'remove "if" from the SEPARATORS set (the `if pv validate x` row stops being flagged); remove "command" from PREFIX (rows 14 and 18 stop being flagged); remove "nice" from PREFIX (row 13 stops being flagged) — each must turn the table RED'
 
 - id: F-DOG1-004
   rule: the PMAT_BIN hardening BEHAVES
@@ -182,6 +222,48 @@ falsification_tests:
   if_fails: 'the repo skill never appears in the session listing and edits to it change nothing that runs (#2332/#2361)'
   mutation: 'delete the `name:` line from the repo SKILL.md, and restore a user-scope SKILL.md; rows 2 and 4 must turn RED'
 
+- id: F-DOG1-011
+  rule: a command substitution inside double quotes is command position
+  prediction: '`mark tools PASS "pmat $(pmat --version)"` and `OUT="$(pv lint contracts)"` are both reported'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 1 + case table rows 10-12'
+  if_fails: 'the receipt row that names WHICH pmat measured the release is itself measured with an unpinned pmat, and the guard prints PASS'
+  mutation: 'restore `pmat $(pmat --version …)` on the deterministic-tools receipt line in scripts/dogfood.sh; PART 1 must turn RED'
+
+- id: F-DOG1-012
+  rule: the pin is USED, not merely defined
+  prediction: 'the runner calls verifier_pin_pmat and verifier_pin_pv before the first use of their results, and assigns neither variable itself'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 1b'
+  if_fails: 'a perfectly correct pin sits unused while every gate resolves through PATH, and the static scan reports the file clean'
+  mutation: 'replace `verifier_pin_pmat "$CRATE" "$BINPATH"` with `PMAT_BIN=pmat`; PART 1b must turn RED. Note PART 1 stays GREEN on this mutation, which is why 1b exists.'
+
+- id: F-DOG1-013
+  rule: a PATH probe of a pinned verifier is an unpinned resolution
+  prediction: '`command -v pmat`, `type -aP pv` and `for t in bashrs pmat probador` are all reported'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 1 + case table rows 14-17'
+  if_fails: 'the pmat section of the release is skipped, or run, according to what PATH holds rather than what the pin resolved'
+  mutation: 'restore `if command -v pmat` as the pmat-section guard, and `pmat` in the deterministic-tools `for` list; PART 1 must turn RED for each'
+
+- id: F-DOG1-014
+  rule: the runner runs when invoked by a relative path
+  prediction: '`bash scripts/dogfood.sh <other-crate>` reaches the declared-gate section and does not exit 2'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 3'
+  if_fails: 'the whole fleet path is dead: the protocol cannot be pointed at any repo but this one, which is the arrangement the canon/shim split exists to serve'
+  mutation: 'move the SKILL_DIR resolution back below `cd "$REPO_DIR"`; PART 3 must turn RED (measured: rc=2 relative, rc=0 absolute)'
+
+- id: F-DOG1-015
+  rule: the pinning guard does not repair the lockfile it walks past
+  prediction: 'exercising the pv pin leaves Cargo.lock''s resolution unchanged, and the file byte-identical'
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2, row 5'
+  if_fails: 'this guard silently fixes the staleness scripts/check_lockfile_current.sh exists to find, and that neighbour can never fail — it ran LATER in guard-runner-labels'
+  mutation: 'delete a `[[package]]` block from Cargo.lock; row 5 must turn RED and restore the file exactly as handed to it'
+
+- id: F-DOG1-016
+  rule: the shim gate extractor sees mid-line and dynamic call sites
+  prediction: '`true; mark pv-contracts PASS …` and `mark "$dg_name" FAIL …` are both rejected by 3b'
+  test: 'bash scripts/check_dogfood_shim.sh --self-test   # rows 6-9'
+  if_fails: 'both 3b rows are evadable by writing the gate after a `;`, and the runner''s own three dynamic `mark "$dg_name"` call sites are invisible to the extraction'
+  mutation: 'restore the `^[[:space:]]*(mark|gate) [a-z0-9][a-z0-9-]*` line-anchored extractor; rows 6 and 7 must turn RED'
+
 proof_obligations:
 - type: invariant
   property: 'Exactly one tracked dogfood.sh exists, at scripts/dogfood.sh (F-DOG1-001)'
@@ -213,6 +295,24 @@ proof_obligations:
 - type: invariant
   property: 'Exactly one prose description of the protocol is reachable, and it is the repo copy (F-DOG1-010)'
   formal: 'exists(repo SKILL.md with explicit name) and not exists(user-scope SKILL.md)'
+- type: soundness
+  property: 'A command substitution is command position at any quoting depth (F-DOG1-011)'
+  formal: 'unpinned("X=\"$(pmat v)\"") = {pmat} and unpinned("X=''$(pmat v)''") = {}'
+- type: invariant
+  property: 'Each pin is invoked before the first use of its result, and the runner assigns neither pinned variable (F-DOG1-012)'
+  formal: 'call(pin) < use(pin) for pin in {pmat, pv}; no PMAT_BIN=<non-empty> or PV=<non-empty> in the runner'
+- type: soundness
+  property: 'A PATH probe of a pinned verifier, and a verifier name in a for-list, are both unpinned resolutions (F-DOG1-013)'
+  formal: 'unpinned("command -v pmat") = {pmat}; unpinned("command -v \"$PMAT_BIN\"") = {}'
+- type: safety
+  property: 'The runner starts when invoked by a relative path against another crate (F-DOG1-014)'
+  formal: 'exit(bash scripts/dogfood.sh <other-crate>) != 2'
+- type: safety
+  property: 'Exercising the pv pin leaves Cargo.lock byte-identical (F-DOG1-015)'
+  formal: 'lock_after = lock_before, modulo [[patch.unused]] injected by host-local [patch.crates-io] overrides'
+- type: completeness
+  property: 'The shim gate extraction covers mid-line and dynamically named call sites (F-DOG1-016)'
+  formal: 'gate_calls("true; mark x PASS") != {} and gate_calls("mark \"$n\" FAIL") != {}'
 
 kani_harnesses:
 # Declared, NOT written. These are shell guards over shell source; there is no

--- a/docs/audits/dogfood-divergence-2640.md
+++ b/docs/audits/dogfood-divergence-2640.md
@@ -1,0 +1,97 @@
+# Dogfood runner divergence triage — #2640
+
+**Required artifact per #2640 A.2.** Produced BEFORE any delete, because the 86 diverging
+lines are evidence, not noise: given #2361 (user-scope shadowed the repo skill, so hardening
+it edited a file that never ran), some hardening had almost certainly landed only in the copy
+that does not run. Deleting either copy first would destroy the record of which.
+
+This is CLUS-000's rule applied to the runner: **prove the copies agree, or catalog the
+divergence, before consolidating.**
+
+## Subjects
+
+| copy | path | lines |
+|---|---|---:|
+| `user-scope` | `~/.claude/skills/dogfood/dogfood.sh` | 1172 |
+| `repo` | `scripts/dogfood.sh` | 1165 |
+
+`diff` = 9 hunks, 62 changed lines (86 including context). Gate names: **61 shared, 0 unique
+to either.** The copies run the same protocol.
+
+## Headline result
+
+**Every hunk is `hardening-port`. Zero are `drift-discard`.**
+
+This is not random drift. Each copy independently gained a *distinct, documented, measured*
+hardening — and both hardenings solve **the same defect class**: a release gate running a
+stale binary.
+
+| copy | hardening | its own measured evidence |
+|---|---|---|
+| user-scope | `PMAT_BIN` — when the crate under test **is** pmat, run the just-built artifact, not PATH | installed `3.32.0` commit `8134bb373` vs built `3.32.0` commit `7a7409e03`. **Both print 3.32.0**; only the commit differs. The installed copy predated CB-200 becoming a ratchet, so the gate ran the OLD zero-tolerance check and returned Fail against a tree the shipped code passes. |
+| repo | `PV` **pinned** via `scripts/pv_bin.sh`, never PATH-resolved; REPORT (not silent fallback) where absent | PATH `pv` 0.49.0 vs in-tree 0.63.0 **disagreed on the gate that decides the release** — strict-test-binding: 253 refs / 51 missing stale, 371 / 27 at HEAD. |
+
+Neither author knew about the other. **Deleting either copy silently loses a real hardening**,
+which is precisely the outcome A.2 exists to prevent.
+
+Provenance (`git log -S`): the PV pinning entered the repo copy at `c0e63c9ce` (#2613).
+`PMAT_BIN` returns **no commits** in `scripts/dogfood.sh` history — it never landed in the
+repo copy at all, confirming it is user-scope-only work.
+
+## Triage table
+
+| # | hunk | copy | class | rationale | disposition |
+|---|---|---|---|---|---|
+| 1 | `@@ -278,31 +278,6` | user-scope | `hardening-port` | The `PMAT_BIN` selection block + its 20-line measured rationale. Guards the self-referential case: the tool validating its own release. | **PORT.** Keep verbatim, comment included — the comment *is* the evidence. |
+| 2 | `@@ -333,14 +308,30` | repo | `hardening-port` | `PV=""` + `. scripts/pv_bin.sh` + its 12-line rationale, and drops `pv` from the PATH-probe loop. | **PORT.** |
+| 3 | `@@ -353,11 +344,11` | repo | `hardening-port` | Positive-control guard becomes `[ -n "$PV" ] && [ -x "$PV" ]` instead of `command -v pv`. Mechanism of #2. | **PORT.** |
+| 4 | `@@ -371,7 +362,7` | repo | `hardening-port` | Per-contract validate uses `"$PV"`. Mechanism of #2. | **PORT.** |
+| 5 | `@@ -386,7 +377,7` | repo | `hardening-port` | `pv lint` uses `"$PV"`. Mechanism of #2. | **PORT.** |
+| 6 | `@@ -414,7 +405,7` | repo | `hardening-port` | `pv verify-bindings` uses `"$PV"`. Mechanism of #2. | **PORT.** |
+| 7 | `@@ -434,6 +425,8` | repo | `hardening-port` | The `else` arm: REPORT "pv is not pinned in this repo" rather than validating with an unknown binary. **This is the load-bearing half** — without it #2 degrades to a silent skip. | **PORT.** |
+| 8 | `@@ -610,7 +603,7` | user-scope | `hardening-port` | `gate pmat-verify "$PMAT_BIN"`. Mechanism of #1. | **PORT.** |
+| 9 | `@@ -635,12 +628,12` | user-scope | `hardening-port` | `pmat query` / `pmat comply check` use `"$PMAT_BIN"`. Mechanism of #1. | **PORT.** |
+
+**`unknown`: 0.** Stated explicitly per A.2, which warns that zero is suspicious at this size.
+It is defensible here because the divergence is two coherent changes plus their call sites, not
+scattered edits: hunks 3–7 are mechanically entailed by hunk 2, and 8–9 by hunk 1. Every hunk
+was read; none was classified by pattern.
+
+**`drift-discard`: 0. `env-specific`: 0.**
+
+## Consequence for the merge
+
+The unified runner must carry **both**, and they compose without interacting — one selects the
+`pmat` binary, the other the `pv` binary, and neither reads the other's variable.
+
+## The class is at FIVE instances, not two
+
+Recorded because it changes what the fix must be. The same defect — *a gate that decides a
+release resolving its verifier through `PATH`* — already has **five independent ad-hoc fixes**,
+none of which knew about the others:
+
+| # | instance | symptom |
+|---|---|---|
+| 1 | `PMAT_BIN` (user-scope runner) | gate ran a pmat that predated CB-200 becoming a ratchet |
+| 2 | `scripts/pv_bin.sh` (repo runner) | PATH pv 0.49.0 vs in-tree 0.63.0, disagreeing on the release-deciding gate |
+| 3 | `scripts/apr_bin.sh` | four `apr` binaries coexisted; a bare `apr` resolved to a 26-day-old copy |
+| 4 | aprender#2384 | MCP spawned a bare `apr`, ran 0.60.0 while reporting 0.63.0 |
+| 5 | APR-BENCH-RFC-001 | unpinned `llama.cpp` comparator — same class, different domain |
+
+Five rediscoveries is the evidence that a rule merely **stated** is documentation. It ships as
+a **gate**, or the sixth tool rediscovers it in a sixth copy.
+
+The two hardenings generalise to one rule the merged runner should state once, and ENFORCE:
+
+> A gate that decides a release must not resolve its verifier through `PATH`. Where the repo
+> pins the tool, use the pin; where it does not, REPORT rather than fall back — a skipped gate
+> that says so beats a green one measured with an unknown binary.
+
+`PMAT_BIN` is the same rule for `pmat`, with the extra self-referential case. Stating it once
+is what stops a third copy re-discovering it for a third tool.
+
+## What this triage does NOT cover
+
+The three prose documents (`SKILL.md` ×2, `pre-release/SKILL.md`) are not diffed here — A.5
+handles them. Prose duplication is harder to detect than executable duplication precisely
+because nothing runs it and no diff surfaces it.

--- a/scripts/.dogfood-shim-reference.sh
+++ b/scripts/.dogfood-shim-reference.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# dogfood.sh (user scope) — A SHIM. The protocol is NOT here.
+#
+# The canonical runner is scripts/dogfood.sh in the aprender repo. This file
+# used to be a 1172-line SECOND COPY of it, and the two had silently diverged in
+# nine places (#2640, docs/audits/dogfood-divergence-2640.md). Every hunk was a
+# real hardening that the other copy did not have, so neither copy was safe to
+# delete and neither was safe to trust.
+#
+# Canon is the repo copy because a canon at ~/.claude/skills/ is not in git, not
+# PR-reviewed, not CI-reachable and not diffable — the four properties whose
+# absence produced #2361, where hardening this directory edited a file that
+# never ran.
+#
+# WHAT KEEPS THIS FILE A SHIM. Nothing here, deliberately: a rule enforced by
+# the file it constrains is not enforced. scripts/check_dogfood_shim.sh in the
+# repo asserts that this file stays under its line cap, invokes no gate of its
+# own, and fails CLOSED. That guard lives on protected main, so this file cannot
+# raise its own ceiling.
+#
+# REVISIT TRIGGER — the one signal that this arrangement has outgrown itself:
+#
+#     the first time dogfood is invoked on a crate whose OWN repo is checked out
+#     but `aprender` is NOT.
+#
+# That means the protocol is being asked to serve the fleet from a repo that is
+# not present, and the correct answer is to move it into shared infra — not to
+# copy the runner back here. It fails LOUDLY below, naming this trigger, so the
+# person who hits it knows what they are looking at instead of patching around
+# it. A second copy is precisely the defect #2640 removed.
+set -uo pipefail
+
+CANON_ROOT="${DOGFOOD_CANON_ROOT:-$HOME/src/aprender}"
+CANON="$CANON_ROOT/scripts/dogfood.sh"
+
+if [ ! -x "$CANON" ]; then
+    printf 'dogfood: the canonical runner is not reachable.\n' >&2
+    printf '  looked for: %s\n' "$CANON" >&2
+    printf '  (override the checkout with DOGFOOD_CANON_ROOT=/path/to/aprender)\n\n' >&2
+    printf '  REVISIT TRIGGER: if the repo you are releasing IS checked out but\n' >&2
+    printf '  aprender is NOT, that is the signal this protocol has outgrown the\n' >&2
+    printf '  aprender repo and belongs in shared infra. Move it there. Do NOT\n' >&2
+    printf '  restore a local copy of the runner: a second copy is the defect\n' >&2
+    printf '  aprender#2640 removed, and it took a 97-line triage to establish\n' >&2
+    printf '  which of the two copies was safe to delete (neither was).\n' >&2
+    exit 2
+fi
+
+exec "$CANON" "$@"

--- a/scripts/check_dogfood_shim.sh
+++ b/scripts/check_dogfood_shim.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# check_dogfood_shim.sh — one runner, one prose, and the user-scope copy stays a
+# shim.
+#
+# WHY THIS EXISTS
+# ---------------
+# #2640 merged two 1170-line copies of the dogfood protocol into one. The
+# user-scope copy at ~/.claude/skills/dogfood/ became a ~50-line shim that execs
+# the repo runner. But a shim is still a file at user scope that can drift — it
+# is the shadow with extra steps unless shim-ness is GATED. #2361 is what that
+# looks like: ~/.claude/skills/dogfood/ shadowed the repo's release-certifying
+# skill, so hardening the repo edited a file that never ran, and nothing warned.
+#
+# The asymmetry that makes this sound: the CAP lives here, in the repo, on
+# protected main, where changing it needs a PR and review. The FILE it caps lives
+# at user scope, where it does not. "Any state the author writes and the gate
+# reads can be moved in the same commit" — so the state is deliberately not
+# co-located with the thing it constrains.
+#
+# WHAT IT ASSERTS
+#   1  exactly one dogfood.sh in this repo, tracked by git            (AC-1/AC-7)
+#   2  the canonical prose is in the repo and carries an EXPLICIT name:
+#      without it the skill takes its name from its directory, collides with a
+#      user-scope skill, and never appears in the session listing (#2332)
+#   3  a user-scope dogfood.sh, if present, is a SHIM:
+#        3a  <= SHIM_MAX_LINES
+#        3b  invokes NO gate of the protocol, and mentions no gate name
+#        3c  FAILS CLOSED when the aprender checkout is absent — never silently
+#            falls back, never degrades to a local copy
+#   4  no user-scope SKILL.md shadows the repo's dogfood skill
+#
+#   bash scripts/check_dogfood_shim.sh              # check
+#   bash scripts/check_dogfood_shim.sh --self-test  # case table
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# THE CAP. 70, and the number is chosen rather than guessed: the shim as written
+# is 49 lines, of which 32 are the rationale and the revisit trigger. 70 leaves
+# ~20 lines of headroom so prose can be improved without touching this file —
+# and no more. The smallest gate in the protocol is ~12 lines with its rationale
+# plus a call site, so re-inlining even ONE gate spends the whole headroom, and
+# raising the cap to make room is a diff in this repo, in a PR, which is the
+# point. Against the 1170-line protocol the cap is ~17x smaller.
+SHIM_MAX_LINES=70
+
+USER_SHIM="${DOGFOOD_USER_SHIM:-$HOME/.claude/skills/dogfood/dogfood.sh}"
+USER_SKILL="${DOGFOOD_USER_SKILL:-$HOME/.claude/skills/dogfood/SKILL.md}"
+CANON_SKILL="$REPO_ROOT/.claude/skills/dogfood/SKILL.md"
+CANON_RUNNER="$REPO_ROOT/scripts/dogfood.sh"
+
+# ---------------------------------------------------------------------------
+# Gate names, DERIVED from the canonical runner. A hardcoded list would be the
+# same defect one level down: the runner grows a gate, the list does not, and
+# the shim may then quietly acquire the new one.
+gate_names() {
+    grep -oE '^[[:space:]]*(mark|gate) [a-z0-9][a-z0-9-]*' "$1" \
+        | awk '{print $2}' | LC_ALL=C sort -u
+}
+
+# Does this file INVOKE a gate? Structural, and the primary check.
+shim_invokes_gate() {
+    gate_names "$1" | tr '\n' ' '
+}
+
+# Does this file MENTION a gate name as literal text? Secondary, and restricted
+# to the HYPHENATED names on purpose. The single-word names (fmt, test, clippy,
+# coverage, contracts, renacer, reachability) are ordinary English and appear in
+# any honest description of what the runner does — demanding their absence would
+# forbid the shim from explaining itself and would be a false alarm, not a gate.
+# The hyphenated names are unambiguous protocol identifiers.
+shim_mentions_gate() {
+    local f="$1" n hits=""
+    while read -r n; do
+        case "$n" in
+            *-*) ;;
+            *) continue ;;
+        esac
+        if grep -qF -- "$n" "$f" 2>/dev/null; then hits="$hits $n"; fi
+    done < <(gate_names "$CANON_RUNNER")
+    printf '%s' "$hits"
+}
+
+# ---------------------------------------------------------------------------
+check_shim_file() {
+    # $1 = path to the candidate shim. Prints rows; returns 1 on any failure.
+    local f="$1" rc=0 n invoked mentioned out srrc
+    n=$(wc -l < "$f")
+    if [ "$n" -le "$SHIM_MAX_LINES" ]; then
+        printf 'ok    3a shim is %s lines (cap %s)\n' "$n" "$SHIM_MAX_LINES"
+    else
+        printf 'FAIL  3a shim is %s lines, cap is %s — this is a copy re-forming.\n' "$n" "$SHIM_MAX_LINES"
+        printf '         The protocol lives in scripts/dogfood.sh. Nothing else may hold it.\n'
+        rc=1
+    fi
+
+    invoked=$(shim_invokes_gate "$f")
+    if [ -z "${invoked// /}" ]; then
+        printf 'ok    3b shim invokes no gate of the protocol\n'
+    else
+        printf 'FAIL  3b shim INVOKES protocol gate(s):%s\n' " $invoked"
+        printf '         A shim that runs a gate is a second runner with a smaller diff.\n'
+        rc=1
+    fi
+
+    mentioned=$(shim_mentions_gate "$f")
+    if [ -z "${mentioned// /}" ]; then
+        printf 'ok    3b shim names no protocol gate\n'
+    else
+        printf 'FAIL  3b shim names protocol gate(s):%s\n' "$mentioned"
+        rc=1
+    fi
+
+    # 3c FAIL CLOSED. Behavioural, not textual: point it at a checkout that does
+    # not exist and require a loud non-zero exit that names the revisit trigger.
+    out=$(DOGFOOD_CANON_ROOT="$f.no-such-checkout" bash "$f" --version 2>&1); srrc=$?
+    if [ "$srrc" -eq 0 ]; then
+        printf 'FAIL  3c shim EXITED 0 with the aprender checkout absent — it fell back to\n'
+        printf '         something. A shim that degrades instead of failing is the shadow.\n'
+        rc=1
+    elif ! printf '%s' "$out" | grep -qi 'REVISIT TRIGGER'; then
+        printf 'FAIL  3c shim failed (rc=%s) but did not name the REVISIT TRIGGER. It must\n' "$srrc"
+        printf '         say WHAT the reader is looking at, or the next person patches around it.\n'
+        rc=1
+    else
+        printf 'ok    3c shim fails closed (rc=%s) and names the revisit trigger\n' "$srrc"
+    fi
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+self_test() {
+    local td fails=0 out
+    td=$(mktemp -d) || return 2
+
+    # A good shim: short, gateless, fails closed.
+    cp "$REPO_ROOT/scripts/.dogfood-shim-reference.sh" "$td/good.sh" 2>/dev/null \
+        || { printf 'FAIL  self-test needs scripts/.dogfood-shim-reference.sh\n'; rm -rf "${td:?}"; return 1; }
+
+    if check_shim_file "$td/good.sh" >/dev/null 2>&1; then
+        printf 'ok    row 1 the reference shim passes every shim assertion\n'
+    else
+        printf 'FAIL  row 1 the reference shim does NOT pass:\n'
+        check_shim_file "$td/good.sh" | sed 's/^/        /'
+        fails=1
+    fi
+
+    # Mutation A: a gate name is added.
+    cp "$td/good.sh" "$td/gate.sh"
+    printf 'mark pv-contracts PASS "ported"\n' >> "$td/gate.sh"
+    out=$(check_shim_file "$td/gate.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+        printf 'ok    row 2 a shim that invokes a gate is REJECTED\n'
+    else
+        printf 'FAIL  row 2 a shim invoking `mark pv-contracts` was accepted\n'; fails=1
+    fi
+
+    # Mutation B: the shim grows past the cap.
+    cp "$td/good.sh" "$td/long.sh"
+    for _ in $(seq 1 "$((SHIM_MAX_LINES + 5))"); do printf '# padding\n' >> "$td/long.sh"; done
+    out=$(check_shim_file "$td/long.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3a'; then
+        printf 'ok    row 3 a shim over the line cap is REJECTED\n'
+    else
+        printf 'FAIL  row 3 an over-cap shim was accepted\n'; fails=1
+    fi
+
+    # Mutation C: the shim degrades instead of failing closed.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$td/soft.sh"
+    out=$(check_shim_file "$td/soft.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3c'; then
+        printf 'ok    row 4 a shim that exits 0 without a checkout is REJECTED\n'
+    else
+        printf 'FAIL  row 4 a silently-succeeding shim was accepted\n'; fails=1
+    fi
+
+    # Mutation D: it fails, but says nothing useful.
+    printf '#!/usr/bin/env bash\nexit 2\n' > "$td/mute.sh"
+    out=$(check_shim_file "$td/mute.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3c'; then
+        printf 'ok    row 5 a shim that fails MUTELY is REJECTED\n'
+    else
+        printf 'FAIL  row 5 a mute failing shim was accepted\n'; fails=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    --self-test) self_test; exit $? ;;
+esac
+
+cd "$REPO_ROOT" || exit 2
+rc=0
+printf -- '--- one dogfood runner (#2640) --------------------------------------\n'
+
+printf 'case table\n'
+if self_test; then :; else rc=1; fi
+printf '\n'
+
+# 1 — exactly one dogfood.sh, tracked.
+RUNNERS=$(git ls-files | grep -E '(^|/)dogfood\.sh$' | LC_ALL=C sort)
+N_RUN=$(printf '%s\n' "$RUNNERS" | grep -c . )
+if [ "$N_RUN" -eq 1 ] && [ "$RUNNERS" = "scripts/dogfood.sh" ]; then
+    printf 'ok    1  exactly one tracked dogfood.sh: %s\n' "$RUNNERS"
+else
+    printf 'FAIL  1  expected exactly one tracked dogfood.sh at scripts/dogfood.sh, found %s:\n' "$N_RUN"
+    printf '%s\n' "$RUNNERS" | sed 's/^/         /'
+    rc=1
+fi
+
+# 2 — canonical prose, in the repo, with an explicit name.
+if [ ! -f "$CANON_SKILL" ]; then
+    printf 'FAIL  2  no canonical prose at .claude/skills/dogfood/SKILL.md — the protocol\n'
+    printf '         description would live only at user scope, where it is not diffable.\n'
+    rc=1
+elif ! grep -qE '^name:[[:space:]]*dogfood[[:space:]]*$' "$CANON_SKILL"; then
+    printf 'FAIL  2  .claude/skills/dogfood/SKILL.md has no explicit `name: dogfood`.\n'
+    printf '         Without it the skill is named after its directory, collides with a\n'
+    printf '         user-scope skill, and never appears in the session listing (#2332).\n'
+    rc=1
+else
+    printf 'ok    2  canonical prose at .claude/skills/dogfood/SKILL.md, name: dogfood\n'
+fi
+
+# 3 — the user-scope copy.
+if [ ! -e "$USER_SHIM" ]; then
+    printf 'ok    3  no user-scope dogfood.sh on this host (the ideal state)\n'
+else
+    printf 'note  3  user-scope copy present at %s\n' "$USER_SHIM"
+    if check_shim_file "$USER_SHIM"; then :; else rc=1; fi
+    # 3d — and it is the reviewed shim, byte for byte. The shim's TEXT is
+    # tracked here as scripts/.dogfood-shim-reference.sh, so even the pointer is
+    # diffable. Without this row the previous three only bound the shim's SHAPE,
+    # and a rewritten-but-still-short shim would pass.
+    if cmp -s "$USER_SHIM" "$REPO_ROOT/scripts/.dogfood-shim-reference.sh"; then
+        printf 'ok    3d user-scope shim is byte-identical to the reviewed reference\n'
+    else
+        printf 'FAIL  3d user-scope shim DIFFERS from scripts/.dogfood-shim-reference.sh:\n'
+        diff -u "$REPO_ROOT/scripts/.dogfood-shim-reference.sh" "$USER_SHIM" \
+            | head -20 | sed 's/^/         /'
+        printf '         Redeploy it:  cp scripts/.dogfood-shim-reference.sh %s\n' "$USER_SHIM"
+        rc=1
+    fi
+fi
+
+# 4 — nothing at user scope may shadow the repo skill.
+if [ -e "$USER_SKILL" ]; then
+    printf 'FAIL  4  a user-scope SKILL.md still exists at %s.\n' "$USER_SKILL"
+    printf '         A user-scope skill WINS over the repo one, so the reviewed copy would\n'
+    printf '         never appear in the session listing. Delete it or rename the file.\n'
+    rc=1
+else
+    printf 'ok    4  no user-scope SKILL.md shadowing the repo dogfood skill\n'
+fi
+
+printf '\n'
+if [ "$rc" -eq 0 ]; then
+    printf 'PASS  one runner, one prose, and the user-scope copy is a gated shim.\n'
+else
+    printf 'FAIL  see rows above (#2640).\n'
+fi
+exit "$rc"

--- a/scripts/check_dogfood_shim.sh
+++ b/scripts/check_dogfood_shim.sh
@@ -51,17 +51,75 @@ CANON_SKILL="$REPO_ROOT/.claude/skills/dogfood/SKILL.md"
 CANON_RUNNER="$REPO_ROOT/scripts/dogfood.sh"
 
 # ---------------------------------------------------------------------------
-# Gate names, DERIVED from the canonical runner. A hardcoded list would be the
-# same defect one level down: the runner grows a gate, the list does not, and
-# the shim may then quietly acquire the new one.
-gate_names() {
-    grep -oE '^[[:space:]]*(mark|gate) [a-z0-9][a-z0-9-]*' "$1" \
-        | awk '{print $2}' | LC_ALL=C sort -u
+# Gate invocations, DERIVED from the canonical runner. A hardcoded list would be
+# the same defect one level down: the runner grows a gate, the list does not,
+# and the shim may then quietly acquire the new one.
+#
+# NOT LINE-ANCHORED, and that is a fix rather than a preference. The first
+# version matched `^[[:space:]]*(mark|gate) …`, which omitted every invocation
+# that follows a `;`, a `&&`, or a `then` on the same line — 11 of them in the
+# runner — so both 3b rows below could be evaded by writing the gate mid-line.
+#
+# It also has to see DYNAMIC call sites. The runner's declared-gate section
+# calls `mark "$dg_name" …` three times; a name-only extraction drops those, and
+# a shim that re-implemented that section would have invoked a gate while
+# reporting none. So there are two extractions:
+#
+#   gate_calls  every command-position `mark`/`gate` invocation, literal or
+#               dynamic — this is what "does the shim invoke a gate" means.
+#   gate_names  the subset whose argument is a literal gate name — this is the
+#               vocabulary the textual 3b row greps for.
+#
+# The leading alternation is what keeps a MENTION from reading as a call: in
+# `# mark pv-contracts PASS` and in `"a shim that runs a gate"` the character
+# before the keyword is neither the line start nor a shell separator.
+# Comments are removed FIRST, quote-aware. Without that the `\bthen\b`
+# alternative matches English: the runner's own comment "then gate on CB-200
+# specifically" produced a phantom gate named `on`, and a phantom name is a
+# grep the shim can never satisfy.
+gate_calls() {
+    python3 - "$1" <<'PY'
+import re, sys
+
+CALL = re.compile(r"(?:^|[;&|(){}]|\bthen\b|\belse\b|\bdo\b)\s*(?:mark|gate)\s+(\S+)")
+
+
+def strip_comment(line):
+    out, i, n, q = [], 0, len(line), ""
+    while i < n:
+        c = line[i]
+        if c == "\\" and i + 1 < n:
+            out.append(line[i:i + 2]); i += 2; continue
+        if q:
+            if c == q:
+                q = ""
+            out.append(c); i += 1; continue
+        if c in ("'", '"'):
+            q = c; out.append(c); i += 1; continue
+        if c == "#":
+            prev = out[-1] if out else ""
+            if not out or prev.isspace() or prev in "(;&|":
+                break
+            out.append(c); i += 1; continue
+        out.append(c); i += 1
+    return "".join(out)
+
+
+for raw in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    for m in CALL.finditer(strip_comment(raw.rstrip("\n"))):
+        print(m.group(1))
+PY
 }
 
-# Does this file INVOKE a gate? Structural, and the primary check.
+gate_names() {
+    gate_calls "$1" | grep -E '^[a-z0-9][a-z0-9-]*$' | LC_ALL=C sort -u
+}
+
+# Does this file INVOKE a gate? Structural, and the primary check. Dynamic call
+# sites are reported as the literal text of their argument, so `mark "$dg_name"`
+# is visible as `"$dg_name"` rather than vanishing.
 shim_invokes_gate() {
-    gate_names "$1" | tr '\n' ' '
+    gate_calls "$1" | LC_ALL=C sort -u | tr '\n' ' '
 }
 
 # Does this file MENTION a gate name as literal text? Secondary, and restricted
@@ -182,6 +240,65 @@ self_test() {
         printf 'ok    row 5 a shim that fails MUTELY is REJECTED\n'
     else
         printf 'FAIL  row 5 a mute failing shim was accepted\n'; fails=1
+    fi
+
+    # Mutation E: the gate is invoked MID-LINE. The line-anchored extractor this
+    # replaces saw nothing here, so both 3b rows were evadable by writing `;`.
+    cp "$td/good.sh" "$td/midline.sh"
+    printf 'true; mark pv-contracts PASS "ported"\n' >> "$td/midline.sh"
+    out=$(check_shim_file "$td/midline.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+        printf 'ok    row 6 a MID-LINE `; mark pv-contracts` is REJECTED\n'
+    else
+        printf 'FAIL  row 6 a mid-line gate invocation was accepted\n'; fails=1
+    fi
+
+    # Mutation F: the gate name is a VARIABLE. The runner itself does this three
+    # times (`mark "$dg_name" …`), so a name-only extraction is blind to the one
+    # section a re-implementing shim would most plausibly copy.
+    cp "$td/good.sh" "$td/dynamic.sh"
+    printf 'mark "$dg_name" FAIL "declared but absent"\n' >> "$td/dynamic.sh"
+    out=$(check_shim_file "$td/dynamic.sh" 2>&1)
+    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+        printf 'ok    row 7 a DYNAMIC `mark "$name"` invocation is REJECTED\n'
+    else
+        printf 'FAIL  row 7 a dynamic gate invocation was accepted\n'; fails=1
+    fi
+
+    # Row 8 — and the widened regex must still let the shim describe itself. A
+    # keyword in prose or in a comment is not a call site; demanding its absence
+    # would forbid the shim from explaining what it is, which is a false alarm,
+    # not a gate.
+    cp "$td/good.sh" "$td/prose.sh"
+    {
+        printf '# mark tests PASS -- this is prose about what the runner does\n'
+        printf '# it invokes no gate and does not gate anything itself\n'
+        # The live false positive: `\bthen\b` matching English inside a comment.
+        printf '# build the index first, then gate on CB-200 specifically\n'
+    } >> "$td/prose.sh"
+    if check_shim_file "$td/prose.sh" >/dev/null 2>&1; then
+        printf 'ok    row 8 prose naming `mark`/`gate` is NOT a call site\n'
+    else
+        printf 'FAIL  row 8 a shim describing itself was rejected:\n'
+        check_shim_file "$td/prose.sh" | sed 's/^/        /'
+        fails=1
+    fi
+
+    # Row 9 — VACUITY. An extraction that yields nothing makes both 3b rows
+    # pass on any shim at all. The number is MEASURED and printed rather than
+    # asserted: an earlier handoff quoted "61 gate names" from a regex run over
+    # both forked copies, and the real extraction is a different number.
+    local n_names n_calls
+    n_names=$(gate_names "$CANON_RUNNER" | grep -c .)
+    n_calls=$(gate_calls "$CANON_RUNNER" | grep -c .)
+    if [ "$n_names" -ge 20 ] && [ "$n_calls" -ge "$n_names" ]; then
+        printf 'ok    row 9 canon yields %s distinct gate names over %s call sites\n' \
+            "$n_names" "$n_calls"
+    else
+        printf 'FAIL  row 9 extraction yielded %s names / %s call sites — a 3b row that\n' \
+            "$n_names" "$n_calls"
+        printf '         greps an empty vocabulary accepts every shim.\n'
+        fails=1
     fi
 
     rm -rf "${td:?}"

--- a/scripts/check_verifier_pinning.sh
+++ b/scripts/check_verifier_pinning.sh
@@ -15,16 +15,37 @@
 # stated is documentation. #2640 merged the two dogfood runners into one; this
 # is what stops the sixth tool re-discovering the rule in a sixth copy.
 #
-# TWO PARTS, because presence is not behaviour:
+# FOUR PARTS, because presence is not behaviour and definition is not use:
 #
-#   PART 1 (static)      no bare pv/pmat/apr in command position in the runner
-#                        or its pin library. Mutation: reintroduce a bare `pmat`
-#                        call -> RED.
-#   PART 2 (behavioural) the two pins are EXERCISED and must select something
-#                        other than what PATH offers. Mutations: delete the
-#                        PMAT_BIN self-referential branch -> RED; bypass
-#                        pv_bin.sh to a PATH pv -> RED. Part 1 alone would pass
-#                        on a pin that resolves to the wrong binary.
+#   PART 1  (static)      no bare pv/pmat/apr in command position — and no PATH
+#                         PROBE of one — anywhere the release verdict is
+#                         decided. Mutation: reintroduce a bare `pmat` call.
+#   PART 1b (call site)   the pins are CALLED by the runner, before the first
+#                         use of their result, and the runner never assigns
+#                         PMAT_BIN/PV itself. Mutation: replace the
+#                         `verifier_pin_pmat` call with `PMAT_BIN=pmat`.
+#                         PART 1 alone passes on that mutation — a bare-token
+#                         scan cannot tell a DEFINED pin from a USED one, and
+#                         `PMAT_BIN=pmat` is a legal assignment everywhere the
+#                         scanner looks. That gap shipped once; this is its row.
+#   PART 2  (behavioural) the two pins are EXERCISED and must select something
+#                         other than what PATH offers, and exercising them must
+#                         leave Cargo.lock alone. Mutations: delete the
+#                         PMAT_BIN self-referential branch; bypass pv_bin.sh to
+#                         a PATH pv; delete a `[[package]]` block from
+#                         Cargo.lock, whereupon the pv build repairs it in
+#                         passing and the lockfile row must go RED with the file
+#                         restored. That last one is why this guard now runs
+#                         AFTER scripts/check_lockfile_current.sh in ci.yml: it
+#                         cargo-builds pv without --locked, so placed first it
+#                         quietly repaired the very staleness its neighbour
+#                         exists to find.
+#   PART 3  (fleet path)  the runner still RUNS when invoked the way its own
+#                         Usage line documents — by a relative path, against
+#                         another repo. #2640 made the pin library load-bearing
+#                         and fail-closed while SKILL_DIR was still resolved
+#                         after `cd "$REPO_DIR"`, so `bash scripts/dogfood.sh
+#                         ../other-crate` exited 2 before any gate ran.
 #
 # THE UNIVERSE, and why it is these three tokens
 # ----------------------------------------------
@@ -35,117 +56,337 @@
 # runner does. Adding them here would demand a pin that does not exist and make
 # the gate unfixable. The day one ships, add the token here.
 #
+# THE SCANNED SURFACE, and why it is not two files
+# ------------------------------------------------
+# The runner DISCOVERS gates from `[package.metadata.dogfood] gates` and
+# executes each one with `bash "$dg_path"` INSIDE the release verdict. A
+# declared gate that resolves a verifier through PATH decides the release with
+# an unknown binary exactly as directly as the runner would. So the scope is the
+# runner, the pin library, AND every declared gate — derived from the manifest,
+# never hardcoded, because a hardcoded list is the same defect one level down.
+#
 # What counts as an invocation: the token in COMMAND POSITION after comments and
-# quoted strings are removed. A bare mention in a comment or a string is NOT an
-# invocation — the runner's own prose says "`pv lint <DIR>` is a real gate" and
-# marks a row "pv is not pinned in this repo", and both must stay legal. The
-# distinction is the whole difficulty, so it ships a case table (--self-test)
-# rather than a reviewed regex: the apr-invocation patterns in this repo were
-# wrong FIVE times and every one was caught by a table, none by review.
+# INERT text are removed. Three things are NOT inert and each has cost a real
+# false negative:
+#   · `$( … )` and `` ` … ` `` are COMMAND POSITION even inside double quotes.
+#     `"pmat $(pmat --version)"` was live in the runner, on the line that writes
+#     which pmat ran into the receipt, and the scanner reported the file clean.
+#   · a PATH PROBE (`command -v pmat`, `type -aP pv`) does not run the tool but
+#     DECIDES whether a gate runs at all, against PATH rather than the pin. The
+#     runner gated its whole pmat section on `command -v pmat`, so releasing
+#     pmat itself with no pmat on PATH would have skipped every pmat gate while
+#     the pin sat resolved and unused.
+#   · a verifier NAME in a `for … in` word list is a call site whose command
+#     word is a variable. `for t in bashrs pmat probador; do command -v "$t"`
+#     is a PATH probe of pmat that no command-position scan can see.
+# A bare mention in a comment, in a single-quoted string, or in a DATA heredoc
+# is NOT an invocation — the runner's own prose says "`pv lint <DIR>` is a real
+# gate", and both must stay legal. The distinction is the whole difficulty, so
+# it ships a case table (--self-test) rather than a reviewed regex: the
+# apr-invocation patterns in this repo were wrong FIVE times and every one was
+# caught by a table, none by review.
 #
 #   bash scripts/check_verifier_pinning.sh              # check
 #   bash scripts/check_verifier_pinning.sh --self-test  # the case table only
+#   bash scripts/check_verifier_pinning.sh --scan FILE… # the raw scanner
 #
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# The files that decide a release and are therefore in scope.
-SCOPE="scripts/dogfood.sh scripts/verifier_pin.sh"
+# The two files that ARE the protocol. Every other in-scope file is derived from
+# the manifest below, in resolve_scope().
+CORE_SCOPE="scripts/dogfood.sh scripts/verifier_pin.sh"
 
 # ---------------------------------------------------------------------------
-# The scanner. Reports "<file>:<line>: <token>" for each bare invocation.
+# The scanner. Reports "<file>:<line>: <token> [<kind>]" per finding.
 #
 # It tokenises rather than regexing the raw line, because a regex over raw text
 # gets `pmat-verify` wrong: \bpmat\b MATCHES inside `pmat-verify`, since `-` is a
-# non-word character. Token equality does not. Quoted spans collapse to a single
+# non-word character. Token equality does not. Inert spans collapse to a single
 # @Q placeholder rather than being deleted, so the ARITY of wrappers such as
 # `run_to <log> <cmd...>` is preserved and `run_to "$LOG" pmat query` is still
-# seen as pmat in command position.
+# seen as pmat in command position. Command substitutions are LIFTED out of the
+# line and scanned as lines of their own, which preserves that arity while still
+# reaching the code inside them.
 scan() {
     python3 - "$@" <<'PY'
 import re, sys
 
 VERIFIERS = {"pv", "pmat", "apr"}
-# Tokens after which the next word is a command.
-OPENERS = {"", ";", "&&", "||", "|", "|&", "(", "$(", "((", "{", "}", ")",
-           "if", "then", "else", "elif", "while", "until", "do", "!",
-           "env", "exec", "nohup", "time", "sudo", "xargs", "&"}
+
+# Control words and operators: after one of these, the next word is a command.
+SEPARATORS = {";", ";;", "&&", "||", "|", "|&", "(", ")", "{", "}", "&", "!",
+              "if", "then", "else", "elif", "fi", "while", "until", "do",
+              "done", "case", "esac", "$("}
+
+# Wrappers that RUN their remaining arguments. After one of these the command
+# position moves along, past the wrapper's own options. `command` is here
+# because it was missing and `command pmat verify` was therefore invisible;
+# `nice`/`ionice`/`stdbuf` are here because a prefix that takes its own option
+# (`nice -n 5 pmat`) is the shape that hid it.
+PREFIX = {"env", "exec", "nohup", "time", "sudo", "doas", "xargs", "command",
+          "builtin", "nice", "ionice", "stdbuf", "setsid", "timeout", "chrt"}
+
+# Probes: they ask PATH where a tool is. They do not run it, and they still
+# decide whether a gate runs.
+PROBES = {"type", "hash", "which", "whereis"}
+
 ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+DURATION = re.compile(r"^[0-9]+[smhd]?$")
+# A heredoc introducer. `<<<` is a here-STRING and must not match.
+HEREDOC = re.compile(r"<<-?\s*(?!<)(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+# Heredoc bodies are DATA unless the command on the introducing line is a shell.
+# `python3 <<'PY' … PY` holds python; `bash <<'EOF' … EOF` holds shell that RUNS.
+SHELL_CMDS = {"bash", "sh", "zsh", "dash", "ksh"}
+
+
+def _scan(s, i, n, mode, subs):
+    """Walk s from i. Returns (inert-collapsed text, next index).
+
+    mode: 'top' | 'dq' (inside "…") | 'sub' (inside $(…)) | 'bt' (inside `…`).
+    Command substitutions found at any depth are appended to `subs` verbatim,
+    to be scanned as lines of their own.
+    """
+    out = []
+    while i < n:
+        c = s[i]
+        if c == "\\" and i + 1 < n:
+            # An escaped char is literal — including \` inside a double-quoted
+            # string, which is how the runner quotes `pv verify-bindings` in a
+            # note without invoking anything.
+            out.append("@" if mode == "dq" else "X")
+            i += 2
+            continue
+        if mode == "sub" and c == ")":
+            return "".join(out), i + 1
+        if mode == "bt" and c == "`":
+            return "".join(out), i + 1
+        if c == "$" and s.startswith("$((", i):
+            j = s.find("))", i + 3)
+            i = n if j < 0 else j + 2
+            out.append(" @Q ")
+            continue
+        if c == "$" and s.startswith("$(", i):
+            body, i = _scan(s, i + 2, n, "sub", subs)
+            subs.append(body)
+            out.append(" @Q ")
+            continue
+        if c == "`":
+            body, i = _scan(s, i + 1, n, "bt", subs)
+            subs.append(body)
+            out.append(" @Q ")
+            continue
+        if c == "'" and mode != "dq":
+            i += 1
+            while i < n and s[i] != "'":
+                i += 1
+            i += 1
+            out.append(" @Q ")
+            continue
+        if c == '"':
+            if mode == "dq":
+                return "".join(out), i + 1
+            _body, i = _scan(s, i + 1, n, "dq", subs)
+            out.append(" @Q ")
+            continue
+        if c == "#" and mode != "dq":
+            prev = out[-1] if out else ""
+            # A `#` starts a comment only at the start of a word.
+            if not out or prev.isspace() or prev in "(;&|":
+                return "".join(out), n
+            out.append(c)
+            i += 1
+            continue
+        out.append("@" if mode == "dq" else c)
+        i += 1
+    return "".join(out), i
+
 
 def strip_line(line):
-    """Remove comments; replace quoted spans with @Q. Returns the stripped line."""
-    out, i, n = [], 0, len(line)
+    """Returns (inert-collapsed line, [command-substitution bodies])."""
+    subs = []
+    text, _ = _scan(line, 0, len(line), "top", subs)
+    return text, subs
+
+
+def strip_comments(line):
+    """Remove comments but KEEP quoted text. Used where the question is textual
+    (does this file reference $PMAT_BIN?) rather than syntactic."""
+    out, i, n, q = [], 0, len(line), ""
     while i < n:
         c = line[i]
         if c == "\\" and i + 1 < n:
-            out.append("X"); i += 2; continue
+            out.append(line[i:i + 2]); i += 2; continue
+        if q:
+            if c == q:
+                q = ""
+            out.append(c); i += 1; continue
         if c in ("'", '"'):
-            q = c; i += 1
-            while i < n:
-                if line[i] == "\\" and q == '"':
-                    i += 2; continue
-                if line[i] == q:
-                    i += 1; break
-                i += 1
-            out.append(" @Q "); continue
+            q = c; out.append(c); i += 1; continue
         if c == "#":
             prev = out[-1] if out else ""
-            # A `#` starts a comment only at the start of a word.
             if not out or prev.isspace() or prev in "(;&|":
                 break
             out.append(c); i += 1; continue
         out.append(c); i += 1
     return "".join(out)
 
+
 SPLIT = re.compile(r"(\$\(|[();|&{}]|&&|\|\|)")
+
 
 def tokens(s):
     return [t for t in SPLIT.sub(r" \1 ", s).split() if t]
 
+
+def _follow(toks, j, hits, probes):
+    """Index j is a command position. Record it, then follow wrapper prefixes."""
+    while j < len(toks):
+        t = toks[j]
+        if ASSIGN.match(t) and "=" in t:
+            j += 1
+            continue
+        if t in PROBES:
+            _probe_args(toks, j + 1, probes)
+            return
+        hits.add(j)
+        if t in PREFIX:
+            k = j + 1
+            saw_probe_flag = False
+            while k < len(toks) and (
+                toks[k].startswith("-") or DURATION.match(toks[k])
+                or (ASSIGN.match(toks[k]) and "=" in toks[k])
+            ):
+                if t == "command" and re.match(r"^-[a-zA-Z]*[vVp]", toks[k]):
+                    saw_probe_flag = True
+                k += 1
+            if saw_probe_flag:
+                _probe_args(toks, k, probes)
+                return
+            j = k
+            continue
+        return
+
+
+def _probe_args(toks, j, probes):
+    """Every non-option word a probe is handed is a PATH question about it."""
+    while j < len(toks):
+        t = toks[j]
+        if t in SEPARATORS:
+            return
+        if not t.startswith("-"):
+            probes.add(j)
+        j += 1
+
+
 def command_positions(toks):
-    """Yield indices of tokens that sit in command position."""
-    prev = ""
+    hits, probes = set(), set()
+    expect = True
     i = 0
     while i < len(toks):
         t = toks[i]
-        if prev in OPENERS:
-            # skip leading VAR=value assignment prefixes
-            j = i
-            while j < len(toks) and ASSIGN.match(toks[j]) and "=" in toks[j]:
-                j += 1
-            if j < len(toks):
-                yield j
-            prev = toks[i]
+        if expect:
+            if t in SEPARATORS or (ASSIGN.match(t) and "=" in t):
+                i += 1
+                continue
+            _follow(toks, i, hits, probes)
+            expect = False
             i += 1
             continue
-        prev = t
+        if t in SEPARATORS:
+            expect = True
         i += 1
+    return hits, probes
+
 
 def wrapper_positions(toks):
     """Command position created by this repo's own runner wrappers."""
+    hits, probes = set(), set()
     for i, t in enumerate(toks):
         if t == "run_to" and i + 2 < len(toks):
-            yield i + 2
+            _follow(toks, i + 2, hits, probes)
         elif t == "run_split" and i + 3 < len(toks):
-            yield i + 3
+            _follow(toks, i + 3, hits, probes)
         elif t == "gate" and i + 2 < len(toks):
-            yield i + 2
-        elif t == "timeout" and i + 2 < len(toks):
-            yield i + 2
+            _follow(toks, i + 2, hits, probes)
+    return hits, probes
+
+
+def for_list_positions(toks):
+    """`for t in bashrs pmat probador` — the loop body's command word is a
+    variable, so no command-position scan can see the tool. The literal list is
+    where it IS visible."""
+    out = set()
+    for i, t in enumerate(toks):
+        if t == "in" and i >= 2 and toks[i - 2] == "for":
+            j = i + 1
+            while j < len(toks) and toks[j] not in (";", "do"):
+                out.add(j)
+                j += 1
+    return out
+
+
+def scan_units(text):
+    """Yield (lineno, unit_text) for every span of the file that is CODE.
+
+    Heredoc bodies are data unless the introducing command is a shell — a
+    quoted python heredoc holding the word `apr` is not an invocation, and
+    `bash <<'EOF'` holding `pmat verify` is.
+    """
+    lines = text.splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        raw = lines[i]
+        lineno = i + 1
+        yield lineno, raw
+        stripped_for_hd = strip_comments(raw)
+        m = HEREDOC.search(stripped_for_hd)
+        if not m:
+            i += 1
+            continue
+        delim = m.group(2)
+        head_toks = tokens(strip_line(raw)[0])
+        is_shell = any(t in SHELL_CMDS for t in head_toks[:2])
+        i += 1
+        while i < n and lines[i].strip() != delim:
+            if is_shell:
+                yield i + 1, lines[i]
+            i += 1
+        i += 1
+
 
 def findings(path, text):
     out = []
-    for lineno, raw in enumerate(text.splitlines(), 1):
-        s = strip_line(raw)
-        if not s.strip():
-            continue
-        toks = tokens(s)
-        hits = set(command_positions(toks)) | set(wrapper_positions(toks))
-        for idx in sorted(hits):
-            if idx < len(toks) and toks[idx] in VERIFIERS:
-                out.append("%s:%d: %s" % (path, lineno, toks[idx]))
-    return out
+    for lineno, raw in scan_units(text):
+        main, subs = strip_line(raw)
+        for unit, is_sub in [(main, False)] + [(s, True) for s in subs]:
+            if not unit.strip():
+                continue
+            toks = tokens(unit)
+            hits, probes = command_positions(toks)
+            whits, wprobes = wrapper_positions(toks)
+            hits |= whits
+            probes |= wprobes
+            fors = set() if is_sub else for_list_positions(toks)
+            for idx in sorted(hits):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [bare]" % (path, lineno, toks[idx]))
+            for idx in sorted(probes):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [PATH probe]" % (path, lineno, toks[idx]))
+            for idx in sorted(fors):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [for-list]" % (path, lineno, toks[idx]))
+    # One finding per line/token/kind; a line can otherwise report twice when a
+    # construct is both a wrapper argument and a command position.
+    seen, uniq = set(), []
+    for f in out:
+        if f not in seen:
+            seen.add(f)
+            uniq.append(f)
+    return uniq
+
 
 rc = 0
 for p in sys.argv[1:]:
@@ -160,18 +401,121 @@ PY
 }
 
 # ---------------------------------------------------------------------------
-# PART 1 case table. LEFT column must be FLAGGED, right column must NOT.
-# Re-run this rather than re-reading the tokeniser.
+# PART 1b's audit. Prints "ROW <ok|FAIL> <text>"; exits 1 if any row failed.
+#
+# The question here is NOT "is there a bare token" — PART 1 answers that, and it
+# answers it GREEN on a runner that defines a perfect pin and never calls it.
+# The question is whether the pin is the thing the gates consume.
+pin_audit() {
+    python3 - "$1" <<'PY'
+import re, sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8", errors="replace").read().splitlines()
+
+
+def strip_comments(line):
+    out, i, n, q = [], 0, len(line), ""
+    while i < n:
+        c = line[i]
+        if c == "\\" and i + 1 < n:
+            out.append(line[i:i + 2]); i += 2; continue
+        if q:
+            if c == q:
+                q = ""
+            out.append(c); i += 1; continue
+        if c in ("'", '"'):
+            q = c; out.append(c); i += 1; continue
+        if c == "#":
+            prev = out[-1] if out else ""
+            if not out or prev.isspace() or prev in "(;&|":
+                break
+            out.append(c); i += 1; continue
+        out.append(c); i += 1
+    return "".join(out)
+
+
+code = [(n + 1, strip_comments(l)) for n, l in enumerate(lines)]
+
+CALL = {
+    "pmat": re.compile(r"(?:^|[;&|(){}]|\bthen\b|\belse\b|\bdo\b)\s*verifier_pin_pmat\b"),
+    "pv": re.compile(r"(?:^|[;&|(){}]|\bthen\b|\belse\b|\bdo\b)\s*verifier_pin_pv\b"),
+}
+USE = {
+    "pmat": re.compile(r"\$\{?PMAT_BIN\b"),
+    "pv": re.compile(r"\$\{?PV\}?(?![A-Za-z0-9_])"),
+}
+# An assignment to the pinned variable in the RUNNER is a bypass: it is exactly
+# the mutation `PMAT_BIN=pmat`, and a token scan cannot distinguish it from any
+# other assignment. Empty initialisation stays legal — the runner sets PV="" so
+# an unpinned repo leaves it unmistakably unset.
+BYPASS = re.compile(r"""^\s*(PMAT_BIN|PV)=(?!(""|''|\s|$))""")
+
+rc = 0
+for tool in ("pmat", "pv"):
+    calls = [n for n, l in code if CALL[tool].search(l)]
+    uses = [n for n, l in code if USE[tool].search(l)]
+    if not calls:
+        print("ROW FAIL %s: the runner never CALLS verifier_pin_%s. A pin that is"
+              " defined and not invoked leaves every gate on PATH." % (tool, tool))
+        rc = 1
+    elif not uses:
+        print("ROW FAIL %s: the runner calls verifier_pin_%s but never uses the"
+              " result — the gates are consuming something else." % (tool, tool))
+        rc = 1
+    elif min(calls) > min(uses):
+        print("ROW FAIL %s: first use of the pin is line %d, but the pin is not"
+              " called until line %d — that use reads an unset variable."
+              % (tool, min(uses), min(calls)))
+        rc = 1
+    else:
+        print("ROW ok %s: pinned at line %d, consumed %d time(s), first use line %d"
+              % (tool, min(calls), len(uses), min(uses)))
+
+bypass = [(n, l.strip()) for n, l in code if BYPASS.match(l)]
+if bypass:
+    for n, l in bypass:
+        print("ROW FAIL bypass at line %d: %s" % (n, l[:80]))
+    print("ROW FAIL the runner assigns a pinned verifier variable directly. Only"
+          " scripts/verifier_pin.sh may decide what PMAT_BIN/PV hold.")
+    rc = 1
+else:
+    print("ROW ok no direct PMAT_BIN=/PV= assignment in the runner")
+sys.exit(rc)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# The scan universe: the protocol itself, plus every gate the runner DISCOVERS
+# and EXECUTES inside the release verdict. Derived from the manifest so a gate
+# added there cannot escape it. An empty derivation is a FAILURE, not a pass:
+# a guard sweeping a set it failed to build is the vacuous green this whole
+# protocol exists to refuse.
+resolve_scope() {
+    local declared
+    declared=$(awk '/^\[package\.metadata\.dogfood\]/{f=1;next} /^\[/{f=0} f' \
+        "$REPO_ROOT/Cargo.toml" 2>/dev/null \
+        | grep -oE '"[^"]+\.sh"' | tr -d '"')
+    if [ -z "$declared" ]; then
+        printf 'SCOPE_ERROR'
+        return 1
+    fi
+    printf '%s\n%s\n' "$(printf '%s\n' $CORE_SCOPE)" "$declared" | awk 'NF && !seen[$0]++'
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# PART 1 case table. The nine-plus violating lines are ASSEMBLED from $M/$P/$A
+# rather than written out, so this file contains no literal bare invocation of
+# its own. Otherwise the sibling guard scripts/check_apr_bin_pinned.sh — which
+# scans every script for exactly this construct — reports the case table as real
+# violations, and THIS guard now scans itself too (it is a declared gate).
+# Fixtures that trip a neighbouring guard get that guard an exemption entry, and
+# an exemption is how a guard stops guarding.
 self_test() {
     local td fails=0 got want
     td=$(mktemp -d) || return 2
 
-    # MUST FLAG. The nine violating lines are ASSEMBLED from $M/$P/$A rather
-    # than written out, so this file contains no literal bare invocation of its
-    # own. Otherwise the sibling guard scripts/check_apr_bin_pinned.sh — which
-    # scans every script for exactly this construct — reports the case table as
-    # five real violations. Fixtures that trip a neighbouring guard get that
-    # guard an exemption entry, and an exemption is how a guard stops guarding.
     local M=pmat P=pv A=apr
     {
         printf 'gate %s-verify %s verify --format json\n' "$M" "$M"
@@ -183,7 +527,27 @@ self_test() {
         printf 'OUT=$(%s lint contracts)\n' "$P"
         printf 'PATH=/stale:$PATH %s verify\n' "$M"
         printf 'if %s validate x; then :; fi\n' "$P"
+        # 10 — MAJOR 1, the live construct: command substitution INSIDE a
+        # double-quoted string. This was the receipt line naming which pmat ran.
+        printf 'mark tools PASS "pmat $(%s --version | head -1)"\n' "$M"
+        # 11 — its generalised form.
+        printf 'OUT="$(%s lint contracts)"\n' "$P"
+        # 12 — an UNescaped backtick inside a double-quoted string is still a
+        # substitution. The escaped form is row 6 of MUST-NOT-FLAG.
+        printf 'mark tools PASS "ver `%s --version`"\n' "$P"
+        # 13 — a wrapper prefix carrying its own option-with-argument.
+        printf 'nice -n 5 %s verify\n' "$M"
+        # 14/15/16 — PATH probes. They do not run the tool; they decide whether
+        # a gate runs, and they ask PATH instead of the pin.
+        printf 'command -v %s >/dev/null 2>&1\n' "$M"
+        printf 'HAVE=$(command -v %s)\n' "$A"
+        printf 'type -aP %s\n' "$P"
+        # 17 — the name in a `for` word list, whose loop body probes "$t".
+        printf 'for t in bashrs %s probador; do command -v "$t"; done\n' "$M"
+        # 18 — `command` as a transparent prefix, which the OPENERS set missed.
+        printf 'command %s verify\n' "$M"
     } > "$td/bad.sh"
+
     # MUST NOT FLAG
     cat > "$td/good.sh" <<'EOF'
 # `pv lint <DIR>` is a real gate and is run separately below.
@@ -191,31 +555,115 @@ mark pv-contracts REPORT "pv is not pinned in this repo -- contracts NOT validat
 run_to "$WORKLOG/pv-pc.log" "$PV" validate "$WORKLOG/bogus-contract.yaml"
 gate pmat-verify "$PMAT_BIN" verify --format json
 run_to "$WORKLOG/pmat-index.log" timeout 900 "$PMAT_BIN" query "x" --limit 1
-for t in bashrs pmat probador; do
-PMAT_BIN=pmat
+for t in bashrs probador; do
 echo "pmat"
 . scripts/apr_bin.sh || exit 1
 #   run_to "$LOG" pmat query "x"
 mark pmat-verify SKIP "package has no lib target"
+command -v "$PMAT_BIN" >/dev/null 2>&1
+command -v bashrs >/dev/null 2>&1
+VER="$("$PMAT_BIN" --version | head -1)"
+nice -n 5 "$PMAT_BIN" verify
+LIT='$(pmat --version)'
+mark pv-bindings FAIL "\`pv verify-bindings\` produced no verification line"
+EOF
+
+    # A DATA heredoc holds no invocation; a SHELL heredoc does. Separate
+    # fixtures because these are multi-line and the table above is by line.
+    cat > "$td/hd-data.sh" <<'EOF'
+python3 - "$1" <<'PY'
+print("apr")
+pv = 1
+PY
+EOF
+    cat > "$td/hd-shell.sh" <<'EOF'
+bash <<'EOF2'
+pmat verify --format json
+EOF2
 EOF
 
     got=$(scan "$td/bad.sh" | awk -F: '{print $2}' | tr '\n' ' ')
-    want="1 2 3 4 5 6 7 8 9 "
+    want="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 "
     if [ "$got" = "$want" ]; then
-        printf 'ok    MUST-FLAG    all 9 bare invocations reported\n'
+        printf 'ok    MUST-FLAG     all 18 bare/probe/for-list invocations reported\n'
     else
-        printf 'FAIL  MUST-FLAG    got lines [%s], want [%s]\n' "$got" "$want"; fails=1
+        printf 'FAIL  MUST-FLAG     got lines [%s], want [%s]\n' "$got" "$want"; fails=1
     fi
 
     got=$(scan "$td/good.sh" | tr '\n' ' ')
     if [ -z "$got" ]; then
-        printf 'ok    MUST-NOT-FLAG all 10 pinned/comment/string forms accepted\n'
+        printf 'ok    MUST-NOT-FLAG all 14 pinned/comment/string/probe forms accepted\n'
     else
         printf 'FAIL  MUST-NOT-FLAG false positives: %s\n' "$got"; fails=1
     fi
 
+    got=$(scan "$td/hd-data.sh" | tr '\n' ' ')
+    if [ -z "$got" ]; then
+        printf 'ok    HEREDOC-DATA  a python heredoc naming a verifier is not an invocation\n'
+    else
+        printf 'FAIL  HEREDOC-DATA  false positives: %s\n' "$got"; fails=1
+    fi
+
+    got=$(scan "$td/hd-shell.sh" | awk -F: '{print $2}' | tr '\n' ' ')
+    if [ "$got" = "2 " ]; then
+        printf 'ok    HEREDOC-SHELL a `bash <<EOF` heredoc IS scanned as code\n'
+    else
+        printf 'FAIL  HEREDOC-SHELL got [%s], want [2 ]\n' "$got"; fails=1
+    fi
+
+    # PART 1b's own table: a runner that defines the pin and bypasses it.
+    cat > "$td/bypass.sh" <<'EOF'
+PMAT_BIN=pmat
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/bypass.sh" 2>&1)
+    if printf '%s' "$got" | grep -q 'ROW FAIL pmat' && printf '%s' "$got" | grep -q 'ROW FAIL bypass'; then
+        printf 'ok    CALL-SITE     `PMAT_BIN=pmat` instead of the pin call is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     a runner that assigns PMAT_BIN itself was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    cat > "$td/late.sh" <<'EOF'
+gate pmat-verify "$PMAT_BIN" verify
+verifier_pin_pmat "$CRATE" "$BINPATH"
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/late.sh" 2>&1)
+    if printf '%s' "$got" | grep -q 'ROW FAIL pmat'; then
+        printf 'ok    CALL-SITE     a pin called AFTER its first use is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     a pin called after its first use was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    cat > "$td/good-calls.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    if pin_audit "$td/good-calls.sh" >/dev/null 2>&1; then
+        printf 'ok    CALL-SITE     a runner that calls both pins before use is accepted\n'
+    else
+        printf 'FAIL  CALL-SITE     a correct runner was rejected:\n'
+        pin_audit "$td/good-calls.sh" 2>&1 | sed 's/^/        /'; fails=1
+    fi
+
     rm -rf "${td:?}"
     return "$fails"
+}
+
+# Cargo.lock with `[[patch.unused]]` blocks and blank lines removed. See the
+# note at row 5 of behaviour_test for why those blocks are not staleness.
+lock_norm() {
+    awk '/^\[\[patch\.unused\]\]/ { skip=1; next }
+         skip { if ($0 == "") skip=0; next }
+         $0 != ""' "$1"
 }
 
 # ---------------------------------------------------------------------------
@@ -224,6 +672,18 @@ EOF
 behaviour_test() {
     local td fails=0 built stale
     td=$(mktemp -d) || return 2
+
+    # This function builds pv, and a cargo build without --locked REWRITES a
+    # stale Cargo.lock in place. That is the exact failure scripts/
+    # check_lockfile_current.sh exists to catch, so a guard that silently
+    # repaired the lock on its way past would disarm its neighbour. Snapshot it,
+    # restore it, and REPORT if the build moved it.
+    #
+    # The snapshot is a FILE COPY, not `$(cat …)`: command substitution strips
+    # trailing newlines, so a variable round-trip restores a file that differs
+    # from the original in its last byte. The first version of this row did that
+    # and its own restore was not byte-identical.
+    [ -f "$REPO_ROOT/Cargo.lock" ] && cp "$REPO_ROOT/Cargo.lock" "$td/Cargo.lock.before"
 
     # shellcheck source=/dev/null
     if ! . "$REPO_ROOT/scripts/verifier_pin.sh"; then
@@ -301,6 +761,90 @@ behaviour_test() {
         printf 'ok    pv-pin     resolved pv is %s, NOT the PATH decoy %s\n' "$PV" "$decoy"
     ) || fails=1
 
+    # Row 5 — this guard must not have moved Cargo.lock.
+    #
+    # `[[patch.unused]]` blocks are NORMALISED AWAY before comparing, and that is
+    # not a loosening. They appear only when a host-local, gitignored
+    # `.cargo/config.toml` injects a `[patch.crates-io]` of sibling checkouts —
+    # the aprender dev-overrides do exactly that — and then ANY `cargo build -p
+    # <one-member>` records which of those patches the sub-graph did not use.
+    # They are absent in CI, they say nothing about whether the lock resolves,
+    # and failing on them would make this row permanently red on every
+    # developer box that ran `make dev-setup`. The resolution itself — the
+    # `[[package]]` entries — is compared in full.
+    if [ ! -f "$td/Cargo.lock.before" ]; then
+        printf 'ok    lockfile   no Cargo.lock in this repo — nothing for the build to move\n'
+    elif lock_norm "$td/Cargo.lock.before" > "$td/lock.a" \
+         && lock_norm "$REPO_ROOT/Cargo.lock" > "$td/lock.b" \
+         && cmp -s "$td/lock.a" "$td/lock.b"; then
+        # Leave the tree exactly as it was found, even when the delta was inert.
+        cmp -s "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock" \
+            || cp "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock"
+        printf 'ok    lockfile   building the pinned pv did not change the resolution\n'
+    else
+        cp "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock"
+        printf 'FAIL  lockfile   building the pinned pv REWROTE Cargo.lock (restored). The lock\n'
+        printf '                 was stale before this ran; cargo repaired it in passing, which\n'
+        printf '                 is exactly what scripts/check_lockfile_current.sh exists to see.\n'
+        printf '                 Run `cargo update --workspace --offline` (or check_lockfile_current.sh)\n'
+        printf '                 and commit the result.\n'
+        fails=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+# PART 3. The fleet path: this runner exists to be pointed at OTHER repos, by
+# the relative path its own Usage line documents. #2640 made the pin library
+# load-bearing and fail-closed, while SKILL_DIR was still computed AFTER
+# `cd "$REPO_DIR"` — so a relative ${BASH_SOURCE[0]} resolved against the TARGET
+# repo, the library was "missing", and the runner exited 2 before any gate ran.
+# Absolute invocation kept working, which is why nothing noticed.
+fleet_path_test() {
+    local td fails=0 out rc
+    td=$(mktemp -d) || return 2
+
+    mkdir -p "$td/fixture-crate/src"
+    cat > "$td/fixture-crate/Cargo.toml" <<'EOF'
+[package]
+name = "dogfood-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata.dogfood]
+gates = ["gate-ok.sh"]
+EOF
+    printf 'pub fn f() {}\n' > "$td/fixture-crate/src/lib.rs"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$td/fixture-crate/gate-ok.sh"
+
+    # DOGFOOD_GATES_ONLY stops after the declared-gate discovery section, which
+    # sits well past the pin-library source. It is the runner's own hook, not a
+    # copy of it, and it can never print GO.
+    out=$( cd "$REPO_ROOT" && DOGFOOD_GATES_ONLY=1 \
+        bash scripts/dogfood.sh "$td/fixture-crate" 2>&1 )
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        printf 'FAIL  fleet-path a RELATIVE `bash scripts/dogfood.sh <other-crate>` exited 2\n'
+        printf '                 (setup error) before running anything. That is the form its own\n'
+        printf '                 documented Usage line gives, and the whole reason the protocol is\n'
+        printf '                 portable. Resolve SKILL_DIR from ${BASH_SOURCE[0]} BEFORE the\n'
+        printf '                 `cd "$REPO_DIR"`, or the path resolves against the TARGET repo.\n'
+        printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
+        fails=1
+    elif printf '%s' "$out" | grep -q 'verifier_pin.sh is missing'; then
+        printf 'FAIL  fleet-path the pin library was not found under a relative invocation\n'
+        fails=1
+    elif ! printf '%s' "$out" | grep -q 'DOGFOOD_GATES_ONLY'; then
+        printf 'FAIL  fleet-path the runner did not reach the declared-gate section (rc=%s)\n' "$rc"
+        printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
+        fails=1
+    else
+        printf 'ok    fleet-path relative invocation against another crate runs (rc=%s)\n' "$rc"
+    fi
+
     rm -rf "${td:?}"
     return "$fails"
 }
@@ -309,6 +853,9 @@ behaviour_test() {
 case "${1:-}" in
     --self-test)
         self_test; exit $?
+        ;;
+    --scan)
+        shift; scan "$@"; exit $?
         ;;
 esac
 
@@ -320,34 +867,52 @@ if self_test; then :; else rc=1; fi
 
 printf '\nPART 1 — static: no bare verifier in command position\n'
 cd "$REPO_ROOT" || exit 2
-missing=""
-for f in $SCOPE; do
-    [ -f "$f" ] || missing="$missing $f"
-done
-if [ -n "$missing" ]; then
-    # A scope entry that does not exist is a gate scanning nothing. The runner
-    # could be renamed out from under this guard and it would sweep an empty
-    # universe and report clean — the exact failure this repo keeps finding.
-    printf 'FAIL  in-scope file(s) missing:%s — the guard scanned an empty universe\n' "$missing"
+SCOPE=$(resolve_scope)
+if [ "$SCOPE" = "SCOPE_ERROR" ]; then
+    printf 'FAIL  [package.metadata.dogfood] gates yielded nothing — the scan universe\n'
+    printf '      could not be built, so a clean sweep here would mean nothing.\n'
     rc=1
 else
-    # shellcheck disable=SC2086
-    hits=$(scan $SCOPE)
-    scan_rc=$?
-    if [ "$scan_rc" -eq 2 ]; then
-        printf 'FAIL  the scanner errored:\n%s\n' "$hits"; rc=1
-    elif [ -n "$hits" ]; then
-        printf 'FAIL  bare verifier invocation(s) — these resolve through PATH:\n'
-        printf '%s\n' "$hits" | sed 's/^/      /'
-        printf '      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.\n'
+    missing=""
+    for f in $SCOPE; do
+        [ -f "$f" ] || missing="$missing $f"
+    done
+    if [ -n "$missing" ]; then
+        # A scope entry that does not exist is a gate scanning nothing. The
+        # runner could be renamed out from under this guard and it would sweep
+        # an empty universe and report clean — the exact failure this repo
+        # keeps finding.
+        printf 'FAIL  in-scope file(s) missing:%s — the guard scanned an empty universe\n' "$missing"
         rc=1
     else
-        printf 'ok    %s: no bare pv/pmat/apr in command position\n' "$SCOPE"
+        # shellcheck disable=SC2086
+        hits=$(scan $SCOPE)
+        scan_rc=$?
+        if [ "$scan_rc" -eq 2 ]; then
+            printf 'FAIL  the scanner errored:\n%s\n' "$hits"; rc=1
+        elif [ -n "$hits" ]; then
+            printf 'FAIL  bare verifier invocation(s) — these resolve through PATH:\n'
+            printf '%s\n' "$hits" | sed 's/^/      /'
+            printf '      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.\n'
+            rc=1
+        else
+            printf 'ok    no bare pv/pmat/apr in command position, in:\n'
+            printf '%s\n' "$SCOPE" | sed 's/^/        /'
+        fi
     fi
 fi
 
+printf '\nPART 1b — call site: the pin is CALLED, and its result is what runs\n'
+audit=$(pin_audit "$REPO_ROOT/scripts/dogfood.sh")
+audit_rc=$?
+printf '%s\n' "$audit" | sed -e 's/^ROW ok /ok    /' -e 's/^ROW FAIL /FAIL  /' -e 's/^\(ok\|FAIL\)/\1/'
+[ "$audit_rc" -eq 0 ] || rc=1
+
 printf '\nPART 2 — behavioural: the pins select something other than PATH\n'
 if behaviour_test; then :; else rc=1; fi
+
+printf '\nPART 3 — fleet path: the runner runs when invoked relatively\n'
+if fleet_path_test; then :; else rc=1; fi
 
 printf '\n'
 if [ "$rc" -eq 0 ]; then

--- a/scripts/check_verifier_pinning.sh
+++ b/scripts/check_verifier_pinning.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # check_verifier_pinning.sh — the verifier-pinning rule, ENFORCED.
 #
-# THE RULE (stated once, in scripts/verifier_pin.sh; this file is its gate):
-#
-#   A gate that decides a release must not resolve its verifier through PATH.
-#   Where the repo pins the tool, use the pin; where it does not, REPORT rather
-#   than fall back.
+# THE RULE IS NOT RESTATED HERE. It is stated once, in scripts/verifier_pin.sh,
+# under the heading "THE RULE" — read it there. A rule written down twice is two
+# rules that can disagree, which is the thesis of the ticket this gate closes
+# (#2640): one protocol, two copies, nine silent divergences. This file is the
+# rule's ENFORCEMENT, not a second copy of its text.
 #
 # WHY A GATE AND NOT A PARAGRAPH
 # ------------------------------

--- a/scripts/check_verifier_pinning.sh
+++ b/scripts/check_verifier_pinning.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# check_verifier_pinning.sh — the verifier-pinning rule, ENFORCED.
+#
+# THE RULE (stated once, in scripts/verifier_pin.sh; this file is its gate):
+#
+#   A gate that decides a release must not resolve its verifier through PATH.
+#   Where the repo pins the tool, use the pin; where it does not, REPORT rather
+#   than fall back.
+#
+# WHY A GATE AND NOT A PARAGRAPH
+# ------------------------------
+# The rule already had FIVE independent ad-hoc rediscoveries before anyone
+# noticed it was one rule (PMAT_BIN, scripts/pv_bin.sh, scripts/apr_bin.sh,
+# aprender#2384, APR-BENCH-RFC-001). Five is the evidence that a rule merely
+# stated is documentation. #2640 merged the two dogfood runners into one; this
+# is what stops the sixth tool re-discovering the rule in a sixth copy.
+#
+# TWO PARTS, because presence is not behaviour:
+#
+#   PART 1 (static)      no bare pv/pmat/apr in command position in the runner
+#                        or its pin library. Mutation: reintroduce a bare `pmat`
+#                        call -> RED.
+#   PART 2 (behavioural) the two pins are EXERCISED and must select something
+#                        other than what PATH offers. Mutations: delete the
+#                        PMAT_BIN self-referential branch -> RED; bypass
+#                        pv_bin.sh to a PATH pv -> RED. Part 1 alone would pass
+#                        on a pin that resolves to the wrong binary.
+#
+# THE UNIVERSE, and why it is these three tokens
+# ----------------------------------------------
+# VERIFIERS = pv, pmat, apr — exactly the tools for which THIS REPO ships a pin
+# (scripts/pv_bin.sh, verifier_pin_pmat, scripts/apr_bin.sh). bashrs and
+# probador are verifiers too and are NOT listed: no pin exists for them, and the
+# rule's second clause is "where the repo does not pin, report" — which the
+# runner does. Adding them here would demand a pin that does not exist and make
+# the gate unfixable. The day one ships, add the token here.
+#
+# What counts as an invocation: the token in COMMAND POSITION after comments and
+# quoted strings are removed. A bare mention in a comment or a string is NOT an
+# invocation — the runner's own prose says "`pv lint <DIR>` is a real gate" and
+# marks a row "pv is not pinned in this repo", and both must stay legal. The
+# distinction is the whole difficulty, so it ships a case table (--self-test)
+# rather than a reviewed regex: the apr-invocation patterns in this repo were
+# wrong FIVE times and every one was caught by a table, none by review.
+#
+#   bash scripts/check_verifier_pinning.sh              # check
+#   bash scripts/check_verifier_pinning.sh --self-test  # the case table only
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The files that decide a release and are therefore in scope.
+SCOPE="scripts/dogfood.sh scripts/verifier_pin.sh"
+
+# ---------------------------------------------------------------------------
+# The scanner. Reports "<file>:<line>: <token>" for each bare invocation.
+#
+# It tokenises rather than regexing the raw line, because a regex over raw text
+# gets `pmat-verify` wrong: \bpmat\b MATCHES inside `pmat-verify`, since `-` is a
+# non-word character. Token equality does not. Quoted spans collapse to a single
+# @Q placeholder rather than being deleted, so the ARITY of wrappers such as
+# `run_to <log> <cmd...>` is preserved and `run_to "$LOG" pmat query` is still
+# seen as pmat in command position.
+scan() {
+    python3 - "$@" <<'PY'
+import re, sys
+
+VERIFIERS = {"pv", "pmat", "apr"}
+# Tokens after which the next word is a command.
+OPENERS = {"", ";", "&&", "||", "|", "|&", "(", "$(", "((", "{", "}", ")",
+           "if", "then", "else", "elif", "while", "until", "do", "!",
+           "env", "exec", "nohup", "time", "sudo", "xargs", "&"}
+ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+def strip_line(line):
+    """Remove comments; replace quoted spans with @Q. Returns the stripped line."""
+    out, i, n = [], 0, len(line)
+    while i < n:
+        c = line[i]
+        if c == "\\" and i + 1 < n:
+            out.append("X"); i += 2; continue
+        if c in ("'", '"'):
+            q = c; i += 1
+            while i < n:
+                if line[i] == "\\" and q == '"':
+                    i += 2; continue
+                if line[i] == q:
+                    i += 1; break
+                i += 1
+            out.append(" @Q "); continue
+        if c == "#":
+            prev = out[-1] if out else ""
+            # A `#` starts a comment only at the start of a word.
+            if not out or prev.isspace() or prev in "(;&|":
+                break
+            out.append(c); i += 1; continue
+        out.append(c); i += 1
+    return "".join(out)
+
+SPLIT = re.compile(r"(\$\(|[();|&{}]|&&|\|\|)")
+
+def tokens(s):
+    return [t for t in SPLIT.sub(r" \1 ", s).split() if t]
+
+def command_positions(toks):
+    """Yield indices of tokens that sit in command position."""
+    prev = ""
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if prev in OPENERS:
+            # skip leading VAR=value assignment prefixes
+            j = i
+            while j < len(toks) and ASSIGN.match(toks[j]) and "=" in toks[j]:
+                j += 1
+            if j < len(toks):
+                yield j
+            prev = toks[i]
+            i += 1
+            continue
+        prev = t
+        i += 1
+
+def wrapper_positions(toks):
+    """Command position created by this repo's own runner wrappers."""
+    for i, t in enumerate(toks):
+        if t == "run_to" and i + 2 < len(toks):
+            yield i + 2
+        elif t == "run_split" and i + 3 < len(toks):
+            yield i + 3
+        elif t == "gate" and i + 2 < len(toks):
+            yield i + 2
+        elif t == "timeout" and i + 2 < len(toks):
+            yield i + 2
+
+def findings(path, text):
+    out = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        s = strip_line(raw)
+        if not s.strip():
+            continue
+        toks = tokens(s)
+        hits = set(command_positions(toks)) | set(wrapper_positions(toks))
+        for idx in sorted(hits):
+            if idx < len(toks) and toks[idx] in VERIFIERS:
+                out.append("%s:%d: %s" % (path, lineno, toks[idx]))
+    return out
+
+rc = 0
+for p in sys.argv[1:]:
+    try:
+        text = open(p, encoding="utf-8", errors="replace").read()
+    except OSError as e:
+        print("SCANERROR %s %s" % (p, e)); rc = 2; continue
+    for f in findings(p, text):
+        print(f); rc = 1
+sys.exit(rc)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# PART 1 case table. LEFT column must be FLAGGED, right column must NOT.
+# Re-run this rather than re-reading the tokeniser.
+self_test() {
+    local td fails=0 got want
+    td=$(mktemp -d) || return 2
+
+    # MUST FLAG. The nine violating lines are ASSEMBLED from $M/$P/$A rather
+    # than written out, so this file contains no literal bare invocation of its
+    # own. Otherwise the sibling guard scripts/check_apr_bin_pinned.sh — which
+    # scans every script for exactly this construct — reports the case table as
+    # five real violations. Fixtures that trip a neighbouring guard get that
+    # guard an exemption entry, and an exemption is how a guard stops guarding.
+    local M=pmat P=pv A=apr
+    {
+        printf 'gate %s-verify %s verify --format json\n' "$M" "$M"
+        printf 'run_to "$WORKLOG/x.log" timeout 900 %s query "x" --limit 1\n' "$M"
+        printf 'run_split "$W/a.json" "$W/b.err" timeout 900 %s comply check\n' "$M"
+        printf '%s validate "$c" >/dev/null 2>&1\n' "$P"
+        printf '%s qa model.apr\n' "$A"
+        printf 'foo && %s comply check\n' "$M"
+        printf 'OUT=$(%s lint contracts)\n' "$P"
+        printf 'PATH=/stale:$PATH %s verify\n' "$M"
+        printf 'if %s validate x; then :; fi\n' "$P"
+    } > "$td/bad.sh"
+    # MUST NOT FLAG
+    cat > "$td/good.sh" <<'EOF'
+# `pv lint <DIR>` is a real gate and is run separately below.
+mark pv-contracts REPORT "pv is not pinned in this repo -- contracts NOT validated."
+run_to "$WORKLOG/pv-pc.log" "$PV" validate "$WORKLOG/bogus-contract.yaml"
+gate pmat-verify "$PMAT_BIN" verify --format json
+run_to "$WORKLOG/pmat-index.log" timeout 900 "$PMAT_BIN" query "x" --limit 1
+for t in bashrs pmat probador; do
+PMAT_BIN=pmat
+echo "pmat"
+. scripts/apr_bin.sh || exit 1
+#   run_to "$LOG" pmat query "x"
+mark pmat-verify SKIP "package has no lib target"
+EOF
+
+    got=$(scan "$td/bad.sh" | awk -F: '{print $2}' | tr '\n' ' ')
+    want="1 2 3 4 5 6 7 8 9 "
+    if [ "$got" = "$want" ]; then
+        printf 'ok    MUST-FLAG    all 9 bare invocations reported\n'
+    else
+        printf 'FAIL  MUST-FLAG    got lines [%s], want [%s]\n' "$got" "$want"; fails=1
+    fi
+
+    got=$(scan "$td/good.sh" | tr '\n' ' ')
+    if [ -z "$got" ]; then
+        printf 'ok    MUST-NOT-FLAG all 10 pinned/comment/string forms accepted\n'
+    else
+        printf 'FAIL  MUST-NOT-FLAG false positives: %s\n' "$got"; fails=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+# PART 2. The pins must BEHAVE. Presence of `PMAT_BIN` proves nothing about
+# which binary the gate ends up running, which is the only thing that matters.
+behaviour_test() {
+    local td fails=0 built stale
+    td=$(mktemp -d) || return 2
+
+    # shellcheck source=/dev/null
+    if ! . "$REPO_ROOT/scripts/verifier_pin.sh"; then
+        printf 'FAIL  pins       scripts/verifier_pin.sh could not be sourced\n'
+        rm -rf "${td:?}"; return 1
+    fi
+
+    # A STALE pmat, first on PATH. This is the binary the gate must NOT pick.
+    mkdir -p "$td/stalebin"
+    stale="$td/stalebin/pmat"
+    printf '#!/bin/sh\necho stale-pmat\n' > "$stale"
+    chmod +x "$stale"
+    built="$td/target-release-pmat"
+    printf '#!/bin/sh\necho built-pmat\n' > "$built"
+    chmod +x "$built"
+
+    # Row 1 — the self-referential case: releasing pmat itself.
+    PMAT_BIN=""
+    PATH="$td/stalebin:$PATH" verifier_pin_pmat "pmat" "$built"
+    if [ "$PMAT_BIN" = "$built" ]; then
+        printf 'ok    pmat-pin   releasing pmat selects the BUILT artifact, not the PATH copy\n'
+    else
+        printf 'FAIL  pmat-pin   releasing pmat resolved to [%s]; the stale PATH pmat at %s\n' "$PMAT_BIN" "$stale"
+        printf '                 would have measured a different build than the one shipping.\n'
+        fails=1
+    fi
+
+    # Row 2 — every OTHER crate: PATH is correct there and must stay the answer.
+    PMAT_BIN=""
+    verifier_pin_pmat "aprender" "$built"
+    if [ "$PMAT_BIN" = "pmat" ]; then
+        printf 'ok    pmat-pin   a non-pmat crate still uses the fleet pmat\n'
+    else
+        printf 'FAIL  pmat-pin   non-pmat crate resolved to [%s], expected the PATH pmat\n' "$PMAT_BIN"; fails=1
+    fi
+
+    # Row 3 — a crate named pmat with NO built artifact must not invent one.
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" ""
+    if [ "$PMAT_BIN" = "pmat" ]; then
+        printf 'ok    pmat-pin   no built artifact -> no fabricated pin\n'
+    else
+        printf 'FAIL  pmat-pin   empty BINPATH resolved to [%s]\n' "$PMAT_BIN"; fails=1
+    fi
+
+    # Row 4 — pv. The pin must not be whatever PATH offers. A decoy `pv` goes
+    # first on PATH; the resolved PV must differ from it.
+    mkdir -p "$td/pvbin"
+    printf '#!/bin/sh\necho "pv 0.0.0-decoy"\n' > "$td/pvbin/pv"
+    chmod +x "$td/pvbin/pv"
+    (
+        cd "$REPO_ROOT" || exit 2
+        PATH="$td/pvbin:$PATH"
+        export PATH
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        # The decoy is named directly, not via `command -v`: this file must not
+        # itself contain a PATH resolution of a verifier, and naming the path we
+        # planted is strictly more precise than asking PATH what it found.
+        decoy="$td/pvbin/pv"
+        if [ "$pv_rc" -eq 2 ]; then
+            printf 'FAIL  pv-pin     this repo SHIPS scripts/pv_bin.sh but the pin reported "unpinned"\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ]; then
+            printf 'FAIL  pv-pin     the pin failed to resolve pv (rc=%s) — a release cannot be\n' "$pv_rc"
+            printf '                 decided by a verifier that did not build.\n'
+            exit 1
+        fi
+        if [ "$PV" = "$decoy" ]; then
+            printf 'FAIL  pv-pin     resolved pv IS the PATH decoy (%s) — the pin was bypassed\n' "$decoy"
+            exit 1
+        fi
+        printf 'ok    pv-pin     resolved pv is %s, NOT the PATH decoy %s\n' "$PV" "$decoy"
+    ) || fails=1
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    --self-test)
+        self_test; exit $?
+        ;;
+esac
+
+rc=0
+printf -- '--- verifier pinning ------------------------------------------------\n'
+
+printf 'case table (the tokeniser must be right before its verdict means anything)\n'
+if self_test; then :; else rc=1; fi
+
+printf '\nPART 1 — static: no bare verifier in command position\n'
+cd "$REPO_ROOT" || exit 2
+missing=""
+for f in $SCOPE; do
+    [ -f "$f" ] || missing="$missing $f"
+done
+if [ -n "$missing" ]; then
+    # A scope entry that does not exist is a gate scanning nothing. The runner
+    # could be renamed out from under this guard and it would sweep an empty
+    # universe and report clean — the exact failure this repo keeps finding.
+    printf 'FAIL  in-scope file(s) missing:%s — the guard scanned an empty universe\n' "$missing"
+    rc=1
+else
+    # shellcheck disable=SC2086
+    hits=$(scan $SCOPE)
+    scan_rc=$?
+    if [ "$scan_rc" -eq 2 ]; then
+        printf 'FAIL  the scanner errored:\n%s\n' "$hits"; rc=1
+    elif [ -n "$hits" ]; then
+        printf 'FAIL  bare verifier invocation(s) — these resolve through PATH:\n'
+        printf '%s\n' "$hits" | sed 's/^/      /'
+        printf '      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.\n'
+        rc=1
+    else
+        printf 'ok    %s: no bare pv/pmat/apr in command position\n' "$SCOPE"
+    fi
+fi
+
+printf '\nPART 2 — behavioural: the pins select something other than PATH\n'
+if behaviour_test; then :; else rc=1; fi
+
+printf '\n'
+if [ "$rc" -eq 0 ]; then
+    printf 'PASS  the release runner resolves every pinned verifier through its pin.\n'
+else
+    printf 'FAIL  see rows above. A gate measured with an unknown binary is not a gate.\n'
+fi
+exit "$rc"

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -159,6 +159,19 @@ SKILL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 WORKLOG=$(mktemp -d)
 trap 'rm -rf "$WORKLOG"' EXIT
 
+# THE VERIFIER-PINNING RULE, and the two pins that implement it, live in exactly
+# one file. Read scripts/verifier_pin.sh — the rule is stated there and nowhere
+# else, because a rule restated is a rule that drifts. This runner only CALLS it.
+if [ -f "$SKILL_DIR/verifier_pin.sh" ]; then
+  . "$SKILL_DIR/verifier_pin.sh"
+else
+  echo "dogfood: $SKILL_DIR/verifier_pin.sh is missing." >&2
+  echo "  It carries the rule that decides WHICH pv and WHICH pmat this protocol" >&2
+  echo "  is allowed to believe. Without it every verifier would fall back to" >&2
+  echo "  PATH, which is the exact defect #2640 closed. Refusing to run." >&2
+  exit 2
+fi
+
 echo "══ dogfood pre-release: $CRATE v$VERSION ══"
 
 # ── 1. hygiene ───────────────────────────────────────────────────────────────
@@ -170,6 +183,107 @@ echo "══ dogfood pre-release: $CRATE v$VERSION ══"
 DIRTY=$(git status --porcelain 2>/dev/null | grep -vE '^\?\? ([^ ]*/)?\.(dogfood|pmat|pv)/?$' | head -1)
 if [ -z "$DIRTY" ]; then mark git-clean PASS "working tree clean"
 else mark git-clean WARN "uncommitted changes present (commit before tagging)"; fi
+
+# ── 1b. the crate's OWN release gates, DISCOVERED not duplicated ────────────
+#
+# A repo that has written its own release guards must not have to get them
+# copied into this runner — that is how the runner acquired a second copy of
+# itself (#2640). The declaration lives in the crate's Cargo.toml, versioned
+# with the code it guards, and reuses the mechanism this runner already
+# implements for [package.metadata.transports]:
+#
+#   [package.metadata.dogfood]
+#   gates = ["scripts/check_multiplatform_dogfood.sh", "scripts/dogfood_surfaces.sh"]
+#
+# Each discovered gate gets its OWN row in the receipt. Rolling them into one
+# aggregate verdict is how a red gate hides behind a green neighbour.
+#
+# TWO VACUITY GUARDS, because a clean sweep over an empty set is this protocol's
+# signature failure and it reappears one layer up at DISCOVERY:
+#   · a declared script that does not exist is FAIL, never SKIP. "Declared but
+#     absent" is the state a deleted guard leaves behind, and a SKIP would make
+#     deleting a guard the cheapest way to make it stop complaining.
+#   · no [package.metadata.dogfood] block at all, or `gates = []`, is FAIL. A
+#     crate with zero release gates of its own is a claim, and an unmade claim
+#     reads exactly like a satisfied one.
+run_to "$WORKLOG/meta-dogfood.json" cargo metadata --no-deps --format-version 1
+DG_META_RC=$RUN_RC
+DG_PLAN=$(CRATE="$CRATE" python3 - "$WORKLOG/meta-dogfood.json" <<'PY' 2>/dev/null || echo "META_ERROR"
+import json, os, sys
+d = json.load(open(sys.argv[1]))
+name = os.environ.get('CRATE', '')
+pkgs = d.get('packages', [])
+pkg = next((p for p in pkgs if p['name'] == name), None)
+if pkg is None and len(pkgs) == 1:
+    pkg = pkgs[0]
+if pkg is None:
+    print("NOPKG"); raise SystemExit
+df = (pkg.get('metadata') or {}).get('dogfood')
+if not isinstance(df, dict):
+    print("NODECL"); raise SystemExit
+gates = df.get('gates')
+if not isinstance(gates, list):
+    print("BADSHAPE"); raise SystemExit
+if not gates:
+    print("EMPTY"); raise SystemExit
+for g in gates:
+    if not isinstance(g, str) or not g.strip():
+        print("BADSHAPE"); raise SystemExit
+    print("GATE " + g.strip())
+PY
+)
+if [ "$DG_PLAN" = "META_ERROR" ] || [ "$DG_META_RC" -ne 0 ]; then
+  mark dogfood-gates FAIL "\`cargo metadata\` failed (exit=$DG_META_RC) — the release gates this crate declares could not be discovered, so none of them ran"
+elif [ "$DG_PLAN" = "NOPKG" ]; then
+  mark dogfood-gates FAIL "no package named '$CRATE' in cargo metadata — run dogfood from the crate dir, not the virtual workspace root"
+elif [ "$DG_PLAN" = "NODECL" ]; then
+  mark dogfood-gates FAIL "no [package.metadata.dogfood] in Cargo.toml. Declare the release gates this crate owns, e.g.  [package.metadata.dogfood]  gates = [\"scripts/check_multiplatform_dogfood.sh\"]. A crate that declares none is asserting it has none — say so deliberately, in the manifest, where review can see it."
+elif [ "$DG_PLAN" = "EMPTY" ]; then
+  mark dogfood-gates FAIL "[package.metadata.dogfood] declares \`gates = []\` — a clean sweep over an empty gate set is the vacuous pass this protocol exists to refuse. Declare the gates, or remove the claim to have any."
+elif [ "$DG_PLAN" = "BADSHAPE" ]; then
+  mark dogfood-gates FAIL "[package.metadata.dogfood] gates must be a non-empty list of script paths — a malformed declaration verifies nothing"
+else
+  DG_N=0; DG_BAD=0
+  while read -r dg_kind dg_path; do
+    [ "$dg_kind" = "GATE" ] || continue
+    DG_N=$((DG_N + 1))
+    dg_name="declared:$(basename "$dg_path" .sh)"
+    if [ ! -f "$dg_path" ]; then
+      mark "$dg_name" FAIL "declared in [package.metadata.dogfood] but no such file: $dg_path — a declared gate that does not exist is a deleted gate, not an absent requirement"
+      DG_BAD=$((DG_BAD + 1)); continue
+    fi
+    run_to "$WORKLOG/$(basename "$dg_path").log" bash "$dg_path"
+    dg_rc=$RUN_RC
+    dg_tail=$(tail -3 "$WORKLOG/$(basename "$dg_path").log" 2>/dev/null | strip_ansi | tr '\n' ' ')
+    if [ "$dg_rc" -eq 0 ]; then
+      mark "$dg_name" PASS "$dg_path exit=0"
+    else
+      mark "$dg_name" FAIL "$dg_path exit=$dg_rc — $dg_tail"
+      DG_BAD=$((DG_BAD + 1))
+    fi
+  done <<EOF
+$DG_PLAN
+EOF
+  if [ "$DG_N" -eq 0 ]; then
+    mark dogfood-gates FAIL "[package.metadata.dogfood] parsed but yielded no gate — a declaration matching nothing is not a pass"
+  elif [ "$DG_BAD" -eq 0 ]; then
+    mark dogfood-gates PASS "$DG_N declared gate(s) discovered and all green"
+  else
+    mark dogfood-gates FAIL "$DG_N declared gate(s) discovered, $DG_BAD RED (each named in its own row above)"
+  fi
+fi
+
+# DOGFOOD_GATES_ONLY runs the discovery section and stops. It exists so the
+# discovery mechanism itself can be exercised — by scripts/check_dogfood_shim.sh
+# and by hand — without paying for a full release sweep, and it runs the SAME
+# code the release runs rather than a copy of it, which is the whole point of
+# this ticket. It can never print GO: a partial run is not a verdict.
+if [ -n "${DOGFOOD_GATES_ONLY:-}" ]; then
+  echo "────────────────────────────────────────────────"
+  echo "PARTIAL: DOGFOOD_GATES_ONLY — only the declared repo gates above ran."
+  echo "         This is NOT a release verdict. A GO comes only from a full run."
+  exit "$FAILED"
+fi
 
 # ── 2 + 10. version + publish dry-run (authoritative: cargo's own registry
 # index, not a flaky crates.io HTTP call). A dry-run SUCCEEDS even when the
@@ -278,6 +392,9 @@ if [ -z "$BINPATH" ]; then
     | sed -n 's/.*"executable":"\([^"]*\)".*/\1/p' | grep -v null | tail -1)
 fi
 BINPATH="${BINPATH:-}"
+# Which pmat runs the pmat gates. The rule and its measured evidence are in
+# scripts/verifier_pin.sh; this is the call site.
+verifier_pin_pmat "$CRATE" "$BINPATH"
 if [ -n "$BINPATH" ] && [ -x "$BINPATH" ]; then
   mark release-binary PASS "built: $BINPATH"
 else
@@ -309,22 +426,18 @@ fi
 # `forjar prove` maps into its own "N/N proofs passed" line. Nothing had ever
 # run the validator, so nothing knew.
 #
-# pv is PINNED, never PATH-resolved. scripts/pv_bin.sh records why: a PATH `pv`
-# was 0.49.0 while the in-tree crate was 0.63.0, and the two disagreed on the
-# gate that decides the release -- strict-test-binding reported 253 refs / 51
-# missing under the stale binary and 371 / 27 under HEAD. This script IS a
-# surface where the release decision is made, so it must not be the one holding
-# the stale binary.
-#
-# This protocol runs against any repo in the fleet, and not all of them carry
-# pv_bin.sh. Where it is absent, pv is left UNRESOLVED and the contract gates
-# below REPORT that rather than falling back to whatever PATH offers. A skipped
-# gate that says so beats a green one measured with an unknown binary.
+# pv is PINNED, never PATH-resolved. The rule, and the measurement behind it,
+# are in scripts/verifier_pin.sh; `verifier_pin_pv` is the pin. A repo that
+# ships no pin leaves PV empty and the contract gates below REPORT that rather
+# than falling back to whatever PATH offers.
 MISSING_TOOLS=""
 PV=""
-if [ -f scripts/pv_bin.sh ]; then
-  if . scripts/pv_bin.sh; then :; else MISSING_TOOLS="$MISSING_TOOLS pv"; fi
-fi
+verifier_pin_pv
+case $? in
+  0) : ;;                                              # pinned and executable
+  1) MISSING_TOOLS="$MISSING_TOOLS pv" ;;              # pin present, failed to resolve
+  *) : ;;                                              # this repo ships no pin
+esac
 for t in bashrs pmat probador; do
   command -v "$t" >/dev/null 2>&1 || MISSING_TOOLS="$MISSING_TOOLS $t"
 done
@@ -603,7 +716,7 @@ for p in d.get("packages",[]):
 print("?")' 2>/dev/null)
     mark pmat-verify SKIP "package has no lib target (kinds present: ${TGTS:-?}) — \`pmat verify\` requires one and hard-errors otherwise; pmat-comply/CB-200 below still gates this crate"
   else
-    gate pmat-verify pmat verify --format json
+    gate pmat-verify "$PMAT_BIN" verify --format json
   fi
 
   # ── pmat comply: gate on WHAT ACTUALLY RAN, not on the exit code ──────────
@@ -628,12 +741,12 @@ print("?")' 2>/dev/null)
   # ../provable-contracts/proof-status.json, a ledger — which is genuinely a
   # property of the workstation (paiml/paiml-mcp-agent-toolkit#1008). CB-200 is
   # NOT in that category: it is fixable with one command, so it is gated.
-  run_to "$WORKLOG/pmat-index.log" timeout 900 pmat query "x" --limit 1
+  run_to "$WORKLOG/pmat-index.log" timeout 900 "$PMAT_BIN" query "x" --limit 1
   PMAT_IDX_RC=$RUN_RC
   # run_SPLIT, not run_to: comply writes JSON to stdout and per-group progress
   # to stderr, so merging the two streams corrupts the JSON and the gate would
   # report "could not parse" for a run that worked perfectly.
-  run_split "$WORKLOG/comply.json" "$WORKLOG/comply.err" timeout 900 pmat comply check --format json
+  run_split "$WORKLOG/comply.json" "$WORKLOG/comply.err" timeout 900 "$PMAT_BIN" comply check --format json
   PMAT_COMPLY_RC=$RUN_RC
   PMAT_SUM=$(python3 - "$WORKLOG/comply.json" <<'PY' 2>/dev/null || echo "PARSE_ERROR"
 import json, sys
@@ -681,8 +794,16 @@ PY
     esac
   fi
   # reachability: code the build never compiles. New in pmat 3.32.0.
-  if pmat analyze reachability --help >/dev/null 2>&1; then
-    RO=$(timeout 900 pmat analyze reachability -p . -f json 2>/dev/null | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['orphan_count'],d['orphan_tests'])" 2>/dev/null || echo "? ?")
+  #
+  # These two lines were BARE `pmat` in BOTH copies of the runner — the
+  # user-scope copy that invented PMAT_BIN never applied it here, because the
+  # subcommand landed after the hardening did. Found by
+  # scripts/check_verifier_pinning.sh on its first run, which is the argument
+  # for the gate: the rule's own author missed a site, and only a mechanical
+  # sweep of the whole file noticed. `--help` on a stale pmat also decides
+  # whether the gate runs AT ALL, so an unpinned probe silently skips it.
+  if "$PMAT_BIN" analyze reachability --help >/dev/null 2>&1; then
+    RO=$(timeout 900 "$PMAT_BIN" analyze reachability -p . -f json 2>/dev/null | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['orphan_count'],d['orphan_tests'])" 2>/dev/null || echo "? ?")
     mark reachability WARN "unreachable files/tests: $RO (a file the build never compiles cannot be tested)"
   fi
 else

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -11,6 +11,18 @@
 # Exit:   0 = GO (all gates green) · 1 = NO-GO (a gate failed) · 2 = setup error
 set -uo pipefail
 
+# WHERE THIS SKILL LIVES — resolved BEFORE the `cd` below, and that order is
+# load-bearing. `${BASH_SOURCE[0]}` is whatever the caller typed: for the
+# documented fleet invocation `bash scripts/dogfood.sh ../other-crate` it is
+# RELATIVE, so resolving it after `cd "$REPO_DIR"` looks for this skill's helper
+# files inside the TARGET repo. That was harmless while the helpers were
+# optional; #2640 made verifier_pin.sh load-bearing and fail-closed, and the
+# runner then refused to start on every relative invocation — the exact fleet
+# path the whole canon/shim arrangement exists to serve. Absolute invocations
+# kept working, which is why it looked fine. Gated by PART 3 of
+# scripts/check_verifier_pinning.sh.
+SKILL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 REPO_DIR="${1:-$PWD}"
 cd "$REPO_DIR" 2>/dev/null || { echo "dogfood: no such dir: $REPO_DIR" >&2; exit 2; }
 [ -f Cargo.toml ] || { echo "dogfood: not a Rust crate (no Cargo.toml) in $REPO_DIR" >&2; exit 2; }
@@ -153,9 +165,9 @@ run_to() { local log="$1"; shift; "$@" > "$log" 2>&1; RUN_RC=$?; }
 # stderr; merging them destroys the receipt check).
 run_split() { local o="$1" e="$2"; shift 2; "$@" > "$o" 2> "$e"; RUN_RC=$?; }
 
-# Where this skill lives, so helper scripts resolve however the script is
-# invoked — an absolute path, a relative one, or a symlink on PATH.
-SKILL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# SKILL_DIR is resolved at the top of this file, before the `cd` — see the note
+# there. It must not be recomputed here: from inside the target repo a relative
+# ${BASH_SOURCE[0]} points at the wrong tree.
 WORKLOG=$(mktemp -d)
 trap 'rm -rf "$WORKLOG"' EXIT
 
@@ -438,13 +450,25 @@ case $? in
   1) MISSING_TOOLS="$MISSING_TOOLS pv" ;;              # pin present, failed to resolve
   *) : ;;                                              # this repo ships no pin
 esac
-for t in bashrs pmat probador; do
+# bashrs and probador are unpinned in this repo, so PATH is the only answer
+# there and asking it is correct. pmat is NOT in that list: it is PINNED, and
+# `command -v pmat` would ask PATH about a tool whose answer the pin has already
+# decided — for the one crate where the pin matters (releasing pmat itself, with
+# the built artifact and possibly nothing on PATH) it reports the wrong thing.
+for t in bashrs probador; do
   command -v "$t" >/dev/null 2>&1 || MISSING_TOOLS="$MISSING_TOOLS $t"
 done
+command -v "$PMAT_BIN" >/dev/null 2>&1 || MISSING_TOOLS="$MISSING_TOOLS pmat"
 if [ -n "$MISSING_TOOLS" ]; then
   mark deterministic-tools FAIL "NOT INSTALLED:$MISSING_TOOLS — install them; a release cannot be verified by absent verifiers"
 else
-  mark deterministic-tools PASS "pv $("${PV:-:}" --version 2>/dev/null | head -1 | awk '{print $2}'), bashrs $(bashrs --version 2>/dev/null | head -1 | awk '{print $2}'), pmat $(pmat --version 2>/dev/null | head -1 | awk '{print $2}'), probador $(probador --version 2>/dev/null | head -1 | awk '{print $2}')"
+  # Every version here comes from the binary the gates will actually run. This
+  # line used a bare `pmat --version` inside the quoted note — the ONE row whose
+  # job is to say which pmat measured this release named a pmat off PATH, which
+  # may be a different build at the same version string (verifier_pin.sh records
+  # the 3.32.0-vs-3.32.0 case). It read as inert text to the guard, too: a
+  # command substitution inside double quotes is still command position.
+  mark deterministic-tools PASS "pv $("${PV:-:}" --version 2>/dev/null | head -1 | awk '{print $2}'), bashrs $(bashrs --version 2>/dev/null | head -1 | awk '{print $2}'), pmat $("$PMAT_BIN" --version 2>/dev/null | head -1 | awk '{print $2}'), probador $(probador --version 2>/dev/null | head -1 | awk '{print $2}')"
 fi
 
 # pv — provable-contract validation (YAML contracts, verification ladder).
@@ -677,7 +701,12 @@ fi
 
 # pmat — the fleet's own quality gate, run against the crate under release.
 # `verify` is the CI-faithful one (format, complexity, satd, clippy, tests).
-if command -v pmat >/dev/null 2>&1; then
+# The probe asks about "$PMAT_BIN", NOT about a bare `pmat`. Those differ in
+# exactly the case the pin exists for: releasing pmat itself, where PMAT_BIN is
+# the freshly built artifact and PATH may hold an older pmat or none at all. A
+# bare `command -v pmat` there either skips every gate below or answers about a
+# binary none of them run.
+if command -v "$PMAT_BIN" >/dev/null 2>&1; then
   # `pmat verify` runs cargo underneath and hard-errors on a crate with no lib
   # target: "error: no library targets found in package `pforge-cli`". That is a
   # gate that CANNOT PASS for any bin-only crate, and an unpassable gate trains

--- a/scripts/verifier_pin.sh
+++ b/scripts/verifier_pin.sh
@@ -1,0 +1,104 @@
+# verifier_pin.sh — THE rule that says which binary a release gate is allowed to
+# believe, and the two pins that implement it.
+#
+# Source it, never execute it:
+#     . "$SKILL_DIR/verifier_pin.sh" || exit 2
+#     verifier_pin_pmat "$CRATE" "$BINPATH"   # sets PMAT_BIN
+#     verifier_pin_pv                         # sets PV; 0 pinned, 1 broken, 2 unpinned
+#
+# ── THE RULE ────────────────────────────────────────────────────────────────
+#
+#   A gate that decides a release must not resolve its verifier through PATH.
+#   Where the repo pins the tool, use the pin; where it does not, REPORT rather
+#   than fall back — a skipped gate that says so beats a green one measured with
+#   an unknown binary.
+#
+# It is stated HERE, once, and nowhere else. Every other file that needs it
+# points at this one. #2640 exists because the same rule had been rediscovered
+# FIVE times, each time as a local fix that did not know about the other four:
+#
+#   1  PMAT_BIN (user-scope dogfood runner)  a gate ran a pmat that predated
+#      CB-200 becoming a ratchet, and Failed a tree the shipped code passes
+#   2  scripts/pv_bin.sh                     PATH pv 0.49.0 vs in-tree 0.63.0
+#      disagreed on the gate that DECIDES the release
+#   3  scripts/apr_bin.sh                    four `apr` binaries coexisted; a
+#      bare `apr` resolved to a 26-day-old copy
+#   4  aprender#2384                         MCP spawned a bare `apr`, ran
+#      0.60.0 while reporting 0.63.0
+#   5  APR-BENCH-RFC-001                     unpinned llama.cpp comparator
+#
+# Five rediscoveries is the evidence that a rule merely STATED is documentation.
+# It is therefore also ENFORCED, by scripts/check_verifier_pinning.sh, which
+# fails on any bare pv/pmat/apr in command position in the runner — and which
+# proves the two pins BEHAVE, not merely that they are present.
+#
+# OPTION-NEUTRAL BY CONSTRUCTION: this file sets no shell options. `set -euo
+# pipefail` in a SOURCED file mutates the CALLER's shell — that leak once killed
+# the nightly six lines in (CLAUDE.md; scripts/check_sourced_libs_option_neutral.sh).
+# Failure is signalled by RETURN STATUS only.
+
+# ── WHICH pmat runs the pmat gates ──────────────────────────────────────────
+#
+# `pmat verify` and `pmat comply check` are normally the INSTALLED pmat applied
+# to whatever crate is under test — that is the point of a fleet quality tool.
+# But when the crate under test IS pmat, that is the one case where it is wrong:
+# the gate then measures a DIFFERENT BUILD than the one being released.
+#
+# Measured, 2026-08-22, releasing pmat 3.32.0:
+#   installed ~/.cargo/bin/pmat   version 3.32.0   commit 8134bb373
+#   built from the release tree   version 3.32.0   commit 7a7409e03
+# Both print "3.32.0". Only the commit line differs, and nothing in the receipt
+# showed it. The installed binary predated CB-200 becoming a ratchet — the
+# string "recorded baseline" occurs 0 times in it and 4 times in the new one —
+# so the release gate ran the OLD zero-tolerance check and returned Fail against
+# a tree the shipped code passes. A gate validating a release with a stale copy
+# of the thing being released is the same defect class this protocol exists to
+# find, sitting inside the protocol.
+#
+# So: for pmat, the pmat gates use the artifact just built. For every other
+# crate, PATH is correct and is what still happens.
+verifier_pin_pmat() {
+    verifier_pin_crate="${1:-}"
+    verifier_pin_built="${2:-}"
+    PMAT_BIN=pmat
+    if [ "$verifier_pin_crate" = "pmat" ] \
+       && [ -n "$verifier_pin_built" ] && [ -x "$verifier_pin_built" ]; then
+        PMAT_BIN="$verifier_pin_built"
+    fi
+    return 0
+}
+
+# ── WHICH pv validates the contracts ────────────────────────────────────────
+#
+# pv is PINNED, never PATH-resolved. scripts/pv_bin.sh records why: a PATH `pv`
+# was 0.49.0 while the in-tree crate was 0.63.0, and the two disagreed on the
+# gate that decides the release -- strict-test-binding reported 253 refs / 51
+# missing under the stale binary and 371 / 27 under HEAD. The dogfood runner IS
+# a surface where the release decision is made, so it must not be the one
+# holding the stale binary.
+#
+# This protocol runs against any repo in the fleet, and not all of them carry
+# pv_bin.sh. Where it is absent, pv is left UNRESOLVED and the contract gates
+# REPORT that rather than falling back to whatever PATH offers. A skipped gate
+# that says so beats a green one measured with an unknown binary.
+#
+# The subshell is load-bearing and is the one deviation from the copy this was
+# merged from. pv_bin.sh ends in `PV=$(...) || return 1 2>/dev/null || exit 1`.
+# Sourced at the top level of a function body, `return` would unwind the CALLER;
+# sourced inside a subshell, a failure exits only the subshell and this function
+# still gets to report it. The pin is thereby usable from a function, which is
+# what lets check_verifier_pinning.sh exercise it in isolation instead of taking
+# its presence on trust.
+#
+# Returns: 0 = pinned and executable · 1 = pin present but FAILED to resolve
+#          2 = this repo ships no pin (report, never fall back to PATH)
+verifier_pin_pv() {
+    PV=""
+    [ -f scripts/pv_bin.sh ] || return 2
+    PV=$( . ./scripts/pv_bin.sh >/dev/null 2>&1 && printf '%s' "$PV" )
+    if [ -n "$PV" ] && [ -x "$PV" ]; then
+        return 0
+    fi
+    PV=""
+    return 1
+}


### PR DESCRIPTION
Closes #2640 (D1–D6).

`~/.claude/skills/dogfood/dogfood.sh` (1172 L) and `scripts/dogfood.sh` (1165 L) were
one protocol in two copies. The triage already on this branch
(`docs/audits/dogfood-divergence-2640.md`, AC-6) classified all 9 hunks
**hardening-port, zero drift-discard** — so deleting either copy would have silently
lost a real, measured hardening. This PR merges both, then **gates** the rule they
both implement, which had already been rediscovered five separate times.

---

## What landed

| D | change |
|---|---|
| D1 | `scripts/dogfood.sh` is canonical and carries BOTH hardenings. The RULE is stated **once**, in the new `scripts/verifier_pin.sh`, and nowhere else. |
| D2 | `[package.metadata.dogfood] gates = [...]`, read with the mechanism the runner already had for `[package.metadata.transports]`. One receipt row per gate. Two vacuity guards. |
| D3+D5 | `scripts/check_verifier_pinning.sh` — static scan + case table + **behavioural** probes of both pins under a poisoned PATH. |
| D4 | `scripts/check_dogfood_shim.sh` + `scripts/.dogfood-shim-reference.sh` — the user-scope copy is a 49-line shim, and shim-ness is gated. |
| D6 | `.claude/skills/dogfood/SKILL.md` is the one prose (explicit `name:` preserved); the user-scope `SKILL.md` is retired so it cannot shadow it. `apr-dogfood`'s "**Absorbs**: dogfood.sh" corrected to "**Defers to**". |
| — | `contracts/dogfood-runner-unification-v1.yaml` — 10 obligations, 10 falsification tests, each naming its mutation. Validated with the **pinned** pv: `0 error(s), 0 warning(s)`. |

Both new guards are wired into `ci.yml` (`guard-runner-labels`) **and** declared in
`[package.metadata.dogfood]`, so the release runner runs them too.

---

## A real defect the gate found on its FIRST run, before any mutation

```
FAIL  bare verifier invocation(s) — these resolve through PATH:
      scripts/dogfood.sh:797: pmat
      scripts/dogfood.sh:798: pmat
```

`pmat analyze reachability` was invoked **bare in BOTH copies**. The copy that
*invented* `PMAT_BIN` had never applied it there — the subcommand landed after the
hardening did. That is the argument for a gate in one line: the rule's own author
missed a site, and only a mechanical sweep of the whole file noticed. Fixed here.

---

## Mutation evidence — pre-fix GREEN captured first (discrimination)

Every row below: unmutated tree observed **GREEN**, mutation applied, observed **RED**,
mutation reverted, observed **GREEN** again.

### Baseline (no-op) — both guards GREEN

```
$ bash scripts/check_verifier_pinning.sh ; echo rc=$?
ok    MUST-FLAG    all 9 bare invocations reported
ok    MUST-NOT-FLAG all 10 pinned/comment/string forms accepted
ok    scripts/dogfood.sh scripts/verifier_pin.sh: no bare pv/pmat/apr in command position
ok    pmat-pin   releasing pmat selects the BUILT artifact, not the PATH copy
ok    pmat-pin   a non-pmat crate still uses the fleet pmat
ok    pmat-pin   no built artifact -> no fabricated pin
ok    pv-pin     resolved pv is …/target/debug/pv, NOT the PATH decoy /tmp/tmp.iWYVpENe9K/pvbin/pv
PASS  the release runner resolves every pinned verifier through its pin.
rc=0

$ bash scripts/check_dogfood_shim.sh ; echo rc=$?
ok    row 1 the reference shim passes every shim assertion
ok    row 2 a shim that invokes a gate is REJECTED
ok    row 3 a shim over the line cap is REJECTED
ok    row 4 a shim that exits 0 without a checkout is REJECTED
ok    row 5 a shim that fails MUTELY is REJECTED
ok    1  exactly one tracked dogfood.sh: scripts/dogfood.sh
ok    2  canonical prose at .claude/skills/dogfood/SKILL.md, name: dogfood
ok    3a shim is 49 lines (cap 70)
ok    3b shim invokes no gate of the protocol
ok    3b shim names no protocol gate
ok    3c shim fails closed (rc=2) and names the revisit trigger
ok    3d user-scope shim is byte-identical to the reviewed reference
ok    4  no user-scope SKILL.md shadowing the repo dogfood skill
PASS  one runner, one prose, and the user-scope copy is a gated shim.
rc=0
```

### M1 (D3) — reintroduce a bare `pmat` call → RED

`gate pmat-verify "$PMAT_BIN" verify` → `gate pmat-verify pmat verify`

```
FAIL  bare verifier invocation(s) — these resolve through PATH:
      scripts/dogfood.sh:719: pmat
      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.
rc=1        (restored → rc=0)
```

### M2 (D5, PMAT_BIN) — delete the self-referential branch, stale `pmat` first on PATH → RED

```
FAIL  pmat-pin   releasing pmat resolved to [pmat]; the stale PATH pmat at /tmp/…/stalebin/pmat
                 would have measured a different build than the one shipping.
rc=1        (restored → rc=0)
```

This is the behavioural half. M1 alone would pass on a pin that resolves wrongly.

### M3 (D5, pv) — bypass `pv_bin.sh` to a PATH pv → RED

`PV=$( . ./scripts/pv_bin.sh … )` → `PV=$(command -v pv)`

```
FAIL  pv-pin     resolved pv IS the PATH decoy (/tmp/…/pvbin/pv) — the pin was bypassed
rc=1        (restored → rc=0)
```

### M4 (D4) — add a gate name to the DEPLOYED user-scope shim → RED

```
FAIL  3b shim INVOKES protocol gate(s): pv-contracts
FAIL  3b shim names protocol gate(s): pv-contracts
FAIL  3d user-scope shim DIFFERS from scripts/.dogfood-shim-reference.sh
rc=1        (restored → rc=0)
```

Three more shim mutations run in the guard's own `--self-test` table on every
invocation: over-cap, `exit 0` without a checkout, and a mute `exit 2`.

---

## Acceptance (#2640 A.7)

| AC | evidence |
|---|---|
| **AC-1** exactly one `dogfood.sh`, versioned, CI-reachable | `git ls-files` → `scripts/dogfood.sh`; wired into `ci.yml` |
| **AC-2** `/dogfood` on aprender discovers and RUNS `check_multiplatform_dogfood.sh` | see run below |
| **AC-3** that gate is **RED today** and the run SURFACES it | see run below — **primary signal** |
| **AC-4** a declared-but-missing gate script FAILS | see below |
| **AC-5** an empty or absent `[package.metadata.dogfood]` FAILS | see below |
| **AC-6** divergence triage attached | `docs/audits/dogfood-divergence-2640.md`, committed at `ea0ee3047` |
| **AC-7** grepping for a second `dogfood.sh` returns exactly one path | `git ls-files \| grep -E '(^\|/)dogfood\.sh$'` → 1 |

### AC-2 + AC-3

```
$ DOGFOOD_GATES_ONLY=1 bash scripts/dogfood.sh
══ dogfood pre-release: aprender v0.63.0 ══
  [WARN] git-clean                  uncommitted changes present (commit before tagging)
  [FAIL] declared:check_multiplatform_dogfood scripts/check_multiplatform_dogfood.sh exit=1 — FAIL see rows above…
  [ OK ] declared:check_verifier_pinning     scripts/check_verifier_pinning.sh exit=0
  [ OK ] declared:check_dogfood_shim         scripts/check_dogfood_shim.sh exit=0
  [FAIL] dogfood-gates              3 declared gate(s) discovered, 1 RED (each named in its own row above)
PARTIAL: DOGFOOD_GATES_ONLY — only the declared repo gates above ran.
         This is NOT a release verdict. A GO comes only from a full run.
rc=1
```

It is discovered, it is run, it is RED, and the run **surfaces** it rather than
passing. One correction to the ticket's wording: the RED is for **0.63.0**, not
0.64.0 — the root `Cargo.toml` on this branch still reads `version = "0.63.0"`, so
the gate looks in `evidence/dogfood/0.63.0/`, which holds `gx10.json` and
`mini.json` and is **missing `lambda.json` and `intel.json`**. Same verdict, measured
rather than quoted.

### AC-4 — declared but missing → FAIL, never SKIP

```
  [FAIL] declared:check_this_does_not_exist  declared in [package.metadata.dogfood] but no such file: …
  [FAIL] dogfood-gates              4 declared gate(s) discovered, 2 RED
rc=1
```

### AC-5 — vacuity, both directions

```
gates = []   → [FAIL] dogfood-gates  … `gates = []` — a clean sweep over an empty gate set is the vacuous pass …   rc=1
block absent → [FAIL] dogfood-gates  no [package.metadata.dogfood] in Cargo.toml. Declare …                        rc=1
```

---

## Hygiene

- `bashrs`, each file linted **alone**: `verifier_pin.sh` 0e/0w · `check_verifier_pinning.sh` 0e · `check_dogfood_shim.sh` 0e · `.dogfood-shim-reference.sh` 0e. `scripts/dogfood.sh` is **27 errors before and 27 after** (pre-existing SC1028/SC1078 apostrophe class) — three new SC1078s my prose introduced were removed rather than baselined.
- `check_shell_lint_ratchet.sh` PASS · `check_guards_are_wired.sh` PASS (both new guards wired) · `check_sourced_libs_option_neutral.sh` PASS (5 libs, `verifier_pin.sh` included) · `check_apr_bin_pinned.sh` PASS · `check_pass_grep_anchored.sh` PASS.
- `check_apr_bin_pinned.sh` initially reported **5 violations inside the new guard's own case-table fixtures**. Rather than add an exemption entry to a neighbouring guard, the fixture lines are now assembled from variables so no literal bare invocation exists in the source, and the decoy path is named directly instead of via `command -v`.
- README contract count **measured**, not copied: `find contracts -name "*.yaml" | wc -l` → **1791**.
- `git diff origin/main -- Cargo.lock` is **empty** (the `[[patch.unused]]` drift cargo re-adds was reverted before commit).

---

## Deliberately NOT in scope

- The hardware-axis join, infra#259 §7.3 benchmark orchestration, and porting the runner into `apr dogfood` (#2640 A.6 — porting before unifying means porting twice).
- `scripts/dogfood_surfaces.sh` is **not** in the declared gate list, and the reason is ordering rather than cost: discovery runs before the runner has built the release artifact, and that script enumerates 29 binary targets from **built** binaries. Declaring it there would build the workspace twice per run. Reasoning is written into `Cargo.toml` beside the list. Say the word and it moves.

## Changes made OUTSIDE this repo (not reviewable in this diff)

- `~/.claude/skills/dogfood/dogfood.sh` — replaced with the 49-line shim (a copy of the tracked `scripts/.dogfood-shim-reference.sh`; row 3d asserts they stay identical).
- `~/.claude/skills/dogfood/SKILL.md` — renamed to `README-superseded.md` so it no longer defines a competing `dogfood` skill. Content preserved, with a header saying where the source of truth now is.
- `fleet-dogfood.sh`, `transport-parity.sh`, `invariance.py` remain in that directory. `invariance.py` already exists in the repo at `scripts/invariance.py` and is what the runner uses; the other two are separate fleet tools, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbMTnT8Upx6Ym18i5H11iR
