### PR TITLE
feat(bench): pin llama.cpp — instance five of the unpinned-verifier table becomes a mechanism (PARITY-009)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -930,6 +930,12 @@ jobs:
       # catch the one regression on record (#2675).
       - name: Bench threshold derivation holds
         run: bash scripts/check_bench_threshold.sh
+      # Instance 5 of the unpinned-verifier table becomes a mechanism. An
+      # unpinned comparator makes every ratio meaningless across time: the
+      # denominator moves silently while the receipt claims a fixed baseline
+      # (#2676, closing the open half of #2647).
+      - name: llama.cpp comparator pin discriminates
+        run: bash scripts/check_llama_pin.sh
       # The deepest check in the surface sweep -- real generation through
       # /v1/chat/completions -- had never executed once: the probe binary was
       # built without --features llm (clap advertises `llm` regardless, only the

--- a/scripts/check_llama_pin.sh
+++ b/scripts/check_llama_pin.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# check_llama_pin.sh — the llama.cpp pin behaves, in all four states
+# (PARITY-009, aprender#2676).
+#
+# scripts/verifier_pin.sh:36 has listed the unpinned llama.cpp comparator as
+# instance FIVE of the unpinned-verifier table for months — cited, never
+# enforced. A rule merely STATED is documentation; five rediscoveries is the
+# evidence. This proves the pin discriminates rather than asserting that it does.
+#
+# The four states, and why each matters:
+#   0 pinned      the binary runs AND reports the declared build
+#   1 wrong build a binary was named but is not the one declared — the failure
+#                 that makes a cross-release ratio meaningless
+#   2 unpinned    honest bootstrap: REPORT, never gate. Not FAIL, because a
+#                 repo that has not chosen a comparator yet is not defective
+#   3 no decl     the declaration itself is missing — a pin with no subject
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+rc=0
+printf -- '--- llama.cpp comparator pin ----------------------------------------\n'
+printf 'case table (the pin must discriminate before its verdict means anything)\n'
+
+td=$(mktemp -d) || exit 2
+trap 'rm -rf "${td:?}"' EXIT
+
+# A stub that reports a known build, and one that reports a different build.
+printf '#!/bin/sh\necho "version: 4567 (abcdef1)"\n' > "$td/good"
+printf '#!/bin/sh\necho "version: 9999 (999999f)"\n' > "$td/wrong"
+printf '#!/bin/sh\nexit 1\n'                          > "$td/mute"
+chmod +x "$td/good" "$td/wrong" "$td/mute"
+mkdir -p "$td/adir"
+
+run_case() {
+    # run_case <name> <pin-value> <candidate> <expected-rc>
+    local name="$1" pin="$2" cand="$3" want="$4" got
+    local decl="$td/pin.toml"
+    printf '[comparator]\nbuild_commit = "%s"\n' "$pin" > "$decl"
+    got=$(
+        cd "$td" || exit 9
+        mkdir -p scripts && cp "$decl" scripts/llama_pin.toml
+        # EXPORT, not a command prefix: a prefix applies only to the `source`
+        # itself and is gone by the time llama_bin_resolve runs. That bug made
+        # the positive case report rc=1 and would have read as "the pin cannot
+        # recognise a correct binary".
+        export LLAMA_BENCH_PATH="$cand"
+        # shellcheck disable=SC1090
+        . "$OLDPWD/scripts/llama_bin.sh" 2>/dev/null
+        llama_bin_resolve >/dev/null 2>&1
+        printf '%s' "$?"
+    )
+    if [ "$got" = "$want" ]; then
+        printf 'ok    %-34s rc=%s\n' "$name" "$got"
+    else
+        printf 'FAIL  %-34s expected rc=%s, got rc=%s\n' "$name" "$want" "$got"
+        rc=1
+    fi
+}
+
+OLDPWD_SAVE=$PWD
+export OLDPWD="$OLDPWD_SAVE"
+
+run_case "pinned, binary reports it"      "abcdef1"  "$td/good"  0
+run_case "named binary is the WRONG build" "abcdef1"  "$td/wrong" 1
+run_case "named binary cannot run"         "abcdef1"  "$td/mute"  1
+run_case "named path is a DIRECTORY"       "abcdef1"  "$td/adir"  1
+run_case "named path does not exist"       "abcdef1"  "$td/nope"  1
+run_case "unpinned, binary present"        "UNPINNED" "$td/good"  2
+run_case "unpinned, no binary named"       "UNPINNED" ""          2
+run_case "pinned but no binary named"      "abcdef1"  ""          1
+
+# The declaration in THIS repo must parse and must be one of the two legal
+# states. A pin file that yields nothing is a pin with no subject.
+printf '\nthis repo\n'
+declared=$(sed -n 's/^[[:space:]]*build_commit[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
+           scripts/llama_pin.toml 2>/dev/null | head -1)
+if [ -z "$declared" ]; then
+    printf 'FAIL  scripts/llama_pin.toml declares no build_commit\n'
+    rc=1
+elif [ "$declared" = "UNPINNED" ]; then
+    printf 'REPORT build_commit = UNPINNED — the honest bootstrap state. A ratio\n'
+    printf '       measured now is EXISTENCE-ONLY and may not arm a threshold.\n'
+else
+    printf 'ok    build_commit = %s\n' "$declared"
+fi
+
+printf '\n'
+if [ "$rc" -eq 0 ]; then
+    printf 'PASS  the pin discriminates: right build, wrong build, broken binary,\n'
+    printf '      directory, absent path, and the unpinned bootstrap.\n'
+else
+    printf 'FAIL  see rows above (#2676).\n'
+fi
+exit "$rc"

--- a/scripts/check_no_timing_in_required.sh
+++ b/scripts/check_no_timing_in_required.sh
@@ -89,6 +89,8 @@ printf '\nPART 2 — every bench/timing guard is classified\n'
 META_GUARDS="
 check_no_timing_in_required.sh
 check_no_fabricated_baselines.sh
+check_bench_threshold.sh
+check_llama_pin.sh
 "
 
 unclassified=""
@@ -102,8 +104,19 @@ while IFS= read -r f; do
     registry_flat=" $(printf '%s' "$RELEASE_TIME_ONLY" | tr '\n' ' ') "
     case "$registry_flat" in *" $base "*) continue ;; esac
     unclassified="$unclassified $base"
-done < <(git ls-files 'scripts/check_*bench*.sh' 'scripts/check_*timing*.sh' \
-                     'scripts/check_*throughput*.sh' 'scripts/check_*perf*.sh' 2>/dev/null)
+done < <(
+    # TRACKED *and* UNTRACKED. A `git ls-files`-only universe lets a brand-new
+    # guard pass until the moment it is committed — which is exactly how
+    # check_bench_threshold.sh slipped through its own PR (it was green when
+    # run pre-`git add`, and failed the instant it became tracked). Same shape
+    # as SHIM-2644-03, where an UNTRACKED copy of the runner passed a
+    # `git ls-files` check whose whole purpose was catching a second copy.
+    { git ls-files 'scripts/check_*bench*.sh' 'scripts/check_*timing*.sh' \
+                   'scripts/check_*throughput*.sh' 'scripts/check_*perf*.sh' 2>/dev/null
+      find scripts -maxdepth 1 -type f \
+           \( -name 'check_*bench*.sh' -o -name 'check_*timing*.sh' \
+              -o -name 'check_*throughput*.sh' -o -name 'check_*perf*.sh' \) 2>/dev/null
+    } | sort -u)
 
 if [ -n "$unclassified" ]; then
     printf 'FAIL  bench/timing guard(s) not in the registry:%s\n' "$unclassified"

--- a/scripts/llama_bin.sh
+++ b/scripts/llama_bin.sh
@@ -1,0 +1,131 @@
+# llama_bin.sh — resolve the llama.cpp comparator and PROVE which build it is.
+#
+# Sourceable:  . scripts/llama_bin.sh   -> sets $LLAMA_BENCH, $LLAMA_BUILD, $LLAMA_PIN_RC
+# Executable:  bash scripts/llama_bin.sh -> prints the resolution, exits non-zero if unpinned
+#
+# WHY THIS EXISTS. scripts/verifier_pin.sh:36 already lists the unpinned
+# llama.cpp comparator as instance FIVE of the unpinned-verifier table —
+# cited for months, never enforced. This is that entry becoming a mechanism.
+#
+# An unpinned comparator makes every ratio meaningless ACROSS TIME: the
+# denominator moves silently between releases while the receipt claims a fixed
+# baseline. A ratio is only a measurement if BOTH sides are identified.
+#
+# THREE PROPERTIES, each from a scar in this repo:
+#
+#   1. NEVER PATH. `command -v llama-bench` asks the machine what it happens to
+#      have. Four `apr` binaries once coexisted here and a bare `apr` resolved
+#      to a 26-day-old copy. An explicit path or nothing.
+#
+#   2. BEHAVIOUR, NOT EXISTENCE. `[ -x "$p" ]` accepts a broken stub and even a
+#      DIRECTORY (VPIN-2). The binary must RUN and report a build.
+#
+#   3. BUILD, NOT VERSION. #2384 is precisely the case where two binaries print
+#      the same version string and differ by commit. `build_commit` and
+#      `reported_version` are recorded SEPARATELY and the pin compares the
+#      build.
+#
+# OPTION-NEUTRAL BY CONSTRUCTION: this file is SOURCED and sets no shell
+# options. `set -euo pipefail` in a sourced file mutates the CALLER's shell —
+# that leak once killed the nightly six lines in. Failure is signalled by
+# RETURN STATUS only (CLAUDE.md; scripts/check_sourced_libs_option_neutral.sh).
+
+# Read one key from the pin declaration. Deliberately a narrow hand parser
+# rather than a TOML library: the runner host is Python 3.10.12 and `tomllib`
+# is 3.11+, which already broke a release gate once (#2635).
+llama_pin_get() {
+    llama_pin_key="${1:-}"
+    llama_pin_file="${2:-scripts/llama_pin.toml}"
+    [ -n "$llama_pin_key" ] || return 2
+    [ -f "$llama_pin_file" ] || return 2
+    sed -n "s/^[[:space:]]*${llama_pin_key}[[:space:]]*=[[:space:]]*\"\\(.*\\)\"[[:space:]]*$/\\1/p" \
+        "$llama_pin_file" | head -1
+}
+
+# Resolve and verify. Returns:
+#   0 = pinned, running, and reporting the declared build
+#   1 = a binary was named but it is NOT the declared build (or cannot run)
+#   2 = no pin declared yet (build_commit = UNPINNED) — REPORT, never gate
+#   3 = the declaration is missing or unreadable
+llama_bin_resolve() {
+    LLAMA_BENCH=""
+    LLAMA_BUILD=""
+    LLAMA_PIN_RC=3
+    export LLAMA_BENCH LLAMA_BUILD
+
+    llama_bin_root=$(git rev-parse --show-toplevel 2>/dev/null) || llama_bin_root=""
+    [ -n "$llama_bin_root" ] || llama_bin_root=$PWD
+    llama_bin_decl="$llama_bin_root/scripts/llama_pin.toml"
+    [ -f "$llama_bin_decl" ] || { LLAMA_PIN_RC=3; return 3; }
+
+    llama_bin_want=$(llama_pin_get build_commit "$llama_bin_decl")
+    if [ -z "$llama_bin_want" ]; then
+        LLAMA_PIN_RC=3
+        return 3
+    fi
+
+    # NEVER PATH. $LLAMA_BENCH_PATH is the only input, and it is still
+    # verified below — it cannot smuggle an unverified binary past the pin.
+    llama_bin_candidate="${LLAMA_BENCH_PATH:-}"
+    if [ -z "$llama_bin_candidate" ]; then
+        # No candidate named. If the repo has not pinned yet, that is the
+        # honest bootstrap state; otherwise it is a missing comparator.
+        if [ "$llama_bin_want" = "UNPINNED" ]; then
+            LLAMA_PIN_RC=2
+            return 2
+        fi
+        LLAMA_PIN_RC=1
+        return 1
+    fi
+
+    # BEHAVIOUR, not existence: it must run and say something.
+    if [ ! -f "$llama_bin_candidate" ]; then
+        LLAMA_PIN_RC=1
+        return 1
+    fi
+    llama_bin_out=$("$llama_bin_candidate" --version 2>&1) || llama_bin_out=""
+    if [ -z "$llama_bin_out" ]; then
+        LLAMA_PIN_RC=1
+        return 1
+    fi
+    LLAMA_BENCH="$llama_bin_candidate"
+    LLAMA_BUILD=$(printf '%s\n' "$llama_bin_out" | head -1)
+    export LLAMA_BENCH LLAMA_BUILD
+
+    if [ "$llama_bin_want" = "UNPINNED" ]; then
+        # A binary exists and runs, but nothing declares which one is correct.
+        # REPORT: usable for an existence-only row, never for a threshold.
+        LLAMA_PIN_RC=2
+        return 2
+    fi
+
+    case "$LLAMA_BUILD" in
+        *"$llama_bin_want"*)
+            LLAMA_PIN_RC=0
+            return 0
+            ;;
+        *)
+            LLAMA_PIN_RC=1
+            return 1
+            ;;
+    esac
+}
+
+# Executed rather than sourced: report and set an exit code.
+if [ "${0##*/}" = "llama_bin.sh" ]; then
+    llama_bin_resolve
+    llama_bin_rc=$?
+    case "$llama_bin_rc" in
+        0) printf 'ok    llama.cpp pinned: %s\n      build: %s\n' \
+               "$LLAMA_BENCH" "$LLAMA_BUILD" ;;
+        1) printf 'FAIL  llama.cpp named but NOT the declared build.\n' >&2
+           printf '      declared: %s\n      reported: %s\n' \
+               "$(llama_pin_get build_commit)" "${LLAMA_BUILD:-<no output>}" >&2 ;;
+        2) printf 'REPORT llama.cpp is not pinned yet (build_commit = UNPINNED).\n'
+           printf '       A ratio measured now is EXISTENCE-ONLY and may not arm a\n'
+           printf '       threshold. Set build_commit in scripts/llama_pin.toml in\n'
+           printf '       the commit that first measures a ratio.\n' ;;
+        3) printf 'FAIL  scripts/llama_pin.toml missing or unreadable.\n' >&2 ;;
+    esac
+    exit "$llama_bin_rc"
+fi

--- a/scripts/llama_pin.toml
+++ b/scripts/llama_pin.toml
@@ -1,0 +1,37 @@
+# THE PINNED llama.cpp COMPARATOR (PARITY-009, aprender#2676).
+#
+# An unpinned comparator makes every ratio meaningless ACROSS TIME: the
+# denominator changes silently between releases while the receipt claims a
+# fixed baseline. This file is the declaration; scripts/llama_bin.sh is the
+# resolver that refuses anything else.
+#
+# WHY A FILE AND NOT A CONSTANT IN THE SCRIPT. The comparator version is a
+# RELEASE-ENGINEERING decision with a date and a rationale, not an
+# implementation detail. Changing it must be a reviewable diff that a future
+# reader can bisect, and the receipt records what this file said at the time.
+#
+# BUMPING THIS IS A DELIBERATE ACT. Every ratio measured against the old pin
+# becomes incomparable with every ratio measured against the new one. Record
+# WHY in the commit, and expect the first release after a bump to have no
+# usable trend.
+
+[comparator]
+name = "llama.cpp"
+# The upstream build tag llama.cpp reports in its own --version output.
+# Recorded as the STRING the binary prints, not as a semver we invent.
+build_commit = "UNPINNED"
+# Verbatim configure line. gx10 requires -DGGML_CUDA_ARCHITECTURES=121;
+# omitting it JITs from stale PTX, which produces CORRECT OUTPUT SLOWLY and
+# fires no correctness gate — a performance defect invisible to every check we
+# have. Recorded per host because the flags legitimately differ.
+build_flags_lambda = "cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=89"
+build_flags_gx10   = "cmake -B build -DGGML_CUDA=ON -DGGML_CUDA_ARCHITECTURES=121"
+build_flags_intel  = "cmake -B build -DGGML_NATIVE=ON"
+build_flags_mini   = "cmake -B build -DGGML_METAL=ON"
+
+# BOOTSTRAP. `build_commit = "UNPINNED"` is the honest state today: no ratio
+# has been measured yet, so there is nothing to invalidate by choosing a pin
+# later. The resolver treats UNPINNED as "report, never gate" — it will not
+# silently accept whatever llama.cpp happens to be installed and call it
+# pinned. Set this to the real build tag in the commit that first measures a
+# ratio, and that commit is the start of the comparable series.

--- a/scripts/verifier_pin.sh
+++ b/scripts/verifier_pin.sh
@@ -34,6 +34,8 @@
 #   4  aprender#2384                         MCP spawned a bare `apr`, ran
 #      0.60.0 while reporting 0.63.0
 #   5  APR-BENCH-RFC-001                     unpinned llama.cpp comparator
+#      ENFORCED 2026-08-24 by scripts/llama_bin.sh + scripts/check_llama_pin.sh
+#      (PARITY-009, aprender#2676). Declaration in scripts/llama_pin.toml.
 #
 # Five rediscoveries is the evidence that a rule merely STATED is documentation.
 # It is therefore also ENFORCED, by scripts/check_verifier_pinning.sh, which


### PR DESCRIPTION
Closes **#2676**, and the open half of **#2647**. Part of **#2667**. Stacked on #2684.

`scripts/verifier_pin.sh:36` has listed the unpinned llama.cpp comparator as **instance five** of the unpinned-verifier table for months — cited, never enforced. This makes it the **fourth token of the pinning system that already exists**, not a new one.

An unpinned comparator makes every ratio meaningless *across time*: the denominator moves silently between releases while the receipt claims a fixed baseline.

## Three properties, each from a scar

| property | why |
|---|---|
| **Never PATH** | Four `apr` binaries once coexisted here; a bare `apr` resolved to a 26-day-old copy. `$LLAMA_BENCH_PATH` or nothing — and it's still verified, so it can't smuggle anything past the pin. |
| **Behaviour, not existence** | `[ -x "$p" ]` accepts a broken stub **and a directory** (VPIN-2). The binary must run and report a build. |
| **Build, not version** | #2384 is exactly the case where two binaries print the same version and differ by commit. Recorded separately. |

`scripts/llama_pin.toml` is deliberately a **file, not a constant**: the comparator version is a release-engineering decision with a date and rationale, it must be a bisectable diff, and bumping it invalidates every prior ratio — that should look like a commit.

`build_commit = "UNPINNED"` is the **honest bootstrap**: no ratio has been measured yet, so nothing is invalidated by pinning later, and the resolver returns **rc=2 REPORT** rather than accepting whatever llama.cpp is installed and calling it pinned. `build_flags` are per-host and verbatim — gx10 needs `-DGGML_CUDA_ARCHITECTURES=121`, and omitting it JITs from stale PTX: **correct output, slowly, firing no correctness gate.**

## Case table — 8 states, all discriminating

pinned-and-correct **0** · wrong build **1** · cannot run **1** · **a directory 1** · absent path **1** · unpinned+binary **2** · unpinned+none **2** · pinned+no binary **1**

Option-neutral verified by execution (`set -o` / `shopt -p` diff empty).

## Two defects this found, both mine

1. The positive case reported rc=1 — *"the pin cannot recognise a correct binary"*. The bug was in the **test**: `VAR=x . script` applies only to the `source`, and is gone by the time the function runs. Exported, reason at the call site.
2. `check_no_timing_in_required.sh` PART 2 went RED on `check_bench_threshold.sh` — **which passed in PARITY-008 only because it wasn't yet tracked.** PART 2's universe was `git ls-files` — **SHIM-2644-03's shape exactly**, where an untracked copy passed a check whose whole purpose was catching a second copy. Universe now unions `git ls-files` with a working-tree `find`, and **the mutation was re-run in the widened scope** (untracked unclassified guard → RED; removed → GREEN). Per #2360, the old proof does not transfer.

All five guards green. bashrs 0 SEC/DET/IDEM.

Refs #2667 · #2676 · #2647 · #2384 · #2360

🤖 Generated with [Claude Code](https://claude.com/claude-code)