### PR TITLE
feat(bench): a bench number is evidence only if it says which path produced it (PARITY-001, PARITY-002)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,6 +559,7 @@ gates = [
     "scripts/check_multiplatform_dogfood.sh",
     "scripts/check_verifier_pinning.sh",
     "scripts/check_dogfood_shim.sh",
+    "scripts/check_bench_receipt.sh",
 ]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ publishing — all backed by YAML provable contracts that fail CI on drift.
 | Metric | Count | Source of truth |
 |-------:|------:|---|
 | Workspace crates | **78** workspace crates | `cargo metadata --no-deps` (NOT `ls crates/` — 4 are `exclude`d, 1 has no Cargo.toml) |
-| Provable contracts | **1791** provable contracts | `find contracts/ -name '*.yaml'` |
+| Provable contracts | **1792** provable contracts | `find contracts/ -name '*.yaml'` |
 | CLI commands | **110** CLI commands | `apr --help` |
 | Book CLI chapters | **112** chapters | `ls book/src/cli/*.md` |
 | Book lib chapters | **71** chapters | `ls book/src/lib/*.md` (parity with `pub mod`) |
@@ -222,7 +222,7 @@ paiml/aprender/
 │   ├── aprender-profile/           # Profiling
 │   ├── aprender-db/ aprender-graph/ aprender-rag/
 │   └── ... (82 crates total)
-├── contracts/                      # 1791 provable YAML contracts
+├── contracts/                      # 1792 provable YAML contracts
 └── book/                           # mdBook documentation
 ```
 
@@ -253,7 +253,7 @@ falsification_tests:
   prediction: apr validate bad-model.apr exits non-zero
 ```
 
-1791 contracts across inference, training, quantization, attention, FFN,
+1792 contracts across inference, training, quantization, attention, FFN,
 tokenization, model formats, CLI safety — and this README itself.
 
 ## Migration from old crates

--- a/contracts/apr-bench-receipt-v1.yaml
+++ b/contracts/apr-bench-receipt-v1.yaml
@@ -1,0 +1,196 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-24'
+  author: PAIML Engineering
+  references:
+  - 'aprender#2667 — EPIC APR-PARITY-001: never let a performance gap reach production'
+  - 'aprender#2668 — PARITY-001: apr bench --json emits raw samples, compute_class, model sha256'
+  - 'aprender#2669 — PARITY-002: this contract'
+  - 'crates/apr-cli/src/dispatch.rs:165 — the fabricated 14x regression, documented in-tree BEFORE this contract existed'
+  - 'crates/apr-cli/Cargo.toml — default features carry no cuda and no wgpu, so the published artifact is CPU-only on every host'
+  - 'scripts/lib/bench_receipt.py — the ONE validator'
+  - 'scripts/check_bench_receipt.sh — the gate, proven against its own 14-case table before its verdict is believed'
+  description: >
+    A benchmark receipt is only evidence if it says WHICH DISPATCH PATH produced
+    the number. This contract holds the two invariants that make it so.
+
+    The failure it exists to refuse is already documented in this repo, at
+    crates/apr-cli/src/dispatch.rs:165: a build that cannot honour a GPU flag
+    reporting success anyway makes the decode beat report `ratio_median=0.070x`
+    and panic — "a fabricated 14x regression with nothing wrong in apr's decode
+    path". `cargo install aprender` builds CPU-only on all four fleet hosts while
+    the llama.cpp comparator runs CUDA or Metal, so a post-publish ratio is not
+    merely unwise, it is UNCOMPUTABLE: it reads ~0.05-0.10, nobody reds a release
+    over it (correctly), the row goes EXISTENCE-ONLY and the threshold never arms.
+
+    That is the check_multiplatform_dogfood shape — a gate that exists, is
+    correct, and never fires for any release. This contract makes it unwriteable
+    rather than merely discouraged.
+
+equations:
+  compute_class_is_the_path_taken:
+    formula: |
+      compute_class = f(features_compiled_in, runtime_available)
+      REQUIRE: cuda   notin features  =>  compute_class != "cuda"
+      REQUIRE: wgpu   notin features  =>  compute_class != "wgpu"
+      REQUIRE: compute_class in { cpu, cuda, metal, wgpu, unknown }
+    domain: 'a bench receipt emitted by apr bench --json'
+    codomain: bool
+    invariants:
+    - 'The field describes the path TAKEN, not the hardware present. A CUDA-capable
+       host running a default-features build is compute_class "cpu".'
+    - 'Feature gates are decisive when ABSENT: a build without the feature cannot
+       take that path, whatever nvidia-smi reports.'
+    - 'An unrecognised value is worse than a missing one, because it reads as measured.'
+
+  cross_class_cannot_arm_a_threshold:
+    formula: |
+      comparability == "cross-class-existence-only"  =>  threshold notin receipt
+    domain: 'a bench receipt carrying a comparison'
+    codomain: bool
+    invariants:
+    - 'A run comparing two different compute classes may RECORD its ratio and may
+       never GATE on it. Writing a threshold beside a cross-class ratio is the
+       born-disarmed shape, and the schema refuses the document rather than
+       trusting a reviewer to notice.'
+
+  raw_samples_survive:
+    formula: |
+      REQUIRE: samples_ms present AND |samples_ms| >= 1
+      REQUIRE: |set(samples_ms)| > 1  when |samples_ms| > 1
+      REQUIRE: n == |samples_ms|
+    domain: 'a bench receipt'
+    codomain: bool
+    invariants:
+    - 'Summary statistics CANNOT be resampled. A receipt carrying only mean and
+       stddev permanently forecloses bootstrap, which is the only threshold method
+       that survived review — the RFC 3-sigma rule returns GREEN on the one
+       regression this repo has on record (derived 19.836% vs actual 19.306%) and
+       gets WEAKER as data accumulates.'
+    - 'A constant sample vector is not a timing distribution. It is the
+       fabricated-measurement shape (F12).'
+    - 'runs_discarded is NOT constrained to zero: the one working throughput
+       harness in this tree discards by construction on token-count inconstancy,
+       so a zero-invariant would contradict the only correct implementation.'
+
+falsification_tests:
+- id: F-BENCH-001
+  rule: compute_class is required and derived
+  prediction: 'A receipt whose provenance lacks compute_class, or asserts a class its
+    feature_set cannot reach, is REJECTED.'
+  test: 'bash scripts/check_bench_receipt.sh   # cases 04, 05, 06'
+  if_fails: 'a CPU-only apr side measured against a CUDA comparator validates cleanly
+    and reports a fabricated ~14x regression (dispatch.rs:165)'
+  mutation: 'drop compute_class from PROVENANCE_REQUIRED in scripts/lib/bench_receipt.py;
+    case 04 must turn RED (observed 2026-08-24, guard exit 1, "expected RED, got GREEN")'
+- id: F-BENCH-002
+  rule: a cross-class run cannot arm a threshold
+  prediction: 'A receipt with comparability=cross-class-existence-only AND a threshold
+    object is REJECTED; the same receipt without the threshold is ACCEPTED.'
+  test: 'bash scripts/check_bench_receipt.sh   # cases 07 (RED) and 13 (GREEN)'
+  if_fails: 'the field is born disarmed — the row goes EXISTENCE-ONLY and the threshold
+    never arms for any release, which is how check_multiplatform_dogfood never passed'
+  mutation: 'disable the comparability branch in the validator; case 07 must turn RED
+    (observed 2026-08-24, guard exit 1)'
+- id: F-BENCH-003
+  rule: raw samples survive and are not fabricated
+  prediction: 'Missing samples_ms, an empty vector, a constant vector, or n disagreeing
+    with the sample count are each REJECTED.'
+  test: 'bash scripts/check_bench_receipt.sh   # cases 01, 02, 03, 10'
+  if_fails: 'bootstrap threshold derivation is permanently foreclosed, and a constant
+    vector passes as a measurement (F12)'
+  mutation: 'emit summary statistics without samples_ms from print_bench_json; case 01
+    must turn RED'
+- id: F-BENCH-004
+  rule: the validator must discriminate before its verdict counts
+  prediction: 'The case table contains at least 14 cases, every one behaves as declared,
+    and the table may grow but never shrink silently.'
+  test: 'bash scripts/check_bench_receipt.sh   # the vacuity floor'
+  if_fails: 'a validator that is all-GREEN or all-RED looks exactly like a healthy one'
+  mutation: 'delete a case file so the count falls below 14; the guard must FAIL on the
+    floor rather than sweep a smaller table clean'
+
+proof_obligations:
+- type: invariant
+  property: 'compute_class is present, in vocabulary, and reachable by the recorded
+    feature_set (F-BENCH-001)'
+  formal: 'forall r: r.provenance.compute_class in CLASSES and (class in {cuda,wgpu} => class in r.provenance.feature_set)'
+- type: invariant
+  property: 'No receipt carries both a cross-class comparability and a threshold (F-BENCH-002)'
+  formal: 'forall r: r.comparability = cross-class-existence-only => threshold notin r'
+- type: soundness
+  property: 'Raw samples are present, non-empty, non-constant, and consistent with n (F-BENCH-003)'
+  formal: 'forall r: |r.samples_ms| >= 1 and (|r.samples_ms| > 1 => |set| > 1) and r.n = |r.samples_ms|'
+- type: invariant
+  property: 'The validator is proven to discriminate before any verdict it emits is
+    believed, and its case table cannot shrink silently (F-BENCH-004)'
+  formal: '|cases| >= 14 and forall c in cases: verdict(c) = declared(c)'
+
+kani_harnesses:
+# These name a REAL Rust surface: compute_class() and provenance_json() exist at
+# crates/apr-cli/src/commands/bench.rs. They are declared here as bounded-proof
+# targets and are NOT yet written — pv counts a declaration, so this is stated
+# plainly rather than left for a reader to discover (the #2644 audit flagged
+# declared-but-unwritten harnesses as score inflation; the remedy is to say so,
+# not to hide the declaration).
+- id: KH-BENCH-001
+  obligation: compute_class_is_the_path_taken
+  property: absent_feature_forecloses_its_class
+  bound: 4
+- id: KH-BENCH-002
+  obligation: cross_class_cannot_arm_a_threshold
+  property: no_document_carries_both_crossclass_and_threshold
+  bound: 4
+- id: KH-BENCH-003
+  obligation: raw_samples_survive
+  property: n_always_equals_sample_count
+  bound: 8
+
+qa_gate:
+  id: F-BENCH-GATE-001
+  name: 'a bench number is evidence only if it says which path produced it'
+  description: >
+    The organising gate for aprender#2667. It is not enough that a receipt exists
+    and parses — the whole failure class this epic addresses is a receipt that
+    exists, parses, looks complete, and describes a measurement that could not
+    have meant what it appears to mean.
+  checks:
+  - compute_class_required
+  - compute_class_reachable_by_features
+  - cross_class_cannot_arm_threshold
+  - raw_samples_present
+  - samples_not_constant
+  - n_agrees_with_samples
+  - discard_reason_when_discarding
+  - validator_case_table_discriminates
+  - case_table_vacuity_floor
+  pass_criteria: >
+    scripts/check_bench_receipt.sh exits 0, which requires BOTH that every case in
+    the committed table behaved as declared AND that every real receipt under
+    evidence/dogfood/ validates. A RED here blocks the receipt from being cited as
+    evidence; it does not block a release on a timing value, and must never be
+    wired into a required status check (see aprender#2671 — the record is eleven
+    wall-clock gate failures).
+
+verification_summary:
+  total_obligations: 4
+  proven: 0
+  tested: 4
+  status: proposed
+  notes: >
+    All four obligations are TESTED by one committed guard whose own
+    discrimination is proven by a 14-case table, and each carries a named
+    mutation OBSERVED turning it RED on 2026-08-24 with the unmutated tree
+    observed GREEN first.
+
+    Nothing here is PROVEN in the L4/L5 sense and the count says so: these are a
+    python validator and a shell guard over JSON documents. The honest ladder
+    position is L3.
+
+    Note what the guard found on its FIRST run, before any mutation: a bare
+    `find evidence -name 'bench-*.json'` also matches
+    evidence/p2c-*/bench-epoch-NNN.json, which are training-epoch artifacts from
+    a different subsystem with a different schema. The validator reported them as
+    defective receipts. Scoping the glob to evidence/dogfood/ is the fix, and the
+    lesson is the one this repo keeps relearning: a guard's UNIVERSE is as
+    load-bearing as its rule.

--- a/crates/apr-cli/src/commands/bench.rs
+++ b/crates/apr-cli/src/commands/bench.rs
@@ -267,6 +267,89 @@ pub(crate) fn run(
 
 /// Print benchmark results as JSON (machine-parseable output).
 /// GH-254→GH-601: Exit code matches `passed` field — non-zero when failed.
+/// PARITY-001 — the dispatch path this binary can actually take.
+///
+/// NOT the hardware present: the path TAKEN. A CUDA-capable host running a
+/// default-features build is `cpu`, because the code that would dispatch to
+/// CUDA was never compiled in. That distinction is the whole point of the
+/// field — a receipt proving WHICH BINARY ran but not WHICH PATH it took
+/// catches the wrong-binary class (five in-tree rediscoveries) and misses the
+/// wrong-compute-class one entirely, which is how a CPU-only apr side
+/// measured against a CUDA comparator validates cleanly and reports the
+/// fabricated 14x regression documented at `dispatch.rs:165`.
+///
+/// Feature gates are read FIRST and are decisive when absent: a build without
+/// the feature cannot take that path, whatever `nvidia-smi` says.
+fn compute_class() -> &'static str {
+    if cfg!(feature = "cuda") {
+        // Built for CUDA. It still only counts as `cuda` if the runtime is
+        // actually there; otherwise this build silently fell back and the
+        // receipt must say so rather than claim the fast path.
+        let runtime = std::process::Command::new("nvidia-smi")
+            .arg("-L")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if runtime {
+            return "cuda";
+        }
+        return "cpu";
+    }
+    if cfg!(feature = "wgpu") {
+        return "wgpu";
+    }
+    "cpu"
+}
+
+/// PARITY-001 — sha256 of a file's contents, for model identity.
+///
+/// A benchmark receipt that names a model by PATH is not reproducible: the
+/// path is a claim about the filesystem, the digest is a claim about the
+/// bytes that were actually fed to the model loader.
+fn file_sha256(path: &Path) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    let mut f = std::fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut f, &mut hasher).ok()?;
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+/// PARITY-001 — the provenance block: which binary produced this receipt.
+///
+/// `resolution` is `path` when the binary was found through `$PATH` and
+/// `pinned` when it came from a pin script. On a release-deciding gate,
+/// `path` is RED — five separate incidents in this repo were a gate
+/// believing the wrong binary (PMAT_BIN, pv_bin.sh, apr_bin.sh, #2384,
+/// unpinned llama.cpp). `reported_version` is recorded SEPARATELY from
+/// `build_commit` because #2384 is exactly the case where they disagree:
+/// two binaries both printed 3.32.0 and only the commit differed.
+fn provenance_json() -> serde_json::Value {
+    let exe = std::env::current_exe().ok();
+    let binary_sha256 = exe.as_deref().and_then(file_sha256);
+    let mut features: Vec<&'static str> = Vec::new();
+    if cfg!(feature = "inference") {
+        features.push("inference");
+    }
+    if cfg!(feature = "cuda") {
+        features.push("cuda");
+    }
+    if cfg!(feature = "wgpu") {
+        features.push("wgpu");
+    }
+    if cfg!(feature = "training") {
+        features.push("training");
+    }
+    serde_json::json!({
+        "binary_path": exe.as_ref().map(|p| p.display().to_string()),
+        "binary_sha256": binary_sha256,
+        "reported_version": env!("CARGO_PKG_VERSION"),
+        "build_commit": option_env!("APR_GIT_SHA").unwrap_or("unknown"),
+        "resolution": "path",
+        "compute_class": compute_class(),
+        "feature_set": features,
+    })
+}
+
 /// CRUX-E-07: emits `latency_p<N>_ms` key per requested percentile point.
 // serde_json::json!() macro uses infallible unwrap internally
 #[allow(clippy::disallowed_methods)]
@@ -289,6 +372,28 @@ fn print_bench_json(path: &Path, result: &BenchResult, percentiles: &[f64]) -> R
             .iter()
             .map(|d| d.as_secs_f64() * 1000.0)
             .collect();
+        // PARITY-001: emit the RAW samples, not only the summary.
+        //
+        // These were already computed here and thrown away after feeding the
+        // percentiles. That is not a convenience loss: summary statistics
+        // CANNOT BE RESAMPLED, so a receipt carrying only mean/stddev
+        // permanently forecloses bootstrap — which is the only threshold
+        // method that survived review (PARITY-008 falsified the RFC's
+        // `3 x pooled relative stddev` against this repo's own data: derived
+        // 19.836% vs actual 19.306%, i.e. GREEN on the one regression we
+        // have on record, and weakening as more data accumulates).
+        obj.insert("samples_ms".to_string(), serde_json::json!(samples_ms));
+        obj.insert("n".to_string(), serde_json::json!(samples_ms.len()));
+        // runs_discarded is deliberately NOT constrained to zero. The one
+        // working throughput harness in this tree discards by construction on
+        // token-count inconstancy, so a zero-invariant would contradict the
+        // only correct implementation we have.
+        obj.insert("runs_discarded".to_string(), serde_json::json!(0));
+        obj.insert("provenance".to_string(), provenance_json());
+        obj.insert(
+            "model_sha256".to_string(),
+            serde_json::json!(file_sha256(path)),
+        );
         for &p in percentiles {
             let key = format!("latency_p{}_ms", p.round() as u64);
             let v = match aprender::metrics::percentile::compute_percentile(&samples_ms, p) {
@@ -726,3 +831,93 @@ include!("benchmark.rs");
 include!("bench_safetensors.rs");
 include!("bench_moe.rs");
 include!("bench_04.rs");
+
+// ── PARITY-001: the bench receipt's provenance fields ───────────────────────
+//
+// These tests assert the two properties that make a receipt usable as
+// evidence rather than as decoration: the raw samples survive, and the
+// compute class describes the path this build can actually take.
+#[cfg(test)]
+mod parity_001_receipt_tests {
+    use super::*;
+
+    /// `compute_class` must be decided by what was COMPILED IN, not by what
+    /// hardware happens to be attached. A default-features build on a machine
+    /// with four GPUs is still `cpu`, because the dispatch code is not there.
+    ///
+    /// This is the assertion that would have refused the fabricated 14x
+    /// regression: a CPU-only apr side measured against a CUDA comparator.
+    #[test]
+    fn compute_class_is_cpu_without_a_gpu_feature() {
+        let class = compute_class();
+        if cfg!(feature = "cuda") || cfg!(feature = "wgpu") {
+            // Built with a GPU feature: the class may legitimately be a GPU
+            // path, or `cpu` if the runtime turned out to be absent.
+            assert!(
+                ["cuda", "wgpu", "cpu"].contains(&class),
+                "unexpected compute_class {class} for a GPU-feature build"
+            );
+        } else {
+            assert_eq!(
+                class, "cpu",
+                "a build without cuda/wgpu features cannot take a GPU path, \
+                 whatever hardware is present — this is the field whose absence \
+                 lets a cross-class ratio validate cleanly"
+            );
+        }
+    }
+
+    /// The class must be one of the values the receipt schema admits. An
+    /// unrecognised value is worse than a missing one: it reads as measured.
+    #[test]
+    fn compute_class_is_in_the_schema_vocabulary() {
+        const ALLOWED: [&str; 5] = ["cpu", "cuda", "metal", "wgpu", "unknown"];
+        assert!(
+            ALLOWED.contains(&compute_class()),
+            "compute_class must be one of {ALLOWED:?}"
+        );
+    }
+
+    /// The provenance block must carry every field the schema requires, and
+    /// must never assert a digest it did not compute.
+    #[test]
+    fn provenance_carries_the_required_fields() {
+        let p = provenance_json();
+        for key in [
+            "binary_path",
+            "binary_sha256",
+            "resolution",
+            "compute_class",
+        ] {
+            assert!(
+                p.get(key).is_some(),
+                "provenance is missing the required key {key}"
+            );
+        }
+        // `reported_version` is recorded separately from `build_commit`
+        // because #2384 is precisely the case where the two disagree.
+        assert!(p.get("reported_version").is_some());
+        assert!(p.get("build_commit").is_some());
+    }
+
+    /// A digest of real bytes, and `None` rather than a placeholder when the
+    /// file is absent. A fabricated digest is the F12 class.
+    #[test]
+    fn file_sha256_digests_bytes_and_refuses_to_invent() {
+        let dir = std::env::temp_dir().join("apr_parity001_sha");
+        let _ = std::fs::create_dir_all(&dir);
+        let f = dir.join("m.bin");
+        std::fs::write(&f, b"abc").expect("write fixture");
+        // sha256("abc") is a fixed, externally checkable constant.
+        assert_eq!(
+            file_sha256(&f).as_deref(),
+            Some("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        );
+        assert_eq!(
+            file_sha256(&dir.join("does-not-exist.bin")),
+            None,
+            "a missing model must yield no digest — never a placeholder"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/scripts/check_bench_receipt.sh
+++ b/scripts/check_bench_receipt.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# check_bench_receipt.sh — the bench receipt validator, proven against its own
+# case table before it is believed (PARITY-001 / PARITY-002, aprender#2668/#2669).
+#
+# WHY A CASE TABLE AND NOT A REVIEW. The verifier-pinning walker in this repo
+# was wrong SIXTEEN times; every one was caught by a must-flag/must-not-flag
+# table and none by reading the pattern. A validator whose own discrimination
+# is unproven is a validator that can go all-GREEN or all-RED without anyone
+# noticing, and either failure looks exactly like health.
+#
+# THE TWO RULES THIS EXISTS TO ENFORCE:
+#
+#   1. `compute_class` is REQUIRED and describes the path TAKEN, not the
+#      hardware present. A receipt proving WHICH BINARY ran but not WHICH
+#      PATH it took catches the wrong-binary class -- five in-tree
+#      rediscoveries -- and misses the wrong-compute-class one entirely.
+#      That miss is how a CPU-only apr side against a CUDA comparator
+#      validates cleanly and reports the fabricated 14x regression already
+#      documented at crates/apr-cli/src/dispatch.rs:165.
+#
+#   2. A cross-class run CANNOT carry a threshold. Born-disarmed made
+#      unwriteable rather than discouraged.
+#
+# Exit: 0 = the table discriminates AND every real receipt is valid
+#       1 = a case behaved wrongly, or a real receipt is invalid
+#       2 = setup error
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+VALIDATOR="scripts/lib/bench_receipt.py"
+CASES="scripts/lib/bench_receipt_cases"
+rc=0
+
+[ -f "$VALIDATOR" ] || { printf 'FAIL  %s is missing\n' "$VALIDATOR"; exit 2; }
+[ -d "$CASES" ]     || { printf 'FAIL  %s is missing\n' "$CASES"; exit 2; }
+
+printf -- '--- bench receipt validator -------------------------------------\n'
+printf 'case table (the validator must be right before its verdict means anything)\n'
+
+n=0; bad=0
+for f in "$CASES"/*.json; do
+    [ -e "$f" ] || continue
+    n=$((n + 1))
+    want=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('_expect','?'))" "$f" 2>/dev/null)
+    python3 "$VALIDATOR" "$f" >/dev/null 2>&1
+    got=$([ $? -eq 0 ] && echo GREEN || echo RED)
+    if [ "$got" != "$want" ]; then
+        printf 'FAIL  %-28s expected %s, got %s\n' "$(basename "$f" .json)" "$want" "$got"
+        bad=$((bad + 1))
+    fi
+done
+
+# VACUITY: a table that matched nothing would sweep clean. The floor is the
+# committed case count; it may grow and may never shrink silently.
+if [ "$n" -lt 14 ]; then
+    printf 'FAIL  case table has %s case(s); at least 14 are required. A shrinking\n' "$n"
+    printf '      table silently narrows what "the validator discriminates" means.\n'
+    rc=1
+elif [ "$bad" -eq 0 ]; then
+    printf 'ok    all %s cases behaved as declared (RED on each defect, GREEN on each control)\n' "$n"
+else
+    rc=1
+fi
+
+# Every real receipt in the tree must validate.
+printf '\nreal receipts\n'
+found=0
+while IFS= read -r r; do
+    found=$((found + 1))
+    if python3 "$VALIDATOR" "$r" >/dev/null 2>&1; then
+        printf 'ok    %s\n' "$r"
+    else
+        printf 'FAIL  %s\n' "$r"
+        python3 "$VALIDATOR" "$r" 2>&1 | sed 's/^/      /'
+        rc=1
+    fi
+done < <(find evidence/dogfood -name 'bench-*.json' -type f 2>/dev/null | sort)
+# SCOPED to evidence/dogfood/ deliberately. A bare `find evidence -name
+# bench-*.json` also matches evidence/p2c-*/bench-epoch-NNN.json, which are
+# TRAINING-EPOCH artifacts from a different subsystem with a different schema
+# -- validating them here would report a defect in a file this validator has
+# no claim over. Found by running this guard before believing it.
+[ "$found" -eq 0 ] && printf 'none yet — the first arrives with PARITY-003 (aprender#2670)\n'
+
+printf '\n'
+if [ "$rc" -eq 0 ]; then
+    printf 'PASS  the validator discriminates, and every receipt present is valid.\n'
+else
+    printf 'FAIL  see rows above. A receipt that cannot be trusted is not evidence.\n'
+fi
+exit "$rc"

--- a/scripts/lib/bench_receipt.py
+++ b/scripts/lib/bench_receipt.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""The ONE validator for a bench receipt (PARITY-002).
+
+Requires Python 3.6+ (json, sys only).
+
+A receipt that proves WHICH BINARY ran but not WHICH DISPATCH PATH it took
+catches the wrong-binary class -- five independent in-tree rediscoveries:
+PMAT_BIN, pv_bin.sh, apr_bin.sh, aprender#2384, the unpinned llama.cpp
+comparator -- and misses the wrong-compute-class one entirely. That miss is
+how a CPU-only apr side measured against a CUDA comparator validates cleanly
+and reports the fabricated 14x regression documented at
+crates/apr-cli/src/dispatch.rs:165 (`ratio_median=0.070x ... with nothing
+wrong in apr's decode path`).
+
+Two rules carry the weight:
+
+  1. compute_class is REQUIRED, and describes the path TAKEN, not the
+     hardware present.
+  2. A cross-class run CANNOT carry a threshold. This is the born-disarmed
+     failure made unwriteable rather than discouraged: the shape where a row
+     goes EXISTENCE-ONLY and the threshold never arms for any release, which
+     is exactly how check_multiplatform_dogfood never passed for any release.
+
+Usage:  bench_receipt.py <receipt.json> [...]
+Exit:   0 all valid - 1 a receipt is invalid - 2 usage/read error
+"""
+import json
+import sys
+
+COMPUTE_CLASSES = ("cpu", "cuda", "metal", "wgpu", "unknown")
+PROVENANCE_REQUIRED = ("binary_path", "binary_sha256", "resolution", "compute_class")
+DISCARD_REASONS = ("early_eos", "negative_delta", "nonzero_exit")
+
+
+def _err(errors, msg):
+    errors.append(msg)
+
+
+def _check_provenance(prov, errors):
+    """Which binary ran, and which path it took."""
+    for key in PROVENANCE_REQUIRED:
+        if key not in prov:
+            _err(errors, "provenance.%s: missing (required)" % key)
+
+    klass = prov.get("compute_class")
+    if klass is not None and klass not in COMPUTE_CLASSES:
+        _err(errors, "provenance.compute_class: %r not in %s"
+                     % (klass, list(COMPUTE_CLASSES)))
+
+    # A class the build cannot reach is a fabricated claim, not a measurement.
+    features = prov.get("feature_set")
+    if isinstance(features, list) and klass in ("cuda", "wgpu") and klass not in features:
+        _err(errors, "provenance.compute_class=%s but feature_set=%s does not "
+                     "contain it -- a build without the feature cannot take "
+                     "that path" % (klass, features))
+
+    sha = prov.get("binary_sha256")
+    if sha is not None and not _is_sha256(sha):
+        _err(errors, "provenance.binary_sha256: not a 64-char lowercase hex digest")
+
+
+def _is_sha256(value):
+    return (isinstance(value, str) and len(value) == 64
+            and all(c in "0123456789abcdef" for c in value))
+
+
+def _check_samples(receipt, errors):
+    """Raw samples survive, and are a distribution rather than a constant."""
+    samples = receipt.get("samples_ms")
+    if samples is None:
+        _err(errors, "samples_ms: missing -- summary statistics cannot be "
+                     "resampled, so a receipt without raw samples permanently "
+                     "forecloses bootstrap threshold derivation")
+        return
+    if not isinstance(samples, list) or not samples:
+        _err(errors, "samples_ms: present but empty -- a measurement over zero "
+                     "samples is a vacuous pass")
+        return
+    if any(not isinstance(x, (int, float)) for x in samples):
+        _err(errors, "samples_ms: contains a non-numeric entry")
+    elif len(samples) > 1 and len(set(samples)) == 1:
+        # F12: a value with the form of a measurement and nothing behind it.
+        _err(errors, "samples_ms: all %d samples identical (%r) -- a real "
+                     "timing distribution is not constant; this is the "
+                     "fabricated-measurement shape (F12)"
+                     % (len(samples), samples[0]))
+
+    n = receipt.get("n")
+    if n is not None and n != len(samples):
+        _err(errors, "n=%r disagrees with len(samples_ms)=%d" % (n, len(samples)))
+
+
+def _check_discards(receipt, errors):
+    """runs_discarded is legal, but never unexplained."""
+    discarded = receipt.get("runs_discarded")
+    if discarded is None:
+        return
+    if not isinstance(discarded, int) or discarded < 0:
+        _err(errors, "runs_discarded: must be an integer >= 0")
+    elif discarded > 0 and receipt.get("discard_reason") not in DISCARD_REASONS:
+        _err(errors, "runs_discarded=%d but discard_reason=%r is not one of %s"
+                     % (discarded, receipt.get("discard_reason"),
+                        list(DISCARD_REASONS)))
+
+
+def _check_cross_class(receipt, errors):
+    """THE STRUCTURAL RULE: a cross-class run cannot arm a threshold."""
+    if receipt.get("comparability") != "cross-class-existence-only":
+        return
+    if "threshold" in receipt:
+        _err(errors, "comparability=cross-class-existence-only carries a "
+                     "threshold object -- a cross-class run cannot arm a "
+                     "threshold. This is the born-disarmed failure: the row "
+                     "goes EXISTENCE-ONLY and the threshold never arms.")
+
+
+def validate(receipt):
+    """Return a list of human-readable errors; empty means valid."""
+    # `_expect` is the case-table annotation, not receipt content.
+    receipt = {k: v for k, v in receipt.items() if k != "_expect"}
+    errors = []
+
+    prov = receipt.get("provenance")
+    if not isinstance(prov, dict):
+        _err(errors, "provenance: missing -- a receipt with no provenance is an "
+                     "anonymous number, not evidence")
+        return errors
+
+    _check_provenance(prov, errors)
+    _check_samples(receipt, errors)
+    _check_discards(receipt, errors)
+    _check_cross_class(receipt, errors)
+    return errors
+
+
+def _validate_one(path):
+    """Validate a single receipt file. Returns (rc, lines_to_print)."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            receipt = json.load(handle)
+    except (OSError, ValueError) as exc:
+        return 2, ["%s: cannot read: %s" % (path, exc)]
+    errors = validate(receipt)
+    if errors:
+        return 1, ["FAIL %s: %s" % (path, e) for e in errors]
+    return 0, ["ok   %s" % path]
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("usage: bench_receipt.py <receipt.json> [...]\n")
+        return 2
+    rc = 0
+    for path in argv[1:]:
+        one_rc, lines = _validate_one(path)
+        for line in lines:
+            print(line)
+        if one_rc == 2:
+            return 2
+        rc = rc or one_rc
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/bench_receipt_cases/00_pristine.json
+++ b/scripts/lib/bench_receipt_cases/00_pristine.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "GREEN"
+}

--- a/scripts/lib/bench_receipt_cases/01_no_samples.json
+++ b/scripts/lib/bench_receipt_cases/01_no_samples.json
@@ -1,0 +1,20 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/02_empty_samples.json
+++ b/scripts/lib/bench_receipt_cases/02_empty_samples.json
@@ -1,0 +1,21 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/03_constant_samples.json
+++ b/scripts/lib/bench_receipt_cases/03_constant_samples.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  100.0,
+  100.0,
+  100.0,
+  100.0,
+  100.0,
+  100.0,
+  100.0
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/04_no_compute_class.json
+++ b/scripts/lib/bench_receipt_cases/04_no_compute_class.json
@@ -1,0 +1,28 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/05_fabricated_cuda.json
+++ b/scripts/lib/bench_receipt_cases/05_fabricated_cuda.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cuda",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/06_bogus_class.json
+++ b/scripts/lib/bench_receipt_cases/06_bogus_class.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "tpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/07_cross_class_thresh.json
+++ b/scripts/lib/bench_receipt_cases/07_cross_class_thresh.json
@@ -1,0 +1,34 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "comparability": "cross-class-existence-only",
+ "threshold": {
+  "value": 0.9,
+  "source": "bootstrap"
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/08_no_provenance.json
+++ b/scripts/lib/bench_receipt_cases/08_no_provenance.json
@@ -1,0 +1,17 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/09_bad_sha_len.json
+++ b/scripts/lib/bench_receipt_cases/09_bad_sha_len.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "cafe",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/10_n_disagrees.json
+++ b/scripts/lib/bench_receipt_cases/10_n_disagrees.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 99,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/11_discard_no_reason.json
+++ b/scripts/lib/bench_receipt_cases/11_discard_no_reason.json
@@ -1,0 +1,29 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 2,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "_expect": "RED"
+}

--- a/scripts/lib/bench_receipt_cases/12_discard_with_reason.json
+++ b/scripts/lib/bench_receipt_cases/12_discard_with_reason.json
@@ -1,0 +1,30 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 2,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "discard_reason": "early_eos",
+ "_expect": "GREEN"
+}

--- a/scripts/lib/bench_receipt_cases/13_crossclass_no_thresh.json
+++ b/scripts/lib/bench_receipt_cases/13_crossclass_no_thresh.json
@@ -1,0 +1,30 @@
+{
+ "model": "/models/q.gguf",
+ "tokens_per_second": 101.3,
+ "n": 7,
+ "samples_ms": [
+  98.2,
+  101.4,
+  99.7,
+  103.1,
+  100.2,
+  97.8,
+  102.6
+ ],
+ "runs_discarded": 0,
+ "model_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+ "provenance": {
+  "binary_path": "/home/x/.cargo/bin/apr",
+  "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reported_version": "0.64.0",
+  "build_commit": "7db0d4c8",
+  "resolution": "path",
+  "compute_class": "cpu",
+  "feature_set": [
+   "inference",
+   "training"
+  ]
+ },
+ "comparability": "cross-class-existence-only",
+ "_expect": "GREEN"
+}

--- a/scripts/unwired_guards_baseline.txt
+++ b/scripts/unwired_guards_baseline.txt
@@ -17,3 +17,11 @@ check_mcp_never_path_resolves_apr.sh
 # Mutation-verified there in three directions (stale receipt version, non-zero
 # install_rc, shortened host matrix).
 check_multiplatform_dogfood.sh
+# check_bench_receipt.sh — a RELEASE gate, not a PR gate. It validates benchmark
+# receipts, which exist only for a version being CUT; on a PR there is no
+# receipt, so wiring it would either red every PR or pass vacuously. It is a
+# declared [package.metadata.dogfood] gate, so the release runner discovers and
+# runs it. Its own discrimination is proven by a committed 14-case table with a
+# vacuity floor, mutation-verified in two directions (drop compute_class from
+# the required set; disable the cross-class rule). See aprender#2668, #2669.
+check_bench_receipt.sh


### PR DESCRIPTION
First two tickets of **#2667**. Closes **#2668**, **#2669**. Nothing gates a release yet — this makes the measurement honest so a threshold can later be *derived* rather than typed.

## PARITY-001 — emit what was already being computed and thrown away

`bench.rs` computed the per-run sample vector, fed it to the percentiles, and dropped it. That is not a convenience loss: **summary statistics cannot be resampled**, so a receipt carrying only mean/stddev *permanently forecloses* bootstrap — the only threshold method that survived review (#2675 falsified the RFC's `3 × pooled relative stddev` against this repo's own data: derived 19.836% vs actual 19.306%, i.e. GREEN on the one regression on record, and **weakening as data accumulates**).

Now emitted: `samples_ms` verbatim, `n`, `runs_discarded` (deliberately **not** constrained to zero — the one working harness discards by construction on token-count inconstancy), `model_sha256`, and a `provenance` block.

### `compute_class` is the point

It records the dispatch path **taken**, not the hardware present. A CUDA-capable host running a default-features build is `cpu`, because the dispatch code was never compiled in.

A receipt proving *which binary ran* but not *which path it took* catches the wrong-binary class — five in-tree rediscoveries — and misses the wrong-compute-class one entirely. That miss is how a CPU-only apr side against a CUDA comparator validates cleanly and reports the fabricated 14× regression this repo **already documents** at `dispatch.rs:165`.

## PARITY-002 — one validator, and a gate that proves it discriminates first

`scripts/lib/bench_receipt.py` is the one validator; `scripts/check_bench_receipt.sh` is the gate. The gate refuses to believe the validator until a **committed 14-case table** behaves as declared, with a vacuity floor: the table may grow, never shrink silently. *(The verifier-pinning walker here was wrong sixteen times; every one was caught by a case table, none by reading the pattern.)*

The load-bearing rule: a run marked `cross-class-existence-only` **cannot carry a threshold object** — born-disarmed made unwriteable rather than discouraged.

## Evidence, both directions, engagement proven

- **14/14** cases behave as declared, including **three discrimination controls** (pristine GREEN; discard-with-reason GREEN; cross-class *without* a threshold GREEN — the rule refuses the pair, not the concept).
- Validator mutations, each RED then restored GREEN: drop `compute_class` from `PROVENANCE_REQUIRED` → case 04 RED, guard exit 1. Disable the comparability branch → case 07 RED, guard exit 1. No-op → exit 0.
- 4 new unit tests; `pv validate` clean; `pv lint contracts/` PASS; bashrs 0 SEC/DET/IDEM.

## Found by running the guard before believing it

A bare `find evidence -name 'bench-*.json'` also matches `evidence/p2c-*/bench-epoch-NNN.json` — training-epoch artifacts from a different subsystem with a different schema — and the validator dutifully reported them as defective. Glob scoped to `evidence/dogfood/`, reason written at the call site. **A guard's universe is as load-bearing as its rule.**

Wired as a declared `[package.metadata.dogfood]` gate — the runner discovers and runs it (`declared:check_bench_receipt … exit=0`). **Deliberately not a required CI check**: the record is eleven wall-clock gate failures (#2671).

Refs #2667 · #2668 · #2669 · #2675

🤖 Generated with [Claude Code](https://claude.com/claude-code)