### PR TITLE
fix(gate): the ratio guard caught 1 of 6 shapes — the headline fabrication was invisible in its own preferred spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -935,6 +935,15 @@ jobs:
       # named by no workflow enforces nothing, and recording that in a baseline
       # file would make the claim true only in the sense that the gap is
       # written down.
+      #
+      # This step is ALSO the I-12 `[X]`-figure gate, which v2.2 §5 listed as
+      # "not written" against this file. It was right: the comparator pattern
+      # required the competitor's name to sit immediately after the ratio, in
+      # ASCII, so of the six shapes §0.1 names it caught one. PERF-010 admits
+      # the connector ("36.9x over FasterTransformer") and U+00D7, and adds
+      # placeholders bound to a unit ("XX tok/s"). Twelve pre-existing sites
+      # surfaced and are baselined shrink-only; one was a LIVE comparator claim
+      # in book/ and is deleted.
       - name: No claim literals on user-facing surfaces
         run: bash scripts/check_no_claim_literals.sh
       - name: No claim-literal guard regression (case table)

--- a/book/src/tools/apr-cli.md
+++ b/book/src/tools/apr-cli.md
@@ -78,19 +78,37 @@ apr serve run model.gguf --port 8080
 # GPU-accelerated server
 apr serve run model.gguf --port 8080 --gpu
 
-# Batched GPU mode (2.9x faster than Ollama)
+# Batched GPU mode
 apr serve run model.gguf --port 8080 --gpu --batch
 ```
 
 ### Performance
 
-| Mode | Model | Throughput | vs Ollama | Memory |
-|------|-------|------------|-----------|--------|
-| GPU (APR Q4K, GH-88) | Qwen 1.5B | **240 tok/s** | — | 1.5 GB |
-| GPU (batched M=16) | Qwen 1.5B | ~850 tok/s | 2.9x | 1.9 GB |
-| GPU (single GGUF) | Qwen 7B | ~68 tok/s | 0.2x | 5.5 GB |
-| CPU (baseline) | Qwen 1.5B | ~18 tok/s | 0.05x | 1.1 GB |
-| Ollama | Qwen 1.5B | ~333 tok/s | 1.0x | - |
+This page publishes no throughput figure, because none of the figures it used
+to publish could name the run that produced them.
+
+Measure your own, on your own hardware:
+
+```bash
+apr bench model.gguf --fast --json > bench.json
+```
+
+Throughput depends on the model, the quantization, the backend and the
+concurrency, so a single number copied from someone else's box tells you very
+little about yours. `apr bench --json` emits the measurement together with the
+machine, the backend and the build it came from — which is the part that makes
+it worth quoting.
+
+> **Withdrawn.** A table here previously published a batched-GPU throughput
+> figure and a ratio against Ollama. Both are withdrawn: the harness that
+> produced them never executed the comparator, so the ratio was never measured
+> at all, and the throughput figure came from the same run. See
+> APR-PERF-GATE-001 §5.2. No replacement ratio is published — under the receipt
+> rule a number reaches this page only with the evidence path that produced it.
+>
+> The figures are deliberately not restated here, even to disown them: a
+> withdrawal that reprints the number leaves the number on the page, where it
+> is what a skimming reader takes away.
 
 ### Endpoints
 

--- a/scripts/check_no_claim_literals.sh
+++ b/scripts/check_no_claim_literals.sh
@@ -45,8 +45,78 @@ CLAIM_RE='(println!|eprintln!|write!|writeln!|format!|\.red\(\)|\.green\(\)|\.ye
 # someone else's number is the same defect as fabricating our own, with a
 # better provenance story, so it is banned by the same guard rather than a
 # second one that could rot separately.
-RATIO_RE='[0-9]+(\.[0-9]+)?x[[:space:]]+(Ollama|ollama|llama\.cpp|llama|vLLM|vllm|PyTorch|torch|FasterTransformer|fastertransformer|SGLang|sglang|TensorRT|tensorrt|TGI|tgi|LMDeploy|lmdeploy|TurboMind|turbomind|static[[:space:]]+batching)'
+#
+# PERF-010 SPLIT THE PATTERN IN TWO, AND THE JOINER IS THE WHOLE FIX. §5's
+# status table listed the `[X]`-figure guard against this file as **not
+# written**, and it was right for a reason a reading of the regex does not
+# surface: the old form required the competitor's name to sit IMMEDIATELY after
+# the ratio, separated by nothing but spaces, and spelled with an ASCII `x`.
+# Both assumptions fail on the way people actually write the claim. Measured
+# against the six shapes the spec itself names, the old pattern caught ONE:
+#
+#   36.9x FasterTransformer          caught       (the only adjacent form)
+#   36.9x over FasterTransformer     MISSED       connector
+#   36.9× over FasterTransformer     MISSED       connector + U+00D7  <- §5's own mutation
+#   23x over static batching         MISSED       connector
+#   1.8x over vLLM                   MISSED       connector
+#   2.93× Ollama                     MISSED       U+00D7 alone
+#
+# The `×` half is not academic: this repo's prose prefers the typographic sign,
+# so the single most quotable fabrication in the epic — "851.8 tok/s = 2.93×
+# Ollama" — was invisible in its own preferred spelling while the ASCII twin on
+# the line below it was caught. And the connector half is what hid a LIVE claim:
+# `book/src/tools/apr-cli.md:81` shipped "Batched GPU mode (2.9x faster than
+# Ollama)" past a green guard, because "faster than" stood between the ratio and
+# the name. That is the most natural English form of the exact sentence this
+# guard exists to ban.
+#
+# `(x|×)` rather than `[x×]`: `×` is two bytes in UTF-8 and a bracket expression
+# under a C locale becomes a BYTE class, which then matches the trailing byte of
+# unrelated multibyte characters. Alternation is locale-safe. (Same reasoning,
+# same words, as check_perf_claims_cite_receipts.sh — one dialect, two guards.)
+#
+# The connector list is deliberately CLOSED and short. It admits comparison
+# words only, so `3x larger than PyTorch uses` stays unmatched: that is a size
+# remark, not a speed ratio, and the case table asserts it. Widening to "any
+# text between a ratio and a competitor name" was tried and collapses into
+# "any ratio on a line that mentions a competitor", which flags a sentence like
+# "Ollama users will find 3x3 convolutions familiar".
+COMPARATOR_RE='Ollama|ollama|llama\.cpp|llama|vLLM|vllm|PyTorch|torch|FasterTransformer|fastertransformer|SGLang|sglang|TensorRT|tensorrt|TGI|tgi|LMDeploy|lmdeploy|TurboMind|turbomind|Orca|static[[:space:]]+batching'
+RATIO_JOIN='([[:space:]]+|[[:space:]]*(faster|slower|speedup)?[[:space:]]*(over|than|vs\.?|versus|compared[[:space:]]+to)[[:space:]]+)'
+RATIO_RE="[0-9]+(\.[0-9]+)?[[:space:]]*(x|×)$RATIO_JOIN($COMPARATOR_RE)"
 TPUT_RE='[0-9]{2,}\+?[[:space:]]*tok/s'
+
+# A PLACEHOLDER THAT HAS BEEN GIVEN A UNIT IS READ AS A MEASUREMENT. PERF-010's
+# second half. `Throughput: XX tok/s` in a shipped chapter does not read to a
+# user as "we have not measured this yet"; it reads as a table someone forgot to
+# finish, and the number that eventually fills it inherits whatever trust the
+# surrounding prose had already earned.
+#
+# THE BINDING TO A UNIT IS THE ENTIRE DESIGN, and skipping it would have shipped
+# a guard that is pure noise. In THIS repo `[X]` is overwhelmingly a MARKDOWN
+# CHECKBOX — `- [X] APPROVED for Production`, `| Section 9 | [X] PASS / [ ] FAIL
+# |` — and a bare ban on the literal would have been born RED against ten
+# checked boxes in docs/qa/ and zero defects. (Worth stating plainly because the
+# collision is with the spec's own vocabulary: APR-PERF-GATE-001 uses `[X]` as a
+# PROVENANCE TAG meaning "external claim about a third-party system", which is
+# the class the RATIO_RE above handles. Neither of those is a placeholder. Three
+# meanings, one spelling.)
+#
+# So a placeholder counts only where a figure would go: immediately before a
+# throughput unit, a memory unit, a latency unit, or a ratio bound to a speed
+# word. Every checkbox form fails that test, and the case table pins six of them
+# as must-not-match controls.
+#
+# Zero live instances today, and that is stated rather than hidden: this is a
+# RATCHET AGAINST A SHAPE, not a cleanup. The mutation table is therefore the
+# only evidence it works, since the tree cannot supply a true positive.
+#
+# Leading boundary is `(^|[^A-Za-z0-9_])` rather than `\b` — `\b` is a GNU
+# extension this file does not otherwise rely on, and the explicit form is what
+# keeps `MAXX tok/s` (a field name) from matching.
+PLACEHOLDER_TOK='(\[X+\]|\[TBD\]|\[TODO\]|\[N\]|TBD|TODO|XX+)'
+PERF_UNIT_RE='(tok/s|tokens/s|tok/sec|(ms|GB|MB)([^A-Za-z0-9]|$)|(x|×)([[:space:]]+(faster|slower|speedup)|[[:space:]]*$)|%[[:space:]]*(faster|slower|speedup))'
+PLACEHOLDER_RE="(^|[^A-Za-z0-9_])${PLACEHOLDER_TOK}[[:space:]]*${PERF_UNIT_RE}"
 
 # A TARGET says what we WANT; a CLAIM says what we GOT. Only the second lies.
 # Lines that name themselves a target, a threshold or a comparison operator are
@@ -165,6 +235,76 @@ if [ "${1:-}" = "--selftest" ]; then
     check nomatch 'println!("Non-kernel time dominates this pass");'     # a magnitude, no cause
     check nomatch '// investigate sampling sync later'                   # a comment, not printed
 
+    # PERF-010: THE MARKDOWN CLASS. Every row above runs through check(), which
+    # requires a Rust print macro on the line -- so not one of them can reach the
+    # detector that actually guards book/ and docs/. Prose has no macro; ALL of
+    # it is the printed surface, so the .md sweep applies the ratio, throughput
+    # and placeholder patterns directly. A table that only ever exercised the
+    # Rust path is how the `[X]`-figure gap survived being "covered by
+    # check_no_claim_literals.sh" in the spec's own status table.
+    mt=0; mf=0
+    check_md() { # check_md <match|nomatch> <one line of markdown>
+        local want="$1" line="$2" got=nomatch
+        # `<<<` and capture-then-test, never `printf | grep -q`: an early-exiting
+        # reader plus pipefail hands the pipeline the PRODUCER's SIGPIPE status
+        # (141) even on a successful match. That exact shape was a live fail-open
+        # on main.
+        if grep -qE "$RATIO_RE|$TPUT_RE|$PLACEHOLDER_RE" <<< "$line" \
+           && ! grep -qE "$TARGET_RE" <<< "$line"; then got=match; fi
+        mt=$((mt+1))
+        if [ "$got" = "$want" ]; then printf '  ok    %-8s %s\n' "$want" "$(printf '%s' "$line" | cut -c1-64)"
+        else printf '  FAIL  want %-8s got %-8s %s\n' "$want" "$got" "$(printf '%s' "$line" | cut -c1-52)"; mf=$((mf+1)); fi
+    }
+    printf -- '--- markdown class: [X] figures, comparators, placeholders ---\n'
+    # THE SIX SHAPES §0.1 NAMES. Row 2 is §5's mutation for this guard verbatim.
+    check_md match   'aprender achieves 36.9x FasterTransformer throughput.'
+    check_md match   'aprender achieves 36.9× over FasterTransformer.'
+    check_md match   'Continuous batching gives 23× over static batching.'
+    check_md match   'Throughput is 1.8× over vLLM on this workload.'
+    check_md match   '| GPU (batched M=16) | Qwen 1.5B | ~850 tok/s | 2.93× Ollama |'
+    # THE LIVE ONE. Verbatim from book/src/tools/apr-cli.md:81, which shipped
+    # past this guard while it was green because "faster than" sat in the join.
+    check_md match   '# Batched GPU mode (2.9x faster than Ollama)'
+    check_md match   'realizar is 8.2x slower than llama.cpp on CPU.'
+    check_md match   'c=4 TTFT = 256ms (10.7x vs llama.cpp 24ms).'
+    # DISCRIMINATION. A ratio is not a claim just because a competitor is named
+    # on the same line, and a size remark is not a speed ratio.
+    check_md nomatch 'Ollama users will recognise the 3x3 convolution kernel.'
+    check_md nomatch 'The .apr file is 3x larger than PyTorch pickle output.'
+    check_md nomatch 'Compression ratio: 24 bits -> 8 bits = 3x smaller.'
+    check_md nomatch 'Target: 2x Ollama throughput on the 1.5B model.'
+    check_md nomatch 'Install Ollama first, then run the comparison harness.'
+    # PLACEHOLDERS BOUND TO A UNIT.
+    check_md match   'Throughput: XX tok/s'
+    check_md match   '| Decode | [TBD] tok/s | 1.9 GB |'
+    check_md match   'apr is [X]x faster than the previous release.'
+    check_md match   'Speedup over the baseline: [TBD]×'
+    check_md match   'Cold start latency: TODO ms'
+    # ...AND THE CHECKBOXES THEY MUST NOT BE CONFUSED WITH. Without these five
+    # rows a bare `\[X\]` ban looks correct and is born red against docs/qa/.
+    # The checkbox rows are built from variables rather than written inline.
+    # bashrs -- which this repo mandates over shellcheck -- parses the `[ ]` and
+    # `[X]` of a MARKDOWN checkbox as a shell test bracket and raises SC1028 /
+    # SC2104 / SC1087 against rows that are correct English. Same class as the
+    # \042 dance for LIT above, and the same remedy: keep the token out of the
+    # source line. scripts/*.sh is gated on a SHRINK-ONLY bashrs error count, so
+    # five false errors here are five someone else has to triage.
+    # Even the ASSIGNMENTS are built from parts: bashrs flags a bare `'[ ]'`
+    # string as SC2104 "missing space before ]". Brackets by name, then.
+    OB='['; CB=']'
+    CHECKED="${OB}X${CB}"; UNCHECKED="${OB} ${CB}"
+    check_md nomatch "- $CHECKED APPROVED for Production"
+    check_md nomatch "| Section 9 Tests/CI/Coverage | $CHECKED PASS / $UNCHECKED FAIL |"
+    check_md nomatch "| 9.1.1 | All tests pass | 0 failures | $CHECKED | $UNCHECKED |"
+    check_md nomatch '- Other modules: TBD from CI results'
+    check_md nomatch 'TODO: add a benchmark harness for the graph module.'
+    check_md nomatch 'The MAXX tok/s field is reserved.'
+    # VACUITY: a table that shrank to nothing would sweep clean.
+    if [ "$mt" -lt 24 ]; then
+        printf '  FAIL  markdown table has %s row(s); at least 24 are required\n' "$mt"; mf=$((mf+1))
+    fi
+    printf '  %s markdown case(s), %s failure(s)\n' "$mt" "$mf"
+
     # PERF-016: the causal class, where NO print macro is on the line. Every row
     # here is invisible to check() above -- that is the whole point of the
     # widening, so the table runs the widened extractor instead.
@@ -212,7 +352,7 @@ if [ "${1:-}" = "--selftest" ]; then
     printf '  %s causal case(s), %s failure(s)\n' "$ct" "$cf"
 
     printf '  %s case(s), %s failure(s)\n' "$t" "$f"
-    [ "$f" -eq 0 ] && [ "$cf" -eq 0 ] || exit 1
+    [ "$f" -eq 0 ] && [ "$cf" -eq 0 ] && [ "$mf" -eq 0 ] || exit 1
     exit 0
 fi
 
@@ -295,7 +435,12 @@ mdfiles=()
 for f in "${SRC[@]}"; do case "$f" in *.md) mdfiles+=("$f") ;; esac; done
 mdhits=""
 if [ "${#mdfiles[@]}" -gt 0 ]; then
-    mdhits=$(grep -InE "$RATIO_RE|$TPUT_RE" "${mdfiles[@]}" 2>/dev/null \
+    # PLACEHOLDER_RE is applied to MARKDOWN ONLY, deliberately. In .rs a bare
+    # `TODO` is an ordinary code comment and SATD there is pmat's gate, not
+    # this one; adding it to the Rust sweep would import a large, already-owned
+    # debt class under a guard that has nothing to say about it. Prose is where
+    # an unfilled figure is read as a filled one.
+    mdhits=$(grep -InE "$RATIO_RE|$TPUT_RE|$PLACEHOLDER_RE" "${mdfiles[@]}" 2>/dev/null \
              | grep -vE "$TARGET_RE" || true)
 fi
 

--- a/scripts/check_perf_claims_cite_receipts.sh
+++ b/scripts/check_perf_claims_cite_receipts.sh
@@ -5,6 +5,7 @@
 #
 #   bash scripts/check_perf_claims_cite_receipts.sh            # gate
 #   bash scripts/check_perf_claims_cite_receipts.sh --selftest # case table
+#   bash scripts/check_perf_claims_cite_receipts.sh --explain   # rule + debt map
 #   bash scripts/check_perf_claims_cite_receipts.sh --update   # re-baseline
 #
 # THE RULE IT ENFORCES (§3.2, verbatim):
@@ -67,6 +68,23 @@ set -uo pipefail
 cd "$(dirname "$0")/.." || exit 2
 
 BASELINE="scripts/perf_claim_citation_baseline.txt"
+
+# ARGUMENT VALIDATION, BEFORE ANY WORK. Every mode below is selected by an
+# equality test against "${1:-}", so before this case existed a typo fell
+# through every one of them and ran the DEFAULT GATE. `--self-test` (the
+# spelling check_gate5_stage.sh uses), `--selftests`, `--updated` — each of
+# those silently ran the ratchet and exited 0, and a caller who believed they
+# had run the case table would have been told PASSED by a mode that never
+# executed a single case. A guard that answers a question it was not asked is
+# the same defect class as a guard that cannot fail.
+case "${1:-}" in
+    ''|--selftest|--update|--explain) : ;;
+    *)
+        printf 'unknown arg: %s\n' "$1" >&2
+        printf 'usage: check_perf_claims_cite_receipts.sh [--selftest|--explain|--update]\n' >&2
+        exit 2
+        ;;
+esac
 
 # ---------------------------------------------------------------- patterns --
 # A SPEED COMPARISON: a ratio bound to a word that means "in less time".
@@ -271,6 +289,46 @@ for rel in "${SRC[@]}"; do
     [ -n "$r" ] && records="${records}${r}"$'\n'
 done
 records=$(printf '%s' "$records" | grep -v '^$' || true)
+
+# ----------------------------------------------------------------- explain --
+# The gate answers "may this land?". --explain answers "what do I do about it?",
+# which is a different question and the one an engineer paying the ratchet down
+# actually has. It prints the rule, the mechanical definition of a citation, and
+# the debt ranked BY FILE — because the work is per-file (open it, find the run
+# that produced the number, cite it) and a flat 146-line list sorted by path
+# hides that 30 files carry it and a handful carry most.
+#
+# It reuses the same scan as the gate rather than describing it. A help text
+# that paraphrases the implementation drifts from it, and the drift is invisible
+# precisely because nothing executes the prose.
+if [ "${1:-}" = "--explain" ]; then
+    printf '\nTHE RULE (APR-PERF-GATE-001 v2.2 section 3.2)\n'
+    printf '  A number in README.md, book/ or docs/ is legal iff it cites an\n'
+    printf '  evidence/ receipt path. This guard enforces it for the class that is\n'
+    printf '  allowed to exist at all: a speed comparison naming no competitor.\n'
+    printf '  A comparator ratio is illegal regardless of citation and is deleted\n'
+    printf '  by check_no_claim_literals.sh instead -- the two are disjoint, so a\n'
+    printf '  line never carries two contradictory remedies.\n'
+    printf '\nWHAT COUNTS AS A CITATION\n'
+    printf '  A token matching evidence/<path>, within %s lines either side of the\n' "$WINDOW"
+    printf '  claim, WHICH RESOLVES TO A FILE THAT EXISTS. A dangling citation is\n'
+    printf '  worse than none -- it buys trust with a file nobody can open -- so it\n'
+    printf '  fails even at a baselined location.\n'
+    printf '\nTHE THREE WAYS TO CLEAR A LINE\n'
+    printf '  1. cite it   add the evidence/ path of the run that produced it\n'
+    printf '  2. delete it if no run produced it, it is not a measurement\n'
+    printf '  3. re-word   if it is a TARGET, say so; a bar needs no receipt\n'
+    printf '\nDEBT BY FILE (uncited speed comparisons, worst first)\n'
+    if [ -n "$records" ]; then
+        printf '%s\n' "$records" | awk -F: '$3=="uncited"{print $1}' \
+            | LC_ALL=C sort | uniq -c | LC_ALL=C sort -rn \
+            | awk '{printf "  %5d  %s\n", $1, $2}'
+    else
+        printf '  none\n'
+    fi
+    printf '\n  %s total\n\n' "$(printf '%s\n' "$records" | grep -c . || true)"
+    exit 0
+fi
 
 if [ "${1:-}" = "--update" ]; then
     {

--- a/scripts/claim_literal_baseline.txt
+++ b/scripts/claim_literal_baseline.txt
@@ -26,12 +26,49 @@
 # §9's whole premise is that a claim a USER READS is the defect. The count rises
 # because the guard now looks where the claims are, not because new claims were
 # written. Shrink-only from here.
+#
+# WIDENED AGAIN 2026-08-28 (PERF-010). Twelve entries were ADDED, which a
+# shrink-only file forbids without an argument, so here it is.
+#
+# The comparator pattern required the competitor's name to sit IMMEDIATELY
+# after the ratio and to be spelled with an ASCII `x`. Both assumptions fail on
+# the way the claim is actually written. Put to the six shapes APR-PERF-GATE-001
+# section 0.1 itself names, the old pattern caught ONE -- it could not see
+# `36.9x over FasterTransformer`, its unicode twin (which is section 5's own
+# stated mutation for this guard), `23x over static batching`, `1.8x over vLLM`,
+# or a bare `2.93x Ollama` written with U+00D7. That is why section 5's status
+# table listed the `[X]`-figure guard as **not written** against this file.
+#
+# The twelve below are what the widened pattern found. NOT ONE IS NEW PROSE:
+# every one predates this commit and was invisible, which is the point. They
+# fall in three groups, and the classification is recorded so the next person
+# paying them down knows which lever applies:
+#
+#   2 rustdoc (`//!`, `///`) five-whys notes on CUDA paths, reaching users via
+#     `cargo doc`. Root-cause engineering notes; the fix is to cite the receipt,
+#     not to delete the analysis.
+#   2 docs/benchmarking-gate-spec.md -- the document that NAMES this defect,
+#     quoting the fabricated figure in order to ban it. The self-reference trap
+#     that has reddened a sibling guard three times in this epic. Baselined
+#     rather than exempted: an exclusion for a whole file is how a guard is made
+#     unable to fail, and two recorded lines cost nothing.
+#   8 dated docs/qa/ five-whys analyses from 2026-01. Historical internal
+#     record, and all but one are ADMISSIONS OF BEING SLOWER. Deleting them
+#     would be conceding nothing and destroying the analysis; they are recorded.
+#
+# The one that is not an admission -- docs/qa/five-whys-gpu-performance-gap-
+# 2026-01-08.md:317, "32B: Now 3.1x faster than Ollama" -- is an UNVERIFIED
+# OVERCLAIM in a dated internal doc, flagged here explicitly rather than quietly
+# ratcheted, because the decode ratio against Ollama was formally WITHDRAWN
+# (measured 1.015-1.109x on sm_89, i.e. parity). It was left in place only
+# because it is a 32B claim and the withdrawal measured 1.5B; nobody has
+# measured 32B, so deleting it would be guessing in the other direction. It
+# needs a receipt or a deletion, and it is somebody's next ticket.
+#
+# FIVE ENTRIES WERE REMOVED in the same commit: the book/src/tools/apr-cli.md
+# Performance table (lines 89-93) is DELETED, along with the `2.9x faster than
+# Ollama` line above it that the widening exposed. Net +7.
 book/src/advanced-testing/popperian-falsification.md:44
-book/src/tools/apr-cli.md:89
-book/src/tools/apr-cli.md:90
-book/src/tools/apr-cli.md:91
-book/src/tools/apr-cli.md:92
-book/src/tools/apr-cli.md:93
 crates/apr-cli/src/commands/bench_safetensors.rs:123
 crates/apr-cli/src/commands/bench_safetensors.rs:124
 crates/apr-cli/src/commands/benchmark.rs:438
@@ -53,6 +90,7 @@ crates/aprender-gpu/src/kernels/attention/paged/flash_decoding/mod.rs:37
 crates/aprender-gpu/src/kernels/attention/paged/flash_decoding/mod.rs:38
 crates/aprender-gpu/src/kernels/gemv/mod.rs:14
 crates/aprender-gpu/src/kernels/quantize/dot/packed_dp4a.rs:32
+crates/aprender-gpu/src/kernels/quantize/dp4a_gemm.rs:10
 crates/aprender-gpu/src/kernels/quantize/q4k/batched.rs:1
 crates/aprender-gpu/src/kernels/quantize/q4k/coalesced/batched_hw_dp4a.rs:15
 crates/aprender-gpu/src/kernels/quantize/q4k/coalesced/batched_hw_dp4a.rs:16
@@ -71,6 +109,7 @@ crates/aprender-serve/src/cuda/executor/layers/batched_layer_par111.rs:10
 crates/aprender-serve/src/cuda/executor/layers/batched_layer_par111.rs:11
 crates/aprender-serve/src/cuda/executor/layers/cublas_prefill/mod.rs:31
 crates/aprender-serve/src/cuda/executor/layers/par-062.rs:257
+crates/aprender-serve/src/cuda/executor/layers/prefill.rs:537
 crates/aprender-serve/src/cuda/executor/layers/reduces.rs:277
 crates/aprender-serve/src/cuda/executor/layers/transformer_layer_batched.rs:32
 crates/aprender-serve/src/cuda/executor/layers/transformer_layer_batched.rs:33
@@ -102,12 +141,15 @@ docs/BEATS.md:134
 docs/BEATS.md:65
 docs/BEATS.md:66
 docs/audits/dogfood-0.63.0-ledger.md:65
+docs/benchmarking-gate-spec.md:235
 docs/benchmarking-gate-spec.md:24
+docs/benchmarking-gate-spec.md:26
 docs/benchmarking-gate-spec.md:308
 docs/model-cards/albor-370m-v1.md:74
 docs/qa-cargo-run-example-conversion-minimize.md:128
 docs/qa/benchmark-matrix-2026-01-09.md:115
 docs/qa/benchmark-matrix-2026-01-09.md:12
+docs/qa/benchmark-matrix-2026-01-09.md:13
 docs/qa/benchmark-matrix-2026-01-09.md:133
 docs/qa/benchmark-matrix-2026-01-09.md:186
 docs/qa/benchmark-matrix-2026-01-09.md:22
@@ -126,7 +168,12 @@ docs/qa/benchmark-matrix-2026-01-09.md:40
 docs/qa/benchmark-matrix-2026-01-09.md:41
 docs/qa/benchmark-matrix-2026-01-09.md:42
 docs/qa/benchmark-matrix-2026-01-09.md:43
+docs/qa/benchmark-matrix-2026-01-09.md:71
+docs/qa/benchmark-matrix-2026-01-09.md:85
+docs/qa/five-whys-16x-cpu-gap-2026-01-09.md:14
 docs/qa/five-whys-16x-cpu-gap-2026-01-09.md:173
+docs/qa/five-whys-16x-cpu-gap-2026-01-09.md:28
+docs/qa/five-whys-16x-cpu-gap-2026-01-09.md:32
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:123
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:14
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:155
@@ -147,6 +194,7 @@ docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:309
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:310
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:311
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:312
+docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:317
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:323
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:391
 docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:398
@@ -160,6 +208,7 @@ docs/qa/phase2-gpu-benchmark-verification-2026-01-08.md:87
 docs/qa/phase2-gpu-qa-verification-2026-01-08.md:280
 docs/qa/phase2-gpu-qa-verification-2026-01-08.md:281
 docs/qa/popperian_falsification_checklist.md:17
+docs/qa/test-matrix-results-2026-01-08.md:138
 docs/qa/test-matrix-results-2026-01-08.md:39
 docs/qa/test-matrix-results-2026-01-08.md:42
 docs/qa/test-matrix-results-2026-01-08.md:60

--- a/scripts/perf_claim_citation_baseline.txt
+++ b/scripts/perf_claim_citation_baseline.txt
@@ -72,7 +72,6 @@ book/src/ml-fundamentals/feature-scaling.md:585
 book/src/ml-fundamentals/graph-algorithms.md:649
 book/src/ml-fundamentals/graph-components-traversal.md:512
 book/src/ml-fundamentals/graph-pathfinding.md:396
-book/src/tools/apr-cli.md:81
 docs/BEATS.md:112
 docs/BEATS.md:121
 docs/BEATS.md:227


### PR DESCRIPTION
Epic #2706 (the receipt rule). PERF-010 part (a) had already landed in #2710 — this is the residual, and the residual was the part that mattered.

## The `[X]`-figure guard was listed as "not written" and the spec was right

Spec §5 line 779 marks it unwritten. Reading `RATIO_RE` it looks written. The reason it wasn't: the pattern required the competitor's name **immediately** after the ratio, in **ASCII `x`**. Of the six shapes §0.1 itself enumerates, it caught one.

I verified this independently on `origin/main` (`de8fbc407`), file tracked via `git add -N`:

| shape | rc on main |
|---|---|
| `36.9x FasterTransformer` | **1** — caught |
| `36.9x over FasterTransformer` | 0 — invisible |
| `36.9× over FasterTransformer` ← §5's own mutation | 0 — invisible |
| `23× over static batching` | 0 — invisible |
| `1.8× over vLLM` | 0 — invisible |
| `2.93× Ollama` (U+00D7) | 0 — invisible |

The U+00D7 row is the one that matters. This repo's prose prefers the typographic sign, so **the epic's most-quoted fabrication was invisible in its preferred spelling while its ASCII twin was caught.** A guard that greps for the rarer of two spellings of the same claim is not a partial guard; on the corpus it actually faces, it is closer to none.

## `[X]` means three different things and the ticket picked the wrong one

Worth recording, because the obvious implementation would have been born red. Spec §0.1:114 defines `[X]` as a **provenance tag** — "External claim about a third-party system" (36.9× FasterTransformer, 23× static batching, 1.8× vLLM). But the literal `[X]` in this repo is overwhelmingly a **markdown checkbox** — roughly ten `- [X] APPROVED for Production` in `docs/qa/`.

A bare ban on the literal, as the ticket described it, would have fired on ten checked boxes and zero defects. Implemented the spec's meaning as the primary guard; the placeholder class (`XX tok/s`, `[TBD]×`) is bound to a **perf unit**, which is what makes it discriminate.

## Mutation table — 22 rows, every rc read as `guard > log 2>&1; rc=$?`

| mutation | rc |
|---|---|
| clean tree, both guards | 0, 0 |
| uncited speed comparison, tracked | 1 |
| same claim + **resolving** `evidence/` citation | 0 |
| same claim + **dangling** citation | 1 |
| a TARGET, not a result | 0 |
| uncited claim in an **untracked** file | 1 |
| the five previously-invisible ratio shapes | 1 ×5 |
| `2.9x faster than Ollama` ← the live `book/` defect | 1 |
| `XX tok/s` · `[TBD]×` · `[X]x faster` | 1, 1, 1 |
| markdown checkboxes | **0** |
| `3x3 convolution` on a line naming Ollama | **0** |
| `3x larger than PyTorch` (size, not speed) | **0** |
| revert | 0, 0 |

The last three are the discrimination set — a guard that reds on those is as useless as one that never reds.

24 new markdown rows in `check_no_claim_literals.sh`'s case table. The existing 12 all required a Rust print macro, so **not one could reach the `.md` detector that guards `book/`** — which is how "covered by check_no_claim_literals.sh" survived in the spec's status table while `book/` went unguarded.

## (c) Comparator claims deleted from `book/`

`book/src/tools/apr-cli.md`, the only live comparator claims in `book/`:

- **:81** `# Batched GPU mode (2.9x faster than Ollama)` — **refuted**: the harness never ran Ollama (§5.2), and the decode ratio was separately withdrawn (measured 1.015–1.109× on sm_89, i.e. parity).
- **:87-93** the whole `vs Ollama` table — the `2.9x`/`0.2x`/`0.05x` column and an `Ollama | ~333 tok/s` row. Refuted *and* unsourced; the `~850 tok/s` came from the same run. Replaced with `apr bench --fast --json`.

The first withdrawal note *restated* the figures and reddened the guard at its own new line — the self-reference trap. Reworded: **a withdrawal that reprints the number leaves the number on the page.**

**Nothing concedes speed.** Every grounded win is untouched (cold-start, LinReg, GaussianNB, SIMD, footprint), and the real `--assert-speedup`/`--skip-ollama` flag docs stay — those are flags, not claims. This declines to publish a ratio nobody measured; under-claiming would be the same reporting failure in the other direction.

## Residual holes — stated, not hidden

1. **The book edit was never validated against a live `apr`.** `check_book_cli_parity.sh` and `check_book_examples_executable.sh` fail on this branch **and byte-identically at HEAD** (`STALE apr BINARY` — no binary built from `de8fbc407`). They fail closed, correctly. Pre-existing and environmental, but this PR does not claim the page validates.
2. **`13× on 200k-token prompts` is still uncaught** — a §0.1 figure with no comparator name. Catching it generically means flagging every ratio.
3. **`docs/specifications/` remains excluded** from both guards (pre-existing). A claim laundered there is invisible.
4. **`book/src/examples/apr-format-deep-dive.md:296-304`** — a load-time table (PyTorch 2.3s / SafeTensors 450ms / GGUF 380ms / .apr 0.8ms). Comparator and unsourced, but times without ratio syntax, so neither guard fires. The implied 562–2875× may be the grounded cold-start win (526–1600×) — **could not tell, so left in place and reported** rather than guessed at in either direction.
5. **12 sites baselined as inherited debt** (shrink-only, argued in the file header). Seven are admissions of being *slower*. The one unverified **overclaim** — `docs/qa/five-whys-gpu-performance-gap-2026-01-08.md:317`, "32B: Now 3.1x faster than Ollama" — is flagged **by name** in the baseline header rather than quietly ratcheted: it is a 32B claim and the withdrawal measured 1.5B, so deleting it would be guessing in the other direction. It needs a receipt or a deletion.

## Verification

`check_guards_are_wired` · `check_shell_lint_ratchet` · `check_pass_grep_anchored` · `check_no_fabricated_baselines` all rc=0. bashrs errors on both edited scripts back to **0**, matching HEAD — the first draft introduced 5 false positives from markdown checkboxes parsed as shell test brackets. The `ci.yml` edit is comment-only and contains no `${{`.

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
