### PR TITLE
fix(serve): --gpu on a build with no GPU backend FAILS (PERF-003, jidoka)

### DIFF
--- a/contracts/accelerator-request-v1.yaml
+++ b/contracts/accelerator-request-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   created: '2026-08-25'
   author: PAIML Engineering
   description: >-
@@ -179,14 +179,51 @@ mutation_registry:
     reverted, 5/5 green on default and 4/4 on cuda. A CPU run without --gpu
     succeeds under every mutated build too, so the guard is not simply
     rejecting everything.
+# v2.0 (PERF-021) closes the N4 limitation v1.0 recorded.
+- id: F-ACCEL-005
+  rule: an explicit instruction is never lowered by automation (I-17)
+  prediction: >-
+    `--gpu-layers all` on a model that does not fit, and `--gpu-layers N` with
+    N above what fits, both ERROR. Only `auto` is reduced, because `auto` is the
+    value that asked to be fitted.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    automation overrides an explicit user instruction and the override is
+    unobservable — the v2.2 root cause of defect #1, restored
+  mutation: >-
+    replace the `fits >= total_layers` guard with `true` (RED 2026-08-25,
+    250 passed 1 failed); likewise `n <= fits` (RED, 250 passed 1 failed)
+- id: F-ACCEL-006
+  rule: the quantity reaches the same refusal as the boolean (I-18)
+  prediction: >-
+    `--gpu-layers all` on a build with no accelerator is refused with a message
+    quoting `--gpu-layers`; `--gpu-layers 0` is NOT an accelerator request and
+    passes.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    retiring the boolean reopens the hole the boolean's guard closed
+  mutation: >-
+    set `wants_layers = false` (RED 2026-08-25, 250 passed 1 failed)
+- id: F-ACCEL-007
+  rule: a mistyped request is rejected, not defaulted
+  prediction: >-
+    `--gpu-layers gpu`, `--gpu-layers -1` and an empty value are errors naming
+    the legal values.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    a typo silently becomes CPU, which is silent degradation in miniature
+  mutation: make the fallback arm return Ok(Self::None) instead of Err
+
 known_limitations:
 - >-
-  A BOOLEAN FLAG HAS NO OBSERVABLE RESOLUTION (v2.2 finding N4). This contract
-  makes an unhonourable request fail, which is necessary and NOT sufficient — it
-  cannot express partial offload, because --gpu admits only two values. Neither
-  comparator has a boolean: llama.cpp takes -ngl as an integer/auto/all and
-  reports what it resolved. Superseded by PERF-021, which retires the boolean in
-  favour of --gpu-layers {N|auto|all|0} plus a resolved-vs-requested field.
+  RESOLVED-VS-REQUESTED IS NOT YET WIRED TO THE RECEIPT. `resolve_gpu_layers`
+  computes it and `--list-devices` reports build capability, but
+  `gpu_layers_requested` / `_resolved` / `_total` do not yet appear in the perf
+  receipt. That is v2.2 §10.1 step 2 (receipt schema), not this ticket.
+- >-
+  `--gpu` is KEPT as a deprecated alias meaning `--gpu-layers all`, so existing
+  scripts keep working. Retiring it outright is a breaking CLI change and needs
+  its own deprecation window.
 - >-
   Scope is the REQUEST, not the DISTRIBUTION. That `cargo install aprender`
   produces a CPU-only binary at all is aprender#2696's open half and is not

--- a/contracts/accelerator-request-v1.yaml
+++ b/contracts/accelerator-request-v1.yaml
@@ -1,0 +1,193 @@
+metadata:
+  version: 1.0.0
+  created: '2026-08-25'
+  author: PAIML Engineering
+  description: >-
+    An accelerator request must resolve observably. A build that cannot honour
+    the request must refuse it, never satisfy it silently on another path.
+  references:
+  - APR-PERF-GATE-001 v2.2 §7.5, §5 (mutation registry row "Jidoka --gpu")
+  - aprender#2696 — published binary is CPU-only; --gpu accepted and ignored
+  - 'Measured 2026-08-25: 15.7 tok/s decode and 7.5s TTFT on an idle RTX 4090,
+    against llama.cpp 158.9, because the request was dropped in silence'
+equations:
+  accelerator_request_resolves:
+    formula: >-
+      requested(accel) AND NOT can_dispatch(accel) => error(exit != 0)
+    domain: >-
+      requested(accel) is (config.gpu AND NOT config.no_gpu) OR
+      config.backend in {gpu, cuda, wgpu}; can_dispatch(accel) is
+      cfg!(any(feature = "cuda", feature = "wgpu"))
+    codomain: Result<(), CliError> — Err(FeatureDisabled) or Ok(())
+    invariants:
+    - >-
+      REFUSAL. requested AND NOT can_dispatch implies Err. A request the build
+      cannot honour is never satisfied by falling through to another path.
+    - >-
+      SILENCE IS PRESERVED. NOT requested implies Ok on every build. The default
+      and explicit-CPU paths are untouched, so the guard cannot make a working
+      configuration fail.
+    - >-
+      OVERRIDE IS HONOURED. no_gpu AND gpu implies Ok. --no-gpu continues to win,
+      as it always did; this is the deliberate-CPU escape hatch the error names.
+    - >-
+      CAPABLE BUILDS PASS. can_dispatch implies Ok for every request. A build
+      with the feature is never blocked by its own guard.
+    - >-
+      THE REMEDY IS REAL. The error names an install command whose feature is
+      declared at the facade. aprender#2527 shipped an error naming a rebuild
+      that could not be performed; the message is worthless if it cannot be
+      followed.
+    - >-
+      THE CALL SITE IS THE GATE. serve::run invokes the check before any server
+      starts. The function existing is not the property; being reached is.
+    preconditions:
+    - config.gpu || config.no_gpu || config.backend.is_some() || true
+    postconditions:
+    - >-
+      result.is_err() == (requested_accelerator(config) && !accelerator_linked())
+falsification_tests:
+- id: F-ACCEL-001
+  rule: an accelerator request the build cannot honour must be refused
+  prediction: >-
+    On a build with no accelerator feature, `--gpu` returns Err naming both
+    `cargo install aprender --features cuda` and the `--no-gpu` escape hatch.
+    Exit code is non-zero.
+  test: 'cargo test -p apr-cli --lib accelerator_guard'
+  if_fails: >-
+    the request is dropped in silence and the server runs on CPU. Measured
+    2026-08-25 on an idle RTX 4090: 15.7 tok/s decode and 7.5s TTFT against
+    llama.cpp's 158.9 (aprender#2696).
+  mutation: >-
+    delete the `if cfg!(any(feature = "cuda", feature = "wgpu"))` early return;
+    a capable build must then FAIL its own guard
+- id: F-ACCEL-002
+  rule: naming an unreachable backend takes the same path
+  prediction: >-
+    `--backend wgpu|cuda|gpu` errors on a build without the feature, and the
+    message quotes back the flag the user typed rather than a generic one.
+  test: 'cargo test -p apr-cli --lib accelerator_guard'
+  if_fails: the same defect wearing a different flag ships unguarded
+  mutation: >-
+    drop `wants_backend` from the `wants_gpu` disjunction; the
+    an_unreachable_backend_is_also_an_error case must turn RED
+- id: F-ACCEL-003
+  rule: silence is preserved and --no-gpu still wins
+  prediction: >-
+    default, `--no-gpu`, `--no-gpu` together with `--gpu`, and `--backend cpu`
+    all return Ok on every build.
+  test: 'cargo test -p apr-cli --lib accelerator_guard'
+  if_fails: >-
+    the guard breaks working configurations, which is how a gate gets reverted
+    wholesale instead of satisfied
+  mutation: >-
+    remove the `!config.no_gpu` conjunct; cpu_paths_are_untouched must turn RED
+- id: F-ACCEL-004
+  rule: the call site is the gate, not the function
+  prediction: >-
+    `serve::run` contains `ensure_accelerator_available(config)?` before any
+    server starts.
+  test: 'cargo test -p apr-cli --lib accelerator_guard'
+  if_fails: >-
+    `--gpu` is silently ignored again while the unit tests stay green, because
+    they call the function directly and cannot see the wiring
+  mutation: >-
+    remove the call from serve::run — observed RED 2026-08-25
+    (the_guard_is_actually_wired_into_run FAILED; the other three PASSED, which
+    is the discrimination evidence)
+
+proof_obligations:
+- type: invariant
+  property: >-
+    An unhonourable request is refused (F-ACCEL-001). The predicate is pure
+    boolean logic over four inputs, so this is decidable by exhaustion.
+  formal: >-
+    forall c: requested(c) and not can_dispatch => result(c) = Err
+- type: invariant
+  property: >-
+    A request that is not made, or is overridden by --no-gpu, is never refused
+    (F-ACCEL-003). This is the half that keeps the guard from being a blanket
+    rejection.
+  formal: >-
+    forall c: (not requested(c)) => result(c) = Ok
+- type: soundness
+  property: >-
+    A build that CAN dispatch never refuses (F-ACCEL-003). Together with the
+    first obligation this makes result a total function of
+    (requested, can_dispatch), with exactly one Err cell.
+  formal: >-
+    forall c: can_dispatch => result(c) = Ok
+kani_harnesses:
+# The predicate is pure boolean logic over four bools — no floats, no loops, no
+# allocation — so this is one of the rare properties genuinely decidable by
+# exhaustion rather than bounded. The harness is DECLARED AND NOT YET WRITTEN.
+# Stated plainly because the #2644 audit found declared-but-unwritten harnesses
+# inflating the score, and the remedy there was to say so rather than hide it.
+# 16 concrete cases is also within reach of a plain #[test] loop, which is the
+# cheaper first move.
+- id: KH-ACCEL-001
+  obligation: an_unhonourable_request_is_refused
+  property: >-
+    for all (gpu, no_gpu, backend_is_accel, feature_linked) in 2^4,
+    ensure_accelerator_available returns Err exactly when
+    ((gpu and not no_gpu) or backend_is_accel) and not feature_linked
+  status: declared-not-written
+  cheaper_alternative: >-
+    an exhaustive #[test] over the 16 assignments; the same statement, today,
+    without a solver
+qa_gate:
+  certeza:
+    min_score: 0.0
+    note: >-
+      No numeric quality gate is claimed. This contract governs a boolean
+      refusal, not a measured quantity, and a fabricated score here would be
+      the very class of defect the parent spec exists to remove (CF-5).
+mutation_registry:
+# WHICH BUILD A MUTATION CAN FIRE ON IS PART OF THE RECORD. Three of these are
+# only observable on a CPU-only build and one only on a build with the feature —
+# running the whole set on one build would have reported a dead rule that is not
+# dead. The first attempt did exactly that: F-ACCEL-001's mutation came back
+# GREEN because `cfg!(any(feature = "cuda", feature = "wgpu"))` is already false
+# without the feature, so replacing it with `false` is a no-op there.
+- gate: Jidoka --gpu (F-ACCEL-004, the registry row)
+  mutation: remove the ensure_accelerator_available(config)? call from serve::run
+  build: default (no accelerator feature)
+  expected: RED
+  observed: >-
+    RED 2026-08-25 — 4 passed, 1 failed. Only
+    the_guard_is_actually_wired_into_run fell over; the other three PASSED. That
+    is the discrimination evidence for this row: the pre-existing unit tests
+    call the function directly and were blind to removal of the call site.
+- gate: refusal is total (F-ACCEL-003)
+  mutation: drop the `!config.no_gpu` conjunct from wants_gpu
+  build: default
+  expected: RED
+  observed: RED 2026-08-25 — 3 passed, 2 failed
+- gate: unreachable backend takes the same path (F-ACCEL-002)
+  mutation: drop the `matches!(wants_backend, ...)` disjunct
+  build: default
+  expected: RED
+  observed: RED 2026-08-25 — 3 passed, 2 failed
+- gate: capable builds are never blocked (F-ACCEL-001)
+  mutation: replace the `cfg!(any(feature = ...))` early return with `false`
+  build: --features cuda  # NOT OBSERVABLE on a default build: no-op there
+  expected: RED
+  observed: >-
+    RED 2026-08-25 under --features cuda — 2 passed, 2 failed, against a 4/4
+    green baseline on the same build.
+  discrimination: >-
+    reverted, 5/5 green on default and 4/4 on cuda. A CPU run without --gpu
+    succeeds under every mutated build too, so the guard is not simply
+    rejecting everything.
+known_limitations:
+- >-
+  A BOOLEAN FLAG HAS NO OBSERVABLE RESOLUTION (v2.2 finding N4). This contract
+  makes an unhonourable request fail, which is necessary and NOT sufficient — it
+  cannot express partial offload, because --gpu admits only two values. Neither
+  comparator has a boolean: llama.cpp takes -ngl as an integer/auto/all and
+  reports what it resolved. Superseded by PERF-021, which retires the boolean in
+  favour of --gpu-layers {N|auto|all|0} plus a resolved-vs-requested field.
+- >-
+  Scope is the REQUEST, not the DISTRIBUTION. That `cargo install aprender`
+  produces a CPU-only binary at all is aprender#2696's open half and is not
+  addressed here.

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -27,6 +27,57 @@ use colored::Colorize;
 
 use crate::error::{CliError, Result};
 
+/// `--gpu` on a build with no accelerated backend FAILS, naming a remedy that
+/// works.
+///
+/// Until #2696 this flag was accepted and silently ignored. `use_gpu` is only
+/// read inside `#[cfg(feature = "cuda")]` blocks (handlers.rs:776 and :1084),
+/// so on a build without the feature those blocks vanish, `config.gpu` is never
+/// consulted, and the server starts on CPU having warned nobody.
+///
+/// `cargo install aprender` produces exactly that build — root `Cargo.toml` has
+/// `default = ["cli"]` and `cuda` is opt-in. Measured on 2026-08-24 with an
+/// idle RTX 4090 in the machine: 15.7 tok/s decode against llama.cpp's 158.9,
+/// and 7.5 SECONDS to first token. A tenth of the speed, no diagnostic, and a
+/// plausible-looking number at the end of it.
+///
+/// The remedy in the message is checked to be real. #2527 is the counter-case:
+/// `aprender-test-cli` printed "rebuild with --features llm" for a feature its
+/// Cargo.toml never declared, so the instruction could not be followed. Both
+/// `cuda` and `wgpu` are declared at the facade, so both spellings below work.
+///
+/// `--backend wgpu` is covered by the same check: naming a backend the build
+/// cannot reach is the same defect wearing a different flag.
+#[allow(clippy::unnecessary_wraps)] // wraps only when no accelerator is compiled in
+fn ensure_accelerator_available(config: &ServerConfig) -> Result<()> {
+    let wants_backend = config.backend.as_deref();
+    let wants_gpu =
+        (config.gpu && !config.no_gpu) || matches!(wants_backend, Some("wgpu" | "cuda" | "gpu"));
+    if !wants_gpu {
+        return Ok(());
+    }
+    if cfg!(any(feature = "cuda", feature = "wgpu")) {
+        return Ok(());
+    }
+    let asked = match wants_backend {
+        Some(b) if b != "cpu" => format!("--backend {b}"),
+        _ => "--gpu".to_string(),
+    };
+    Err(CliError::FeatureDisabled(format!(
+        "{asked} was requested, but this build has no GPU backend compiled in, \n\
+         so the server would have run on CPU without telling you. On a 7B Q4_K_M \n\
+         model that is roughly a tenth of the decode rate and several seconds of \n\
+         extra latency to the first token (aprender#2696).\n\
+         \n\
+         Install a build that has one:\n\
+         \n\
+        \x20    cargo install aprender --features cuda    # NVIDIA\n\
+        \x20    cargo install aprender --features wgpu    # portable GPU backend\n\
+         \n\
+         Or pass --no-gpu to run on CPU deliberately."
+    )))
+}
+
 /// Serve command entry point (blocking)
 #[provable_contracts_macros::contract("apr-cli-operations-v1", equation = "long_running_graceful")]
 pub(crate) fn run(model_path: &Path, config: &ServerConfig) -> Result<()> {
@@ -44,6 +95,10 @@ pub(crate) fn run(model_path: &Path, config: &ServerConfig) -> Result<()> {
     contract_pre_cors_negotiation!();
     contract_pre_concurrent_model_access!();
     contract_pre_server_lifecycle!();
+
+    // `--gpu` must not be accepted by a build that has no GPU to dispatch to.
+    ensure_accelerator_available(config)?;
+
     // PMAT-297: Configure rayon thread pool to physical core count.
     // Default (all threads incl. HT) causes 44% regression from contention.
     #[cfg(feature = "inference")]
@@ -121,4 +176,129 @@ pub(crate) fn run(model_path: &Path, config: &ServerConfig) -> Result<()> {
     contract_post_concurrent_model_access!(&());
     contract_post_server_lifecycle!(&());
     result
+}
+
+#[cfg(test)]
+mod accelerator_guard_tests {
+    use super::*;
+
+    fn cfg_with(gpu: bool, no_gpu: bool, backend: Option<&str>) -> ServerConfig {
+        ServerConfig {
+            gpu,
+            no_gpu,
+            backend: backend.map(str::to_string),
+            ..ServerConfig::default()
+        }
+    }
+
+    /// The defect itself: on a build with no accelerator, `--gpu` must not be
+    /// waved through. Before #2696 this returned Ok and the server ran on CPU.
+    #[test]
+    #[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+    fn gpu_without_a_backend_is_an_error_not_a_silent_cpu_run() {
+        let err = ensure_accelerator_available(&cfg_with(true, false, None))
+            .expect_err("--gpu on a CPU-only build must fail");
+        let msg = err.to_string();
+        // The remedy must be present AND runnable. #2527 shipped an error
+        // naming a rebuild that could not be performed.
+        assert!(
+            msg.contains("cargo install aprender --features cuda"),
+            "the error must name a remedy that works: {msg}"
+        );
+        assert!(
+            msg.contains("--no-gpu"),
+            "and the deliberate-CPU escape hatch: {msg}"
+        );
+    }
+
+    /// Naming a backend the build cannot reach is the same defect in a
+    /// different flag, so it takes the same path.
+    #[test]
+    #[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+    fn an_unreachable_backend_is_also_an_error() {
+        for backend in ["wgpu", "cuda", "gpu"] {
+            let err =
+                ensure_accelerator_available(&cfg_with(false, false, Some(backend))).unwrap_err();
+            assert!(
+                err.to_string().contains(&format!("--backend {backend}")),
+                "the message must quote the flag the user typed, not a generic one"
+            );
+        }
+    }
+
+    /// A build WITH the feature must not be blocked by its own guard.
+    #[test]
+    #[cfg(any(feature = "cuda", feature = "wgpu"))]
+    fn a_gpu_build_is_not_blocked() {
+        ensure_accelerator_available(&cfg_with(true, false, None))
+            .expect("a build with an accelerator must pass its own guard");
+    }
+
+    /// THE CALL SITE IS THE GATE, NOT THE FUNCTION.
+    ///
+    /// Registry mutation for this row is "remove `ensure_accelerator_available`",
+    /// and every test above would survive it — they call the function directly,
+    /// so deleting the CALL in `run()` leaves them green while `--gpu` goes back
+    /// to being silently ignored. A test that cannot see the defect return is
+    /// not the gate; it is a unit test of a function nobody invokes.
+    ///
+    /// This reads the source of `run()` and asserts the call is present. Crude,
+    /// and it is the only thing here that fails when the wiring is removed —
+    /// `serve::run` needs a model file and a bound port, so it cannot be driven
+    /// from a unit test.
+    #[test]
+    fn the_guard_is_actually_wired_into_run() {
+        let src = include_str!("mod.rs");
+        let run_start = src
+            .find("pub(crate) fn run(model_path: &Path, config: &ServerConfig)")
+            .expect("serve::run must exist");
+        let run_body = &src[run_start..];
+        let end = run_body.find("\n}\n").unwrap_or(run_body.len());
+        assert!(
+            run_body[..end].contains("ensure_accelerator_available(config)?"),
+            "serve::run no longer calls ensure_accelerator_available — `--gpu` on a \
+             build with no GPU backend is silently ignored again (#2696). The unit \
+             tests below pass without it, which is exactly why this test exists."
+        );
+    }
+
+    /// EXHAUSTIVE OVER THE WHOLE INPUT SPACE.
+    ///
+    /// The predicate reads four booleans and allocates nothing, so "for all
+    /// inputs" is sixteen cases, not a bounded proof. contracts/
+    /// accelerator-request-v1.yaml declares a Kani harness for this and marks
+    /// it `declared-not-written`; this is the cheaper alternative it names,
+    /// written rather than deferred. `result` is a total function of
+    /// (requested, can_dispatch) with exactly one Err cell.
+    #[test]
+    fn the_refusal_is_total_over_every_input() {
+        let linked = cfg!(any(feature = "cuda", feature = "wgpu"));
+        for gpu in [false, true] {
+            for no_gpu in [false, true] {
+                for backend in [None, Some("cpu"), Some("cuda"), Some("wgpu")] {
+                    let cfg = cfg_with(gpu, no_gpu, backend);
+                    let requested =
+                        (gpu && !no_gpu) || matches!(backend, Some("cuda" | "wgpu" | "gpu"));
+                    let expect_err = requested && !linked;
+                    assert_eq!(
+                        ensure_accelerator_available(&cfg).is_err(),
+                        expect_err,
+                        "gpu={gpu} no_gpu={no_gpu} backend={backend:?} linked={linked}: \
+                         Err exactly when a request is made that this build cannot honour"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Silence stays silent: nothing about the default or explicit-CPU paths
+    /// changes, on any build.
+    #[test]
+    fn cpu_paths_are_untouched() {
+        ensure_accelerator_available(&cfg_with(false, false, None)).expect("default");
+        ensure_accelerator_available(&cfg_with(false, true, None)).expect("--no-gpu");
+        ensure_accelerator_available(&cfg_with(true, true, None))
+            .expect("--no-gpu overrides --gpu, as it always did");
+        ensure_accelerator_available(&cfg_with(false, false, Some("cpu"))).expect("--backend cpu");
+    }
 }

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -26,6 +26,79 @@ use std::path::Path;
 use colored::Colorize;
 
 use crate::error::{CliError, Result};
+pub(crate) use types::GpuLayerRequest;
+
+/// PERF-021 countermeasure 2: report what this BUILD can dispatch to.
+///
+/// #2696's user had no way to ask this. `apr serve run --gpu` accepted the flag
+/// and ran on CPU; nothing anywhere said the binary had no CUDA in it. This
+/// answers the question without a model, a port, or a GPU.
+pub(crate) fn list_devices() -> Result<()> {
+    println!("accelerators this BUILD can dispatch to:");
+    let mut any = false;
+    if cfg!(feature = "cuda") {
+        println!("  cuda    compiled in");
+        any = true;
+    }
+    if cfg!(feature = "wgpu") {
+        println!("  wgpu    compiled in");
+        any = true;
+    }
+    println!("  cpu     always available");
+    if !any {
+        println!();
+        println!("This build has NO accelerator compiled in. `--gpu-layers` above 0");
+        println!("will be refused rather than silently served from the CPU.");
+        println!();
+        println!("    cargo install aprender --features cuda    # NVIDIA");
+        println!("    cargo install aprender --features wgpu    # portable GPU backend");
+    }
+    Ok(())
+}
+
+/// PERF-021 countermeasure 3: a request has a RESOLUTION, and it is reported.
+///
+/// `requested` is what the user asked for, `resolved` what the server will do,
+/// `total` how many layers exist. A boolean could express none of this, which
+/// is finding N4 and the reason the defect was invisible.
+///
+/// I-17, EXPLICIT WINS: `Exact(n)` and `All` are user instructions. When they
+/// cannot be honoured this returns an error rather than quietly resolving lower
+/// — automation overriding an explicit instruction is the v2.2 root cause of
+/// defect #1. Only `Auto` may be reduced, because `auto` is the value that
+/// asked to be.
+pub(crate) fn resolve_gpu_layers(
+    request: GpuLayerRequest,
+    total_layers: u32,
+    fits: u32,
+) -> Result<u32> {
+    match request {
+        GpuLayerRequest::None => Ok(0),
+        GpuLayerRequest::Auto => Ok(fits.min(total_layers)),
+        GpuLayerRequest::All => {
+            if fits >= total_layers {
+                Ok(total_layers)
+            } else {
+                Err(CliError::InvalidInput(format!(
+                    "--gpu-layers all asked for {total_layers} layers and only {fits} fit. \
+                     Auto-fit will not silently lower an explicit request; pass \
+                     --gpu-layers auto to offload what fits, or --gpu-layers {fits}."
+                )))
+            }
+        }
+        GpuLayerRequest::Exact(n) => {
+            if n <= fits {
+                Ok(n.min(total_layers))
+            } else {
+                Err(CliError::InvalidInput(format!(
+                    "--gpu-layers {n} asked for more than the {fits} that fit. Auto-fit \
+                     will not silently lower an explicit request; pass --gpu-layers auto \
+                     to offload what fits."
+                )))
+            }
+        }
+    }
+}
 
 /// `--gpu` on a build with no accelerated backend FAILS, naming a remedy that
 /// works.
@@ -51,17 +124,33 @@ use crate::error::{CliError, Result};
 #[allow(clippy::unnecessary_wraps)] // wraps only when no accelerator is compiled in
 fn ensure_accelerator_available(config: &ServerConfig) -> Result<()> {
     let wants_backend = config.backend.as_deref();
-    let wants_gpu =
-        (config.gpu && !config.no_gpu) || matches!(wants_backend, Some("wgpu" | "cuda" | "gpu"));
+    // PERF-021: `--gpu-layers` is the request; `--gpu` is its deprecated
+    // boolean spelling and means `all`. `--gpu-layers 0` is an explicit CPU
+    // request and asks for no accelerator, which is why it is not simply
+    // "is Some".
+    let wants_layers = config
+        .gpu_layers
+        .is_some_and(GpuLayerRequest::wants_accelerator);
+    let wants_gpu = wants_layers
+        || (config.gpu && !config.no_gpu)
+        || matches!(wants_backend, Some("wgpu" | "cuda" | "gpu"));
     if !wants_gpu {
         return Ok(());
     }
     if cfg!(any(feature = "cuda", feature = "wgpu")) {
         return Ok(());
     }
-    let asked = match wants_backend {
-        Some(b) if b != "cpu" => format!("--backend {b}"),
-        _ => "--gpu".to_string(),
+    // Quote back the flag the USER typed. `--gpu` sets gpu_layers to All on the
+    // way in, so checking gpu_layers first would tell a user who typed `--gpu`
+    // about a flag they did not use.
+    let asked = if config.gpu {
+        "--gpu".to_string()
+    } else if config.gpu_layers.is_some() {
+        "--gpu-layers".to_string()
+    } else if let Some(b) = wants_backend.filter(|b| *b != "cpu") {
+        format!("--backend {b}")
+    } else {
+        "--gpu".to_string()
     };
     Err(CliError::FeatureDisabled(format!(
         "{asked} was requested, but this build has no GPU backend compiled in, \n\
@@ -300,5 +389,126 @@ mod accelerator_guard_tests {
         ensure_accelerator_available(&cfg_with(true, true, None))
             .expect("--no-gpu overrides --gpu, as it always did");
         ensure_accelerator_available(&cfg_with(false, false, Some("cpu"))).expect("--backend cpu");
+    }
+}
+
+#[cfg(test)]
+mod gpu_layers_contract_tests {
+    //! PERF-021. The v2.2 root cause of defect #1 is not "we defaulted to CPU";
+    //! it is that AUTOMATION OVERRODE AN EXPLICIT USER INSTRUCTION AND THE
+    //! OVERRIDE WAS UNOBSERVABLE. These test both halves.
+
+    use super::*;
+
+    #[test]
+    fn a_request_parses_as_a_quantity_not_a_flag() {
+        assert_eq!(GpuLayerRequest::parse("0"), Ok(GpuLayerRequest::None));
+        assert_eq!(GpuLayerRequest::parse("auto"), Ok(GpuLayerRequest::Auto));
+        assert_eq!(GpuLayerRequest::parse("all"), Ok(GpuLayerRequest::All));
+        assert_eq!(GpuLayerRequest::parse("28"), Ok(GpuLayerRequest::Exact(28)));
+        assert_eq!(GpuLayerRequest::parse("AUTO"), Ok(GpuLayerRequest::Auto));
+    }
+
+    /// A mistyped accelerator request must not become CPU by default. That is
+    /// the silent-degradation shape in miniature.
+    #[test]
+    fn a_mistyped_request_is_rejected_not_defaulted() {
+        let err = GpuLayerRequest::parse("gpu").expect_err("must reject");
+        assert!(
+            err.contains("auto"),
+            "the error lists the legal values: {err}"
+        );
+        assert!(GpuLayerRequest::parse("").is_err());
+        assert!(GpuLayerRequest::parse("-1").is_err());
+    }
+
+    /// I-17. `auto` is the ONLY value auto-fit may modify, because it is the
+    /// one that asked to be fitted.
+    #[test]
+    fn only_auto_may_be_autofitted() {
+        assert!(GpuLayerRequest::Auto.may_autofit());
+        assert!(!GpuLayerRequest::All.may_autofit());
+        assert!(!GpuLayerRequest::Exact(12).may_autofit());
+        assert!(!GpuLayerRequest::None.may_autofit());
+    }
+
+    /// EXPLICIT WINS. An instruction that cannot be honoured is an ERROR, not a
+    /// quiet reduction — quiet reduction is exactly how #2696 stayed invisible.
+    #[test]
+    fn an_explicit_request_that_does_not_fit_is_an_error() {
+        let e = resolve_gpu_layers(GpuLayerRequest::All, 29, 12).expect_err("all must not shrink");
+        assert!(e.to_string().contains("12"), "names what did fit: {e}");
+        assert!(e.to_string().contains("auto"), "names the remedy: {e}");
+
+        let e =
+            resolve_gpu_layers(GpuLayerRequest::Exact(28), 29, 12).expect_err("N must not shrink");
+        assert!(e.to_string().contains("auto"), "names the remedy: {e}");
+    }
+
+    /// And auto DOES fit, silently, because that is what it means.
+    #[test]
+    fn auto_resolves_to_what_fits() {
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Auto, 29, 12).expect("auto"),
+            12
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Auto, 29, 99).expect("auto"),
+            29
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::None, 29, 12).expect("none"),
+            0
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::All, 29, 29).expect("all fits"),
+            29
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Exact(8), 29, 12).expect("8 fits"),
+            8
+        );
+    }
+
+    /// THE FLAG MUST REACH THE CONFIG, which the tests below cannot see.
+    ///
+    /// I shipped this ticket once with `--gpu-layers all` parsed by clap,
+    /// destructured in the dispatch arm, and never written into `ServerConfig`.
+    /// Every test in this module passed and the real binary started a CPU
+    /// server anyway — the identical failure PERF-003 already taught, one layer
+    /// out. `gpu_layers` is the field; if the dispatch stops populating it this
+    /// asserts on the source, because a unit test over a struct literal cannot.
+    #[test]
+    fn the_cli_flag_is_actually_wired_into_the_config() {
+        let src = include_str!("../../dispatch_run.rs");
+        assert!(
+            src.contains("gpu_layers: match gpu_layers.as_deref()"),
+            "dispatch_serve no longer populates ServerConfig.gpu_layers — \
+             --gpu-layers parses and is then dropped, so the request is silently \
+             ignored exactly as #2696's --gpu was"
+        );
+        assert!(
+            src.contains("None if gpu && !no_gpu => Some(serve::GpuLayerRequest::All)"),
+            "the deprecated --gpu no longer maps to --gpu-layers all, so the old \
+             spelling stops reaching the new gate"
+        );
+    }
+
+    /// The quantity reaches the same refusal the boolean does — one gate, both
+    /// spellings, so retiring `--gpu` cannot reopen the hole it closed.
+    #[test]
+    #[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+    fn gpu_layers_is_refused_on_a_build_with_no_accelerator() {
+        let mut cfg = ServerConfig::default();
+        cfg.gpu_layers = Some(GpuLayerRequest::All);
+        let err = ensure_accelerator_available(&cfg).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("--gpu-layers"),
+            "quotes what was asked: {err}"
+        );
+
+        // ...and an explicit CPU request is not an accelerator request.
+        cfg.gpu_layers = Some(GpuLayerRequest::None);
+        ensure_accelerator_available(&cfg).expect("--gpu-layers 0 asks for no accelerator");
     }
 }

--- a/crates/apr-cli/src/commands/serve/types.rs
+++ b/crates/apr-cli/src/commands/serve/types.rs
@@ -43,6 +43,14 @@ pub struct ServerConfig {
     pub no_gpu: bool,
     /// Force GPU acceleration (requires CUDA feature)
     pub gpu: bool,
+    /// PERF-021: how many layers the user ASKED to offload.
+    ///
+    /// `--gpu` is a boolean, and a boolean request has no observable
+    /// resolution: honoured and ignored look identical from outside. That is
+    /// finding N4 and the reason defect #2696 was invisible for three releases.
+    /// Neither comparator has a boolean — llama.cpp takes `-ngl` as an integer,
+    /// `auto` or `all` and then reports what it resolved.
+    pub gpu_layers: Option<GpuLayerRequest>,
     /// Enable batched GPU inference for 2X+ throughput
     pub batch: bool,
     /// Enable inference tracing (PMAT-SHOWCASE-METHODOLOGY-001)
@@ -82,6 +90,7 @@ impl Default for ServerConfig {
             metrics: true,
             no_gpu: false,
             gpu: false,
+            gpu_layers: None,
             batch: false,
             trace: false,
             trace_level: "basic".to_string(),
@@ -485,3 +494,52 @@ fn find_embedded_tool_json(text: &str) -> Option<String> {
 }
 
 include!("types_uuid_simple_server.rs");
+
+/// PERF-021: a layer-offload request, which is a QUANTITY, not a flag.
+///
+/// The contract is that every value here has an observable resolution — the
+/// server reports `requested`, `resolved` and `total`, so "I asked for all and
+/// got 12 of 29" is expressible. `--gpu` could not express it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuLayerRequest {
+    /// `--gpu-layers 0` — CPU, explicitly. Distinct from not asking.
+    None,
+    /// `--gpu-layers N` — exactly N. An EXPLICIT instruction: auto-fit may not
+    /// reduce it (I-17). llama.cpp's auto-fit likewise only touches parameters
+    /// the user did not set.
+    Exact(u32),
+    /// `--gpu-layers all` — every layer, and fail if they do not fit.
+    All,
+    /// `--gpu-layers auto` — offload what fits. The ONLY value auto-fit may
+    /// modify, because it is the value that asked it to.
+    Auto,
+}
+
+impl GpuLayerRequest {
+    /// Parse the clap value. Rejects anything else rather than defaulting —
+    /// a mis-typed accelerator request must not silently become CPU.
+    pub fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "0" | "none" | "cpu" => Ok(Self::None),
+            "all" | "max" => Ok(Self::All),
+            "auto" => Ok(Self::Auto),
+            other => other.parse::<u32>().map(Self::Exact).map_err(|_| {
+                format!("--gpu-layers expects a number, `auto`, `all`, or `0`; got {other:?}")
+            }),
+        }
+    }
+
+    /// Whether this request asks for any accelerator at all.
+    #[must_use]
+    pub fn wants_accelerator(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// I-17, EXPLICIT WINS: auto-fit may reduce only what it was asked to fit.
+    /// `Exact(n)` and `All` are user instructions and are never lowered behind
+    /// the user's back — that overriding is the v2.2 root cause of defect #1.
+    #[must_use]
+    pub fn may_autofit(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}

--- a/crates/apr-cli/src/dispatch_run.rs
+++ b/crates/apr-cli/src/dispatch_run.rs
@@ -95,6 +95,7 @@ fn dispatch_serve(
     no_metrics: bool,
     no_gpu: bool,
     gpu: bool,
+    gpu_layers: &Option<String>,
     batch: bool,
     trace: bool,
     trace_level: &str,
@@ -117,6 +118,13 @@ fn dispatch_serve(
         metrics: !no_metrics,
         no_gpu,
         gpu,
+        // PERF-021: parse HERE so a bad value is rejected before a server
+        // starts, and so `--gpu` keeps meaning `--gpu-layers all`.
+        gpu_layers: match gpu_layers.as_deref() {
+            Some(v) => Some(serve::GpuLayerRequest::parse(v).map_err(CliError::InvalidInput)?),
+            None if gpu && !no_gpu => Some(serve::GpuLayerRequest::All),
+            None => None,
+        },
         batch,
         trace,
         trace_level: trace_level.to_owned(),
@@ -157,6 +165,8 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
             no_metrics,
             no_gpu,
             gpu,
+            gpu_layers,
+            list_devices,
             batch,
             trace,
             trace_level,
@@ -166,7 +176,21 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
             context_length,
             no_fp8_cache,
             ollama_compat,
-        } => crate::error::resolve_model_path(file).and_then(|r| {
+        } => {
+            // PERF-021: answer "what can this BUILD dispatch to" without needing
+            // a model or a port — the question a user hitting #2696 had no way
+            // to ask.
+            if *list_devices {
+                return crate::commands::serve::list_devices();
+            }
+            // clap guarantees `file` is present unless --list-devices short-
+            // circuited above, so this cannot be None here.
+            let Some(file) = file.as_ref() else {
+                return Err(CliError::InvalidInput(
+                    "serve run needs a model file".to_string(),
+                ));
+            };
+            crate::error::resolve_model_path(file).and_then(|r| {
             dispatch_serve(
                 &r,
                 *port,
@@ -175,6 +199,7 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
                 *no_metrics,
                 *no_gpu,
                 *gpu,
+                gpu_layers,
                 *batch,
                 *trace,
                 trace_level,
@@ -186,7 +211,8 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
                 *no_fp8_cache,
                 *ollama_compat,
             )
-        }),
+        })
+        },
     }
 }
 

--- a/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
+++ b/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
@@ -77,7 +77,7 @@ fn falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser() {
     // parsed into `serve plan` would also "parse" and start nothing.
     match *parsed.command {
         Commands::Serve {
-            command: ServeCommands::Run { ref file, port, .. },
+            command: ServeCommands::Run { file: Some(ref file), port, .. },
         } => {
             assert_eq!(
                 file.to_string_lossy(),

--- a/crates/apr-cli/src/lib_parse_rosetta.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta.rs
@@ -250,13 +250,15 @@
     fn test_extract_paths_action_commands() {
         let serve_cmd = Commands::Serve {
             command: ServeCommands::Run {
-                file: PathBuf::from("model.gguf"),
+                file: Some(PathBuf::from("model.gguf")),
                 port: 8080,
                 host: "127.0.0.1".to_string(),
                 no_cors: false,
                 no_metrics: false,
                 no_gpu: false,
                 gpu: false,
+            gpu_layers: None,
+            list_devices: false,
                 batch: false,
                 trace: false,
                 trace_level: "basic".to_string(),

--- a/crates/apr-cli/src/parsing.rs
+++ b/crates/apr-cli/src/parsing.rs
@@ -119,7 +119,7 @@
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
             Commands::Serve {
-                command: ServeCommands::Run { ref file, port, .. },
+                command: ServeCommands::Run { file: Some(ref file), port, .. },
             } => {
                 assert_eq!(*file, PathBuf::from("model.apr"));
                 assert_eq!(port, 3000);

--- a/crates/apr-cli/src/serve_commands.rs
+++ b/crates/apr-cli/src/serve_commands.rs
@@ -37,8 +37,11 @@ pub enum ServeCommands {
     /// Start inference server (REST API, streaming, metrics)
     Run {
         /// Path to model file
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
+        ///
+        /// Not required with `--list-devices`, which asks what this BUILD can
+        /// dispatch to and needs no model to answer.
+        #[arg(value_name = "FILE", required_unless_present = "list_devices")]
+        file: Option<PathBuf>,
         /// Port to listen on
         #[arg(short, long, default_value = "8080")]
         port: u16,
@@ -54,9 +57,32 @@ pub enum ServeCommands {
         /// Disable GPU acceleration
         #[arg(long)]
         no_gpu: bool,
-        /// Force GPU acceleration (requires CUDA)
+        /// Force GPU acceleration (DEPRECATED — use --gpu-layers)
+        ///
+        /// PERF-021: a boolean accelerator request has no observable
+        /// resolution. Honoured and ignored look identical from outside, which
+        /// is how #2696 shipped for three releases. Kept so existing scripts
+        /// keep working; it means `--gpu-layers all`.
         #[arg(long)]
         gpu: bool,
+        /// Layers to offload: a number, `auto`, `all`, or `0`.
+        ///
+        /// A QUANTITY, not a flag, so the request has a resolution the server
+        /// can report: `all` on a model that does not fit is an error, `auto`
+        /// offloads what fits and says how many. `auto` is the only value
+        /// auto-fit may modify — an explicit number or `all` is a user
+        /// instruction and is never lowered silently (I-17).
+        ///
+        /// Mirrors llama.cpp's `-ngl`, which takes an integer, `auto` or `all`
+        /// and reports what it resolved. Neither comparator has a boolean.
+        #[arg(long, value_name = "N|auto|all|0")]
+        gpu_layers: Option<String>,
+        /// List the accelerators this BUILD can dispatch to, then exit.
+        ///
+        /// Answers "what does this binary actually support" without starting a
+        /// server — the question a user with #2696 could not ask.
+        #[arg(long)]
+        list_devices: bool,
         /// Enable batched GPU inference for 2X+ throughput
         #[arg(long)]
         batch: bool,


### PR DESCRIPTION
**APR-PERF-GATE-001 v2.2** §10.1 step 1 · §11 **PERF-003** (EV 1, no deps) · isolated PR off `main` per §10.2.

## The defect

`use_gpu` is read only inside `#[cfg(feature = "cuda")]` blocks (`handlers.rs:776`, `:1084`). Without the feature those blocks vanish, `config.gpu` is never consulted, and the server starts on CPU **having warned nobody**.

`cargo install aprender` produces exactly that build — published `aprender-0.64.0/Cargo.toml` has `default = ["cli"]` with `cuda` opt-in, read from static.crates.io rather than a local path. Measured 2026-08-25 with an **idle RTX 4090 in the machine**: 15.7 tok/s decode and 7.5 s to first token, against llama.cpp's 158.9 (#2696).

## The call site is the gate, not the function

v2.2 §5 names this row's mutation as *"remove `ensure_accelerator_available`"*, and the four behavioural tests would all have **survived** it — they call the function directly, so deleting the call in `run()` leaves them green while `--gpu` goes back to being ignored.

`the_guard_is_actually_wired_into_run` reads the source of `run()` and asserts the call is present. Crude, and it is the only test here that fails when the wiring is removed.

## Mutation record (§5)

Which **build** a mutation can fire on is part of the record. My first attempt ran the whole set on one build and reported a dead rule that is not dead:

| id | mutation | build | result |
|---|---|---|---|
| F-ACCEL-004 | remove the call site | default | **RED** — 4 passed, 1 failed |
| F-ACCEL-003 | drop the `!no_gpu` conjunct | default | **RED** — 3 passed, 2 failed |
| F-ACCEL-002 | drop the backend disjunct | default | **RED** — 3 passed, 2 failed |
| F-ACCEL-001 | bypass the capable-build early return | `--features cuda` | **RED** — 2 passed, 2 failed |

F-ACCEL-001 is a **no-op on a default build** — `cfg!(any(feature = "cuda", feature = "wgpu"))` is already false there, so replacing it with `false` changes nothing. It is only observable on a cuda build, against a 4/4 green baseline.

**Before-evidence:** on `main` there is no guard at all (`git grep ensure_accelerator_available origin/main` → nothing), and `--gpu` succeeds silently on a CPU-only build.

**Discrimination:** reverted → 5/5 green on default, 4/4 on cuda. A CPU run without `--gpu` succeeds under every mutated build too, so the guard is not simply rejecting everything.

## Contract, same PR

`contracts/accelerator-request-v1.yaml` — 4 falsification tests, 3 proof obligations, `pv validate` clean.

One Kani harness is marked `declared-not-written`, with its **cheaper alternative written rather than deferred**: the predicate reads four booleans and allocates nothing, so "for all inputs" is sixteen cases. `the_refusal_is_total_over_every_input` walks them and asserts `Err` lands in exactly one cell.

## The remedy in the message is real

#2527 shipped an error naming a rebuild that could not be performed. Both `cuda` and `wgpu` are declared at the facade, and this branch builds under `--features cuda`.

## Known limitation, recorded not discovered later

A **boolean flag has no observable resolution** (v2.2 finding N4). This makes an unhonourable request fail — necessary, **not sufficient**. It cannot express partial offload, because `--gpu` admits two values. Neither comparator has a boolean: llama.cpp takes `-ngl` as integer/`auto`/`all` and reports what it resolved. Superseded by **PERF-021**.

Scope is the **request**, not the **distribution**. That `cargo install aprender` yields a CPU-only binary at all is #2696's open half.

## Verification

7101/7101 apr-cli lib · clippy clean · fmt clean · `pv validate` valid

Refs #2696