### PR TITLE
fix(ci): the nightly bench lane now MEASURES, and can fail (PARITY-006)

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -1,21 +1,95 @@
-# Nightly Benchmarks — criterion performance tracking
-# Calls sovereign-ci.yml with run_benchmarks: true
+# Nightly Bench — a lane that MEASURES, and that CAN FAIL.
+#
+# WHAT THIS REPLACED, and why it had to be replaced rather than tuned. The old
+# file delegated to paiml/.github sovereign-ci.yml with `run_benchmarks: true`,
+# which was a TRIPLE no-op for this repo (aprender#2673):
+#
+#   1. The probe found nothing. That job gates on `ls benches/*.rs`, and
+#      aprender has NO root benches/ — all 120 bench .rs files live under
+#      crates/*/benches/. The else branch printed "No benches/ directory —
+#      skipping".
+#   2. The job could not fail: `continue-on-error: true` on the whole thing.
+#   3. Nothing compared two runs. Output went to a 90-day bench-results.txt
+#      artifact and was never read back.
+#
+# Net: 120 bench targets, never executed by aprender CI, behind a green tick.
+#
+# WHY NOT JUST FIX THE PROBE. The probe lives in an upstream reusable workflow;
+# changing it is a cross-repo edit, and it would still leave (2) and (3). This
+# lane is repo-local, small, and fails.
+#
+# SCOPE IS DELIBERATELY SMALL. The fleet is 150 W power-capped and intel hosts
+# 16 CI runners; two concurrent workspace-tests starved the box on 2026-08-23.
+# Running 120 criterion targets nightly would be muda and would evict the merge
+# queue. This runs the measurements that a release actually reads, and SAYS
+# what it did not run rather than implying coverage it does not have.
 name: Nightly Bench
 
 on:
   schedule:
-    - cron: "30 5 * * *"  # 05:30 UTC (after nightly builds at 04:00)
+    - cron: "30 5 * * *"  # 05:30 UTC, after the nightly builds at 04:00
   workflow_dispatch:
 
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  bench:
-    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
-    with:
-      repo: ${{ github.event.repository.name }}
-      run_benchmarks: true
-    secrets: inherit
+permissions:
+  contents: read
 
+jobs:
+  measure:
+    runs-on: [self-hosted, X64, Linux, clean-room]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      # The receipt validator's own case table must discriminate before any
+      # number it blesses means anything.
+      - name: Bench receipt validator discriminates
+        run: bash scripts/check_bench_receipt.sh
+
+      # The threshold derivation, re-falsified on every run so the correction
+      # to BENCH-003 cannot rot back (#2675).
+      - name: Bench threshold derivation holds
+        run: bash scripts/check_bench_threshold.sh
+
+      # The comparator pin's case table. The gate exits 0 when the pin
+      # DISCRIMINATES; the repo's own UNPINNED bootstrap state is REPORTed
+      # inside it, not signalled by an exit code.
+      #
+      # A first version of this step branched on `rc == 2` to treat UNPINNED as
+      # a notice — DEAD CODE, because that value comes from llama_bin.sh's
+      # resolver, never from this checker. Found by running the step instead of
+      # reasoning about it: it printed "pinned" on a tree whose declaration
+      # says UNPINNED.
+      - name: llama.cpp comparator pin discriminates
+        run: bash scripts/check_llama_pin.sh
+
+      # The measurement itself. `--ignored` because a wall-clock assertion in a
+      # normally-running test is the class that has failed eleven times here;
+      # this lane runs it explicitly and prints numbers for a human.
+      - name: Q4_K GEMV parallel-vs-serial (#2567)
+        run: |
+          set -o pipefail
+          cargo test -p aprender-compute --lib issue_2567_measure --release \
+            -- --ignored --nocapture 2>&1 | tee /tmp/bench.log
+          grep -q '^speedup' /tmp/bench.log || {
+            echo "::error::the measurement produced no speedup line — silence is red"
+            exit 1
+          }
+
+      # SAY WHAT WAS NOT RUN. A lane that implies coverage it does not have is
+      # the shape this whole epic exists to remove.
+      - name: Declare the coverage this lane does NOT have
+        run: |
+          cat <<'EOS'
+          NOT measured by this lane, stated rather than implied:
+            · the other criterion targets under crates/*/benches (120 files).
+              Running them nightly on a 150 W-capped, 16-runner box would evict
+              the merge queue; see aprender#2673.
+            · any apr-vs-llama.cpp ratio. That is pre-publish and needs
+              --features cuda from the tree (aprender#2677).
+            · aarch64 and macOS. This runner is x86_64 Linux; the four-host
+              numbers come from the post-publish receipts (aprender#2670).
+          EOS

--- a/crates/aprender-compute/src/backends/q4k/gemv/mod.rs
+++ b/crates/aprender-compute/src/backends/q4k/gemv/mod.rs
@@ -200,7 +200,41 @@ fn matmul_q4k_f32_parallel(
     output
 }
 
-/// Fallback for non-x86_64
+/// Q4_K GEMV on non-x86_64: SCALAR PER ROW, BUT ACTUALLY PARALLEL (#2567).
+///
+/// This function was named `..._parallel` and called `scalar::matmul_q4k_f32`
+/// — the serial routine — directly. On every ARM machine the hottest kernel in
+/// quantized inference therefore ran single-threaded, silently, and no gate
+/// could see it: the numbers are correct and only the speed is wrong.
+///
+/// The fix is not new SIMD. The parallel structure above has NOTHING
+/// x86-specific in it — chunking rows across threads is architecture-neutral,
+/// and the x86 path already falls back to `scalar::compute_chunk_q4k_scalar`
+/// per chunk when neither AVX-512 nor AVX2 is present. That is exactly the
+/// shape needed here, so aarch64 gets N-core parallelism over the same scalar
+/// inner kernel it was already using, with no new unsafe code and no change to
+/// the arithmetic.
+///
+/// A NEON inner kernel remains open (#2567 also covers the SIMD half). This
+/// closes the half that is a plain structural omission rather than missing
+/// intrinsics — and it is the half the function's own NAME already promised.
+///
+/// MEASURED ON gx10 (GB10, aarch64, 20 cores), 8960x1536, release, 10 warmups:
+///
+///   serial   median 2.17 ms   (2.166 - 2.181, 0.7% spread)
+///   parallel median 1.79 ms   (1.757 - 1.811, 3% spread)
+///   speedup  1.21x
+///
+/// 1.21x from up to 12 threads is modest, and the reason is in this file
+/// already: thread::scope spawns threads on EVERY CALL, and the x86 threshold
+/// comment above puts that overhead at ~40us. Twelve spawns is ~0.48 ms, about
+/// 27% of the 1.79 ms parallel time. It is not DRAM bandwidth — 7.4 MiB in
+/// 1.79 ms is 4.3 GB/s, far below what GB10 unified memory sustains.
+///
+/// So a thread POOL would recover most of the remaining headroom, and the NEON
+/// kernel would cut the per-byte work the threads are dividing. Both are
+/// larger changes; this one is the structural defect, fixed, with the number
+/// stated rather than rounded up.
 #[cfg(not(target_arch = "x86_64"))]
 fn matmul_q4k_f32_parallel(
     q4k_data: &[u8],
@@ -208,5 +242,278 @@ fn matmul_q4k_f32_parallel(
     out_dim: usize,
     in_dim: usize,
 ) -> Vec<f32> {
-    scalar::matmul_q4k_f32(q4k_data, input, out_dim, in_dim)
+    use std::thread;
+
+    // Same policy as the x86 path: fewer threads with larger chunks, for cache
+    // efficiency rather than raw thread count.
+    let num_threads = thread::available_parallelism().map(|p| p.get()).unwrap_or(4).min(12);
+
+    // One thread is not parallel; fall through rather than pay scope overhead.
+    if num_threads <= 1 || out_dim == 0 {
+        return scalar::matmul_q4k_f32(q4k_data, input, out_dim, in_dim);
+    }
+
+    let chunk_size = out_dim.div_ceil(num_threads);
+    let num_blocks_per_row = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+    let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
+
+    let mut output: Vec<f32> = Vec::with_capacity(out_dim);
+    // SAFETY: every chunk's compute_chunk_q4k_scalar writes every element in
+    // its chunk before any read, exactly as the x86_64 path above relies on.
+    unsafe {
+        output.set_len(out_dim);
+    }
+
+    thread::scope(|s| {
+        let input_ref = input;
+        let q4k_ref = q4k_data;
+        for (chunk_idx, chunk) in output.chunks_mut(chunk_size).enumerate() {
+            let start_row = chunk_idx * chunk_size;
+            s.spawn(move || {
+                scalar::compute_chunk_q4k_scalar(
+                    q4k_ref,
+                    input_ref,
+                    chunk,
+                    start_row,
+                    out_dim,
+                    in_dim,
+                    num_blocks_per_row,
+                    row_bytes,
+                );
+            });
+        }
+    });
+
+    output
+}
+
+// ── #2567: the aarch64 "parallel" path is parallel, and still exact ────────
+#[cfg(test)]
+mod issue_2567_aarch64_parallel_tests {
+    use super::*;
+
+    /// Build a Q4_K buffer of the right size. The CONTENTS do not need to be
+    /// meaningful for this test: both paths dequantise the same bytes with the
+    /// same routine, so any deterministic filling exercises the property under
+    /// test — that CHUNKING ACROSS THREADS changes nothing.
+    fn q4k_buffer(out_dim: usize, in_dim: usize) -> Vec<u8> {
+        let blocks = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+        let n = out_dim * blocks * SUPER_BLOCK_BYTES;
+        // Bytes are kept <= 0x3F so that any f16 scale field built from
+        // them has a small exponent and decodes FINITE. Unconstrained bytes
+        // produce NaN scales, which trips the AVX-512 path's own dequant
+        // postcondition (`result.iter().all(|v| v.is_finite())`) — a fixture
+        // defect that reads as a kernel failure.
+        (0..n).map(|i| ((i * 31 + 7) % 0x40) as u8).collect()
+    }
+
+    fn input_vec(in_dim: usize) -> Vec<f32> {
+        (0..in_dim).map(|i| ((i % 17) as f32 - 8.0) * 0.125).collect()
+    }
+
+    /// THE CORRECTNESS PROPERTY, tested on EVERY architecture: the CHUNK
+    /// BOUNDARY is invisible.
+    ///
+    /// Each output row is an independent dot product, so splitting rows across
+    /// threads must give bit-identical results however the split falls. This
+    /// is the only thing the aarch64 change actually claims, and it is about
+    /// chunking rather than about NEON — so it runs here on x86 too.
+    ///
+    /// TWO WRONG ORACLES CAME FIRST, and both are worth recording because each
+    /// looked like a bug in the new code:
+    ///
+    ///   1. Comparing `matmul_q4k_f32_parallel` against `scalar::matmul_q4k_f32`
+    ///      failed on x86 with `-15746.977 != -15746.998`. On x86 that function
+    ///      IS the AVX path; ~1e-6 is FMA reassociation, not a chunking fault.
+    ///
+    ///   2. Comparing chunked `compute_chunk_q4k_scalar` against
+    ///      `scalar::matmul_q4k_f32` failed EVEN AT ONE CHUNK, with
+    ///      `-15746.977 != -15746.947`. The two scalar routines are not each
+    ///      other's oracle: `matmul_q4k_f32` accumulates into a 4-wide array
+    ///      (`acc = [0.0f32; 4]`) while `compute_chunk_q4k_scalar` uses a
+    ///      single running `sum`. Different summation order, ~2e-6, and it
+    ///      predates this change — the x86 parallel path has always had it in
+    ///      its own scalar fallback.
+    ///
+    /// So the assertion is chunk-invariance of ONE kernel against ITSELF.
+    #[test]
+    fn the_chunk_boundary_is_invisible() {
+        for (out_dim, in_dim) in [(1, 256), (7, 256), (16, 512), (33, 256), (64, 256)] {
+            let data = q4k_buffer(out_dim, in_dim);
+            let input = input_vec(in_dim);
+            let num_blocks_per_row = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+            let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
+
+            let run = |threads: usize| -> Vec<f32> {
+                let chunk_size = out_dim.div_ceil(threads);
+                let mut out = vec![0.0f32; out_dim];
+                for (idx, chunk) in out.chunks_mut(chunk_size).enumerate() {
+                    scalar::compute_chunk_q4k_scalar(
+                        &data,
+                        &input,
+                        chunk,
+                        idx * chunk_size,
+                        out_dim,
+                        in_dim,
+                        num_blocks_per_row,
+                        row_bytes,
+                    );
+                }
+                out
+            };
+
+            let one = run(1);
+            for threads in [2usize, 3, 5, 12, 64] {
+                let many = run(threads);
+                for (i, (a, b)) in one.iter().zip(many.iter()).enumerate() {
+                    assert_eq!(
+                        a.to_bits(),
+                        b.to_bits(),
+                        "[{out_dim}, {in_dim}] threads={threads} row {i}: \
+                         {a} != {b}. A chunk boundary changed the arithmetic."
+                    );
+                }
+            }
+        }
+    }
+
+    /// The aarch64 path now uses `compute_chunk_q4k_scalar`, so its numbers
+    /// shift from the old `matmul_q4k_f32` by that summation-order difference.
+    /// It must be that difference and nothing larger — a real defect would not
+    /// sit at 1e-5 relative.
+    #[test]
+    fn the_kernel_switch_is_only_summation_order() {
+        for (out_dim, in_dim) in [(7, 256), (33, 256), (64, 512)] {
+            let data = q4k_buffer(out_dim, in_dim);
+            let input = input_vec(in_dim);
+            let old = scalar::matmul_q4k_f32(&data, &input, out_dim, in_dim);
+
+            let num_blocks_per_row = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+            let row_bytes = num_blocks_per_row * SUPER_BLOCK_BYTES;
+            let mut new = vec![0.0f32; out_dim];
+            scalar::compute_chunk_q4k_scalar(
+                &data,
+                &input,
+                &mut new,
+                0,
+                out_dim,
+                in_dim,
+                num_blocks_per_row,
+                row_bytes,
+            );
+
+            for (i, (a, b)) in old.iter().zip(new.iter()).enumerate() {
+                // The synthetic buffer is arbitrary bytes, so some rows decode
+                // f16 scales that are NaN or infinite. Both kernels must AGREE
+                // on that — a row finite in one and not the other would be a
+                // real defect — but a NaN pair carries no magnitude to compare.
+                assert_eq!(
+                    a.is_finite(),
+                    b.is_finite(),
+                    "[{out_dim}, {in_dim}] row {i}: finiteness disagrees ({a} vs {b})"
+                );
+                if !a.is_finite() {
+                    continue;
+                }
+                let denom = a.abs().max(b.abs()).max(1.0);
+                let rel = (a - b).abs() / denom;
+                assert!(
+                    rel < 1e-4,
+                    "[{out_dim}, {in_dim}] row {i}: {a} vs {b} (rel {rel:.3e}) — \
+                     larger than summation-order reassociation explains"
+                );
+            }
+        }
+    }
+
+    /// Degenerate shapes must not panic or read out of bounds — the short
+    /// final chunk and the single-row case are where an off-by-one in the
+    /// chunk arithmetic would show.
+    #[test]
+    fn degenerate_shapes_are_safe() {
+        for (out_dim, in_dim) in [(1, 256), (2, 256), (3, 256)] {
+            let data = q4k_buffer(out_dim, in_dim);
+            let input = input_vec(in_dim);
+            let out = matmul_q4k_f32_parallel(&data, &input, out_dim, in_dim);
+            assert_eq!(out.len(), out_dim);
+            // Not asserting finiteness: the buffer is arbitrary bytes and
+            // some decode to NaN f16 scales. What matters here is that the
+            // chunk arithmetic does not panic or read out of bounds.
+        }
+    }
+}
+
+// ── #2567: the measurement, run explicitly on the host that has the defect ─
+//
+// `--ignored` on purpose: this is a TIMING observation, and a wall-clock
+// assertion in a normally-running test is the class that has failed eleven
+// times in this repo. It prints numbers for a human to read and asserts only
+// that the parallel path is not SLOWER, which is a correctness-of-dispatch
+// claim rather than a performance threshold.
+//
+//   cargo test -p aprender-compute --lib issue_2567_measure -- --ignored --nocapture
+#[cfg(test)]
+mod issue_2567_measure {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    #[ignore = "timing observation; run explicitly on the host under test"]
+    fn parallel_vs_serial_on_an_ffn_shaped_matmul() {
+        // 8960x1536 is the FFN layer the x86 threshold comment names as the
+        // case the parallel dispatch exists to catch.
+        let (out_dim, in_dim) = (8960usize, 1536usize);
+        let blocks = in_dim.div_ceil(SUPER_BLOCK_SIZE);
+        // See q4k_buffer: bytes <= 0x3F keep every f16 scale finite.
+        let data: Vec<u8> = (0..out_dim * blocks * SUPER_BLOCK_BYTES)
+            .map(|i| ((i * 31 + 7) % 0x40) as u8)
+            .collect();
+        let input: Vec<f32> = (0..in_dim).map(|i| ((i % 17) as f32 - 8.0) * 0.125).collect();
+
+        let time = |f: &dyn Fn() -> Vec<f32>| -> Vec<f64> {
+            let mut out = Vec::new();
+            // TEN warmups, not two. A first measurement on gx10 discarded two
+            // and produced a BIMODAL serial series — 6.59, 6.60, 6.60, 4.55,
+            // 2.13, 2.14, 2.15 ms — whose median (4.55) sat in the empty space
+            // between the two modes and inflated the reported speedup. The
+            // machine was still settling (cache/DVFS). A median is only
+            // meaningful over a settled distribution, so the warmup runs until
+            // it is one.
+            for i in 0..17 {
+                let t = Instant::now();
+                let r = f();
+                std::hint::black_box(&r);
+                let ms = t.elapsed().as_secs_f64() * 1000.0;
+                if i >= 10 {
+                    out.push(ms);
+                }
+            }
+            out
+        };
+
+        let serial = time(&|| scalar::matmul_q4k_f32(&data, &input, out_dim, in_dim));
+        let parallel = time(&|| matmul_q4k_f32_parallel(&data, &input, out_dim, in_dim));
+
+        let median = |v: &[f64]| {
+            let mut s = v.to_vec();
+            s.sort_by(|a, b| a.partial_cmp(b).expect("finite timings"));
+            s[s.len() / 2]
+        };
+        let (ms_s, ms_p) = (median(&serial), median(&parallel));
+        println!("arch            {}", std::env::consts::ARCH);
+        println!("threads         {:?}", std::thread::available_parallelism());
+        println!("shape           {out_dim}x{in_dim}");
+        println!("serial   median {ms_s:.2} ms   samples {serial:?}");
+        println!("parallel median {ms_p:.2} ms   samples {parallel:?}");
+        println!("speedup         {:.2}x", ms_s / ms_p);
+
+        // NOT a threshold. Only: dispatching to the parallel path must not be
+        // slower than the serial one it replaced. On x86 both are the same
+        // family so this is near 1.0; on aarch64 before this fix it was
+        // exactly 1.0 by construction, because "parallel" called serial.
+        assert!(
+            ms_p <= ms_s * 1.5,
+            "parallel ({ms_p:.2} ms) is materially slower than serial ({ms_s:.2} ms)"
+        );
+    }
 }

--- a/crates/aprender-compute/src/backends/q4k/gemv/mod.rs
+++ b/crates/aprender-compute/src/backends/q4k/gemv/mod.rs
@@ -506,6 +506,15 @@ mod issue_2567_measure {
         println!("serial   median {ms_s:.2} ms   samples {serial:?}");
         println!("parallel median {ms_p:.2} ms   samples {parallel:?}");
         println!("speedup         {:.2}x", ms_s / ms_p);
+        // ON X86 THIS RATIO CONFLATES TWO EFFECTS. `matmul_q4k_f32_parallel`
+        // is the AVX path there, so the number is SIMD *and* threads against a
+        // pure-scalar serial baseline — 77x in release, which says nothing
+        // about the change this test exists for. On aarch64 both sides are the
+        // same scalar kernel and the ratio isolates parallelism alone, which
+        // is why the figure quoted for #2567 is the aarch64 one.
+        if cfg!(target_arch = "x86_64") {
+            println!("note            x86: ratio is SIMD+threads vs scalar, not parallelism alone");
+        }
 
         // NOT a threshold. Only: dispatching to the parallel path must not be
         // slower than the serial one it replaced. On x86 both are the same

--- a/scripts/bench_host_receipt.sh
+++ b/scripts/bench_host_receipt.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# bench_host_receipt.sh — add the CPU-class bench block to this host's receipt
+# (PARITY-003, aprender#2670).
+#
+# RUN THIS ON THE HOST, AFTER `cargo install aprender`, in the same sitting as
+# install_rc. It measures the PUBLISHED artifact, which is the only thing a
+# post-publish receipt may speak about.
+#
+# CPU-class, apr-vs-apr, NO COMPARATOR. `cargo install aprender` builds CPU-only
+# on every host in the matrix while llama.cpp runs CUDA or Metal, so a ratio
+# here is uncomputable rather than merely unwise: it reads ~0.05-0.10 and the
+# threshold never arms. The comparator ratio lives pre-publish (#2677).
+#
+# NEVER PATH for the binary under test: a bare `apr` on the release host
+# resolved to a 49-day-old 0.60.0 during the 0.64.0 sweep, shadowing a fresh
+# install, because ~/.local/bin precedes ~/.cargo/bin. $APR_UNDER_TEST or the
+# cargo root, and the receipt records which.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+HOST="${1:-}"
+MODEL="${2:-}"
+if [ -z "$HOST" ] || [ -z "$MODEL" ]; then
+    printf 'usage: bench_host_receipt.sh <host> <model-path>\n' >&2
+    printf '  host  one of the names in check_multiplatform_dogfood.sh HOSTS\n' >&2
+    exit 2
+fi
+
+VERSION=$(awk -F'"' '/^version *=/{print $2; exit}' Cargo.toml)
+RECEIPT="evidence/dogfood/$VERSION/$HOST.json"
+[ -f "$RECEIPT" ] || { printf 'FAIL  no receipt at %s — run the install sweep first\n' "$RECEIPT" >&2; exit 1; }
+[ -f "$MODEL" ]   || { printf 'FAIL  no model at %s\n' "$MODEL" >&2; exit 1; }
+
+APR="${APR_UNDER_TEST:-}"
+if [ -z "$APR" ]; then
+    APR="$(cargo install --list 2>/dev/null >/dev/null; printf '%s' "${CARGO_HOME:-$HOME/.cargo}/bin/apr")"
+fi
+[ -x "$APR" ] || { printf 'FAIL  no installed apr at %s\n' "$APR" >&2; exit 1; }
+
+printf 'measuring %s on %s with %s\n' "$("$APR" --version 2>&1 | head -1)" "$HOST" "$MODEL"
+
+tmp=$(mktemp) || exit 2
+trap 'rm -f "${tmp:?}"' EXIT
+if ! "$APR" bench "$MODEL" --json > "$tmp" 2>/dev/null; then
+    printf 'FAIL  apr bench exited non-zero; NOT writing a bench block.\n' >&2
+    printf '      A receipt that records a failed measurement as a measurement is\n' >&2
+    printf '      the fabricated-measurement shape (F12).\n' >&2
+    exit 1
+fi
+
+# The bench JSON must validate BEFORE it is written into the receipt. A block
+# that could not stand alone must not be laundered by nesting.
+if ! python3 scripts/lib/bench_receipt.py "$tmp" >/dev/null 2>&1; then
+    printf 'FAIL  apr bench output does not validate:\n' >&2
+    python3 scripts/lib/bench_receipt.py "$tmp" 2>&1 | sed 's/^/      /' >&2
+    exit 1
+fi
+
+RECEIPT="$RECEIPT" BENCH="$tmp" python3 - <<'PY'
+import json, os
+receipt_path = os.environ["RECEIPT"]
+with open(receipt_path, encoding="utf-8") as h:
+    receipt = json.load(h)
+with open(os.environ["BENCH"], encoding="utf-8") as h:
+    receipt["bench"] = json.load(h)
+with open(receipt_path, "w", encoding="utf-8") as h:
+    json.dump(receipt, h, indent=2)
+    h.write("\n")
+print("  wrote bench block into %s" % receipt_path)
+PY
+
+python3 scripts/lib/bench_receipt.py --bench "$RECEIPT" >/dev/null 2>&1 || {
+    printf 'FAIL  the written receipt does not validate\n' >&2; exit 1; }
+printf 'ok    bench block written and validated\n'

--- a/scripts/check_multiplatform_dogfood.sh
+++ b/scripts/check_multiplatform_dogfood.sh
@@ -37,6 +37,9 @@ HOSTS="lambda intel gx10 mini"
 
 VERSION="$(awk -F'"' '/^version *=/{print $2; exit}' Cargo.toml)"
 DIR="evidence/dogfood/$VERSION"
+# ONE validator, shared with scripts/check_bench_receipt.sh. Two readers of one
+# schema is the divergence class #2640 exists to close.
+REPO_BENCH_VALIDATOR="scripts/lib/bench_receipt.py"
 rc=0
 
 printf -- '--- multi-platform dogfood receipts for %s -------------------------\n' "$VERSION"
@@ -116,6 +119,35 @@ for h in $HOSTS; do
         rc=1
     else
         printf 'ok    %-7s %s verified %s (install rc=0)\n' "$h" "$VERSION" "${when:-undated}"
+    fi
+
+    # ── the bench block (PARITY-003, aprender#2670) ────────────────────────
+    #
+    # CPU-CLASS, apr-vs-apr, NO COMPARATOR — and that is a decision, not an
+    # omission. `cargo install aprender` builds CPU-only on every host in this
+    # matrix (crates/apr-cli/Cargo.toml `default` carries no cuda, no wgpu),
+    # while llama.cpp runs CUDA on lambda/gx10 and Metal on mini. A ratio here
+    # would read ~0.05-0.10, nobody would red a release over it (correctly),
+    # the row would go EXISTENCE-ONLY and the threshold would never arm — the
+    # exact shape this gate itself had before #2658. The tree already documents
+    # that collapse at crates/apr-cli/src/dispatch.rs:165.
+    #
+    # An apr-vs-apr self-ratchet catches OUR regressions, which is the goal,
+    # without inventing a number nobody will act on. The comparator ratio lives
+    # in the pre-publish phase where --features cuda exists (#2677).
+    #
+    # ABSENT is not FAIL yet: the block arrives with the first release cut
+    # after this lands, and a gate that fails for a version that predates it is
+    # a gate nobody can satisfy. It is REPORTed so the absence is visible.
+    if ! python3 "$REPO_BENCH_VALIDATOR" --has-bench "$f" >/dev/null 2>&1; then
+        printf 'REPORT %-6s no bench block yet — arrives with the first cut after #2670\n' "$h"
+    elif python3 "$REPO_BENCH_VALIDATOR" --bench "$f" >/dev/null 2>&1; then
+        bmed=$(python3 "$REPO_BENCH_VALIDATOR" --bench-median "$f" 2>/dev/null)
+        printf 'ok    %-7s bench: median %s ms, CPU-class self-ratchet\n' "$h" "${bmed:-?}"
+    else
+        printf 'FAIL  %-7s bench block present but INVALID:\n' "$h"
+        python3 "$REPO_BENCH_VALIDATOR" --bench "$f" 2>&1 | sed 's/^/          /'
+        rc=1
     fi
 done
 

--- a/scripts/lib/bench_receipt.py
+++ b/scripts/lib/bench_receipt.py
@@ -25,6 +25,7 @@ Usage:  bench_receipt.py <receipt.json> [...]
 Exit:   0 all valid - 1 a receipt is invalid - 2 usage/read error
 """
 import json
+import statistics
 import sys
 
 COMPUTE_CLASSES = ("cpu", "cuda", "metal", "wgpu", "unknown")
@@ -133,6 +134,16 @@ def validate(receipt):
     return errors
 
 
+def _bench_of(receipt):
+    """The bench block, or None. A HOST receipt nests it under `bench`; a bare
+    bench receipt IS the block."""
+    if isinstance(receipt.get("bench"), dict):
+        return receipt["bench"]
+    if "samples_ms" in receipt:
+        return receipt
+    return None
+
+
 def _validate_one(path):
     """Validate a single receipt file. Returns (rc, lines_to_print)."""
     try:
@@ -146,9 +157,60 @@ def _validate_one(path):
     return 0, ["ok   %s" % path]
 
 
+def _load(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _mode_has_bench(path):
+    """Exit 0 iff a bench block is PRESENT. Says nothing about validity."""
+    try:
+        return 0 if _bench_of(_load(path)) is not None else 1
+    except (OSError, ValueError):
+        return 2
+
+
+def _mode_bench(path):
+    """Validate the bench block of a host receipt."""
+    try:
+        bench = _bench_of(_load(path))
+    except (OSError, ValueError) as exc:
+        sys.stderr.write("%s: cannot read: %s\n" % (path, exc))
+        return 2
+    if bench is None:
+        sys.stderr.write("%s: no bench block\n" % path)
+        return 1
+    errors = validate(bench)
+    for e in errors:
+        print("FAIL %s: %s" % (path, e))
+    return 1 if errors else 0
+
+
+def _mode_bench_median(path):
+    """Print the median of the bench block's raw samples."""
+    try:
+        bench = _bench_of(_load(path))
+    except (OSError, ValueError):
+        return 2
+    if not bench or not bench.get("samples_ms"):
+        return 1
+    print(round(statistics.median(bench["samples_ms"]), 3))
+    return 0
+
+
+MODES = {
+    "--has-bench": _mode_has_bench,
+    "--bench": _mode_bench,
+    "--bench-median": _mode_bench_median,
+}
+
+
 def main(argv):
+    if len(argv) >= 3 and argv[1] in MODES:
+        return MODES[argv[1]](argv[2])
     if len(argv) < 2:
-        sys.stderr.write("usage: bench_receipt.py <receipt.json> [...]\n")
+        sys.stderr.write("usage: bench_receipt.py [--bench|--has-bench|"
+                         "--bench-median] <receipt.json> [...]\n")
         return 2
     rc = 0
     for path in argv[1:]:


### PR DESCRIPTION
Closes **#2673**. Part of **#2667**. Stacked on #2689. **Sequenced after #2670** as you required — the receipt path exists before the old lane is replaced, so there's no window with nothing.

## What was there — a triple no-op

`nightly-bench.yml` delegated to upstream `sovereign-ci.yml` with `run_benchmarks: true`:

1. **The probe found nothing.** It gates on `ls benches/*.rs`; aprender has **no root `benches/`** — all **120** bench files live under `crates/*/benches/`. Else branch: *"No benches/ directory — skipping"*.
2. **The job could not fail** — `continue-on-error: true` on the whole thing.
3. **Nothing compared two runs.** Output went to a 90-day artifact, never read back.

Net: **120 bench targets never executed by aprender CI, behind a green tick.**

Fixing the probe upstream is a cross-repo edit and would still leave (2) and (3). This lane is repo-local, small, and fails.

## What it runs — and what it says it doesn't

Runs: the receipt validator's case table · the threshold falsification (so the BENCH-003 correction can't rot back) · the comparator pin's case table · the #2567 measurement, with `grep -q '^speedup'` so **silence is red**.

**Declares its own gaps**: the other 120 criterion targets, any apr-vs-llama.cpp ratio (pre-publish, needs `--features cuda`), and aarch64/macOS. Scope is small on purpose — 150 W-capped fleet, 16 runners on one box, and two concurrent workspace-tests starved it on 2026-08-23.

## Two defects found by *running* the steps, not reasoning about them

- **My pin step branched on `rc == 2`** to treat UNPINNED as a notice. **Dead code** — that value comes from `llama_bin.sh`'s resolver, never from the checker, which exits 0 when its case table discriminates. The step printed **"pinned"** on a tree whose declaration says **UNPINNED**. Removed.
- **The measurement prints 61–77× in release on x86**, and that number means almost nothing for #2567: there `matmul_q4k_f32_parallel` **is** the AVX path, so the ratio is SIMD *and* threads against a pure-scalar baseline. On aarch64 both sides are the same scalar kernel and the ratio isolates parallelism — which is why the figure quoted for #2567 is the aarch64 **1.21×**. The test now prints that caveat itself.

Every step executed locally before commit.

Refs #2667 · #2673 · #2670 · #2675 · #2676 · #2567

🤖 Generated with [Claude Code](https://claude.com/claude-code)