### PR TITLE
feat(bench): the CPU-class bench block on the four-host receipts — apr-vs-apr, no comparator (PARITY-003)

### DIFF
--- a/scripts/bench_host_receipt.sh
+++ b/scripts/bench_host_receipt.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# bench_host_receipt.sh — add the CPU-class bench block to this host's receipt
+# (PARITY-003, aprender#2670).
+#
+# RUN THIS ON THE HOST, AFTER `cargo install aprender`, in the same sitting as
+# install_rc. It measures the PUBLISHED artifact, which is the only thing a
+# post-publish receipt may speak about.
+#
+# CPU-class, apr-vs-apr, NO COMPARATOR. `cargo install aprender` builds CPU-only
+# on every host in the matrix while llama.cpp runs CUDA or Metal, so a ratio
+# here is uncomputable rather than merely unwise: it reads ~0.05-0.10 and the
+# threshold never arms. The comparator ratio lives pre-publish (#2677).
+#
+# NEVER PATH for the binary under test: a bare `apr` on the release host
+# resolved to a 49-day-old 0.60.0 during the 0.64.0 sweep, shadowing a fresh
+# install, because ~/.local/bin precedes ~/.cargo/bin. $APR_UNDER_TEST or the
+# cargo root, and the receipt records which.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+HOST="${1:-}"
+MODEL="${2:-}"
+if [ -z "$HOST" ] || [ -z "$MODEL" ]; then
+    printf 'usage: bench_host_receipt.sh <host> <model-path>\n' >&2
+    printf '  host  one of the names in check_multiplatform_dogfood.sh HOSTS\n' >&2
+    exit 2
+fi
+
+VERSION=$(awk -F'"' '/^version *=/{print $2; exit}' Cargo.toml)
+RECEIPT="evidence/dogfood/$VERSION/$HOST.json"
+[ -f "$RECEIPT" ] || { printf 'FAIL  no receipt at %s — run the install sweep first\n' "$RECEIPT" >&2; exit 1; }
+[ -f "$MODEL" ]   || { printf 'FAIL  no model at %s\n' "$MODEL" >&2; exit 1; }
+
+APR="${APR_UNDER_TEST:-}"
+if [ -z "$APR" ]; then
+    APR="$(cargo install --list 2>/dev/null >/dev/null; printf '%s' "${CARGO_HOME:-$HOME/.cargo}/bin/apr")"
+fi
+[ -x "$APR" ] || { printf 'FAIL  no installed apr at %s\n' "$APR" >&2; exit 1; }
+
+printf 'measuring %s on %s with %s\n' "$("$APR" --version 2>&1 | head -1)" "$HOST" "$MODEL"
+
+tmp=$(mktemp) || exit 2
+trap 'rm -f "${tmp:?}"' EXIT
+if ! "$APR" bench "$MODEL" --json > "$tmp" 2>/dev/null; then
+    printf 'FAIL  apr bench exited non-zero; NOT writing a bench block.\n' >&2
+    printf '      A receipt that records a failed measurement as a measurement is\n' >&2
+    printf '      the fabricated-measurement shape (F12).\n' >&2
+    exit 1
+fi
+
+# The bench JSON must validate BEFORE it is written into the receipt. A block
+# that could not stand alone must not be laundered by nesting.
+if ! python3 scripts/lib/bench_receipt.py "$tmp" >/dev/null 2>&1; then
+    printf 'FAIL  apr bench output does not validate:\n' >&2
+    python3 scripts/lib/bench_receipt.py "$tmp" 2>&1 | sed 's/^/      /' >&2
+    exit 1
+fi
+
+RECEIPT="$RECEIPT" BENCH="$tmp" python3 - <<'PY'
+import json, os
+receipt_path = os.environ["RECEIPT"]
+with open(receipt_path, encoding="utf-8") as h:
+    receipt = json.load(h)
+with open(os.environ["BENCH"], encoding="utf-8") as h:
+    receipt["bench"] = json.load(h)
+with open(receipt_path, "w", encoding="utf-8") as h:
+    json.dump(receipt, h, indent=2)
+    h.write("\n")
+print("  wrote bench block into %s" % receipt_path)
+PY
+
+python3 scripts/lib/bench_receipt.py --bench "$RECEIPT" >/dev/null 2>&1 || {
+    printf 'FAIL  the written receipt does not validate\n' >&2; exit 1; }
+printf 'ok    bench block written and validated\n'

--- a/scripts/check_multiplatform_dogfood.sh
+++ b/scripts/check_multiplatform_dogfood.sh
@@ -37,6 +37,9 @@ HOSTS="lambda intel gx10 mini"
 
 VERSION="$(awk -F'"' '/^version *=/{print $2; exit}' Cargo.toml)"
 DIR="evidence/dogfood/$VERSION"
+# ONE validator, shared with scripts/check_bench_receipt.sh. Two readers of one
+# schema is the divergence class #2640 exists to close.
+REPO_BENCH_VALIDATOR="scripts/lib/bench_receipt.py"
 rc=0
 
 printf -- '--- multi-platform dogfood receipts for %s -------------------------\n' "$VERSION"
@@ -116,6 +119,35 @@ for h in $HOSTS; do
         rc=1
     else
         printf 'ok    %-7s %s verified %s (install rc=0)\n' "$h" "$VERSION" "${when:-undated}"
+    fi
+
+    # ── the bench block (PARITY-003, aprender#2670) ────────────────────────
+    #
+    # CPU-CLASS, apr-vs-apr, NO COMPARATOR — and that is a decision, not an
+    # omission. `cargo install aprender` builds CPU-only on every host in this
+    # matrix (crates/apr-cli/Cargo.toml `default` carries no cuda, no wgpu),
+    # while llama.cpp runs CUDA on lambda/gx10 and Metal on mini. A ratio here
+    # would read ~0.05-0.10, nobody would red a release over it (correctly),
+    # the row would go EXISTENCE-ONLY and the threshold would never arm — the
+    # exact shape this gate itself had before #2658. The tree already documents
+    # that collapse at crates/apr-cli/src/dispatch.rs:165.
+    #
+    # An apr-vs-apr self-ratchet catches OUR regressions, which is the goal,
+    # without inventing a number nobody will act on. The comparator ratio lives
+    # in the pre-publish phase where --features cuda exists (#2677).
+    #
+    # ABSENT is not FAIL yet: the block arrives with the first release cut
+    # after this lands, and a gate that fails for a version that predates it is
+    # a gate nobody can satisfy. It is REPORTed so the absence is visible.
+    if ! python3 "$REPO_BENCH_VALIDATOR" --has-bench "$f" >/dev/null 2>&1; then
+        printf 'REPORT %-6s no bench block yet — arrives with the first cut after #2670\n' "$h"
+    elif python3 "$REPO_BENCH_VALIDATOR" --bench "$f" >/dev/null 2>&1; then
+        bmed=$(python3 "$REPO_BENCH_VALIDATOR" --bench-median "$f" 2>/dev/null)
+        printf 'ok    %-7s bench: median %s ms, CPU-class self-ratchet\n' "$h" "${bmed:-?}"
+    else
+        printf 'FAIL  %-7s bench block present but INVALID:\n' "$h"
+        python3 "$REPO_BENCH_VALIDATOR" --bench "$f" 2>&1 | sed 's/^/          /'
+        rc=1
     fi
 done
 

--- a/scripts/lib/bench_receipt.py
+++ b/scripts/lib/bench_receipt.py
@@ -25,6 +25,7 @@ Usage:  bench_receipt.py <receipt.json> [...]
 Exit:   0 all valid - 1 a receipt is invalid - 2 usage/read error
 """
 import json
+import statistics
 import sys
 
 COMPUTE_CLASSES = ("cpu", "cuda", "metal", "wgpu", "unknown")
@@ -133,6 +134,16 @@ def validate(receipt):
     return errors
 
 
+def _bench_of(receipt):
+    """The bench block, or None. A HOST receipt nests it under `bench`; a bare
+    bench receipt IS the block."""
+    if isinstance(receipt.get("bench"), dict):
+        return receipt["bench"]
+    if "samples_ms" in receipt:
+        return receipt
+    return None
+
+
 def _validate_one(path):
     """Validate a single receipt file. Returns (rc, lines_to_print)."""
     try:
@@ -146,9 +157,60 @@ def _validate_one(path):
     return 0, ["ok   %s" % path]
 
 
+def _load(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _mode_has_bench(path):
+    """Exit 0 iff a bench block is PRESENT. Says nothing about validity."""
+    try:
+        return 0 if _bench_of(_load(path)) is not None else 1
+    except (OSError, ValueError):
+        return 2
+
+
+def _mode_bench(path):
+    """Validate the bench block of a host receipt."""
+    try:
+        bench = _bench_of(_load(path))
+    except (OSError, ValueError) as exc:
+        sys.stderr.write("%s: cannot read: %s\n" % (path, exc))
+        return 2
+    if bench is None:
+        sys.stderr.write("%s: no bench block\n" % path)
+        return 1
+    errors = validate(bench)
+    for e in errors:
+        print("FAIL %s: %s" % (path, e))
+    return 1 if errors else 0
+
+
+def _mode_bench_median(path):
+    """Print the median of the bench block's raw samples."""
+    try:
+        bench = _bench_of(_load(path))
+    except (OSError, ValueError):
+        return 2
+    if not bench or not bench.get("samples_ms"):
+        return 1
+    print(round(statistics.median(bench["samples_ms"]), 3))
+    return 0
+
+
+MODES = {
+    "--has-bench": _mode_has_bench,
+    "--bench": _mode_bench,
+    "--bench-median": _mode_bench_median,
+}
+
+
 def main(argv):
+    if len(argv) >= 3 and argv[1] in MODES:
+        return MODES[argv[1]](argv[2])
     if len(argv) < 2:
-        sys.stderr.write("usage: bench_receipt.py <receipt.json> [...]\n")
+        sys.stderr.write("usage: bench_receipt.py [--bench|--has-bench|"
+                         "--bench-median] <receipt.json> [...]\n")
         return 2
     rc = 0
     for path in argv[1:]:


### PR DESCRIPTION
Closes **#2670**. Part of **#2667**. Stacked on #2687. The **post-publish half** of the parity work.

## CPU-class, apr-vs-apr, no comparator — a decision, not an omission

`cargo install aprender` builds **CPU-only** on every host in the matrix while llama.cpp runs CUDA on lambda/gx10 and Metal on mini. A ratio here is **uncomputable**, not merely unwise: it reads ~0.05–0.10, nobody would red a release over it (correctly), the row goes EXISTENCE-ONLY and **the threshold never arms**.

That is the shape *this very gate* had before #2658 — it had never passed for any release. The tree already documents the collapse at `dispatch.rs:165`.

An **apr-vs-apr self-ratchet** catches our own regressions — the actual goal — without inventing a number nobody will act on. The comparator ratio lives pre-publish, where `--features cuda` exists (#2677).

**Absent is REPORT, not FAIL.** The block arrives with the first cut after this lands; a gate that fails for a version predating it is a gate nobody can satisfy, and that's how a row becomes a step everyone walks past.

## One validator

`bench_receipt.py` gains `--has-bench` / `--bench` / `--bench-median` rather than the multiplatform gate growing **a second reader of the same schema**. Two readers of one schema is the divergence class #2640 exists to close — and I hit that exact shape earlier this week (CI-3/VP-05, where the runner and its guard each parsed `[package.metadata.dogfood]` differently).

## The producer refuses to fabricate

It won't write a block it can't validate, and won't write one **at all** if `apr bench` exited non-zero — recording a failed measurement as a measurement is precisely F12. It never PATH-resolves the binary under test: a bare `apr` on the release host resolved to a **49-day-old 0.60.0** during the 0.64.0 sweep, shadowing a fresh install.

## Mutation matrix — 8 cases, all as declared

| case | result |
|---|---|
| constant samples (F12) | **RED** |
| no `compute_class` | **RED** |
| `compute_class: cuda` on a cpu build | **RED** |
| empty samples (vacuous) | **RED** |
| cross-class carrying a threshold | **RED** |
| `n` disagreeing with sample count | **RED** |
| all four blocks valid | GREEN *(discrimination)* |
| one block absent | GREEN *(REPORT, not FAIL)* |

The four 0.64.0 receipts are restored byte-identical after the sweep. bashrs 0 SEC/DET/IDEM.

Refs #2667 · #2670 · #2658 · #2640

🤖 Generated with [Claude Code](https://claude.com/claude-code)