### PR TITLE
chore(release): 0.64.0 — the audit release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-08-23
+
+The **audit** release. v0.62.0 fixed gates that could not fail and v0.63.0 asked
+whether the thing we validated was the thing we ship. This one is what the same
+question found when it was pointed at everything else: 67 commits, four of them
+integration batches folding a further 44 reviewed PRs.
+
+The pattern that keeps recurring is a gate reporting success over a measurement
+it never made. `apr qa --assert-tps` divided its threshold by ten or discarded
+it outright (#2372). `deny.toml` was 7.2 KB of security policy that ran in no
+workflow at all, and had drifted until it failed on main (#2523). FALSIFY-MONO-011
+had never once scanned a crate (#2476). The README contract-count guard ran
+nowhere (#2485). A required check's verdict was decided by directory order
+(#2562). A meta-guard passed on a *comment*, so the MSRV floor ran nowhere
+(#2551). Every verdict `apr rosetta` printed was unfalsifiable — compare-inference,
+fingerprint and verify all exited 0 no matter what (#2420). Make recipes ran
+without `pipefail`, so the release gate could not fail (#2550).
+
+### User-visible correctness
+
+- **SSE streaming deleted every space and newline** — responses arrived as
+  `Thequickbrownfox` (#2367).
+- **Ollama clients silently dropped every `apr` response**: `created_at` was a
+  bare epoch instead of RFC 3339 (#2371).
+- **Six native routes were dead** on every `apr serve run model.gguf`, and one
+  request could kill the server (#2429). Three more Ollama routes were mounted
+  and advertised to nobody (#2475).
+- A **GGUF without a context-length key refused every prompt** (#2479).
+- An **unknown quantisation type was written to APR labelled F32** (#2488); a
+  tensor that could not be read was dropped and the count only saw the
+  survivors (#2428); a **1 KiB fragment of a 991 MB model was certified
+  `valid: true`** (#2564); a complete MoE model was rejected as
+  truncated/corrupt (#2541).
+- `--offline` downloaded anyway on pull, chat and showcase (#2416).
+- `apr rerank` aborted with a library panic on ordinary flag values (#2414);
+  `apr data` crashed on `--ngram 0` and reported 49 duplicates as zero (#2423);
+  `apr explain` printed "File not found" on stdout and exited 0 (#2368).
+
+### Provenance — the 0.63.0 theme, continued where it still leaked
+
+- `apr` 0.63.0 **ran apr 0.60.0**: both subprocess backends resolved a bare
+  `apr` through `$PATH` (#2424). Two MCP tools did the same, so the server
+  reported results for code it was not running (#2563).
+- The release receipt was **citing pv 0.49.0** while the in-tree crate was
+  0.63.0, and the two disagree on the gate that decides the release (#2552).
+
+### Publishing
+
+- A bare `tests/` exclude is not root-anchored — it **dropped 443 files** from
+  the published `aprender-serve` (#2365); 5.4 MB of build scratch was shipping
+  to crates.io, unseen by the guard meant to stop it (#2487).
+- `apr-cli` **could not be published at all**: it depended on a `publish = false`
+  crate (#2540). A dev-dep alias reinstated the publish cycle it was added to
+  remove (#2560), and the cascade could not see the three facades it must ship
+  (#2561).
+- An unused dependency was breaking docs.rs for every downstream crate (#2468).
+- `make publish` could destroy `.cargo/config.toml` with no recoverable backup
+  (#2637).
+
+### CI and the cost of running it
+
+- Three wall-clock assertions made the required `workspace-test` check
+  non-deterministic (#2425); a 100 ns comparison in a required check blocked
+  every open PR (#2490).
+- `workspace-test` used a different sccache cap and evicted the shared cache
+  (#2545); two lib tests asserted nothing and took 19 minutes (#2533); the
+  README CLI-count guard did a 14-minute build and then failed printing nothing
+  (#2536).
+- coverage-nightly reported a **blank percentage** whenever measurement failed
+  (#2538).
+
+### Dogfood
+
+The dogfood protocol was audited against itself across five batches (#2449,
+#2451, #2453, #2457, #2458) — "nine gates that could not fail, found in the
+tooling that judges us" — and the 0.63.0 crates.io dogfood produced a 190-finding
+defect ledger, each mapped to its issue (#2409). CLAUDE.md gained a Verification
+Discipline section enumerating the ways that sweep fooled itself (#2363).
+
+
 ## [0.63.0] - 2026-08-01
 
 The **provenance** release. v0.62.0 fixed gates that could not fail; this one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-cgp",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "apr-format"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "apr-cli",
  "aprender-core",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-compute"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-bench-tokenizer"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-core",
  "criterion 0.7.0",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cbtop"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cgp"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-gpu",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-common"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "zstd",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-contracts-macros",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-compute-xtask"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "bashrs",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.5.1",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts",
  "clap",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aes-gcm",
  "alsa",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cuda-edge"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-gpu",
  "proptest",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-cupti"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "bindgen",
  "bitflags 2.13.0",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-data"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aes-gcm",
  "aprender-test-lib",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-distribute"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-compute",
  "aprender-db",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-explain"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-gpu",
  "aprender-present-core",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-fft"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gemm-codegen"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-gpu"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-common",
  "aprender-simulate",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-graph"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-compute",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-image"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-mcp"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-monte-carlo"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender",
  "assert_cmd",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-orchestrate"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-common",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-yaml",
  "clap",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts-macros",
  "criterion 0.7.0",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-layout"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-core",
  "criterion 0.7.0",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-lib"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts",
  "aprender-present-core",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-core",
  "bitvec",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-test-macros",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-test-macros"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-widgets"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-core",
  "aprender-present-yaml",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-yaml"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-core",
  "proptest",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile-core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "hex",
  "serde",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-ptx-debug"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "clap",
  "proptest",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-certify"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-qa-certify",
  "aprender-qa-gen",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-gen"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-report"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-qa-runner"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-qa-gen",
@@ -1194,14 +1194,14 @@ dependencies = [
 
 [[package]]
 name = "aprender-quant"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "half",
 ]
 
 [[package]]
 name = "aprender-rag"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-common",
  "aprender-compute",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rag-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-rag",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-rand"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-registry"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "aprender-core",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-shell"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-core",
  "clap",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-simulate"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts",
  "aprender-contracts-macros",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-solve"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "half",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-sparse"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tensor"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "criterion 0.7.0",
  "proptest",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-test-lib",
  "assert_cmd",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-derive"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-js-gen"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-lib"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-compute",
  "aprender-present-core",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-test-showcase"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-present-terminal",
  "aprender-test-lib",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-bench"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-common"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-viz",
  "clap",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-distill"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-inspect"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-lora"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-shell"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-train",
  "aprender-train-common",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-train-wasm"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-tsp"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender",
  "assert_cmd",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "chrono",
  "criterion 0.5.1",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-verify-ml"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-compute",
  "aprender-core",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "approx",
  "aprender-common",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-adaptive"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-zram-core",
  "proptest",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-cli"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-zram-adaptive",
  "aprender-zram-core",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-gpu",
  "criterion 0.7.0",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-zram-generator"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-zram-core",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/aprender"
@@ -211,9 +211,9 @@ minijinja = { version = "2.14", features = ["loader", "serde"] }
 # `crates/aprender-contracts` (lib name `provable_contracts`). Declaring it from
 # crates.io compiled a SECOND copy of the contract engine alongside the in-tree
 # one — exactly the duplicate-crate + publish-cycle the consolidation removed.
-provable-contracts = { path = "crates/aprender-contracts", version = "0.63.0", package = "aprender-contracts" }
-provable-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.63.0", package = "aprender-contracts-macros" }
-aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.63.0" }
+provable-contracts = { path = "crates/aprender-contracts", version = "0.64.0", package = "aprender-contracts" }
+provable-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.64.0", package = "aprender-contracts-macros" }
+aprender-contracts-macros = { path = "crates/aprender-contracts-macros", version = "0.64.0" }
 
 # YAML
 serde_yaml = "0.9"
@@ -225,56 +225,56 @@ hf-hub = { version = "0.4", default-features = false, features = ["ureq"] }
 hf-xet = "1.5.1"
 
 # Workspace-internal crates (paths within the monorepo)
-aprender-compute = { path = "crates/aprender-compute", version = "0.63.0" }
-aprender-gpu = { path = "crates/aprender-gpu", version = "0.63.0" }
-aprender-quant = { path = "crates/aprender-quant", version = "0.63.0" }
-aprender-serve = { path = "crates/aprender-serve", version = "0.63.0" }
-realizar = { path = "crates/aprender-serve", version = "0.63.0", package = "aprender-serve" }
-alimentar = { path = "crates/aprender-data", version = "0.63.0", package = "aprender-data" }
-pacha = { path = "crates/aprender-registry", version = "0.63.0", package = "aprender-registry" }
+aprender-compute = { path = "crates/aprender-compute", version = "0.64.0" }
+aprender-gpu = { path = "crates/aprender-gpu", version = "0.64.0" }
+aprender-quant = { path = "crates/aprender-quant", version = "0.64.0" }
+aprender-serve = { path = "crates/aprender-serve", version = "0.64.0" }
+realizar = { path = "crates/aprender-serve", version = "0.64.0", package = "aprender-serve" }
+alimentar = { path = "crates/aprender-data", version = "0.64.0", package = "aprender-data" }
+pacha = { path = "crates/aprender-registry", version = "0.64.0", package = "aprender-registry" }
 # APR-MONO self-containment: legacy sibling lib-name aliases -> in-monorepo crates (2026-06-12)
-trueno-quant = { path = "crates/aprender-quant", version = "0.63.0", package = "aprender-quant" }
-trueno-db = { path = "crates/aprender-db", version = "0.63.0", package = "aprender-db" }
-trueno-viz = { path = "crates/aprender-viz", version = "0.63.0", package = "aprender-viz" }
-trueno-rag = { path = "crates/aprender-rag", version = "0.63.0", package = "aprender-rag" }
-trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.63.0", package = "aprender-cuda-edge" }
-renacer-core = { path = "crates/aprender-profile-core", version = "0.63.0", package = "aprender-profile-core" }
-repartir = { path = "crates/aprender-distribute", version = "0.63.0", package = "aprender-distribute" }
-simular = { path = "crates/aprender-simulate", version = "0.63.0", package = "aprender-simulate" }
-probar = { path = "crates/aprender-test-lib", version = "0.63.0", package = "aprender-test-lib" }
+trueno-quant = { path = "crates/aprender-quant", version = "0.64.0", package = "aprender-quant" }
+trueno-db = { path = "crates/aprender-db", version = "0.64.0", package = "aprender-db" }
+trueno-viz = { path = "crates/aprender-viz", version = "0.64.0", package = "aprender-viz" }
+trueno-rag = { path = "crates/aprender-rag", version = "0.64.0", package = "aprender-rag" }
+trueno-cuda-edge = { path = "crates/aprender-cuda-edge", version = "0.64.0", package = "aprender-cuda-edge" }
+renacer-core = { path = "crates/aprender-profile-core", version = "0.64.0", package = "aprender-profile-core" }
+repartir = { path = "crates/aprender-distribute", version = "0.64.0", package = "aprender-distribute" }
+simular = { path = "crates/aprender-simulate", version = "0.64.0", package = "aprender-simulate" }
+probar = { path = "crates/aprender-test-lib", version = "0.64.0", package = "aprender-test-lib" }
 # `jugar-probar` is the crates.io/lib name of the same in-tree crate as `probar`
 # above. Both aliases resolve to ONE package; consumers that spelled it
 # `jugar-probar = "0.4"|"0.5"|"1.0"` were building three extra copies.
-jugar-probar = { path = "crates/aprender-test-lib", version = "0.63.0", package = "aprender-test-lib" }
+jugar-probar = { path = "crates/aprender-test-lib", version = "0.64.0", package = "aprender-test-lib" }
 # NOTE: the matching `jugar-probar-derive` alias already exists further down this
 # same table (it points at crates/aprender-test-derive). crates/aprender-test-lib
 # was pinning `jugar-probar-derive = "=1.0.3"` from crates.io regardless — the
 # alias was sitting there unused.
-aprender-train = { path = "crates/aprender-train", version = "0.63.0" }
-entrenar = { path = "crates/aprender-train", version = "0.63.0", package = "aprender-train" }
-aprender-train-common = { path = "crates/aprender-train-common", version = "0.63.0" }
-aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.63.0" }
-aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.63.0" }
-aprender-contracts = { path = "crates/aprender-contracts", version = "0.63.0" }
-aprender-profile = { path = "crates/aprender-profile", version = "0.63.0" }
-aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.63.0" }
-aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.63.0" }
-aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.63.0" }
-aprender-zram-cli = { path = "crates/aprender-zram-cli", version = "0.63.0" }
-aprender-present-core = { path = "crates/aprender-present-core", version = "0.63.0" }
-aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.63.0" }
-aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.63.0" }
-aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.63.0" }
-aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.63.0" }
-aprender-present-test = { path = "crates/aprender-present-test", version = "0.63.0" }
-aprender-db = { path = "crates/aprender-db", version = "0.63.0" }
-aprender-graph = { path = "crates/aprender-graph", version = "0.63.0" }
-aprender-rag = { path = "crates/aprender-rag", version = "0.63.0" }
-aprender-rag-cli = { path = "crates/aprender-rag-cli", version = "0.63.0" }
-aprender-qa-cli = { path = "crates/aprender-qa-cli", version = "0.63.0" }
-aprender-cgp = { path = "crates/aprender-cgp", version = "0.63.0" }
-aprender-contracts-cli = { path = "crates/aprender-contracts-cli", version = "0.63.0" }
-aprender-data = { path = "crates/aprender-data", version = "0.63.0" }
+aprender-train = { path = "crates/aprender-train", version = "0.64.0" }
+entrenar = { path = "crates/aprender-train", version = "0.64.0", package = "aprender-train" }
+aprender-train-common = { path = "crates/aprender-train-common", version = "0.64.0" }
+aprender-train-distill = { path = "crates/aprender-train-distill", version = "0.64.0" }
+aprender-orchestrate = { path = "crates/aprender-orchestrate", version = "0.64.0" }
+aprender-contracts = { path = "crates/aprender-contracts", version = "0.64.0" }
+aprender-profile = { path = "crates/aprender-profile", version = "0.64.0" }
+aprender-profile-core = { path = "crates/aprender-profile-core", version = "0.64.0" }
+aprender-zram-core = { path = "crates/aprender-zram-core", version = "0.64.0" }
+aprender-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.64.0" }
+aprender-zram-cli = { path = "crates/aprender-zram-cli", version = "0.64.0" }
+aprender-present-core = { path = "crates/aprender-present-core", version = "0.64.0" }
+aprender-present-terminal = { path = "crates/aprender-present-terminal", version = "0.64.0" }
+aprender-present-widgets = { path = "crates/aprender-present-widgets", version = "0.64.0" }
+aprender-present-layout = { path = "crates/aprender-present-layout", version = "0.64.0" }
+aprender-present-yaml = { path = "crates/aprender-present-yaml", version = "0.64.0" }
+aprender-present-test = { path = "crates/aprender-present-test", version = "0.64.0" }
+aprender-db = { path = "crates/aprender-db", version = "0.64.0" }
+aprender-graph = { path = "crates/aprender-graph", version = "0.64.0" }
+aprender-rag = { path = "crates/aprender-rag", version = "0.64.0" }
+aprender-rag-cli = { path = "crates/aprender-rag-cli", version = "0.64.0" }
+aprender-qa-cli = { path = "crates/aprender-qa-cli", version = "0.64.0" }
+aprender-cgp = { path = "crates/aprender-cgp", version = "0.64.0" }
+aprender-contracts-cli = { path = "crates/aprender-contracts-cli", version = "0.64.0" }
+aprender-data = { path = "crates/aprender-data", version = "0.64.0" }
 
 # Additional external deps needed by sub-crates
 serde_yaml_ng = "0.10"
@@ -319,25 +319,25 @@ wasmtime = "43"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)
-trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.63.0", package = "aprender-zram-core" }
-trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.63.0", package = "aprender-zram-adaptive" }
-trueno = { path = "crates/aprender-compute", version = "0.63.0", package = "aprender-compute" }
-presentar-core = { path = "crates/aprender-present-core", version = "0.63.0", package = "aprender-present-core" }
-presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.63.0", package = "aprender-present-terminal" }
-presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.63.0", package = "aprender-present-widgets" }
-presentar-layout = { path = "crates/aprender-present-layout", version = "0.63.0", package = "aprender-present-layout" }
-presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.63.0", package = "aprender-present-yaml" }
-presentar-test = { path = "crates/aprender-present-test", version = "0.63.0", package = "aprender-present-test" }
-presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.63.0", package = "aprender-present-test-macros" }
-jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.63.0", package = "aprender-test-derive" }
-batuta-common = { path = "crates/aprender-common", version = "0.63.0", package = "aprender-common" }
+trueno-zram-core = { path = "crates/aprender-zram-core", version = "0.64.0", package = "aprender-zram-core" }
+trueno-zram-adaptive = { path = "crates/aprender-zram-adaptive", version = "0.64.0", package = "aprender-zram-adaptive" }
+trueno = { path = "crates/aprender-compute", version = "0.64.0", package = "aprender-compute" }
+presentar-core = { path = "crates/aprender-present-core", version = "0.64.0", package = "aprender-present-core" }
+presentar-terminal = { path = "crates/aprender-present-terminal", version = "0.64.0", package = "aprender-present-terminal" }
+presentar-widgets = { path = "crates/aprender-present-widgets", version = "0.64.0", package = "aprender-present-widgets" }
+presentar-layout = { path = "crates/aprender-present-layout", version = "0.64.0", package = "aprender-present-layout" }
+presentar-yaml = { path = "crates/aprender-present-yaml", version = "0.64.0", package = "aprender-present-yaml" }
+presentar-test = { path = "crates/aprender-present-test", version = "0.64.0", package = "aprender-present-test" }
+presentar-test-macros = { path = "crates/aprender-present-test-macros", version = "0.64.0", package = "aprender-present-test-macros" }
+jugar-probar-derive = { path = "crates/aprender-test-derive", version = "0.64.0", package = "aprender-test-derive" }
+batuta-common = { path = "crates/aprender-common", version = "0.64.0", package = "aprender-common" }
 # APR-MONO sibling aliases — MUST use workspace refs, NEVER crates.io versions.
 # Hard-pinning these to crates.io creates a diamond: sub-crates pull older
 # aprender versions → multiple `aprender` crates in Cargo.lock = MUDA.
-renacer = { path = "crates/aprender-profile", version = "0.63.0", package = "aprender-profile" }
-entrenar-lora = { path = "crates/aprender-train-lora", version = "0.63.0", package = "aprender-train-lora" }
-batuta = { path = "crates/aprender-orchestrate", version = "0.63.0", package = "aprender-orchestrate" }
-trueno-graph = { path = "crates/aprender-graph", version = "0.63.0", package = "aprender-graph" }
+renacer = { path = "crates/aprender-profile", version = "0.64.0", package = "aprender-profile" }
+entrenar-lora = { path = "crates/aprender-train-lora", version = "0.64.0", package = "aprender-train-lora" }
+batuta = { path = "crates/aprender-orchestrate", version = "0.64.0", package = "aprender-orchestrate" }
+trueno-graph = { path = "crates/aprender-graph", version = "0.64.0", package = "aprender-graph" }
 
 [workspace.lints.rust]
 # Safety
@@ -519,7 +519,7 @@ semicolon_if_nothing_returned = "allow"  # Style preference
 
 [package]
 name = "aprender"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Noah Gift <noah@paiml.com>"]
@@ -549,9 +549,9 @@ required-features = ["cli"]
 # (e.g. apr-cookbook, downstream apps) don't pull apr-cli's heavy transitive
 # dep graph (renacer/profile/inference/zram/visualization). `cargo install
 # aprender` still works because `cli` is in default features. See GH-1599.
-apr-cli = { path = "crates/apr-cli", version = "0.63.0", default-features = true, optional = true }
+apr-cli = { path = "crates/apr-cli", version = "0.64.0", default-features = true, optional = true }
 # Core ML library (lib name = "aprender")
-aprender_ml = { path = "crates/aprender-core", version = "0.63.0", package = "aprender-core" }
+aprender_ml = { path = "crates/aprender-core", version = "0.64.0", package = "aprender-core" }
 
 [features]
 default = ["cli"]

--- a/crates/apr-cli/Cargo.toml
+++ b/crates/apr-cli/Cargo.toml
@@ -102,12 +102,12 @@ libc = "0.2"
 
 [dependencies]
 # Core aprender library
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", default-features = true, features = ["format-compression"] }
 # Provable-contracts engine — `apr beat-run` parses + evaluates BeatBenchmark contracts (PMAT-741)
 aprender-contracts = { workspace = true }
 
 # MCP (Model Context Protocol) server — `apr mcp` subcommand
-aprender-mcp = { path = "../aprender-mcp", version = "0.63.0" }
+aprender-mcp = { path = "../aprender-mcp", version = "0.64.0" }
 async-stream = "0.3"
 provable-contracts-macros = { workspace = true }
 
@@ -118,7 +118,7 @@ batuta-common = { workspace = true }
 # Non-optional since claude-code-parity-apr M150 (outcome-parity Phase 3
 # requires apr code in default builds). GH-344: path dep via
 # .cargo/config.toml.dev-overrides; CI uses checkout+symlink.
-batuta = { version = "0.63.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
+batuta = { version = "0.64.0", path = "../aprender-orchestrate", package = "aprender-orchestrate", default-features = false, features = ["agents", "agents-inference", "agents-mcp", "rag"] }
 
 # Inference engine (workspace path dep — enables cuda/gpu feature forwarding)
 # GH-573: shim (0.9.1) didn't forward cuda feature → 0.7 tok/s instead of 273 tok/s
@@ -209,7 +209,7 @@ pacha = { workspace = true }
 # published-crate dependency cycle the APR-MONO consolidation removed, and
 # (b) was never actually linked, so every `trueno_explain::` path in
 # commands/ptx_explain.rs failed to resolve.
-trueno-explain = { path = "../aprender-explain", version = "0.63.0", package = "aprender-explain", optional = true }
+trueno-explain = { path = "../aprender-explain", version = "0.64.0", package = "aprender-explain", optional = true }
 
 # ML tuning: LoRA/QLoRA configuration and memory planning (GH-176, PMAT-184)
 entrenar-lora = { workspace = true, optional = true }

--- a/crates/aprender-bench-compute/Cargo.toml
+++ b/crates/aprender-bench-compute/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", features = ["format-quantize"] }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", features = ["format-quantize"] }
 
 # Reference implementation for A/B comparison
 # Pure Rust (no BLAS) to keep comparison fair — both are pure Rust SIMD

--- a/crates/aprender-bench-tokenizer/Cargo.toml
+++ b/crates/aprender-bench-tokenizer/Cargo.toml
@@ -11,7 +11,7 @@ disallowed_methods = "allow"
 
 [dependencies]
 # The implementation under test
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core" }
 
 # HuggingFace reference for A/B comparison
 # Regular dep (not dev-dep) because [[bench]] harness=false binaries can't see dev-deps

--- a/crates/aprender-cbtop/Cargo.toml
+++ b/crates/aprender-cbtop/Cargo.toml
@@ -24,7 +24,7 @@ presentar-terminal = { workspace = true }
 
 # Compute backends
 trueno = { workspace = true }
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 # Terminal handling
 crossterm = "0.28"

--- a/crates/aprender-cgp/Cargo.toml
+++ b/crates/aprender-cgp/Cargo.toml
@@ -36,7 +36,7 @@ num_cpus = "1.17"
 comfy-table = "7"
 colored = "3"
 # GPU profiling: direct cuBLAS measurement (OWN THE STACK)
-trueno-gpu = { path = "../aprender-gpu", version = "0.63.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
+trueno-gpu = { path = "../aprender-gpu", version = "0.64.0", features = ["cuda"], optional = true, package = "aprender-gpu" }
 
 [features]
 default = []

--- a/crates/aprender-compute/Cargo.toml
+++ b/crates/aprender-compute/Cargo.toml
@@ -41,11 +41,11 @@ futures-intrusive = { version = "0.5", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 # Native CUDA monitoring via trueno-gpu (TRUENO-SPEC-010)
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", optional = true, package = "aprender-gpu" }
 # PMAT-336: Provable contracts compile-time enforcement
 provable-contracts-macros = { workspace = true }
 # P1a: Sovereign GEMM microkernel codegen (compile-time shape specialization)
-trueno-gemm-codegen = { version = "0.63.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
+trueno-gemm-codegen = { version = "0.64.0", path = "../aprender-gemm-codegen", package = "aprender-gemm-codegen" }
 # Tracing/profiling support (renacer integration)
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }

--- a/crates/aprender-contracts-cli/Cargo.toml
+++ b/crates/aprender-contracts-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "pv"
 path = "src/main.rs"
 
 [dependencies]
-aprender-contracts = { path = "../aprender-contracts", version = "0.63.0" }
+aprender-contracts = { path = "../aprender-contracts", version = "0.64.0" }
 clap = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aprender-contracts/Cargo.toml
+++ b/crates/aprender-contracts/Cargo.toml
@@ -19,7 +19,7 @@ kani = []
 name = "provable_contracts"
 
 [dependencies]
-provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.63.0", package = "aprender-contracts-macros" }
+provable-contracts-macros = { path = "../aprender-contracts-macros", version = "0.64.0", package = "aprender-contracts-macros" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aprender-core/Cargo.toml
+++ b/crates/aprender-core/Cargo.toml
@@ -96,7 +96,7 @@ trueno-quant = { workspace = true }
 # APR-2231: sovereign `.apr` container leaf. aprender-core From-wraps its
 # AprFormatError into AprenderError and re-exports it (no API break). Leaf has
 # no dependency back on core, so this introduces no publish cycle.
-apr-format = { path = "../apr-format", version = "0.63" }
+apr-format = { path = "../apr-format", version = "0.64" }
 
 # NOTE: trueno-rag (=aprender-rag) removed (APR-MONO self-containment): aprender-rag
 # depends on aprender-core + aprender-serve, so core→rag closed a core→rag→serve→core

--- a/crates/aprender-cuda-edge/Cargo.toml
+++ b/crates/aprender-cuda-edge/Cargo.toml
@@ -15,7 +15,7 @@ name = "trueno_cuda_edge"
 [dependencies]
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/aprender-explain/Cargo.toml
+++ b/crates/aprender-explain/Cargo.toml
@@ -25,7 +25,7 @@ presentar-terminal = { workspace = true }
 crossterm = "0.28"
 
 # Internal dependency for PTX generation
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", package = "aprender-gpu", features = ["cuda"] }
 
 [dev-dependencies]
 proptest = "1.4"

--- a/crates/aprender-graph/Cargo.toml
+++ b/crates/aprender-graph/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 thiserror = "2"
 
 # Phase 2+ dependencies
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core" }                                        # Sparse matrix ops, PageRank
 trueno = { workspace = true }
 
 # Phase 3: GPU acceleration (optional - requires wgpu-capable hardware)

--- a/crates/aprender-monte-carlo/Cargo.toml
+++ b/crates/aprender-monte-carlo/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-monte-carlo"
 
 [dependencies]
-aprender = { path = "../../", version = "0.63.0" }
+aprender = { path = "../../", version = "0.64.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"

--- a/crates/aprender-orchestrate/Cargo.toml
+++ b/crates/aprender-orchestrate/Cargo.toml
@@ -126,7 +126,7 @@ pacha = { workspace = true, optional = true }
 realizar = { workspace = true, optional = true }
 
 # ML algorithms and training (native-only)
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", optional = true }
 entrenar = { workspace = true, optional = true }
 alimentar = { workspace = true, optional = true }
 

--- a/crates/aprender-profile/Cargo.toml
+++ b/crates/aprender-profile/Cargo.toml
@@ -74,7 +74,7 @@ trueno = { workspace = true }
 
 # Machine learning for anomaly detection (Sprint 23)
 # GH-581: Use path dep to avoid trueno version skew with local workspace
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core" }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core" }
 
 # Lock-free data structures for ring buffer (Sprint 40)
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "crossbeam-queue", "std"] }
@@ -112,7 +112,7 @@ crossterm = "0.28"
 
 # SIMD-accelerated visualization primitives (sister project)
 # NOTE: `monitor` feature removed upstream (#1979); this crate uses only viz primitives.
-trueno-viz = { version = "0.63.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
+trueno-viz = { version = "0.64.0", path = "../aprender-viz", package = "aprender-viz", default-features = false }
 
 # OpenTelemetry for distributed tracing (Sprint 30)
 opentelemetry = { version = "0.31.0", optional = true }

--- a/crates/aprender-qa-cli/Cargo.toml
+++ b/crates/aprender-qa-cli/Cargo.toml
@@ -23,10 +23,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
-aprender-qa-gen = { version = "0.63.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.63.0", path = "../aprender-qa-runner" }
-aprender-qa-report = { version = "0.63.0", path = "../aprender-qa-report" }
-aprender-qa-certify = { version = "0.63.0", path = "../aprender-qa-certify" }
+aprender-qa-gen = { version = "0.64.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.64.0", path = "../aprender-qa-runner" }
+aprender-qa-report = { version = "0.64.0", path = "../aprender-qa-report" }
+aprender-qa-certify = { version = "0.64.0", path = "../aprender-qa-certify" }
 ctrlc = "3.4"
 safetensors = { workspace = true }
 colored = "2.2"

--- a/crates/aprender-qa-report/Cargo.toml
+++ b/crates/aprender-qa-report/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 colored = "2.2"
 csv = "1.3"
-aprender-qa-gen = { version = "0.63.0", path = "../aprender-qa-gen" }
-aprender-qa-runner = { version = "0.63.0", path = "../aprender-qa-runner" }
+aprender-qa-gen = { version = "0.64.0", path = "../aprender-qa-gen" }
+aprender-qa-runner = { version = "0.64.0", path = "../aprender-qa-runner" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/aprender-qa-runner/Cargo.toml
+++ b/crates/aprender-qa-runner/Cargo.toml
@@ -22,14 +22,14 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
-aprender-qa-gen = { version = "0.63.0", path = "../aprender-qa-gen" }
+aprender-qa-gen = { version = "0.64.0", path = "../aprender-qa-gen" }
 hostname = "0.4"
 rayon = "1.10"
 sha2 = "0.10"
 regex = { workspace = true }
 num_cpus = "1.16"
 safetensors = { workspace = true }
-jugar-probar = { version = "0.63.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
+jugar-probar = { version = "0.64.0", path = "../aprender-test-lib", package = "aprender-test-lib", features = ["llm-types"] }
 # Test fixtures dependencies (optional)
 tempfile = { version = "3", optional = true }
 half = { version = "2.4", optional = true }

--- a/crates/aprender-rag-cli/Cargo.toml
+++ b/crates/aprender-rag-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aprender-rag-cli"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 authors = ["Pragmatic AI Labs"]
 description = "CLI for Trueno-RAG pipeline"

--- a/crates/aprender-rag/Cargo.toml
+++ b/crates/aprender-rag/Cargo.toml
@@ -63,7 +63,7 @@ fastembed = { version = "5", optional = true }
 
 # NVIDIA Embed Nemotron 8B via realizar GGUF infrastructure (GH-3)
 # Large model (~4-32GB depending on quantization), requires GGUF file
-realizar = { version = "0.63.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
+realizar = { version = "0.64.0", path = "../aprender-serve", package = "aprender-serve", default-features = false, optional = true }
 
 
 # Eval: LLM-as-judge via Anthropic API (PMAT-015)

--- a/crates/aprender-registry/Cargo.toml
+++ b/crates/aprender-registry/Cargo.toml
@@ -42,7 +42,7 @@ zstd = { version = "0.13", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 # Ecosystem integration
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", optional = true }
 alimentar = { workspace = true, optional = true }
 
 # HTTP client (optional)

--- a/crates/aprender-serve/Cargo.toml
+++ b/crates/aprender-serve/Cargo.toml
@@ -49,7 +49,7 @@ name = "realizar"
 trueno = { workspace = true, features = ["gpu"] }
 # CUDA PTX generation and runtime for NVIDIA GPUs (optional, pure Rust, no LLVM/nvcc)
 # v0.4.12: BatchedQ6K, MultiWarp, RopeNeox, FlashDecoding kernels
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true, features = ["cuda"] }  # APR-MONO single-source-of-truth
 # KV cache storage (for attention caching)
 trueno-db = { workspace = true, optional = true }
 # K-quantization formats (Q4_K, Q5_K, Q6_K) - Toyota Way: ONE source of truth
@@ -63,7 +63,7 @@ renacer-core = { workspace = true }
 
 # ML algorithms and .apr model format (optional for aprender model serving)
 # v0.24.1: chat templates, GGUF tokenizer preservation (local may be newer)
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", optional = true }
 
 # Data loading library (optional for data pipeline examples)
 alimentar = { workspace = true, optional = true }

--- a/crates/aprender-shell/Cargo.toml
+++ b/crates/aprender-shell/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 
 [dependencies]
 # Use path for local dev, crates.io for release
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", features = ["format-encryption", "format-compression", "format-homomorphic"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/aprender-simulate/Cargo.toml
+++ b/crates/aprender-simulate/Cargo.toml
@@ -57,7 +57,7 @@ crossterm = { version = "0.28", optional = true }
 # ComputeBlocks from presentar-terminal (SIMD-optimized TUI widgets)
 # Path deps to avoid jugar-probar prod dep chain (CB-081)
 presentar-terminal = { workspace = true, optional = true }
-presentar-core = { version = "0.63.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
+presentar-core = { version = "0.64.0", path = "../aprender-present-core", package = "aprender-present-core", default-features = false, optional = true }
 
 # WASM (optional)
 wasm-bindgen = { version = "0.2", optional = true }

--- a/crates/aprender-test-cli/Cargo.toml
+++ b/crates/aprender-test-cli/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library (was: jugar-probar) — dep key preserves Rust identifier
-jugar-probar = { path = "../aprender-test-lib", version = "0.63.0", package = "aprender-test-lib" }
+jugar-probar = { path = "../aprender-test-lib", version = "0.64.0", package = "aprender-test-lib" }
 
 # CLI framework
 clap = { workspace = true }

--- a/crates/aprender-train-bench/Cargo.toml
+++ b/crates/aprender-train-bench/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.63.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.64.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-distill/Cargo.toml
+++ b/crates/aprender-train-distill/Cargo.toml
@@ -33,7 +33,7 @@ shard-batch-source = []
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.63.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.64.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-inspect/Cargo.toml
+++ b/crates/aprender-train-inspect/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.63.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.64.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-lora/Cargo.toml
+++ b/crates/aprender-train-lora/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.63.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.64.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/aprender-train-shell/Cargo.toml
+++ b/crates/aprender-train-shell/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 entrenar = { workspace = true }
-entrenar-common = { version = "0.63.0", path = "../aprender-train-common", package = "aprender-train-common" }
+entrenar-common = { version = "0.64.0", path = "../aprender-train-common", package = "aprender-train-common" }
 clap = { version = "4.5", features = ["derive"] }
 rustyline = "14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/aprender-train/Cargo.toml
+++ b/crates/aprender-train/Cargo.toml
@@ -80,9 +80,9 @@ provable-contracts-macros = { workspace = true }
 # Core PAIML stack
 ndarray = "0.16"
 trueno = { workspace = true, features = ["parallel"] }
-trueno-gpu = { version = "0.63.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
+trueno-gpu = { version = "0.64.0", path = "../aprender-gpu", package = "aprender-gpu", optional = true }  # CUDA compute (APR-MONO single-source-of-truth)
 realizar = { workspace = true, optional = true }
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core" }  # ML interpret module + .apr format + tokenizers
 trueno-viz = { workspace = true, features = ["terminal"] }
 batuta-common = { workspace = true, optional = true }  # WithDimensions trait for `viz` feature (APR-MONO §S #1978)
 presentar-terminal = { workspace = true, optional = true }

--- a/crates/aprender-tsp/Cargo.toml
+++ b/crates/aprender-tsp/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 name = "aprender-tsp"
 
 [dependencies]
-aprender = { path = "../../", version = "0.63.0" }
+aprender = { path = "../../", version = "0.64.0" }
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
 crc32fast = "1.4"

--- a/crates/aprender-verify-ml/Cargo.toml
+++ b/crates/aprender-verify-ml/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 trueno = { workspace = true }
 
 # Machine learning for bug prediction (optional)
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", optional = true }
 
 # LLM fine-tuning integration (optional)
 entrenar = { workspace = true, optional = true }

--- a/crates/aprender-viz/Cargo.toml
+++ b/crates/aprender-viz/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["visualization", "graphics", "science", "wasm"]
 
 [dependencies]
 # Core SIMD/GPU acceleration
-trueno = { version = "0.63.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
+trueno = { version = "0.64.0", path = "../aprender-compute", package = "aprender-compute", default-features = false }
 
 # Shared Batuta stack utilities (display traits, formatting)
 batuta-common = { workspace = true }
@@ -29,10 +29,10 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Optional: ML integration
-aprender = { path = "../aprender-core", version = "0.63.0", package = "aprender-core", optional = true }
+aprender = { path = "../aprender-core", version = "0.64.0", package = "aprender-core", optional = true }
 
 # Optional: Graph integration
-trueno-graph = { version = "0.63.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
+trueno-graph = { version = "0.64.0", path = "../aprender-graph", package = "aprender-graph", default-features = false, optional = true }
 
 # Optional: Database integration
 trueno-db = { workspace = true, optional = true }

--- a/crates/facades/Cargo.lock
+++ b/crates/facades/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "aprender-contracts-macros",
  "regex",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/facades/provable-contracts-macros/Cargo.toml
+++ b/crates/facades/provable-contracts-macros/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # facade resolves. `scripts/check_facade_compat.sh` fails if this version ever
 # drifts from the aprender workspace version — these manifests are excluded
 # from the root workspace, so `cargo set-version` does NOT reach them.
-upstream = { path = "../../aprender-contracts-macros", version = "0.63.0", package = "aprender-contracts-macros" }
+upstream = { path = "../../aprender-contracts-macros", version = "0.64.0", package = "aprender-contracts-macros" }
 
 [features]
 default = []

--- a/crates/facades/provable-contracts/Cargo.toml
+++ b/crates/facades/provable-contracts/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 # facade resolves. `scripts/check_facade_compat.sh` fails if this version ever
 # drifts from the aprender workspace version — these manifests are excluded
 # from the root workspace, so `cargo set-version` does NOT reach them.
-upstream = { path = "../../aprender-contracts", version = "0.63.0", package = "aprender-contracts" }
+upstream = { path = "../../aprender-contracts", version = "0.64.0", package = "aprender-contracts" }
 
 [dev-dependencies]
 # Used by three of the vendored 0.3.1 example programs. They were regular


### PR DESCRIPTION
The version bump for **v0.64.0**. 67 commits since 0.63.0, four of them integration batches folding a further 44 reviewed PRs.

## Bumped with the repo's own tool, not a bare `cargo set-version`

`scripts/bump-version.sh 0.64.0` — which exists precisely because `cargo set-version --workspace` **cannot reach** `crates/facades/` (it is `exclude`d from the root workspace), and `check_facade_compat.sh` rows R3/R5 are wired into CI. A bump that skips those three files reds its own release commit (#2559).

Verified after the run:
- both facade `upstream` pins at 0.64.0
- `crates/facades/Cargo.lock` current under `--locked`
- `crates/facades`'s **own** version left at **0.4.0** — independent by design (#2546)

| guard | result |
|---|---|
| `check_facade_compat.sh` (+ `--self-test`) | exit 0 |
| `check_facade_order_gate.sh` | exit 0 |
| `check_lockfile_current.sh` | exit 0 (`cargo metadata --locked` resolves) |

## CHANGELOG

Every issue number cited in the new entry was resolved against the tracker before committing — **44/44**. (My first verification pass silently checked nothing, because zsh does not word-split unquoted variables and the whole list arrived as one token; redone in bash.)

The theme is continuous: v0.62.0 fixed gates that could not fail, v0.63.0 asked whether the thing validated was the thing shipped, and 0.64.0 is what that question found everywhere else — `--assert-tps` divided by ten, 7.2 KB of security policy running in no workflow, a falsification suite that had never scanned a crate, a required check decided by directory order, a meta-guard that passed on a comment. With the user-visible half beside it: SSE deleting every space (`Thequickbrownfox`), Ollama clients dropping every response over a bare-epoch timestamp, six dead native routes, a 1 KiB fragment of a 991 MB model certified `valid: true`, 443 files missing from a published crate.

## Deliberately not in this commit

`crates/aprender-train-canary` stays at 0.63.0 — workspace-excluded, `publish = false`, absent from crates.io, so not a cascade risk. The bumper knows about only *one* excluded workspace by name; filed as **#2655** rather than fixed by an unscoped edit inside a release commit.

Refs #2546 · #2559 · #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)