### PR TITLE
docs(dogfood): the audit record, the contract and the skill say what the repo does (QUAL-016)

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -725,12 +725,18 @@ of 3.32.0.
 
 So: `cargo install --path . --root <scratch>` the release tree, and run that
 binary against **every repo in the sovereign stack**. The roster is the one
-`~/src/infra/machines/clean-room/Makefile` declares — aprender, whisper-apr,
-forjar, depyler, bashrs, duende, rmedia, copia, pepita, pzsh, cohete, pforge.
+`~/src/infra/machines/clean-room/Makefile` declares — read it from the
+Makefile, never from a list restated here: the previous sentence enumerated
+12 repos while the Makefile declared 13 (pmat itself was the one missing —
+#2644 audit, SHIM-05), which is what a restated list does.
 They span 10 to 60,980 files of code nobody wrote to make pmat look good.
 
-Harness: `scripts/../fleet-dogfood.sh` in this skill directory, one repo per
-invocation.
+Harness: `fleet-dogfood.sh` — an UNGUARDED user-scope helper
+(`~/.claude/skills/dogfood/`), not tracked in any repo and not part of the
+certified protocol (#2644 audit, SHIM-05: user-scope siblings already
+demonstrate drift). Treat its output as a convenience, not evidence; the
+certified path is `scripts/dogfood.sh` per repo. Tracking-or-deleting these
+helpers is part of the one-runner consolidation (infra#270).
 
 **Install to a SCRATCH root, never over `~/.cargo/bin`.** And use the built
 artifact for pmat's own gates: the installed `pmat` and the release tree both
@@ -760,7 +766,9 @@ serves over MCP, **zero** had a top-tier coverage row while the 18 it does not
 serve scored higher. The tested surface and the served surface were nearly
 disjoint.
 
-Harness: `transport-parity.sh` in this skill directory. For each repo it asks
+Harness: `transport-parity.sh` — likewise an unguarded user-scope helper, not
+tracked in any repo (#2644 audit, SHIM-05; see the fleet-dogfood.sh note
+above). For each repo it asks
 one question over **CLI, MCP stdio and HTTP** and compares the answers. The
 finding it produces is not "a transport is broken" — it is **"the transports
 DISAGREE"**, which is worse, because each looks correct alone.

--- a/contracts/dogfood-runner-unification-v1.yaml
+++ b/contracts/dogfood-runner-unification-v1.yaml
@@ -3,7 +3,7 @@ metadata:
   created: '2026-08-23'
   author: PAIML Engineering
   references:
-  - 'docs/audits/dogfood-divergence-2640.md — the required triage: 9 hunks, 62 changed lines, ALL classified hardening-port, zero drift-discard'
+  - 'docs/audits/dogfood-divergence-2640.md — the required triage: 9 hunks, ALL classified hardening-port, zero drift-discard (the changed-lines constant this line once restated was impossible and is corrected in the doc — DIV-1)'
   - 'scripts/dogfood.sh — the one canonical runner (aprender#2640)'
   - 'scripts/verifier_pin.sh — THE verifier-pinning rule, stated once, plus the two pins'
   - 'scripts/check_verifier_pinning.sh — the gate: static scan + behavioural probe of both pins'
@@ -347,6 +347,16 @@ falsification_tests:
   if_fails: 'evidence nests inside the tree as next-run dirt (DF-3), or a crashed run leaves a previous or garbage verdict readable as current (DF-12)'
   mutation: 'restore RECEIPT_DIR="$REPO_DIR/.dogfood" (nested .dogfood reappears under a relative arg) or write directly to $RECEIPT (corrupt write leaves garbage at the evidence name); both observed pre-fix 2026-08-23'
 
+- id: F-DOG1-025
+  rule: a diagnosis names the cause it observed
+  prediction: >
+    When pv is unavailable the REPORT note distinguishes the two causes it can
+    tell apart: rc=1 (scripts/pv_bin.sh present, the pin FAILED to resolve)
+    reports the pin failure; rc=2 (this repo ships no pin) reports the absence.
+  test: 'drive the pv-contracts REPORT arm with VERIFIER_PIN_PV_RC=1 and =2'
+  if_fails: 'the one note explaining why contracts went unvalidated names the wrong cause, sending the operator to the wrong component (DIV-4; the CI-4 shape in a second place)'
+  mutation: 'collapse the branch back to the single unconditional note; rc=1 must again claim "no scripts/pv_bin.sh" for a file that exists (observed pre-fix 2026-08-23)'
+
 proof_obligations:
 - type: invariant
   property: 'Exactly one tracked dogfood.sh exists, at scripts/dogfood.sh (F-DOG1-001)'
@@ -418,6 +428,9 @@ proof_obligations:
 - type: invariant
   property: 'A receipt exists iff it is complete and parseable: absolute anchor, SHA-stamped, .partial + atomic rename; runner artefact dirs (.dogfood/.pmat/.pv) are gitignored so a run never dirties the tree its next run measures (F-DOG1-024)'
   formal: 'exists(receipt-*.json) => parseable and complete; mutates(run, tracked_files) = {}'
+- type: invariant
+  property: 'Every diagnosis names the cause it observed, and every count this contract or its referenced audit states is reproducible from an extraction the text names (F-DOG1-025; DIV-1/DIV-2 corrections)'
+  formal: 'note(cause) = observed_cause; forall n in stated_counts: reproducible(n, named_extraction)'
 kani_harnesses:
 # Declared, NOT written. These are shell guards over shell source; there is no
 # Rust surface for Kani to model-check, and inventing one would be theatre. The
@@ -467,9 +480,9 @@ qa_gate:
     release verified by an unknown binary is an unverified release that says GO.
 
 verification_summary:
-  total_obligations: 23
+  total_obligations: 24
   proven: 0
-  tested: 23
+  tested: 24
   status: proposed
   notes: >
     Every obligation above is TESTED (none PROVEN in the L4/L5 sense — shell

--- a/docs/audits/dogfood-divergence-2640.md
+++ b/docs/audits/dogfood-divergence-2640.md
@@ -1,6 +1,6 @@
 # Dogfood runner divergence triage — #2640
 
-**Required artifact per #2640 A.2.** Produced BEFORE any delete, because the 86 diverging
+**Required artifact per #2640 A.2.** Produced BEFORE any delete, because the diverging
 lines are evidence, not noise: given #2361 (user-scope shadowed the repo skill, so hardening
 it edited a file that never ran), some hardening had almost certainly landed only in the copy
 that does not run. Deleting either copy first would destroy the record of which.
@@ -15,8 +15,25 @@ divergence, before consolidating.**
 | `user-scope` | `~/.claude/skills/dogfood/dogfood.sh` | 1172 |
 | `repo` | `scripts/dogfood.sh` | 1165 |
 
-`diff` = 9 hunks, 62 changed lines (86 including context). Gate names: **61 shared, 0 unique
-to either.** The copies run the same protocol.
+`diff` = 9 hunks — the position-verified hunk table below is the load-bearing record.
+(This line originally asserted "62 changed lines (86 including context)": both constants
+were arithmetically impossible against the table's own @@ headers — the net delta 1172→1165
+makes added+deleted odd for ANY diff of these files, and the nine -U3 hunks render ≥ ~120
+lines with context. The #2644 audit caught it, DIV-1; a derived table needs no restated
+count, which is v1.13 P7's rule.) Gate names, re-measured (#2644 audit, DIV-2): the
+pre-merge repo copy emits **32** gate names by command-position extraction
+(`(?:^|;|&&|\|\||then|else|do|\{)\s*(mark|gate)\s+"?([a-z][a-z0-9:_-]*)`), and **every one
+of the 32 is present in the unified runner** — zero lost, one gained (`dogfood-gates`, the
+new discovery gate). That set comparison is the load-bearing claim and it is reproducible
+today against `origin/main:scripts/dogfood.sh` and `c4ebd2712:scripts/dogfood.sh`.
+
+This line originally read "61 shared, 0 unique to either". The 61 was a prose-token scrape
+that counted comment words — `already`, `would`, `unpassable` — as gate names; only 32 of
+the 61 tokens were gates. **And the both-sides half is no longer re-verifiable**: the
+user-scope runner source is not recoverable (`~/.claude/skills/dogfood/README-superseded.md`
+preserves the prose, not the 1172-line script), so "identical on both sides" stands as a
+triage-time record, not a reproducible measurement. Stated rather than quietly kept. The
+copies ran the same protocol.
 
 ## Headline result
 
@@ -80,6 +97,13 @@ none of which knew about the others:
 
 Five rediscoveries is the evidence that a rule merely **stated** is documentation. It ships as
 a **gate**, or the sixth tool rediscovers it in a sixth copy.
+
+**Enforcement status, row by row (#2644 audit, DIV-3):** rows 1–3 are enforced by executable
+mechanism on this branch (`verifier_pin.sh` + `check_verifier_pinning.sh`). Rows 4 and 5 are
+**citation-only** — nothing in this branch scans either decision surface. Reading this table
+as five-enforced is the same self-description drift the table documents. Row 4's surface is
+tracked in aprender#2647; row 5's mechanism belongs to the APR-BENCH epic (#2588), where the
+`llama.cpp` baseline is actually invoked.
 
 The two hardenings generalise to one rule the merged runner should state once, and ENFORCE:
 

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -645,7 +645,14 @@ if [ -n "${PV:-}" ] && [ -x "$PV" ]; then
     mark pv-contracts SKIP "no contracts/ directory in this crate"
   fi
 else
-  mark pv-contracts REPORT "pv is not pinned in this repo (no scripts/pv_bin.sh) — contracts NOT validated. A PATH-resolved pv is refused on purpose: 0.49.0 and 0.63.0 disagree on the binding gate, so a verdict from an unknown pv is not a verdict."
+  # Branch on WHY pv is absent: rc=1 (pin present, FAILED) and rc=2 (no pin
+  # shipped) used to share one note claiming "no scripts/pv_bin.sh" — a wrong
+  # diagnosis whenever the file exists and the build failed (#2644, DIV-4).
+  if [ "${VERIFIER_PIN_PV_RC:-2}" -eq 1 ]; then
+    mark pv-contracts REPORT "scripts/pv_bin.sh is PRESENT but the pin FAILED to build/resolve pv (its diagnostics are on stderr above) — contracts NOT validated. A PATH-resolved pv is refused on purpose: 0.49.0 and 0.63.0 disagree on the binding gate."
+  else
+    mark pv-contracts REPORT "pv is not pinned in this repo (no scripts/pv_bin.sh) — contracts NOT validated. A PATH-resolved pv is refused on purpose: 0.49.0 and 0.63.0 disagree on the binding gate, so a verdict from an unknown pv is not a verdict."
+  fi
 fi
 
 # bashrs — shell purification (bashrs 6.66.2).


### PR DESCRIPTION
**Batch 4 of the #2644 audit fix cycle** (PMAT-745). **Stacked on #2651**. Closes **DIV-1, DIV-2, DIV-3, DIV-4, SHIM-05**.

Five self-description defects, each measured rather than argued.

- **DIV-1** — the doc's "9 hunks, 62 changed lines (86 including context)" is impossible against its own hunk table (net delta 1172→1165 makes added+deleted **odd** for any diff of these files; nine -U3 hunks render ≥ ~120 with context). The false 62 had been **restated into the contract's references block** — the mismeasurement shipped into a contract. Both constants dropped for the position-verified table (v1.13 P7: a contract never carries a count constant).
- **DIV-2** — "61 shared gate names" was a prose-token scrape counting `already`, `would`, `unpassable` as gates. Re-derived independently with a command-position extraction (method written into the doc): **32**, all present in the unified runner — zero lost, one gained (`dogfood-gates`), reproducible today against `origin/main` and `c4ebd2712`.
  **And what could not be re-verified now says so**: the user-scope runner source is unrecoverable, so "identical on both sides" is a triage-time record, not a measurement. My first draft of this correction asserted both-sides agreement I had not measured — the original defect, repeated inside its own fix. Caught on re-read, before commit.
- **DIV-3** — the five-instance table read as five-enforced; rows 4–5 are citation-only. Per-row enforcement status, with trackers (#2647, #2588).
- **DIV-4** — the pv REPORT arm claimed "no `scripts/pv_bin.sh`" even when the file exists and the pin *failed* — the CI-4 shape in a second place. Branches on `VERIFIER_PIN_PV_RC`; both directions verified on byte-exact extracts (rc=1 diverges fixed-vs-HEAD, rc=2 identical → discrimination).
- **SHIM-05** — roster sentence listed 12 repos against a Makefile declaring 13 (pmat itself missing) → now says read the Makefile; two Harness lines cited `fleet-dogfood.sh` / `transport-parity.sh` as certified protocol when neither is tracked in any repo → labelled as unguarded user-scope helpers, with infra#270 carrying track-or-delete.

Contract F-DOG1-025 + self-description obligation; `pv validate` clean; `check_dogfood_shim` 0.

Refs #2640 · #2644 audit · #2648 · v1.13 P7

🤖 Generated with [Claude Code](https://claude.com/claude-code)