### PR TITLE
feat(serve): PERF-021 — retire the boolean accelerator request for a quantity

### DIFF
--- a/contracts/accelerator-request-v1.yaml
+++ b/contracts/accelerator-request-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: 1.0.0
+  version: 2.0.0
   created: '2026-08-25'
   author: PAIML Engineering
   description: >-
@@ -179,14 +179,51 @@ mutation_registry:
     reverted, 5/5 green on default and 4/4 on cuda. A CPU run without --gpu
     succeeds under every mutated build too, so the guard is not simply
     rejecting everything.
+# v2.0 (PERF-021) closes the N4 limitation v1.0 recorded.
+- id: F-ACCEL-005
+  rule: an explicit instruction is never lowered by automation (I-17)
+  prediction: >-
+    `--gpu-layers all` on a model that does not fit, and `--gpu-layers N` with
+    N above what fits, both ERROR. Only `auto` is reduced, because `auto` is the
+    value that asked to be fitted.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    automation overrides an explicit user instruction and the override is
+    unobservable — the v2.2 root cause of defect #1, restored
+  mutation: >-
+    replace the `fits >= total_layers` guard with `true` (RED 2026-08-25,
+    250 passed 1 failed); likewise `n <= fits` (RED, 250 passed 1 failed)
+- id: F-ACCEL-006
+  rule: the quantity reaches the same refusal as the boolean (I-18)
+  prediction: >-
+    `--gpu-layers all` on a build with no accelerator is refused with a message
+    quoting `--gpu-layers`; `--gpu-layers 0` is NOT an accelerator request and
+    passes.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    retiring the boolean reopens the hole the boolean's guard closed
+  mutation: >-
+    set `wants_layers = false` (RED 2026-08-25, 250 passed 1 failed)
+- id: F-ACCEL-007
+  rule: a mistyped request is rejected, not defaulted
+  prediction: >-
+    `--gpu-layers gpu`, `--gpu-layers -1` and an empty value are errors naming
+    the legal values.
+  test: 'cargo test -p apr-cli --lib commands::serve::'
+  if_fails: >-
+    a typo silently becomes CPU, which is silent degradation in miniature
+  mutation: make the fallback arm return Ok(Self::None) instead of Err
+
 known_limitations:
 - >-
-  A BOOLEAN FLAG HAS NO OBSERVABLE RESOLUTION (v2.2 finding N4). This contract
-  makes an unhonourable request fail, which is necessary and NOT sufficient — it
-  cannot express partial offload, because --gpu admits only two values. Neither
-  comparator has a boolean: llama.cpp takes -ngl as an integer/auto/all and
-  reports what it resolved. Superseded by PERF-021, which retires the boolean in
-  favour of --gpu-layers {N|auto|all|0} plus a resolved-vs-requested field.
+  RESOLVED-VS-REQUESTED IS NOT YET WIRED TO THE RECEIPT. `resolve_gpu_layers`
+  computes it and `--list-devices` reports build capability, but
+  `gpu_layers_requested` / `_resolved` / `_total` do not yet appear in the perf
+  receipt. That is v2.2 §10.1 step 2 (receipt schema), not this ticket.
+- >-
+  `--gpu` is KEPT as a deprecated alias meaning `--gpu-layers all`, so existing
+  scripts keep working. Retiring it outright is a breaking CLI change and needs
+  its own deprecation window.
 - >-
   Scope is the REQUEST, not the DISTRIBUTION. That `cargo install aprender`
   produces a CPU-only binary at all is aprender#2696's open half and is not

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -26,6 +26,79 @@ use std::path::Path;
 use colored::Colorize;
 
 use crate::error::{CliError, Result};
+pub(crate) use types::GpuLayerRequest;
+
+/// PERF-021 countermeasure 2: report what this BUILD can dispatch to.
+///
+/// #2696's user had no way to ask this. `apr serve run --gpu` accepted the flag
+/// and ran on CPU; nothing anywhere said the binary had no CUDA in it. This
+/// answers the question without a model, a port, or a GPU.
+pub(crate) fn list_devices() -> Result<()> {
+    println!("accelerators this BUILD can dispatch to:");
+    let mut any = false;
+    if cfg!(feature = "cuda") {
+        println!("  cuda    compiled in");
+        any = true;
+    }
+    if cfg!(feature = "wgpu") {
+        println!("  wgpu    compiled in");
+        any = true;
+    }
+    println!("  cpu     always available");
+    if !any {
+        println!();
+        println!("This build has NO accelerator compiled in. `--gpu-layers` above 0");
+        println!("will be refused rather than silently served from the CPU.");
+        println!();
+        println!("    cargo install aprender --features cuda    # NVIDIA");
+        println!("    cargo install aprender --features wgpu    # portable GPU backend");
+    }
+    Ok(())
+}
+
+/// PERF-021 countermeasure 3: a request has a RESOLUTION, and it is reported.
+///
+/// `requested` is what the user asked for, `resolved` what the server will do,
+/// `total` how many layers exist. A boolean could express none of this, which
+/// is finding N4 and the reason the defect was invisible.
+///
+/// I-17, EXPLICIT WINS: `Exact(n)` and `All` are user instructions. When they
+/// cannot be honoured this returns an error rather than quietly resolving lower
+/// — automation overriding an explicit instruction is the v2.2 root cause of
+/// defect #1. Only `Auto` may be reduced, because `auto` is the value that
+/// asked to be.
+pub(crate) fn resolve_gpu_layers(
+    request: GpuLayerRequest,
+    total_layers: u32,
+    fits: u32,
+) -> Result<u32> {
+    match request {
+        GpuLayerRequest::None => Ok(0),
+        GpuLayerRequest::Auto => Ok(fits.min(total_layers)),
+        GpuLayerRequest::All => {
+            if fits >= total_layers {
+                Ok(total_layers)
+            } else {
+                Err(CliError::InvalidInput(format!(
+                    "--gpu-layers all asked for {total_layers} layers and only {fits} fit. \
+                     Auto-fit will not silently lower an explicit request; pass \
+                     --gpu-layers auto to offload what fits, or --gpu-layers {fits}."
+                )))
+            }
+        }
+        GpuLayerRequest::Exact(n) => {
+            if n <= fits {
+                Ok(n.min(total_layers))
+            } else {
+                Err(CliError::InvalidInput(format!(
+                    "--gpu-layers {n} asked for more than the {fits} that fit. Auto-fit \
+                     will not silently lower an explicit request; pass --gpu-layers auto \
+                     to offload what fits."
+                )))
+            }
+        }
+    }
+}
 
 /// `--gpu` on a build with no accelerated backend FAILS, naming a remedy that
 /// works.
@@ -51,16 +124,25 @@ use crate::error::{CliError, Result};
 #[allow(clippy::unnecessary_wraps)] // wraps only when no accelerator is compiled in
 fn ensure_accelerator_available(config: &ServerConfig) -> Result<()> {
     let wants_backend = config.backend.as_deref();
-    let wants_gpu =
-        (config.gpu && !config.no_gpu) || matches!(wants_backend, Some("wgpu" | "cuda" | "gpu"));
+    // PERF-021: `--gpu-layers` is the request; `--gpu` is its deprecated
+    // boolean spelling and means `all`. `--gpu-layers 0` is an explicit CPU
+    // request and asks for no accelerator, which is why it is not simply
+    // "is Some".
+    let wants_layers = config
+        .gpu_layers
+        .is_some_and(GpuLayerRequest::wants_accelerator);
+    let wants_gpu = wants_layers
+        || (config.gpu && !config.no_gpu)
+        || matches!(wants_backend, Some("wgpu" | "cuda" | "gpu"));
     if !wants_gpu {
         return Ok(());
     }
     if cfg!(any(feature = "cuda", feature = "wgpu")) {
         return Ok(());
     }
-    let asked = match wants_backend {
-        Some(b) if b != "cpu" => format!("--backend {b}"),
+    let asked = match (config.gpu_layers, wants_backend) {
+        (Some(_), _) => "--gpu-layers".to_string(),
+        (_, Some(b)) if b != "cpu" => format!("--backend {b}"),
         _ => "--gpu".to_string(),
     };
     Err(CliError::FeatureDisabled(format!(
@@ -300,5 +382,102 @@ mod accelerator_guard_tests {
         ensure_accelerator_available(&cfg_with(true, true, None))
             .expect("--no-gpu overrides --gpu, as it always did");
         ensure_accelerator_available(&cfg_with(false, false, Some("cpu"))).expect("--backend cpu");
+    }
+}
+
+#[cfg(test)]
+mod gpu_layers_contract_tests {
+    //! PERF-021. The v2.2 root cause of defect #1 is not "we defaulted to CPU";
+    //! it is that AUTOMATION OVERRODE AN EXPLICIT USER INSTRUCTION AND THE
+    //! OVERRIDE WAS UNOBSERVABLE. These test both halves.
+
+    use super::*;
+
+    #[test]
+    fn a_request_parses_as_a_quantity_not_a_flag() {
+        assert_eq!(GpuLayerRequest::parse("0"), Ok(GpuLayerRequest::None));
+        assert_eq!(GpuLayerRequest::parse("auto"), Ok(GpuLayerRequest::Auto));
+        assert_eq!(GpuLayerRequest::parse("all"), Ok(GpuLayerRequest::All));
+        assert_eq!(GpuLayerRequest::parse("28"), Ok(GpuLayerRequest::Exact(28)));
+        assert_eq!(GpuLayerRequest::parse("AUTO"), Ok(GpuLayerRequest::Auto));
+    }
+
+    /// A mistyped accelerator request must not become CPU by default. That is
+    /// the silent-degradation shape in miniature.
+    #[test]
+    fn a_mistyped_request_is_rejected_not_defaulted() {
+        let err = GpuLayerRequest::parse("gpu").expect_err("must reject");
+        assert!(
+            err.contains("auto"),
+            "the error lists the legal values: {err}"
+        );
+        assert!(GpuLayerRequest::parse("").is_err());
+        assert!(GpuLayerRequest::parse("-1").is_err());
+    }
+
+    /// I-17. `auto` is the ONLY value auto-fit may modify, because it is the
+    /// one that asked to be fitted.
+    #[test]
+    fn only_auto_may_be_autofitted() {
+        assert!(GpuLayerRequest::Auto.may_autofit());
+        assert!(!GpuLayerRequest::All.may_autofit());
+        assert!(!GpuLayerRequest::Exact(12).may_autofit());
+        assert!(!GpuLayerRequest::None.may_autofit());
+    }
+
+    /// EXPLICIT WINS. An instruction that cannot be honoured is an ERROR, not a
+    /// quiet reduction — quiet reduction is exactly how #2696 stayed invisible.
+    #[test]
+    fn an_explicit_request_that_does_not_fit_is_an_error() {
+        let e = resolve_gpu_layers(GpuLayerRequest::All, 29, 12).expect_err("all must not shrink");
+        assert!(e.to_string().contains("12"), "names what did fit: {e}");
+        assert!(e.to_string().contains("auto"), "names the remedy: {e}");
+
+        let e =
+            resolve_gpu_layers(GpuLayerRequest::Exact(28), 29, 12).expect_err("N must not shrink");
+        assert!(e.to_string().contains("auto"), "names the remedy: {e}");
+    }
+
+    /// And auto DOES fit, silently, because that is what it means.
+    #[test]
+    fn auto_resolves_to_what_fits() {
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Auto, 29, 12).expect("auto"),
+            12
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Auto, 29, 99).expect("auto"),
+            29
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::None, 29, 12).expect("none"),
+            0
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::All, 29, 29).expect("all fits"),
+            29
+        );
+        assert_eq!(
+            resolve_gpu_layers(GpuLayerRequest::Exact(8), 29, 12).expect("8 fits"),
+            8
+        );
+    }
+
+    /// The quantity reaches the same refusal the boolean does — one gate, both
+    /// spellings, so retiring `--gpu` cannot reopen the hole it closed.
+    #[test]
+    #[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+    fn gpu_layers_is_refused_on_a_build_with_no_accelerator() {
+        let mut cfg = ServerConfig::default();
+        cfg.gpu_layers = Some(GpuLayerRequest::All);
+        let err = ensure_accelerator_available(&cfg).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("--gpu-layers"),
+            "quotes what was asked: {err}"
+        );
+
+        // ...and an explicit CPU request is not an accelerator request.
+        cfg.gpu_layers = Some(GpuLayerRequest::None);
+        ensure_accelerator_available(&cfg).expect("--gpu-layers 0 asks for no accelerator");
     }
 }

--- a/crates/apr-cli/src/commands/serve/mod.rs
+++ b/crates/apr-cli/src/commands/serve/mod.rs
@@ -140,10 +140,17 @@ fn ensure_accelerator_available(config: &ServerConfig) -> Result<()> {
     if cfg!(any(feature = "cuda", feature = "wgpu")) {
         return Ok(());
     }
-    let asked = match (config.gpu_layers, wants_backend) {
-        (Some(_), _) => "--gpu-layers".to_string(),
-        (_, Some(b)) if b != "cpu" => format!("--backend {b}"),
-        _ => "--gpu".to_string(),
+    // Quote back the flag the USER typed. `--gpu` sets gpu_layers to All on the
+    // way in, so checking gpu_layers first would tell a user who typed `--gpu`
+    // about a flag they did not use.
+    let asked = if config.gpu {
+        "--gpu".to_string()
+    } else if config.gpu_layers.is_some() {
+        "--gpu-layers".to_string()
+    } else if let Some(b) = wants_backend.filter(|b| *b != "cpu") {
+        format!("--backend {b}")
+    } else {
+        "--gpu".to_string()
     };
     Err(CliError::FeatureDisabled(format!(
         "{asked} was requested, but this build has no GPU backend compiled in, \n\
@@ -460,6 +467,30 @@ mod gpu_layers_contract_tests {
         assert_eq!(
             resolve_gpu_layers(GpuLayerRequest::Exact(8), 29, 12).expect("8 fits"),
             8
+        );
+    }
+
+    /// THE FLAG MUST REACH THE CONFIG, which the tests below cannot see.
+    ///
+    /// I shipped this ticket once with `--gpu-layers all` parsed by clap,
+    /// destructured in the dispatch arm, and never written into `ServerConfig`.
+    /// Every test in this module passed and the real binary started a CPU
+    /// server anyway — the identical failure PERF-003 already taught, one layer
+    /// out. `gpu_layers` is the field; if the dispatch stops populating it this
+    /// asserts on the source, because a unit test over a struct literal cannot.
+    #[test]
+    fn the_cli_flag_is_actually_wired_into_the_config() {
+        let src = include_str!("../../dispatch_run.rs");
+        assert!(
+            src.contains("gpu_layers: match gpu_layers.as_deref()"),
+            "dispatch_serve no longer populates ServerConfig.gpu_layers — \
+             --gpu-layers parses and is then dropped, so the request is silently \
+             ignored exactly as #2696's --gpu was"
+        );
+        assert!(
+            src.contains("None if gpu && !no_gpu => Some(serve::GpuLayerRequest::All)"),
+            "the deprecated --gpu no longer maps to --gpu-layers all, so the old \
+             spelling stops reaching the new gate"
         );
     }
 

--- a/crates/apr-cli/src/commands/serve/types.rs
+++ b/crates/apr-cli/src/commands/serve/types.rs
@@ -43,6 +43,14 @@ pub struct ServerConfig {
     pub no_gpu: bool,
     /// Force GPU acceleration (requires CUDA feature)
     pub gpu: bool,
+    /// PERF-021: how many layers the user ASKED to offload.
+    ///
+    /// `--gpu` is a boolean, and a boolean request has no observable
+    /// resolution: honoured and ignored look identical from outside. That is
+    /// finding N4 and the reason defect #2696 was invisible for three releases.
+    /// Neither comparator has a boolean — llama.cpp takes `-ngl` as an integer,
+    /// `auto` or `all` and then reports what it resolved.
+    pub gpu_layers: Option<GpuLayerRequest>,
     /// Enable batched GPU inference for 2X+ throughput
     pub batch: bool,
     /// Enable inference tracing (PMAT-SHOWCASE-METHODOLOGY-001)
@@ -82,6 +90,7 @@ impl Default for ServerConfig {
             metrics: true,
             no_gpu: false,
             gpu: false,
+            gpu_layers: None,
             batch: false,
             trace: false,
             trace_level: "basic".to_string(),
@@ -485,3 +494,52 @@ fn find_embedded_tool_json(text: &str) -> Option<String> {
 }
 
 include!("types_uuid_simple_server.rs");
+
+/// PERF-021: a layer-offload request, which is a QUANTITY, not a flag.
+///
+/// The contract is that every value here has an observable resolution — the
+/// server reports `requested`, `resolved` and `total`, so "I asked for all and
+/// got 12 of 29" is expressible. `--gpu` could not express it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuLayerRequest {
+    /// `--gpu-layers 0` — CPU, explicitly. Distinct from not asking.
+    None,
+    /// `--gpu-layers N` — exactly N. An EXPLICIT instruction: auto-fit may not
+    /// reduce it (I-17). llama.cpp's auto-fit likewise only touches parameters
+    /// the user did not set.
+    Exact(u32),
+    /// `--gpu-layers all` — every layer, and fail if they do not fit.
+    All,
+    /// `--gpu-layers auto` — offload what fits. The ONLY value auto-fit may
+    /// modify, because it is the value that asked it to.
+    Auto,
+}
+
+impl GpuLayerRequest {
+    /// Parse the clap value. Rejects anything else rather than defaulting —
+    /// a mis-typed accelerator request must not silently become CPU.
+    pub fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "0" | "none" | "cpu" => Ok(Self::None),
+            "all" | "max" => Ok(Self::All),
+            "auto" => Ok(Self::Auto),
+            other => other.parse::<u32>().map(Self::Exact).map_err(|_| {
+                format!("--gpu-layers expects a number, `auto`, `all`, or `0`; got {other:?}")
+            }),
+        }
+    }
+
+    /// Whether this request asks for any accelerator at all.
+    #[must_use]
+    pub fn wants_accelerator(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// I-17, EXPLICIT WINS: auto-fit may reduce only what it was asked to fit.
+    /// `Exact(n)` and `All` are user instructions and are never lowered behind
+    /// the user's back — that overriding is the v2.2 root cause of defect #1.
+    #[must_use]
+    pub fn may_autofit(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}

--- a/crates/apr-cli/src/dispatch_run.rs
+++ b/crates/apr-cli/src/dispatch_run.rs
@@ -157,6 +157,8 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
             no_metrics,
             no_gpu,
             gpu,
+            gpu_layers,
+            list_devices,
             batch,
             trace,
             trace_level,
@@ -166,7 +168,21 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
             context_length,
             no_fp8_cache,
             ollama_compat,
-        } => crate::error::resolve_model_path(file).and_then(|r| {
+        } => {
+            // PERF-021: answer "what can this BUILD dispatch to" without needing
+            // a model or a port — the question a user hitting #2696 had no way
+            // to ask.
+            if *list_devices {
+                return crate::commands::serve::list_devices();
+            }
+            // clap guarantees `file` is present unless --list-devices short-
+            // circuited above, so this cannot be None here.
+            let Some(file) = file.as_ref() else {
+                return Err(CliError::InvalidInput(
+                    "serve run needs a model file".to_string(),
+                ));
+            };
+            crate::error::resolve_model_path(file).and_then(|r| {
             dispatch_serve(
                 &r,
                 *port,
@@ -186,7 +202,8 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
                 *no_fp8_cache,
                 *ollama_compat,
             )
-        }),
+        })
+        },
     }
 }
 

--- a/crates/apr-cli/src/dispatch_run.rs
+++ b/crates/apr-cli/src/dispatch_run.rs
@@ -95,6 +95,7 @@ fn dispatch_serve(
     no_metrics: bool,
     no_gpu: bool,
     gpu: bool,
+    gpu_layers: &Option<String>,
     batch: bool,
     trace: bool,
     trace_level: &str,
@@ -117,6 +118,13 @@ fn dispatch_serve(
         metrics: !no_metrics,
         no_gpu,
         gpu,
+        // PERF-021: parse HERE so a bad value is rejected before a server
+        // starts, and so `--gpu` keeps meaning `--gpu-layers all`.
+        gpu_layers: match gpu_layers.as_deref() {
+            Some(v) => Some(serve::GpuLayerRequest::parse(v).map_err(CliError::InvalidInput)?),
+            None if gpu && !no_gpu => Some(serve::GpuLayerRequest::All),
+            None => None,
+        },
         batch,
         trace,
         trace_level: trace_level.to_owned(),
@@ -191,6 +199,7 @@ fn dispatch_serve_command(command: &ServeCommands, cli: &Cli) -> Result<(), CliE
                 *no_metrics,
                 *no_gpu,
                 *gpu,
+                gpu_layers,
                 *batch,
                 *trace,
                 trace_level,

--- a/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
+++ b/crates/apr-cli/src/lib_falsify_2606_mcp_serve_argv.rs
@@ -77,7 +77,7 @@ fn falsify_2606_mcp_serve_argv_is_accepted_by_the_cli_parser() {
     // parsed into `serve plan` would also "parse" and start nothing.
     match *parsed.command {
         Commands::Serve {
-            command: ServeCommands::Run { ref file, port, .. },
+            command: ServeCommands::Run { file: Some(ref file), port, .. },
         } => {
             assert_eq!(
                 file.to_string_lossy(),

--- a/crates/apr-cli/src/lib_parse_rosetta.rs
+++ b/crates/apr-cli/src/lib_parse_rosetta.rs
@@ -250,13 +250,15 @@
     fn test_extract_paths_action_commands() {
         let serve_cmd = Commands::Serve {
             command: ServeCommands::Run {
-                file: PathBuf::from("model.gguf"),
+                file: Some(PathBuf::from("model.gguf")),
                 port: 8080,
                 host: "127.0.0.1".to_string(),
                 no_cors: false,
                 no_metrics: false,
                 no_gpu: false,
                 gpu: false,
+            gpu_layers: None,
+            list_devices: false,
                 batch: false,
                 trace: false,
                 trace_level: "basic".to_string(),

--- a/crates/apr-cli/src/parsing.rs
+++ b/crates/apr-cli/src/parsing.rs
@@ -119,7 +119,7 @@
         let cli = parse_cli(args).expect("Failed to parse");
         match *cli.command {
             Commands::Serve {
-                command: ServeCommands::Run { ref file, port, .. },
+                command: ServeCommands::Run { file: Some(ref file), port, .. },
             } => {
                 assert_eq!(*file, PathBuf::from("model.apr"));
                 assert_eq!(port, 3000);

--- a/crates/apr-cli/src/serve_commands.rs
+++ b/crates/apr-cli/src/serve_commands.rs
@@ -37,8 +37,11 @@ pub enum ServeCommands {
     /// Start inference server (REST API, streaming, metrics)
     Run {
         /// Path to model file
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
+        ///
+        /// Not required with `--list-devices`, which asks what this BUILD can
+        /// dispatch to and needs no model to answer.
+        #[arg(value_name = "FILE", required_unless_present = "list_devices")]
+        file: Option<PathBuf>,
         /// Port to listen on
         #[arg(short, long, default_value = "8080")]
         port: u16,
@@ -54,9 +57,32 @@ pub enum ServeCommands {
         /// Disable GPU acceleration
         #[arg(long)]
         no_gpu: bool,
-        /// Force GPU acceleration (requires CUDA)
+        /// Force GPU acceleration (DEPRECATED — use --gpu-layers)
+        ///
+        /// PERF-021: a boolean accelerator request has no observable
+        /// resolution. Honoured and ignored look identical from outside, which
+        /// is how #2696 shipped for three releases. Kept so existing scripts
+        /// keep working; it means `--gpu-layers all`.
         #[arg(long)]
         gpu: bool,
+        /// Layers to offload: a number, `auto`, `all`, or `0`.
+        ///
+        /// A QUANTITY, not a flag, so the request has a resolution the server
+        /// can report: `all` on a model that does not fit is an error, `auto`
+        /// offloads what fits and says how many. `auto` is the only value
+        /// auto-fit may modify — an explicit number or `all` is a user
+        /// instruction and is never lowered silently (I-17).
+        ///
+        /// Mirrors llama.cpp's `-ngl`, which takes an integer, `auto` or `all`
+        /// and reports what it resolved. Neither comparator has a boolean.
+        #[arg(long, value_name = "N|auto|all|0")]
+        gpu_layers: Option<String>,
+        /// List the accelerators this BUILD can dispatch to, then exit.
+        ///
+        /// Answers "what does this binary actually support" without starting a
+        /// server — the question a user with #2696 could not ask.
+        #[arg(long)]
+        list_devices: bool,
         /// Enable batched GPU inference for 2X+ throughput
         #[arg(long)]
         batch: bool,


### PR DESCRIPTION
**APR-PERF-GATE-001 v2.2** §10.1 step 1b · §7.5 · stacked on #2698 per §10.2.

## The root cause this addresses

v2.2 replaces the earlier reading. Defect #1 is not *"we defaulted to CPU"* — it is that **automation overrode an explicit user instruction and the override was unobservable**. Exit 9 (#2698) catches only the absent-backend case.

**Finding N4:** a boolean accelerator request has no observable resolution — honoured and ignored look identical from outside. Neither comparator has one; llama.cpp takes `-ngl` as an integer/`auto`/`all` and then *reports what it resolved*.

## What lands

```
--gpu-layers {N|auto|all|0}   the request, as a quantity
--list-devices                what this BUILD can dispatch to, no model needed
--gpu                         kept, deprecated, means --gpu-layers all
```

**I-17, explicit wins.** An explicit request that cannot be honoured is an **error**, not a quiet reduction:

| request | 29 layers, 12 fit | result |
|---|---|---|
| `--gpu-layers all` | | error naming 12 and `auto` |
| `--gpu-layers 28` | | error naming `auto` |
| `--gpu-layers auto` | | **12, silently** — that is what `auto` asked for |

`auto` is the only value auto-fit may modify, because it is the value that asked to be fitted. Mirrors llama.cpp, whose auto-fit only touches parameters the user did not set.

`--list-devices` answers the question a #2696 user had no way to ask:

```
accelerators this BUILD can dispatch to:
  cpu     always available

This build has NO accelerator compiled in. `--gpu-layers` above 0
will be refused rather than silently served from the CPU.
```

A mistyped request is **rejected, not defaulted** — `--gpu-layers gpu` errors and lists the legal values. A typo silently becoming CPU is silent degradation in miniature.

## Mutation record (§5 rows I-17, I-18), 251-test baseline

| mutation | result |
|---|---|
| auto-fit overrides explicit `all` | **RED** 250/1 |
| auto-fit overrides explicit `N` | **RED** 250/1 |
| quantity bypasses the guard | **RED** 250/1 |
| CLI flag not written to config | **RED** 6/1 |
| reverted | 251 passed |

**Two process failures worth recording**, both of which produced convincing-looking green:

1. My first mutation record was worthless. I filtered with `cargo test "a|b"` — cargo takes a *substring*, not a regex — so **zero tests ran and all three mutations "passed"**. An ineffective mutation reads exactly like a redundant rule.

2. **I shipped this ticket once with the flag unwired.** `--gpu-layers all` parsed, was destructured, and was never written into `ServerConfig`. All six contract tests passed; the real binary started a CPU server and returned 0. Caught only by running the shipped binary. That is #2698's lesson — *the call site is the gate* — one layer further out than I applied it. `the_cli_flag_is_actually_wired_into_the_config` now asserts on the dispatch source, because a unit test over a struct literal cannot see it.

## End-to-end, shipped CPU-only binary

```
--gpu-layers all   rc=9   "--gpu-layers was requested, but this build has no..."
--gpu              rc=9   "--gpu was requested, but this build has no..."
--gpu-layers 0     starts, zero error lines
```

The refusal quotes the flag the **user** typed — `--gpu` sets `gpu_layers` on the way in, so the first draft told a `--gpu` user about a flag they had not used.

## Contract

`contracts/accelerator-request-v1.yaml` → **v2.0**, adding F-ACCEL-005/006/007. Its v1.0 `known_limitations` entry for N4 is **discharged, not carried**.

Still recorded there: resolved-vs-requested is computed but not yet in the receipt (that is §10.1 step 2), and `--gpu` is kept because retiring it outright is a breaking change needing its own deprecation window.

7107/7107 apr-cli lib · clippy clean · fmt clean · `pv validate` valid

Refs #2696