### PR TITLE
fix(dogfood): pins arrive where the gates run — exported, early, behavior-verified, fail-closed (QUAL-014)

### DIFF
--- a/contracts/dogfood-runner-unification-v1.yaml
+++ b/contracts/dogfood-runner-unification-v1.yaml
@@ -264,6 +264,36 @@ falsification_tests:
   if_fails: 'both 3b rows are evadable by writing the gate after a `;`, and the runner''s own three dynamic `mark "$dg_name"` call sites are invisible to the extraction'
   mutation: 'restore the `^[[:space:]]*(mark|gate) [a-z0-9][a-z0-9-]*` line-anchored extractor; rows 6 and 7 must turn RED'
 
+- id: F-DOG1-017
+  rule: pin delivery
+  prediction: >
+    The pins arrive in CHILD processes: every gate discovered from
+    [package.metadata.dogfood] runs with PMAT_BIN and PV present in its
+    environment, PMAT_BIN nonempty for a non-pmat crate. The fleet fixture's
+    gate-pin-delivery.sh probe asserts this through the real runner.
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2 row 3d + PART 3 delivery probe'
+  if_fails: 'the pins are shell-local — pin_audit certifies consumption the environment never carries, and every discovered gate resolves its verifier through PATH (#2644, VPIN-4)'
+  mutation: 'strip the export statements from scripts/verifier_pin.sh; row 3d and the fleet-path delivery probe must both turn RED (observed 2026-08-23, 7 sites stripped)'
+- id: F-DOG1-018
+  rule: fail closed on the artifact
+  prediction: >
+    Releasing pmat with a missing, non-executable, --version-mute, or
+    directory-shaped built artifact leaves PMAT_BIN EMPTY and returns 1 —
+    never the silent PATH fallback that measured a stale 3.32.0 against a
+    3.32.0 release.
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2 rows 3 and 3b'
+  if_fails: 'a PATH pmat that is not the build being released decides the release of pmat itself (#2644, VPIN-1/VPIN-2)'
+  mutation: 'restore the pre-#2644 verifier_pin_pmat (bare -x check, unconditional return 0); rows 3 and 3b must turn RED (observed 2026-08-23)'
+- id: F-DOG1-019
+  rule: pin resolution is repo-anchored and channel-proof
+  prediction: >
+    verifier_pin_pv resolves from any subdirectory of the repo (git names the
+    root), clears an inherited PV_BIN before sourcing the freshness authority,
+    and on failure emits the pv_bin.sh diagnostics instead of swallowing them.
+  test: 'bash scripts/check_verifier_pinning.sh   # PART 2 rows 4b and 4c'
+  if_fails: 'the pin lies from subdirectories ("this repo ships no pin"), or an exported stale path rides through an otherwise-green pin (#2644, VPIN-5/VPIN-6/VP-04)'
+  mutation: 'replace the git-rooted discovery with $PWD, or drop the unset PV_BIN; row 4c (respectively 4b) must turn RED (both observed 2026-08-23, engagement verified)'
+
 proof_obligations:
 - type: invariant
   property: 'Exactly one tracked dogfood.sh exists, at scripts/dogfood.sh (F-DOG1-001)'
@@ -314,6 +344,15 @@ proof_obligations:
   property: 'The shim gate extraction covers mid-line and dynamically named call sites (F-DOG1-016)'
   formal: 'gate_calls("true; mark x PASS") != {} and gate_calls("mark \"$n\" FAIL") != {}'
 
+- type: invariant
+  property: 'Both pins EXPORT their result and resolve BEFORE the first discovered gate executes; a child process of the runner observes PMAT_BIN and PV (F-DOG1-017)'
+  formal: 'forall g in discovered_gates: env(g) contains PMAT_BIN, PV; resolve_time(pins) < exec_time(g)'
+- type: soundness
+  property: 'verifier_pin_pmat accepts only an artifact that answers --version; missing/mute/directory artifacts leave the pin EMPTY with rc=1 when the crate is pmat (F-DOG1-018)'
+  formal: 'crate = pmat and not behaves(built) => PMAT_BIN = "" and rc = 1'
+- type: soundness
+  property: 'verifier_pin_pv is repo-root-anchored, clears the PV_BIN environment channel, and surfaces pv_bin.sh diagnostics on failure (F-DOG1-019)'
+  formal: 'resolve(pv) independent of cwd within repo; PV_BIN not in env(source(pv_bin.sh)); rc = 1 => diagnostics on stderr'
 kani_harnesses:
 # Declared, NOT written. These are shell guards over shell source; there is no
 # Rust surface for Kani to model-check, and inventing one would be theatre. The
@@ -349,6 +388,8 @@ qa_gate:
   - verifier_pinning_case_table
   - pmat_pin_behaviour
   - pv_pin_behaviour
+  - pin_delivery_to_children
+  - pin_fails_closed_on_artifact
   - gate_discovery_runs_each
   - gate_discovery_vacuity
   - shim_shape
@@ -361,12 +402,21 @@ qa_gate:
     release verified by an unknown binary is an unverified release that says GO.
 
 verification_summary:
-  total_obligations: 10
+  total_obligations: 19
   proven: 0
-  tested: 10
+  tested: 19
   status: proposed
   notes: >
-    All ten obligations are TESTED by two committed guards, both wired into CI and
+    Every obligation above is TESTED (none PROVEN in the L4/L5 sense — shell
+    guards over shell source; the honest ladder position is L3). The counts are
+    above are schema-required fields (pv rejects a summary without them) and
+    were MEASURED from this file's own lists at edit time, not maintained by
+    hand — the previous values (10/10) had drifted from the body (16) exactly
+    as v1.13 P7 predicts for any count constant a contract restates. Until the
+    schema can derive them, any edit to the obligation lists must re-measure
+    these two numbers in the same commit.
+
+    All obligations are TESTED by two committed guards, both wired into CI and
     both declared in [package.metadata.dogfood] so the release runner itself runs
     them. Each carries a named mutation that was OBSERVED turning it RED on
     2026-08-23, with the unmutated tree observed GREEN first (discrimination).

--- a/scripts/check_verifier_pinning.sh
+++ b/scripts/check_verifier_pinning.sh
@@ -720,13 +720,56 @@ behaviour_test() {
         printf 'FAIL  pmat-pin   non-pmat crate resolved to [%s], expected the PATH pmat\n' "$PMAT_BIN"; fails=1
     fi
 
-    # Row 3 — a crate named pmat with NO built artifact must not invent one.
+    # Row 3 — a crate named pmat with NO built artifact FAILS CLOSED: rc=1 and
+    # an EMPTY pin. This row used to bless the silent PATH fallback — the exact
+    # stale-3.32.0-measuring-3.32.0 incident the lib's header records (#2644,
+    # VPIN-1). The old expectation is preserved here as the mutation direction:
+    # a lib reverted to the fallback turns this row RED.
     PMAT_BIN=""
     verifier_pin_pmat "pmat" ""
-    if [ "$PMAT_BIN" = "pmat" ]; then
-        printf 'ok    pmat-pin   no built artifact -> no fabricated pin\n'
+    r3_rc=$?
+    if [ "$r3_rc" -eq 1 ] && [ -z "$PMAT_BIN" ]; then
+        printf 'ok    pmat-pin   no built artifact -> rc=1, EMPTY pin (fail closed, no PATH fallback)\n'
     else
-        printf 'FAIL  pmat-pin   empty BINPATH resolved to [%s]\n' "$PMAT_BIN"; fails=1
+        printf 'FAIL  pmat-pin   no built artifact resolved to [%s] rc=%s — a silent\n' "$PMAT_BIN" "$r3_rc"
+        printf '                 fallback here measures a PATH pmat that is not the build\n'
+        printf '                 being released (the recorded incident, again)\n'
+        fails=1
+    fi
+
+    # Row 3b — behavior, not existence: a directory and a broken stub both pass
+    # `-x`; neither can answer `--version`; neither may become the pin (#2644,
+    # VPIN-2).
+    mkdir -p "$td/notabinary"
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" "$td/notabinary"
+    r3b_rc=$?
+    printf '#!/bin/sh\nexit 97\n' > "$td/brokenstub"
+    chmod +x "$td/brokenstub"
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" "$td/brokenstub"
+    r3c_rc=$?
+    if [ "$r3b_rc" -eq 1 ] && [ "$r3c_rc" -eq 1 ] && [ -z "$PMAT_BIN" ]; then
+        printf 'ok    pmat-pin   a directory and a --version-mute stub are both REFUSED\n'
+    else
+        printf 'FAIL  pmat-pin   non-working artifact accepted (dir rc=%s, stub rc=%s, pin=[%s])\n' "$r3b_rc" "$r3c_rc" "$PMAT_BIN"
+        fails=1
+    fi
+
+    # Row 3d — delivery: the pin must reach a CHILD process. Every discovered
+    # gate is one, and an unexported pin is consumption pin_audit certifies but
+    # the environment never carries (#2644, VPIN-4).
+    PMAT_BIN=""
+    printf '#!/bin/sh\necho built-pmat\n' > "$td/okstub"
+    chmod +x "$td/okstub"
+    verifier_pin_pmat "pmat" "$td/okstub"
+    r3d_child=$(bash -c 'printf %s "${PMAT_BIN:-UNSET}"')
+    if [ "$r3d_child" = "$td/okstub" ]; then
+        printf 'ok    pmat-pin   the pin arrives in a child process (exported)\n'
+    else
+        printf 'FAIL  pmat-pin   child saw [%s] — the pin is shell-local and every\n' "$r3d_child"
+        printf '                 discovered gate runs unpinned\n'
+        fails=1
     fi
 
     # Row 4 — pv. The pin must not be whatever PATH offers. A decoy `pv` goes
@@ -759,6 +802,52 @@ behaviour_test() {
             exit 1
         fi
         printf 'ok    pv-pin     resolved pv is %s, NOT the PATH decoy %s\n' "$PV" "$decoy"
+    ) || fails=1
+
+    # Row 4b — the PV_BIN environment channel is CLEARED before the pin sources
+    # pv_bin.sh: an inherited PV_BIN short-circuits the cargo build pv_bin.sh
+    # itself names "THE FRESHNESS AUTHORITY", so an exported stale path would
+    # ride straight through an otherwise-green pin (#2644, VPIN-6/VP-04).
+    (
+        cd "$REPO_ROOT" || exit 2
+        printf '#!/bin/sh\necho pv 0.0.0-poison\n' > "$td/pv-poison"
+        chmod +x "$td/pv-poison"
+        PV_BIN="$td/pv-poison"
+        export PV_BIN
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        if [ "$pv_rc" -eq 0 ] && [ "$PV" = "$td/pv-poison" ]; then
+            printf 'FAIL  pv-pin     an inherited PV_BIN (%s) rode through the pin —\n' "$PV_BIN"
+            printf '                 the freshness authority was bypassed by the environment\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ]; then
+            printf 'FAIL  pv-pin     pin failed under an inherited PV_BIN (rc=%s) — clearing\n' "$pv_rc"
+            printf '                 the channel must not break resolution\n'
+            exit 1
+        fi
+        printf 'ok    pv-pin     an inherited PV_BIN is cleared; the pin resolved %s\n' "$PV"
+    ) || fails=1
+
+    # Row 4c — the pin works from a SUBDIRECTORY of the repo. The cwd-relative
+    # form returned 2 ("this repo ships no pin") from anywhere below the root —
+    # a false statement that downgraded every pv gate to REPORT (#2644, VPIN-5).
+    (
+        cd "$REPO_ROOT/scripts" || exit 2
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        if [ "$pv_rc" -eq 2 ]; then
+            printf 'FAIL  pv-pin     from scripts/ the pin says "this repo ships no pin" — the\n'
+            printf '                 discovery is cwd-relative and lies from any subdirectory\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ] || [ -z "$PV" ]; then
+            printf 'FAIL  pv-pin     pin failed from a subdirectory (rc=%s)\n' "$pv_rc"
+            exit 1
+        fi
+        printf 'ok    pv-pin     the pin resolves from a subdirectory of the repo\n'
     ) || fails=1
 
     # Row 5 — this guard must not have moved Cargo.lock.
@@ -815,10 +904,23 @@ edition = "2021"
 publish = false
 
 [package.metadata.dogfood]
-gates = ["gate-ok.sh"]
+gates = ["gate-ok.sh", "gate-pin-delivery.sh"]
 EOF
     printf 'pub fn f() {}\n' > "$td/fixture-crate/src/lib.rs"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$td/fixture-crate/gate-ok.sh"
+    # The committed catcher for the unexported-pin mutation (#2644, VPIN-4):
+    # this gate runs as a CHILD of the runner, exactly like every discovered
+    # gate, and asserts the pins ARRIVED. PMAT_BIN must be nonempty (the policy
+    # answer for a non-pmat crate); PV must EXIST in the environment — this
+    # fixture ships no pin, so its VALUE is legitimately empty, but an absent
+    # VARIABLE means the runner resolved pins it never delivered.
+    cat > "$td/fixture-crate/gate-pin-delivery.sh" <<'EOF'
+#!/usr/bin/env bash
+[ "${PMAT_BIN+set}" = set ] || { echo "PMAT_BIN not delivered to child env"; exit 1; }
+[ -n "$PMAT_BIN" ] || { echo "PMAT_BIN empty for a non-pmat crate"; exit 1; }
+[ "${PV+set}" = set ] || { echo "PV not delivered to child env"; exit 1; }
+exit 0
+EOF
 
     # DOGFOOD_GATES_ONLY stops after the declared-gate discovery section, which
     # sits well past the pin-library source. It is the runner's own hook, not a
@@ -834,15 +936,28 @@ EOF
         printf '                 `cd "$REPO_DIR"`, or the path resolves against the TARGET repo.\n'
         printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
         fails=1
-    elif printf '%s' "$out" | grep -q 'verifier_pin.sh is missing'; then
+    elif grep -q 'verifier_pin.sh is missing' <<< "$out"; then
         printf 'FAIL  fleet-path the pin library was not found under a relative invocation\n'
         fails=1
-    elif ! printf '%s' "$out" | grep -q 'DOGFOOD_GATES_ONLY'; then
+    elif ! grep -q 'DOGFOOD_GATES_ONLY' <<< "$out"; then
         printf 'FAIL  fleet-path the runner did not reach the declared-gate section (rc=%s)\n' "$rc"
         printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
         fails=1
+    elif [ "$rc" -ne 0 ]; then
+        # The fixture's gates include gate-pin-delivery.sh, the committed
+        # catcher for the unexported-pin mutation. A nonzero rc here with the
+        # section reached means a declared gate went RED — most likely the
+        # probe reporting pins that never arrived. Printing "ok (rc=1)" at
+        # this point would be a catcher that observes and does not gate.
+        printf 'FAIL  fleet-path the fixture run reached the declared-gate section but exited %s\n' "$rc"
+        printf '%s\n' "$out" | grep -E 'declared:|dogfood-gates|not delivered|empty for' | tail -6 | sed 's/^/                 /'
+        fails=1
+    elif ! grep -q 'declared:gate-pin-delivery' <<< "$out"; then
+        printf 'FAIL  fleet-path the pin-delivery probe left no row in the output — a\n'
+        printf '                 catcher that did not run is indistinguishable from one that passed\n'
+        fails=1
     else
-        printf 'ok    fleet-path relative invocation against another crate runs (rc=%s)\n' "$rc"
+        printf 'ok    fleet-path relative invocation runs; pin-delivery probe green (rc=%s)\n' "$rc"
     fi
 
     rm -rf "${td:?}"

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -184,6 +184,22 @@ else
   exit 2
 fi
 
+# THE PINS RESOLVE BEFORE ANY GATE RUNS. The declared gates below execute as
+# CHILD processes and consume the pins from the environment (the lib exports
+# them) — a pin resolved after they ran is a pin delivered to nobody, while
+# pin_audit certified consumption the environment never carried (#2644, VPIN-4).
+#
+# The pmat pin is called here with NO artifact: for every crate but pmat that
+# already yields the final answer (the fleet pmat). For the one crate where the
+# artifact matters — releasing pmat itself — it cannot exist before the build,
+# so this phase leaves PMAT_BIN EMPTY there and any declared gate consuming it
+# fails closed rather than measuring a PATH binary that is not the build being
+# released. The post-build call further down upgrades the pin to the artifact.
+verifier_pin_pmat "$CRATE" ""
+PV=""
+verifier_pin_pv
+VERIFIER_PIN_PV_RC=$?
+
 echo "══ dogfood pre-release: $CRATE v$VERSION ══"
 
 # ── 1. hygiene ───────────────────────────────────────────────────────────────
@@ -405,8 +421,21 @@ if [ -z "$BINPATH" ]; then
 fi
 BINPATH="${BINPATH:-}"
 # Which pmat runs the pmat gates. The rule and its measured evidence are in
-# scripts/verifier_pin.sh; this is the call site.
+# scripts/verifier_pin.sh; this is the post-build call site — the early phase
+# above already delivered the policy answer to the declared gates, and this one
+# upgrades the pin to the just-built artifact for the case where the crate IS
+# pmat. Its verdict gets a row in EVERY receipt: a pin that reports only on
+# failure is the version-conditional vanish this audit just closed (DF-9 class).
 verifier_pin_pmat "$CRATE" "$BINPATH"
+VERIFIER_PIN_PMAT_RC=$?
+if [ "$VERIFIER_PIN_PMAT_RC" -ne 0 ]; then
+  mark pmat-pin FAIL "releasing pmat but the built artifact is missing or failed behavior verification (--version) — refusing the PATH fallback: a stale fleet pmat measuring a pmat release is the recorded 3.32.0-vs-3.32.0 incident (see scripts/verifier_pin.sh). Every pmat gate below is unverifiable against the artifact being released"
+elif [ "$CRATE" = "pmat" ]; then
+  mark pmat-pin PASS "releasing pmat: gates measure the BUILT artifact ($PMAT_BIN), behavior-verified"
+else
+  mark pmat-pin PASS "fleet pmat is the correct verifier for a non-pmat crate (exported to declared gates)"
+fi
+readonly PMAT_BIN
 if [ -n "$BINPATH" ] && [ -x "$BINPATH" ]; then
   mark release-binary PASS "built: $BINPATH"
 else
@@ -443,13 +472,16 @@ fi
 # ships no pin leaves PV empty and the contract gates below REPORT that rather
 # than falling back to whatever PATH offers.
 MISSING_TOOLS=""
-PV=""
-verifier_pin_pv
-case $? in
-  0) : ;;                                              # pinned and executable
+# pv was pinned ONCE, in the early phase before any gate ran (the declared gates
+# consume it from the environment); this consumes that verdict rather than
+# resolving a second time — two resolutions can disagree, and the one the gates
+# already used is the only one that matters.
+case "$VERIFIER_PIN_PV_RC" in
+  0) : ;;                                              # pinned, exported, behavior-verified
   1) MISSING_TOOLS="$MISSING_TOOLS pv" ;;              # pin present, failed to resolve
   *) : ;;                                              # this repo ships no pin
 esac
+readonly PV
 # bashrs and probador are unpinned in this repo, so PATH is the only answer
 # there and asking it is correct. pmat is NOT in that list: it is PINNED, and
 # `command -v pmat` would ask PATH about a tool whose answer the pin has already

--- a/scripts/verifier_pin.sh
+++ b/scripts/verifier_pin.sh
@@ -3,8 +3,16 @@
 #
 # Source it, never execute it:
 #     . "$SKILL_DIR/verifier_pin.sh" || exit 2
-#     verifier_pin_pmat "$CRATE" "$BINPATH"   # sets PMAT_BIN
-#     verifier_pin_pv                         # sets PV; 0 pinned, 1 broken, 2 unpinned
+#     verifier_pin_pmat "$CRATE" "$BINPATH"   # sets+EXPORTS PMAT_BIN; 0 pinned,
+#                                             # 1 releasing pmat with no working artifact
+#     verifier_pin_pv                         # sets+EXPORTS PV; 0 pinned, 1 broken, 2 unpinned
+#
+# Both pins EXPORT their result: the gates this protocol discovers from
+# [package.metadata.dogfood] run as CHILD processes, and a shell-local pin is a
+# pin delivered to nobody — pin_audit would certify consumption the environment
+# never carried (#2644 audit, VPIN-4). Both pins verify BEHAVIOR, not existence:
+# `-x` accepts a broken stub and even a directory; only the binary answering
+# `--version` is evidence it can verify anything (#2644, VPIN-2).
 #
 # ── THE RULE ────────────────────────────────────────────────────────────────
 #
@@ -57,13 +65,39 @@
 #
 # So: for pmat, the pmat gates use the artifact just built. For every other
 # crate, PATH is correct and is what still happens.
+# Returns: 0 = pinned (the fleet pmat for a non-pmat crate, the behavior-verified
+#              built artifact when the crate IS pmat)
+#          1 = releasing pmat with a missing or non-working artifact — PMAT_BIN is
+#              left EMPTY and the caller must fail closed. The old behavior fell
+#              back to the PATH pmat silently, which is the recorded incident
+#              above happening again with this file watching (#2644, VPIN-1).
+#
+# The behavior check is `--version` answering with SOMETHING, deliberately not a
+# version-equality assert: the measurement above is two binaries both printing
+# "3.32.0" while running different code. A version string cannot discriminate
+# builds; a binary that cannot even print one cannot verify anything.
 verifier_pin_pmat() {
     verifier_pin_crate="${1:-}"
     verifier_pin_built="${2:-}"
     PMAT_BIN=pmat
-    if [ "$verifier_pin_crate" = "pmat" ] \
-       && [ -n "$verifier_pin_built" ] && [ -x "$verifier_pin_built" ]; then
+    export PMAT_BIN
+    if [ "$verifier_pin_crate" = "pmat" ]; then
+        if [ -z "$verifier_pin_built" ]; then
+            PMAT_BIN=""
+            export PMAT_BIN
+            return 1
+        fi
+        verifier_pin_ver=""
+        if [ -f "$verifier_pin_built" ]; then
+            verifier_pin_ver=$("$verifier_pin_built" --version 2>/dev/null) || verifier_pin_ver=""
+        fi
+        if [ -z "$verifier_pin_ver" ]; then
+            PMAT_BIN=""
+            export PMAT_BIN
+            return 1
+        fi
         PMAT_BIN="$verifier_pin_built"
+        export PMAT_BIN
     fi
     return 0
 }
@@ -90,15 +124,54 @@ verifier_pin_pmat() {
 # what lets check_verifier_pinning.sh exercise it in isolation instead of taking
 # its presence on trust.
 #
-# Returns: 0 = pinned and executable · 1 = pin present but FAILED to resolve
+# Pin discovery anchors to the REPO, not the caller's cwd: `[ -f scripts/... ]`
+# from a subdirectory of a repo that DOES ship the pin returned 2, whose
+# documented meaning is "this repo ships no pin" — a false statement that
+# downgraded every pv gate to REPORT (#2644, VPIN-5). git names the root; a
+# non-git directory falls back to cwd, where the relative form was already
+# correct.
+#
+# The subshell also CLEARS the PV_BIN environment channel before sourcing:
+# pv_bin.sh honors an inherited PV_BIN and skips the cargo build it calls "THE
+# FRESHNESS AUTHORITY", so an exported stale path would ride straight through
+# the pin (#2644, VPIN-6/VP-04). Inside the subshell the unset is contained —
+# the caller's environment is untouched, per the option-neutral rule above.
+#
+# On failure the diagnostics pv_bin.sh wrote are no longer swallowed (#2644,
+# VPIN-3): they land in a kept tempfile whose tail is printed to stderr, so
+# rc=1 arrives saying WHICH stage failed instead of arriving mute.
+#
+# Returns: 0 = pinned, exported, and behavior-verified (`--version` answered)
+#          1 = pin present but FAILED to resolve (diagnostics on stderr)
 #          2 = this repo ships no pin (report, never fall back to PATH)
 verifier_pin_pv() {
     PV=""
-    [ -f scripts/pv_bin.sh ] || return 2
-    PV=$( . ./scripts/pv_bin.sh >/dev/null 2>&1 && printf '%s' "$PV" )
-    if [ -n "$PV" ] && [ -x "$PV" ]; then
+    export PV
+    verifier_pin_root=$(git rev-parse --show-toplevel 2>/dev/null) || verifier_pin_root=""
+    [ -n "$verifier_pin_root" ] || verifier_pin_root=$PWD
+    [ -f "$verifier_pin_root/scripts/pv_bin.sh" ] || return 2
+    verifier_pin_pv_log=$(mktemp) || return 1
+    # The subshell is load-bearing (see the note above); the `if` wrapper keeps
+    # a failing command substitution from killing an errexit caller before the
+    # diagnostics below can be printed.
+    if PV=$( cd "$verifier_pin_root" && unset PV_BIN \
+             && . ./scripts/pv_bin.sh >"$verifier_pin_pv_log" 2>&1 \
+             && printf '%s' "$PV" ); then :; fi
+    verifier_pin_ver=""
+    if [ -n "$PV" ] && [ -f "$PV" ]; then
+        verifier_pin_ver=$("$PV" --version 2>/dev/null) || verifier_pin_ver=""
+    fi
+    if [ -n "$verifier_pin_ver" ]; then
+        export PV
+        rm -f "$verifier_pin_pv_log"
         return 0
     fi
     PV=""
+    export PV
+    {
+        echo "verifier_pin_pv: the pin failed to resolve a working pv."
+        echo "  pv_bin.sh diagnostics (kept at $verifier_pin_pv_log):"
+        tail -15 "$verifier_pin_pv_log" 2>/dev/null | sed 's/^/    /'
+    } >&2
     return 1
 }


### PR DESCRIPTION
**Batch 1 of the #2644 audit fix cycle** (39 findings, skeptic-confirmed + no-op-controlled; APR-QUALITY-001 v1.13 P3). Ticket: PMAT-742. **Stacked on #2644** — retargets to main when it merges.

Closes findings **VPIN-1, VPIN-2, VPIN-3, VPIN-4 (major), VPIN-5, VPIN-6/VP-04**, plus the VP-06 here-string drive-by (v1.13 P5) in the function that was already open.

## The core defect (VPIN-4)

The pins were shell-local and resolved *after* the declared gates had executed. Every gate discovered from `[package.metadata.dogfood]` runs as a **child process** — it could not receive `PMAT_BIN`/`PV` under any spelling, while `pin_audit` certified consumption the environment never carried. Now: pins resolve immediately after the lib is sourced (before any gate), the lib exports what it pins, and the post-build call upgrades the pmat pin for the releasing-pmat case with a row in **every** receipt.

## Six-part DoD

1. **pmat work add** — PMAT-742
2. **branch → PR** — this one
3. **Mutation RED** — five mutation classes, all RED with engagement proven: export-strip (7 sites → row 3d + delivery probe), fallback-restore (rows 3+3b), cwd-relative (row 4c), PV_BIN-uncleared (row 4b; first attempt did **not** engage, caught by its own engagement check, redone), early-phase-removal (delivery probe)
4. **Discrimination both directions** — no-op GREEN ×2 bracketing the matrix; falsification suite T1–T14 green incl. option-neutrality (`set -o` diff empty) and errexit-caller survival
5. **pv contract same PR** — F-DOG1-017..019 + 3 obligations; `pv validate` clean; summary counts re-measured (they had drifted 10-vs-16 = finding CI-1; the schema *forces* the constant → #2648)
6. **Invalidated doc claims same PR** — lib header usage/return semantics rewritten; runner call-site comments updated

## Guard co-evolution

PART 2 row 3 **flips**: it used to bless the silent PATH fallback (the recorded 3.32.0-measuring-3.32.0 incident); the old expectation is preserved as the mutation direction. New rows 3b/3d/4b/4c. The fleet fixture gains `gate-pin-delivery.sh` — the committed catcher, run as a real child of the real runner — and `fleet_path_test` now **gates** on it (previously it printed `ok (rc=1)` over a red fixture gate).

bashrs: 0 new SEC/DET/IDEM lines (pristine dogfood.sh baseline 7 = post-edit 7; both new/edited guard files 0).

Refs #2640 · audit findings on #2644 · #2648 · v1.13 P3/P5

🤖 Generated with [Claude Code](https://claude.com/claude-code)