### PR TITLE
fix(dogfood): eleven gates stop reading absence as health — empty-and-zero is the only PASS shape (QUAL-009)

### DIFF
--- a/contracts/dogfood-runner-unification-v1.yaml
+++ b/contracts/dogfood-runner-unification-v1.yaml
@@ -294,6 +294,46 @@ falsification_tests:
   if_fails: 'the pin lies from subdirectories ("this repo ships no pin"), or an exported stale path rides through an otherwise-green pin (#2644, VPIN-5/VPIN-6/VP-04)'
   mutation: 'replace the git-rooted discovery with $PWD, or drop the unset PV_BIN; row 4c (respectively 4b) must turn RED (both observed 2026-08-23, engagement verified)'
 
+- id: F-DOG1-020
+  rule: empty-and-zero is the only PASS shape
+  prediction: >
+    A probe whose empty output means PASS fails on rc != 0. security-2nd-source
+    WARNs "did not run" when gh api dies; version-unpublished FAILs when the
+    dry-run dies without the already-exists marker; git-clean FAILs outside a
+    git repository. Empty output from a dead call is never a clean measurement.
+  test: 'drive the three gate blocks with a failing gh shim, DRC!=0, and a non-git fixture (see the #2644 batch-2 drivers)'
+  if_fails: 'the absence of a measurement wears the measurement PASS — the DF-1/DF-7/DF-8 laundering primitive (|| true + empty-means-pass) is back'
+  mutation: 'restore `2>/dev/null || true` on the gh api call: a dead call must again print PASS "0 open Dependabot alerts" (observed pre-fix 2026-08-23)'
+- id: F-DOG1-021
+  rule: no verdict-bearing pipe into an early-exit consumer
+  prediction: >
+    version-unpublished reads its marker through a here-string: an
+    already-published version whose marker precedes more than a pipe buffer of
+    dry-run output still turns the gate RED under pipefail.
+  test: 'drive the version-unpublished block with the marker + >64KiB tail under set -uo pipefail'
+  if_fails: 'SIGPIPE(141) inverts the verdict — a PUBLISHED version reads "not yet published" (DF-2; the same construct inverted the other way in the guard, VP-06)'
+  mutation: 'restore `printf | grep -q`; the 300KB-tail driver must again show the false PASS (observed pre-fix 2026-08-23)'
+- id: F-DOG1-022
+  rule: a gate may not vanish from the receipt
+  prediction: >
+    The reachability row appears in every receipt — WARN when the sweep ran,
+    SKIP naming the missing subcommand when this pmat cannot run it. An
+    unreadable --help on the release binary is cli-surface FAIL, and
+    transport-absence declines to assert over the unreadable surface.
+  test: 'drive the reachability block with a pre-3.32.0 pmat shim, and cli-surface with a binary that crashes on --help'
+  if_fails: 'a version-conditional vanish (DF-9) or a SKIP cascading into a PASS over an empty surface (DF-4) — a gate that vanishes reads as a gate that passed'
+  mutation: 'remove the reachability else-arm (row vanishes), or restore `|| true` on the --help capture (SKIP + vacuous absence PASS); each observed pre-fix 2026-08-23'
+- id: F-DOG1-023
+  rule: gates measure the universe they name
+  prediction: >
+    The contracts gate finds the Makefile the way changelog does (find_up), so
+    a workspace member runs the L4/falsification suite instead of degrading to
+    WARN; pv-contracts validates every contracts/**/*.yaml, not only the top
+    level; a discovery failure names the component that died.
+  test: 'drive the contracts gate from a workspace-member fixture with a root Makefile; place a broken contract in contracts/sub/'
+  if_fails: 'the sovereign differentiator silently skips for every workspace member (DF-5), and a third of the corpus sits outside the gate carrying its name (DF-6)'
+  mutation: 'restore the cwd-only `grep Makefile` or the top-level glob; the member fixture must again WARN and the nested broken contract must again pass unseen (observed pre-fix 2026-08-23)'
+
 proof_obligations:
 - type: invariant
   property: 'Exactly one tracked dogfood.sh exists, at scripts/dogfood.sh (F-DOG1-001)'
@@ -353,6 +393,15 @@ proof_obligations:
 - type: soundness
   property: 'verifier_pin_pv is repo-root-anchored, clears the PV_BIN environment channel, and surfaces pv_bin.sh diagnostics on failure (F-DOG1-019)'
   formal: 'resolve(pv) independent of cwd within repo; PV_BIN not in env(source(pv_bin.sh)); rc = 1 => diagnostics on stderr'
+- type: soundness
+  property: 'Every probe whose empty output means PASS fails on rc != 0 — empty-and-zero is the only PASS shape (F-DOG1-020); no verdict-bearing pipe feeds an early-exit consumer under pipefail (F-DOG1-021)'
+  formal: 'probe_rc != 0 => verdict in {WARN(did-not-run), FAIL}; verdict_channel(marker) = herestring'
+- type: invariant
+  property: 'Every gate name the runner can emit appears in every receipt with an explicit outcome; no version- or capability-conditional vanish (F-DOG1-022)'
+  formal: 'forall g in gate_names(runner): exists row in receipt with row.gate = g'
+- type: invariant
+  property: 'Each gate iterates the universe its name claims: find_up for root-kept files, recursive discovery for contracts/, component-accurate failure attribution (F-DOG1-023)'
+  formal: 'universe(gate) = universe(gate.name); fail(discovery) names the failing component'
 kani_harnesses:
 # Declared, NOT written. These are shell guards over shell source; there is no
 # Rust surface for Kani to model-check, and inventing one would be theatre. The
@@ -402,9 +451,9 @@ qa_gate:
     release verified by an unknown binary is an unverified release that says GO.
 
 verification_summary:
-  total_obligations: 19
+  total_obligations: 22
   proven: 0
-  tested: 19
+  tested: 22
   status: proposed
   notes: >
     Every obligation above is TESTED (none PROVEN in the L4/L5 sense — shell

--- a/scripts/check_verifier_pinning.sh
+++ b/scripts/check_verifier_pinning.sh
@@ -592,7 +592,9 @@ EOF
 
     got=$(scan "$td/good.sh" | tr '\n' ' ')
     if [ -z "$got" ]; then
-        printf 'ok    MUST-NOT-FLAG all 14 pinned/comment/string/probe forms accepted\n'
+        # count derived from the fixture, never restated: the prose "all 14"
+        # had drifted from a 16-line corpus (#2644 audit, VP-10 rider)
+        printf 'ok    MUST-NOT-FLAG all %s pinned/comment/string/probe fixture lines accepted\n' "$(grep -c . "$td/good.sh")"
     else
         printf 'FAIL  MUST-NOT-FLAG false positives: %s\n' "$got"; fails=1
     fi
@@ -908,6 +910,15 @@ gates = ["gate-ok.sh", "gate-pin-delivery.sh"]
 EOF
     printf 'pub fn f() {}\n' > "$td/fixture-crate/src/lib.rs"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$td/fixture-crate/gate-ok.sh"
+    # The fixture is a REAL git repo with a clean tree: since the DF-7 fix a
+    # non-git directory is a deliberate git-clean FAIL, and this test asserts
+    # rc=0 through the runner. Hooks and identity are pinned so no host config
+    # can dirty the run.
+    git -C "$td/fixture-crate" -c init.defaultBranch=fixture init -q
+    git -C "$td/fixture-crate" -c user.name=dogfood -c user.email=dogfood@fixture \
+        -c core.hooksPath=/dev/null add -A
+    git -C "$td/fixture-crate" -c user.name=dogfood -c user.email=dogfood@fixture \
+        -c core.hooksPath=/dev/null commit -q --no-verify -m fixture
     # The committed catcher for the unexported-pin mutation (#2644, VPIN-4):
     # this gate runs as a CHILD of the runner, exactly like every discovered
     # gate, and asserts the pins ARRIVED. PMAT_BIN must be nonempty (the policy
@@ -982,6 +993,8 @@ if self_test; then :; else rc=1; fi
 
 printf '\nPART 1 — static: no bare verifier in command position\n'
 cd "$REPO_ROOT" || exit 2
+SCAN_ERR=$(mktemp)
+trap 'rm -f "$SCAN_ERR"' EXIT
 SCOPE=$(resolve_scope)
 if [ "$SCOPE" = "SCOPE_ERROR" ]; then
     printf 'FAIL  [package.metadata.dogfood] gates yielded nothing — the scan universe\n'
@@ -1001,18 +1014,28 @@ else
         rc=1
     else
         # shellcheck disable=SC2086
-        hits=$(scan $SCOPE)
+        hits=$(scan $SCOPE 2>"$SCAN_ERR")
         scan_rc=$?
-        if [ "$scan_rc" -eq 2 ]; then
-            printf 'FAIL  the scanner errored:\n%s\n' "$hits"; rc=1
-        elif [ -n "$hits" ]; then
+        # Only ENUMERATED (rc, output) shapes carry meanings: (0, empty) is
+        # clean and (1, findings) is findings. Everything else — an input-
+        # selective tokeniser crash is exit 1 with an empty stdout and a
+        # traceback on stderr — is a scanner failure, and the old
+        # rc==2-only branch printed "ok no bare pv/pmat/apr" over a scan that
+        # scanned nothing (#2644 audit, F8 rider; v1.13 P1).
+        if [ "$scan_rc" -eq 0 ] && [ -z "$hits" ]; then
+            printf 'ok    no bare pv/pmat/apr in command position, in:\n'
+            printf '%s\n' "$SCOPE" | sed 's/^/        /'
+        elif [ "$scan_rc" -eq 1 ] && [ -n "$hits" ]; then
             printf 'FAIL  bare verifier invocation(s) — these resolve through PATH:\n'
             printf '%s\n' "$hits" | sed 's/^/      /'
             printf '      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.\n'
             rc=1
         else
-            printf 'ok    no bare pv/pmat/apr in command position, in:\n'
-            printf '%s\n' "$SCOPE" | sed 's/^/        /'
+            printf 'FAIL  the scanner did not produce a verdict (rc=%s, %s finding lines) — an\n' "$scan_rc" "$(grep -c . <<< "$hits")"
+            printf '      unenumerated exit shape is a scan that cannot be believed:\n'
+            sed 's/^/      /' "$SCAN_ERR" 2>/dev/null | tail -5
+            printf '%s\n' "$hits" | grep . | sed 's/^/      /' | head -5
+            rc=1
         fi
     fi
 fi

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -208,9 +208,16 @@ echo "══ dogfood pre-release: $CRATE v$VERSION ══"
 # creates. Excluding them is not hiding dirt — it is refusing to let the
 # measurement fail itself. Everything else, including untracked shell scripts,
 # still counts. Ask the crate to gitignore all three.
-DIRTY=$(git status --porcelain 2>/dev/null | grep -vE '^\?\? ([^ ]*/)?\.(dogfood|pmat|pv)/?$' | head -1)
-if [ -z "$DIRTY" ]; then mark git-clean PASS "working tree clean"
-else mark git-clean WARN "uncommitted changes present (commit before tagging)"; fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  # A failed `git status` used to leave DIRTY empty, and empty read as clean:
+  # the absence of the measurement wearing the measurement's PASS (#2644, DF-7).
+  # A release is a tag; a directory that cannot carry one fails the gate.
+  mark git-clean FAIL "not a git repository — cleanliness cannot be measured and a tag cannot exist; a missing measurement is RED, never clean"
+else
+  DIRTY=$(git status --porcelain 2>/dev/null | grep -vE '^\?\? ([^ ]*/)?\.(dogfood|pmat|pv)/?$' | head -1)
+  if [ -z "$DIRTY" ]; then mark git-clean PASS "working tree clean"
+  else mark git-clean WARN "uncommitted changes present (commit before tagging)"; fi
+fi
 
 # ── 1b. the crate's OWN release gates, DISCOVERED not duplicated ────────────
 #
@@ -260,8 +267,13 @@ for g in gates:
     print("GATE " + g.strip())
 PY
 )
-if [ "$DG_PLAN" = "META_ERROR" ] || [ "$DG_META_RC" -ne 0 ]; then
+if [ "$DG_META_RC" -ne 0 ]; then
   mark dogfood-gates FAIL "\`cargo metadata\` failed (exit=$DG_META_RC) — the release gates this crate declares could not be discovered, so none of them ran"
+elif [ "$DG_PLAN" = "META_ERROR" ]; then
+  # cargo succeeded; the python step died. The old message blamed cargo with
+  # "failed (exit=0)" attached — an operator sent to the wrong component
+  # (#2644, CI-4).
+  mark dogfood-gates FAIL "gate discovery's python3 step failed (cargo metadata itself exited 0) — the declaration could not be parsed, so no declared gate ran"
 elif [ "$DG_PLAN" = "NOPKG" ]; then
   mark dogfood-gates FAIL "no package named '$CRATE' in cargo metadata — run dogfood from the crate dir, not the virtual workspace root"
 elif [ "$DG_PLAN" = "NODECL" ]; then
@@ -302,8 +314,9 @@ EOF
 fi
 
 # DOGFOOD_GATES_ONLY runs the discovery section and stops. It exists so the
-# discovery mechanism itself can be exercised — by scripts/check_dogfood_shim.sh
-# and by hand — without paying for a full release sweep, and it runs the SAME
+# discovery mechanism itself can be exercised — by
+# scripts/check_verifier_pinning.sh's fleet-path test, and by hand — without
+# paying for a full release sweep, and it runs the SAME
 # code the release runs rather than a copy of it, which is the whole point of
 # this ticket. It can never print GO: a partial run is not a verdict.
 if [ -n "${DOGFOOD_GATES_ONLY:-}" ]; then
@@ -318,10 +331,20 @@ fi
 # version exists (it only warns), so the "already exists" string — not the exit
 # code — is what tells us the version is taken.
 DRY=$(env -u CARGO_REGISTRY_TOKEN cargo publish --dry-run --allow-dirty 2>&1); DRC=$?
-if printf '%s' "$DRY" | grep -qiE "already (exists|uploaded)"; then
+# Here-string, never `printf | grep -q`: with the marker early and more than a
+# pipe buffer behind it, grep exits at first match, printf takes SIGPIPE, and
+# under pipefail the `if` reads 141 — a PUBLISHED version marked "not yet
+# published" (#2644, DF-2; the same construct inverted a verdict the other way
+# in the pinning guard, VP-06).
+if grep -qiE "already (exists|uploaded)" <<< "$DRY"; then
   mark version-unpublished FAIL "$CRATE $VERSION is ALREADY on crates.io — bump the version"
+elif [ "$DRC" -ne 0 ]; then
+  # No already-exists marker AND the dry-run itself died: the registry was
+  # never consulted, so "not yet published" is an assertion with no source
+  # behind it (#2644, DF-8) — same empty-and-zero rule as the advisory gate.
+  mark version-unpublished FAIL "cargo publish --dry-run failed (exit=$DRC) with no already-exists marker — the registry was never consulted, so the version's status is UNKNOWN: $(tail -2 <<< "$DRY" | strip_ansi | tr '\n' ' ' | cut -c1-120)"
 else
-  mark version-unpublished PASS "$VERSION not yet published"
+  mark version-unpublished PASS "$VERSION not yet published (dry-run exit 0, no already-exists marker)"
 fi
 
 # ── 3. changelog mentions the version ───────────────────────────────────────
@@ -378,11 +401,19 @@ else mark security FAIL "cargo-deny not installed — the advisory scan did not 
 # believed. Absence of `gh` is reported too: a source that did not run is not
 # a source that found nothing.
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  # rc is captured, stderr is kept, and a FAILED call routes to the did-not-run
+  # branch: `2>/dev/null … || true` made an empty result from a dead call
+  # indistinguishable from a clean scan (#2644, DF-1). The rule this encodes:
+  # a probe whose empty output means PASS must FAIL on rc!=0 — "empty-and-zero"
+  # is the only PASS shape (v1.13 P7).
   DEPA=$(gh api "repos/{owner}/{repo}/dependabot/alerts" --paginate \
            --jq '.[] | select(.state=="open") |
                  "\(.security_advisory.severity)|\(.dependency.package.name)|\(.security_vulnerability.first_patched_version.identifier // "no-fix")"' \
-         2>/dev/null || true)
-  if [ -z "$DEPA" ]; then
+         2>"$WORKLOG/depa.err")
+  DEPA_RC=$?
+  if [ "$DEPA_RC" -ne 0 ]; then
+    mark security-2nd-source WARN "gh api FAILED (exit=$DEPA_RC: $(tail -1 "$WORKLOG/depa.err" 2>/dev/null | strip_ansi | cut -c1-100)) — the second advisory source did NOT run; an empty result from a failed call is not a clean scan"
+  elif [ -z "$DEPA" ]; then
     mark security-2nd-source PASS "GitHub Advisory DB (independent of RustSec): 0 open Dependabot alerts"
   else
     DN=$(printf '%s\n' "$DEPA" | grep -c . )
@@ -525,14 +556,17 @@ if [ -n "${PV:-}" ] && [ -x "$PV" ]; then
     else
     PV_FAILED=""
     PV_N=0
-    for c in contracts/*.yaml; do
-      [ -e "$c" ] || continue
+    # `find`, not a top-level glob: 549 of aprender's contracts live in
+    # subdirectories and were silently outside the gate that carries the word
+    # "contracts" in its name (#2644, DF-6). Sorted for a deterministic
+    # receipt; NUL-delimited so no path shape can split.
+    while IFS= read -r -d '' c; do
       case "$(basename "$c")" in
         binding.yaml) continue ;;   # a binding REGISTRY, not a contract
       esac
       PV_N=$((PV_N + 1))
-      "$PV" validate "$c" >/dev/null 2>&1 || PV_FAILED="$PV_FAILED $(basename "$c")"
-    done
+      "$PV" validate "$c" >/dev/null 2>&1 || PV_FAILED="$PV_FAILED ${c#contracts/}"
+    done < <(find contracts -name '*.yaml' -type f -print0 | sort -z)
     if [ "$PV_N" -eq 0 ]; then
       mark pv-contracts FAIL "contracts/ exists but contains no validatable contract — a glob matching nothing is not a pass"
     elif [ -n "$PV_FAILED" ]; then
@@ -866,6 +900,11 @@ PY
   if "$PMAT_BIN" analyze reachability --help >/dev/null 2>&1; then
     RO=$(timeout 900 "$PMAT_BIN" analyze reachability -p . -f json 2>/dev/null | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['orphan_count'],d['orphan_tests'])" 2>/dev/null || echo "? ?")
     mark reachability WARN "unreachable files/tests: $RO (a file the build never compiles cannot be tested)"
+  else
+    # The if-with-no-else made this row VANISH on any pmat without the
+    # subcommand — violating this script's own receipt-completeness rule
+    # (#2644, DF-9): a gate that vanishes reads as a gate that passed.
+    mark reachability SKIP "this pmat has no \`analyze reachability\` (pre-3.32.0) — the orphan sweep did NOT run"
   fi
 else
   mark pmat-verify WARN "pmat not installed — the fleet quality gate did NOT run"
@@ -889,8 +928,21 @@ fi
 # 2>/dev/null || true`, is dead twice over: `pv lint` on a FILE passes over zero
 # contracts, and `|| true` would swallow it anyway.
 # Correct shape (copia's): `do pv validate "$$c" || exit 1; done`.
-if grep -qE '^contracts:' Makefile 2>/dev/null; then
-  MK_RECIPE=$(awk '/^contracts:/{f=1;next} /^[^\t]/{f=0} f' Makefile)
+# The Makefile is discovered like the CHANGELOG is: a workspace member keeps
+# its Makefile at the repo root, and looking only in the crate dir silently
+# degraded the sovereign differentiator to a non-gating WARN for every member
+# (#2644, DF-5 — changelog and coverage were fixed this way; this gate was not).
+# First Makefile that DECLARES the target, not the first that exists: a member
+# Makefile without `contracts:` must not shadow the root one that has it
+# (residual found verifying DF-5).
+MKPATH=""
+for mk_cand in Makefile "$REPO_ROOT/Makefile"; do
+  if [ -f "$mk_cand" ] && grep -qE '^contracts:' "$mk_cand" 2>/dev/null; then
+    MKPATH="$mk_cand"; break
+  fi
+done
+if [ -n "$MKPATH" ]; then
+  MK_RECIPE=$(awk '/^contracts:/{f=1;next} /^[^\t]/{f=0} f' "$MKPATH")
   MK_SMELL=""
   printf '%s' "$MK_RECIPE" | grep -qE 'for .*; *do' \
     && ! printf '%s' "$MK_RECIPE" | grep -qE '\|\| *exit' \
@@ -902,7 +954,7 @@ if grep -qE '^contracts:' Makefile 2>/dev/null; then
   else
     mark contracts-exit-integrity PASS "\`contracts:\` recipe propagates failure (no bare for-loop, no \`|| true\`)"
   fi
-  gate contracts make contracts
+  gate contracts make -C "$(dirname "$MKPATH")" contracts
 else
   mark contracts WARN "no contracts make target"
 fi
@@ -975,12 +1027,17 @@ else mark publish-dry-run FAIL "$(printf '%s' "$DRY" | grep -iE 'error' | head -
 #     transport is an unverified one, and this turns "we have no HTTP surface"
 #     from an assumption into an enforced fact.
 if [ -x "$BINPATH" ]; then
-  CLI_HELP=$("$BINPATH" --help 2>&1 || true)
+  CLI_HELP=$("$BINPATH" --help 2>&1); CLI_HELP_RC=$?
   SUBS=$(printf '%s\n' "$CLI_HELP" \
     | awk '/[Cc]ommands:/{f=1;next} /^[A-Za-z].*:[[:space:]]*$/{f=0} f' \
-    | grep -oE '^[[:space:]]+[a-z][a-z0-9-]+' | tr -d ' ' | sort -u)
-  if [ -z "$SUBS" ]; then
-    mark cli-surface SKIP "binary advertises no subcommands in --help"
+    | grep -oE '^[[:space:]]+[a-z][a-z0-9_-]+' | tr -d ' ' | sort -u)
+  if [ "$CLI_HELP_RC" -ne 0 ]; then
+    # `|| true` used to discard this exit; a binary that CRASHES on --help
+    # then read as "advertises no subcommands" — a SKIP cascading into
+    # transport-absence PASSing over an empty surface (#2644, DF-4).
+    mark cli-surface FAIL "the release binary cannot answer --help (exit=$CLI_HELP_RC) — the advertised surface is unknowable: $(tail -1 <<< "$CLI_HELP" | strip_ansi | cut -c1-100)"
+  elif [ -z "$SUBS" ]; then
+    mark cli-surface SKIP "binary advertises no subcommands in --help (--help exit 0; Commands section empty or absent)"
   else
     CLI_BAD=""
     CLI_N=0
@@ -1067,9 +1124,13 @@ else
   fi
 
   # (c) absence of UNDECLARED transports, probed on the real binary.
+  if [ "${CLI_HELP_RC:-0}" -ne 0 ]; then
+    mark transport-absence SKIP "not evaluated: the binary could not answer --help (cli-surface is RED above), so the advertised surface is unknown — asserting absence over an unreadable surface is a vacuous pass (#2644, DF-4)"
+    TP_INTRUDERS=""
+  else
   TP_INTRUDERS=""
   for probe in mcp serve http api rpc; do
-    printf '%s\n' "$SUBS" | grep -qx "$probe" || continue
+    grep -qx "$probe" <<< "$SUBS" || continue
     # `serve` names no protocol. A subcommand called `serve` may be an HTTP
     # listener OR an MCP stdio server — pforge's is the latter — so demanding an
     # `http` declaration for it forces a crate to declare a transport it does
@@ -1093,6 +1154,7 @@ else
     mark transport-absence FAIL "binary advertises undeclared transport surface:$TP_INTRUDERS — declare it in [package.metadata.transports] with an e2e target, or remove it. An undeclared transport is an unverified one."
   else
     mark transport-absence PASS "no undeclared mcp/http surface advertised by the binary"
+  fi
   fi
 
   # (b) run each declared transport's e2e target, naming it with --test.
@@ -1315,7 +1377,9 @@ for line in os.environ.get("ROWS", "").split("\n"):
         continue
     parts = line.split("\t")
     name, result = parts[0], parts[1] if len(parts) > 1 else ""
-    note = parts[2].replace("\r", "\n") if len(parts) > 2 else ""
+    # rejoin: a literal TAB inside a gate note (log tails carry them) used to
+    # silently drop everything after it (#2644, DF-10)
+    note = "\t".join(parts[2:]).replace("\r", "\n") if len(parts) > 2 else ""
     gates.append({"gate": name, "result": result, "note": note})
 print(json.dumps({
     "crate": os.environ["CRATE"], "version": os.environ["VERSION"],


### PR DESCRIPTION
**Batch 2 of the #2644 audit fix cycle** (v1.13 P1/P5/P7). **Stacked on #2649** (QUAL-014) — retargets as the stack merges. Closes **DF-1, DF-2, DF-4, DF-5, DF-6, DF-7, DF-8, DF-9, DF-10, DF-11, CI-4** plus riders **F8, VP-10, SHIM-07a**.

## Three rules, eleven gates

- **Empty-and-zero is the only PASS shape** (v1.13 P7): security-2nd-source (DF-1 — a dead `gh api` read as *0 alerts*), version-unpublished on a dead dry-run (DF-8), git-clean in a non-git dir (DF-7).
- **The pipefail-SIGPIPE rail** (v1.13 P5): DF-2's `printf | grep -q` inverted a PUBLISHED version into "not yet published" — demonstrated live at 307KB (status 141 on HEAD). Here-strings now.
- **A gate that vanishes reads as a gate that passed** (QUAL-009): reachability's version-conditional vanish (DF-9), crashed `--help` cascading into a vacuous transport-absence PASS (DF-4), and the guard's own PART 1 printing "ok" over a crashed scanner (F8 — only enumerated (rc, output) shapes carry meanings now).

Plus universe fidelity: contracts gate finds the declaring Makefile (DF-5, incl. the member-shadows-root residual found *during* verification), pv-contracts goes recursive over 549 previously-invisible contracts (DF-6), discovery failures name the component that died (CI-4), snake_case subcommands parse whole (DF-11), TAB-bearing notes survive into the receipt (DF-10).

## Verification (independent agents, both directions, engagement receipts)

13/13 findings: fixed block correct on defect input AND healthy input; pre-fix block reproduces the wrong verdict with the **same** input; PATH shims (`gh`, `cargo`, `python3`, pmat, crashing binaries) logged every invocation; extracts diff-verified byte-exact against both versions. The full-guard run caught one interaction regression (DF-7 × non-git fleet fixture) — fixed here, guard exits 0.

Contract: F-DOG1-020..023 + 3 obligations, `pv validate` clean. bashrs: 0 new error-lines.

Refs #2640 · #2644 audit · #2648 · v1.13 P1/P5/P7

🤖 Generated with [Claude Code](https://claude.com/claude-code)