### PR TITLE
fix(guards): the epic's primary gate hid behind its own filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -943,6 +943,28 @@ jobs:
         run: bash scripts/check_no_competing_harnesses.sh
       - name: Competing-harness guard can still go RED (case table)
         run: bash scripts/check_no_competing_harnesses.sh --selftest
+      # APR-PERF-GATE-001's PRIMARY gate — Arms A/B1/B2/C/D/E and
+      # cell-completeness — was invoked by NOTHING: no workflow, no Makefile
+      # target, no [package.metadata.dogfood] entry. `git grep perf_gate --
+      # .github Makefile` returned rc=1. The meta-guard could not see it because
+      # it globbed check_*.sh and this file is perf_gate.sh; that universe is
+      # now derived from selftest capability instead.
+      #
+      # SELFTEST ONLY, and that is not a shortcut. The real gate needs
+      # --host/--phase/--workload/--receipt; no PR can supply a receipt, because
+      # receipts come from the nightly push hosts (§4.9.1). Wiring the gate
+      # itself at merge phase would be a required check that can never PASS —
+      # the mirror of one that can never fail. And declaring it in the dogfood
+      # gates is worse: dogfood.sh:293 runs `bash "$dg_path"` with NO arguments,
+      # perf_gate.sh:326 requires four, so every release sweep would report
+      # exit=2 forever — a usage error indistinguishable from a real regression.
+      #
+      # What this DOES buy: the 17-case selftest genuinely discriminates
+      # (disabling the B1 aggregate floor drops it to 15 passed, 2 broken), so a
+      # gate that silently stops discriminating now fails here rather than
+      # certifying a release later.
+      - name: Perf gate can still discriminate (APR-PERF-GATE-001, case table)
+        run: bash scripts/perf_gate.sh --selftest
       # The threshold rule is DERIVED, and the rule it replaced is falsified by
       # execution on every run rather than by a comment. 3-sigma pooled does not
       # catch the one regression on record (#2675).

--- a/scripts/check_guards_are_wired.sh
+++ b/scripts/check_guards_are_wired.sh
@@ -40,9 +40,35 @@ BASELINE="${REPO_ROOT}/scripts/unwired_guards_baseline.txt"
 
 # Guards named by no workflow, one per line, sorted.
 unwired_in() {
-    local root="$1" g base
-    for g in "$root"/scripts/check_*.sh; do
+    local root="$1" g base seen=""
+    # THE UNIVERSE WAS BUILT FROM THE FILENAME, AND A GUARD HID BEHIND ITS OWN.
+    #
+    # This globbed scripts/check_*.sh only. scripts/perf_gate.sh — which
+    # implements Arms A/B1/B2/C/D/E and cell-completeness for
+    # APR-PERF-GATE-001, the epic the operator calls the most important gate in
+    # the project — is invoked by NO workflow, NO Makefile target and NO
+    # [package.metadata.dogfood] entry, and this meta-guard reported PASS the
+    # whole time because the file is not called check_*.
+    #
+    # Proven by mutation rather than argued: copying that file BYTE-FOR-BYTE to
+    # scripts/check_perf_gate.sh makes this guard fail immediately —
+    # "unwired guards grew 4 -> 5 / NEW: check_perf_gate.sh". Same content, same
+    # non-wiring; only the name differed.
+    #
+    # So the universe is DERIVED, not enumerated: a script that ships a
+    # `--selftest` / `--self-test` mode is CLAIMING to be a guard, and that
+    # claim is what makes it one. Hardcoding a second list of "guards that are
+    # not called check_*" would be the same defect one level up — the shape
+    # already fixed three times in this epic (cascade TIERS[], book.yml paths,
+    # book example features).
+    for g in "$root"/scripts/check_*.sh "$root"/scripts/*.sh; do
         [ -f "$g" ] || continue
+        case "$(basename "$g")" in
+            check_*) ;;   # always in scope
+            *) grep -qE '^[[:space:]]*(--selftest|--self-test|"--selftest"|"--self-test")\)' "$g" 2>/dev/null || continue ;;
+        esac
+        case " $seen " in *" $(basename "$g") "*) continue ;; esac
+        seen="$seen $(basename "$g")"
         base=$(basename "$g")
         # EXECUTION, not mention. `grep -rqF -- "$base"` matched the script's
         # NAME anywhere in the workflows tree -- including inside a `#` comment.
@@ -105,7 +131,20 @@ fi
 
 printf '=== every check_*.sh must be named by a workflow (check_guards_are_wired.sh) ===\n'
 
-total=$(find "$REPO_ROOT/scripts" -maxdepth 1 -name 'check_*.sh' | wc -l | tr -d ' ')
+# COUNT THE UNIVERSE THAT WAS ACTUALLY SCANNED, not a proxy for it. This
+# counted check_*.sh only, so after the universe was widened it printed
+# "72 guard(s) scanned, 5 named by no workflow" over a 73-file universe — a
+# self-inconsistent line, and the exact shape of a number that misleads whoever
+# reads it next. Derived the same way unwired_in() derives its universe.
+total=$(
+  {
+    find "$REPO_ROOT/scripts" -maxdepth 1 -name 'check_*.sh'
+    for f in "$REPO_ROOT"/scripts/*.sh; do
+      case "$(basename "$f")" in check_*) continue ;; esac
+      grep -qE '^[[:space:]]*(--selftest|--self-test|"--selftest"|"--self-test")\)' "$f" 2>/dev/null \
+        && printf '%s\n' "$f"
+    done
+  } | sort -u | wc -l | tr -d ' ')
 
 # Vacuity: a glob that matched nothing would report zero unwired guards and look
 # like a pass. That is the exact failure mode this guard is about.


### PR DESCRIPTION
Epic #2706 (the receipt rule). Item 2 of [`APR-PERF-GATE-001-RESTART.md`](https://github.com/paiml/aprender/blob/main/docs/specifications/APR-PERF-GATE-001-RESTART.md).

## The gate runs nowhere

```
git grep perf_gate -- .github Makefile   →  rc=1, 0 matches
[package.metadata.dogfood] gates          →  absent
bash scripts/perf_gate.sh --selftest      →  rc=0, "17 passed, 0 broken"
```

`perf_gate.sh` implements **Arms A/B1/B2/C/D/E** and cell-completeness. Written, selftested, executed by no one.

The meta-guard that exists to catch this reported PASS throughout, because `check_guards_are_wired.sh:44` globbed `scripts/check_*.sh` and the file is named `perf_gate.sh`. **A guard's universe built from the wrong side** — the filename, not the role.

Proven by mutation, not argued: copying the file **byte-for-byte** to `check_perf_gate.sh` makes the meta-guard fail instantly — *"unwired guards grew 4 → 5 / NEW: check_perf_gate.sh"*. Same content, same non-wiring, different name.

Worth recording: `check_no_competing_harnesses.sh` **is** wired, so CI has been defending `perf_gate.sh`'s monopoly as THE benchmarking entrypoint while never running it.

## The universe is derived, not enumerated

A script shipping `--selftest` is *claiming* to be a guard, and that claim puts it in scope. A hardcoded list of "guards not called check_*" would be the same defect one level up — already fixed three times in this epic (cascade `TIERS[]`, `book.yml` paths, book example features). Exactly one script qualifies today.

## Selftest only at merge phase — a decision, not a shortcut

- The real gate needs `--host/--phase/--workload/--receipt`. **No PR can supply a receipt** (§4.9.1 — they come from nightly push hosts). Wiring the gate itself would be a required check that can never PASS.
- Declaring it in the dogfood gates is worse: `dogfood.sh:293` runs `bash "$dg_path"` with **no arguments**, `perf_gate.sh:326` requires four. Measured: **rc=2**, usage error, forever — indistinguishable from a real regression in the sweep.

What it buys: the 17-case selftest genuinely discriminates (disabling the B1 floor → *"15 passed, 2 broken"*), so a gate that silently stops discriminating fails at merge rather than certifying a release later.

## Also fixed: a self-inconsistent count

`total` was computed from `find -name check_*.sh` after the universe widened, printing *"72 guard(s) scanned, 5 named by no workflow"* over a 73-file universe. Now derived the same way the universe is: **73**.

## Case table, re-mutated in the widened scope

```
unwire perf_gate.sh (new scope)          rc=1  RED, "NEW: perf_gate.sh"
unwire check_no_claim_literals.sh (old)  rc=1  RED, old scope still works
clean tree                               rc=0  GREEN
--self-test                              rc=0
perf_gate.sh --selftest                  rc=0  17 passed, 0 broken
```

The old-scope mutation **failed on the first attempt** (rc=0): that guard is invoked twice — guard and selftest — and removing one line left it named. The guard was right; the mutation was insufficient. A mutation that doesn't turn a gate red means either the gate is broken or the mutation is, and assuming the first produces a "fix" for working code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)