### PR TITLE
fix(perf): the parity chain read a filename nothing writes — three spellings, zero blocks emitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,6 +995,29 @@ jobs:
       # the label of a performance result (#2677).
       - name: Benchmark fairness protocol is complete
         run: bash scripts/check_bench_protocol.sh
+      # PERF-004. scripts/perf_gate.sh read a receipt schema NOTHING in the tree
+      # wrote: four real artifacts all returned rc=1 and the only input that
+      # passed was the gate's own synthetic fixture. The tempting repair is to
+      # default the missing fields, which would hand-assign five numbers no
+      # instrument produces. scripts/perf-receipt-fields.yaml classifies every
+      # field the gate reads as PRODUCED, DERIVED, POLICY or UNMEASURED, and
+      # this holds the classification to the tree in both directions -- a new
+      # unclassified requirement, and an entry whose producer has since been
+      # deleted, are each a FAIL.
+      - name: Every field the perf gate reads has a producer or a named owner
+        run: bash scripts/check_perf_receipt_fields_have_producers.sh
+      - name: Schema-map guard can still go RED (case table + 5 mutations)
+        run: bash scripts/check_perf_receipt_fields_have_producers.sh --self-test
+      # The converter that closes the loop, end to end: a BenchmarkReport this
+      # repo can actually produce reaches a verdict, and what remains failing is
+      # the UNMEASURED bucket BY NAME rather than a schema error.
+      - name: Receipt converter round-trips into a gate verdict
+        run: python3 scripts/lib/perf_receipt.py --selftest
+      # NOT a second `perf_gate.sh --selftest` step. This commit was authored
+      # before #2709 landed, and carried its own copy; two identically-scoped
+      # invocations under two names is how a check comes to look twice as
+      # covered as it is. The case table runs once, above, as "Perf gate can
+      # still discriminate".
       # The deepest check in the surface sweep -- real generation through
       # /v1/chat/completions -- had never executed once: the probe binary was
       # built without --features llm (clap advertises `llm` regardless, only the

--- a/scripts/check_no_timing_in_required.sh
+++ b/scripts/check_no_timing_in_required.sh
@@ -93,6 +93,7 @@ check_llama_pin.sh
 check_no_fabricated_baselines.sh
 check_no_timing_in_required.sh
 check_perf_claims_cite_receipts.sh
+check_perf_receipt_fields_have_producers.sh
 "
 # check_perf_claims_cite_receipts.sh (PERF-010) matches `check_*perf*.sh` and
 # turned this guard RED the moment the file appeared — verified before wiring
@@ -106,6 +107,11 @@ check_perf_claims_cite_receipts.sh
 # be actively wrong: that list BANS a guard from the required workflows, and
 # APR-PERF-GATE-001 §4.1 puts the claim guards in the merge phase precisely
 # because they are text-only and deterministic.
+# check_perf_receipt_fields_have_producers.sh matched on `perf`, and asserts no
+# duration of any kind: it reads a YAML classification and the text of two
+# reader scripts. Its one timing-shaped token is the word `timeouts` inside a
+# comment, naming a RECEIPT FIELD rather than a bound. Verified by reading it
+# rather than by trusting the name, which is what the heuristic above cannot do.
 
 unclassified=""
 while IFS= read -r f; do

--- a/scripts/check_perf_receipt_fields_have_producers.sh
+++ b/scripts/check_perf_receipt_fields_have_producers.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# check_perf_receipt_fields_have_producers.sh — PERF-004.
+#
+# WHY THIS EXISTS
+# ---------------
+# scripts/perf_gate.sh read a receipt schema that NOTHING IN THIS TREE WROTE.
+# Four real artifacts were tried against it and all four returned rc=1; the only
+# input that passed was the gate's own synthetic fixture, a string literal
+# inside the gate. Nobody noticed for the length of an epic, because the gate
+# ran green against itself and every real input failed with one line that said
+# "schema" and named nothing.
+#
+# The dangerous repair is the obvious one: teach the gate to fill in the missing
+# fields. `requested`, `completed`, `timeouts`, `drain_ms` and
+# `tokenization.method` all look like the same kind of gap and they are not.
+# Two are derivable from counts the harness already records. Three are
+# UNMEASURED -- nothing in this tree measures them -- and defaulting those three
+# would hand-assign three numbers no instrument produced, wearing the shape of
+# measurements. That is the defect APR-PERF-GATE-001 exists to remove, arriving
+# as its own fix.
+#
+# So scripts/perf-receipt-fields.yaml classifies every field the gate reads, and
+# this guard holds the classification to the tree:
+#
+#   1. every field the gate reads is classified            (no silent new gap)
+#   2. every classified field is actually read              (no rotting entry)
+#   3. PRODUCED/DERIVED name a producer that still exists   (no rotting claim)
+#   4. UNMEASURED names an owning ticket and a spec section (no orphan gap)
+#   5. every receiver in the reader scripts is accounted    (no silent miss)
+#
+# Rule 5 is the one that keeps the other four honest. The extractor INCLUDES a
+# receiver by default and fails on one it does not recognise, so a new read
+# through an unfamiliar variable is a loud false alarm rather than a field that
+# quietly leaves the universe. A guard whose universe can shrink without saying
+# so is the shape that made three earlier guards in this epic blind.
+#
+#   bash scripts/check_perf_receipt_fields_have_producers.sh              # gate
+#   bash scripts/check_perf_receipt_fields_have_producers.sh --self-test  # case table
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------- the check --
+run_check() {
+  local root="$1"
+  python3 - "$root" <<'PY'
+import os, re, sys, yaml
+
+root = sys.argv[1]
+LEDGER = os.path.join(root, "scripts", "perf-receipt-fields.yaml")
+GATE = os.path.join(root, "scripts", "perf_gate.sh")
+DELEGATE = os.path.join(root, "scripts", "lib", "bench_receipt.py")
+
+# Receiver -> the path prefix a read through it addresses. A receiver absent
+# from BOTH this map and the ledger's non_receipt_receivers list is an error,
+# never a skip.
+PREFIX = {
+    GATE: {"r": "", "b": "bands[].", "bands": "bands[].",
+           "kv": "kv.", "itl": "itl.", "inj": "injector."},
+    DELEGATE: {"receipt": "", "prov": "provenance.",
+               "subj_prov": "provenance.", "comp_prov": "provenance."},
+}
+
+# EVERY literal key access, both quote styles. The extractor is TOTAL: each
+# match must be attributed to a receiver, and one it cannot attribute is an
+# error rather than a skip. The first version matched double quotes only and
+# silently dropped `kv['admission_rejected']` inside an f-string -- a field that
+# happened to be classified anyway through its other spelling, which is exactly
+# how a parser's blind spot survives review. A guard's own parser is the part
+# most likely to be wrong and least likely to be read.
+TOKEN = re.compile(r"""\.get\(\s*(['"])(\w+)\1|\[\s*(['"])(\w+)\3\s*\]""")
+# Text immediately before a token, when the receiver is a plain name possibly
+# followed by subscripts: `r`, `bands[c]`, `m["arms"]["B1"]`.
+RECV = re.compile(r'([A-Za-z_]\w*)(?:\[[^\]]*\])*\s*$')
+# ... and when it is `(<name>.get("outer") or {})`, the one chained form in use.
+CHAIN = re.compile(r'([A-Za-z_]\w*)\.get\(\s*[\'"](\w+)[\'"]\s*\)\s*or\s*\{\}\s*\)\s*$')
+# ... and `(<name> or {})`, the null-coalescing form, where the receiver is the
+# name and the key is not qualified any further.
+COALESCE = re.compile(r'([A-Za-z_]\w*)\s*or\s*(?:\{\}|\[\])\s*\)\s*$')
+TUPLE = re.compile(r'^(PROVENANCE_REQUIRED|JOIN_KEY_REQUIRED)\s*=\s*\(([^)]*)\)', re.M)
+
+errors = []
+with open(LEDGER, encoding="utf-8") as fh:
+    ledger = yaml.safe_load(fh)
+fields = ledger.get("fields") or {}
+skip_recv = ledger.get("non_receipt_receivers") or {}
+dispatch = set(ledger.get("dispatch_keys") or [])
+
+
+def read_set(path):
+    """Every receipt field this file reads, as a qualified path."""
+    base = os.path.basename(path)
+    allowed = skip_recv.get(base) or {}
+    prefix = PREFIX[path]
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+    found = set()
+    for match in TOKEN.finditer(src):
+        name = match.group(2) or match.group(4)
+        before = src[:match.start()]
+        chain = CHAIN.search(before)
+        coalesce = COALESCE.search(before)
+        if chain:
+            recv, outer = chain.group(1), chain.group(2)
+            qualified = outer + "." + name
+        elif coalesce:
+            recv, qualified = coalesce.group(1), name
+        else:
+            plain = RECV.search(before)
+            if not plain:
+                line = src.count("\n", 0, match.start()) + 1
+                errors.append(
+                    "%s:%d has a literal key access %r the extractor cannot "
+                    "attribute to a receiver. Give it a named receiver, or "
+                    "teach the extractor the shape -- an unattributed read "
+                    "leaves this guard's universe without saying so."
+                    % (base, line, name))
+                continue
+            recv, qualified = plain.group(1), name
+        if recv in allowed:
+            continue
+        if recv not in prefix:
+            errors.append(
+                "%s reads `%s.%s` through receiver %r, which is neither a "
+                "known receipt receiver nor listed under "
+                "non_receipt_receivers in the ledger. Classify it: a receiver "
+                "the extractor does not recognise silently removes its fields "
+                "from this guard's universe." % (base, recv, name, recv))
+            continue
+        if qualified in dispatch and not prefix[recv]:
+            continue
+        found.add(prefix[recv] + qualified)
+    for _tuple_name, body in TUPLE.findall(src):
+        for item in re.findall(r'"(\w+)"', body):
+            found.add("provenance." + item)
+    return found
+
+
+universe = set()
+for path in (GATE, DELEGATE):
+    universe |= read_set(path)
+
+for name in sorted(universe - set(fields)):
+    errors.append(
+        "field %r is READ by the gate and absent from the ledger. Classify it "
+        "PRODUCED, DERIVED, POLICY or UNMEASURED -- an unclassified required "
+        "field is how the gate came to read a schema nothing writes." % name)
+
+for name in sorted(set(fields) - universe):
+    errors.append(
+        "field %r is classified in the ledger and read by nothing. A stale "
+        "entry makes the map look more complete than the gate is." % name)
+
+for name in sorted(set(fields) & universe):
+    spec = fields[name] or {}
+    klass = spec.get("class")
+    if klass in ("PRODUCED", "DERIVED"):
+        prod = spec.get("producer") or {}
+        rel, symbol = prod.get("file"), prod.get("symbol")
+        if not rel or not symbol:
+            errors.append("%s is %s and names no producer file+symbol" % (name, klass))
+            continue
+        target = os.path.join(root, rel)
+        if not os.path.exists(target):
+            errors.append("%s names producer %s, which does not exist" % (name, rel))
+            continue
+        with open(target, encoding="utf-8", errors="replace") as fh:
+            if symbol not in fh.read():
+                errors.append(
+                    "%s claims %s produces it via %r, and that text is no "
+                    "longer in the file. A producer claim that nothing checks "
+                    "rots into a fiction." % (name, rel, symbol))
+        if klass == "DERIVED" and not spec.get("formula"):
+            errors.append("%s is DERIVED and states no formula" % name)
+    elif klass == "POLICY":
+        rel = spec.get("policy")
+        if not rel or not os.path.exists(os.path.join(root, rel)):
+            errors.append("%s is POLICY and names no existing decision file" % name)
+    elif klass == "UNMEASURED":
+        if not re.match(r'^(PERF|BENCH)-\d{3}$', str(spec.get("owner") or "")):
+            errors.append(
+                "%s is UNMEASURED with owner=%r. Unmeasured is UNMEASURED WITH "
+                "AN OWNER; without one the gap has no route to being closed."
+                % (name, spec.get("owner")))
+        if "§" not in str(spec.get("spec") or ""):
+            errors.append("%s is UNMEASURED and cites no spec section" % name)
+        if not (spec.get("needs") or "").strip():
+            errors.append(
+                "%s is UNMEASURED and says nothing about what would have to be "
+                "instrumented. 'absent' is a schema error; 'the drain rule is "
+                "not implemented in any client' is a finding." % name)
+    else:
+        errors.append("%s has class=%r, which is not one of PRODUCED, DERIVED, "
+                      "POLICY, UNMEASURED" % (name, klass))
+
+# VACUITY. A sweep over an empty universe is clean and means nothing; the gate
+# reads well over a dozen receipt fields and always will.
+if len(universe) < 12:
+    errors.append("the extracted universe collapsed to %d field(s). A clean "
+                  "sweep over nothing is not a pass." % len(universe))
+
+if errors:
+    print("FAIL  perf receipt schema map")
+    for e in errors:
+        print("      " + e)
+    sys.exit(1)
+counts = {}
+for name in universe:
+    counts[(fields[name] or {}).get("class")] = counts.get((fields[name] or {}).get("class"), 0) + 1
+print("ok    %d field(s) read by the gate, all classified: %s"
+      % (len(universe), ", ".join("%s=%d" % kv for kv in sorted(counts.items()))))
+PY
+}
+
+# ------------------------------------------------------------- case table ---
+# Every mutation below is applied to a COPY of the tree, the guard is re-run
+# against that copy, and the expected colour is asserted. A guard seen only
+# passing is not evidence; these rows are the evidence, and they are re-run by
+# CI rather than recorded in a commit message.
+self_test() {
+  local pass=0 fail=0
+  # NOT `local`: the EXIT trap below runs after this function has returned, and
+  # a local would be out of scope by then -- `${td:?}` would fire on every run
+  # and print a failure after a clean pass.
+  td="$(mktemp -d)" || exit 2
+  case "$td" in
+    /tmp/*|/var/folders/*) : ;;
+    *) printf 'refusing to rm -rf %s\n' "${td:-<empty>}" >&2; exit 2 ;;
+  esac
+  trap 'rm -rf "${td:?}"' EXIT
+
+  _fixture() { # name -> a fresh copy of the tree at $td/$1
+    rm -rf "${td:?}/$1"
+    mkdir -p "$td/$1/scripts/lib" "$td/$1/crates" "$td/$1/evidence"
+    cp "$ROOT/scripts/perf_gate.sh" "$td/$1/scripts/"
+    cp "$ROOT/scripts/perf-receipt-fields.yaml" "$td/$1/scripts/"
+    cp "$ROOT/scripts/perf-matrix.yaml" "$td/$1/scripts/"
+    cp "$ROOT/scripts/lib/bench_receipt.py" "$td/$1/scripts/lib/"
+    cp "$ROOT/scripts/lib/parity_block.py" "$td/$1/scripts/lib/"
+    mkdir -p "$td/$1/crates/aprender-test-lib/src/llm" "$td/$1/crates/apr-cli/src/commands"
+    cp "$ROOT/crates/aprender-test-lib/src/llm/loadtest.rs" "$td/$1/crates/aprender-test-lib/src/llm/"
+    cp "$ROOT/crates/aprender-test-lib/src/llm/benchmark.rs" "$td/$1/crates/aprender-test-lib/src/llm/"
+  }
+
+  _expect() { # name, expected(pass|fail)
+    local got
+    if run_check "$td/$1" >/dev/null 2>&1; then got=pass; else got=fail; fi
+    if [ "$got" = "$2" ]; then
+      printf '  ok    %-38s expect=%s\n' "$1" "$2"; pass=$((pass + 1))
+    else
+      printf '  BROKE %-38s expected %s got %s\n' "$1" "$2" "$got"; fail=$((fail + 1))
+    fi
+  }
+
+  # The tree as it stands. If this is not green the rest proves nothing.
+  _fixture clean_tree
+  _expect clean_tree pass
+
+  # MUTATION 1 -- the defect that produced this ticket, in miniature: the gate
+  # grows a requirement nobody classified.
+  _fixture read_without_ledger_entry
+  cat >> "$td/read_without_ledger_entry/scripts/perf_gate.sh" <<'MUT'
+arm_f_prefill() { python3 -c 'r={}; print(r.get("prefill_efficiency"))'; }
+MUT
+  _expect read_without_ledger_entry fail
+
+  # MUTATION 2 -- the map claims more coverage than the gate has.
+  _fixture ledger_entry_nothing_reads
+  printf '  invented_field:\n    class: DERIVED\n    required: always\n    producer: {file: scripts/perf_gate.sh, symbol: "arm_a_scaling"}\n    formula: nothing reads this\n' \
+    >> "$td/ledger_entry_nothing_reads/scripts/perf-receipt-fields.yaml"
+  _expect ledger_entry_nothing_reads fail
+
+  # MUTATION 3 -- an unmeasured gap loses its owner and becomes permanent.
+  _fixture unmeasured_without_owner
+  sed -i 's/^    owner: PERF-004$//' \
+    "$td/unmeasured_without_owner/scripts/perf-receipt-fields.yaml"
+  _expect unmeasured_without_owner fail
+
+  # MUTATION 4 -- THE FORBIDDEN REPAIR. An unmeasured field is relabelled as
+  # produced, which is precisely how five invented numbers would enter the
+  # receipt wearing the shape of measurements. The producer claim is checked
+  # against the file, so the relabel cannot stand on its own.
+  _fixture unmeasured_laundered_to_produced
+  python3 - "$td/unmeasured_laundered_to_produced/scripts/perf-receipt-fields.yaml" <<'MUT'
+import re, sys
+p = sys.argv[1]
+s = open(p, encoding="utf-8").read()
+s = s.replace(
+    "  drain_ms:\n    class: UNMEASURED",
+    '  drain_ms:\n    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, '
+    'symbol: "let drain_ms"}\n    formula: recorded by the client\n    class: PRODUCED')
+open(p, "w", encoding="utf-8").write(s)
+MUT
+  _expect unmeasured_laundered_to_produced fail
+
+  # MUTATION 5 -- a read through a receiver the extractor does not know. It
+  # must be loud, not skipped: a receiver that silently drops out of the map
+  # takes its fields with it.
+  _fixture unknown_receiver
+  cat >> "$td/unknown_receiver/scripts/perf_gate.sh" <<'MUT'
+arm_g_mystery() { python3 -c 'zz={}; print(zz.get("mystery"))'; }
+MUT
+  _expect unknown_receiver fail
+
+  # DISCRIMINATION -- a SECOND read of a field the ledger already classifies is
+  # not a violation. Without this row the guard could be keying on the size of
+  # the file, or on the count of reads, and every mutation above would still
+  # look correct.
+  _fixture second_read_of_ledgered_field
+  printf 'x=$(python3 -c "r={}; r.get(\\"drain_ms\\")")\n' \
+    >> "$td/second_read_of_ledgered_field/scripts/perf_gate.sh"
+  _expect second_read_of_ledgered_field pass
+
+  # DISCRIMINATION -- editing a producer file without touching the cited symbol
+  # leaves the map intact. A guard that reddened on any edit to loadtest.rs
+  # would be trained away within a week.
+  _fixture unrelated_producer_edit
+  printf '\n// an unrelated comment\n' \
+    >> "$td/unrelated_producer_edit/crates/aprender-test-lib/src/llm/loadtest.rs"
+  _expect unrelated_producer_edit pass
+
+  printf '  %d passed, %d broken\n' "$pass" "$fail"
+  [ "$fail" = 0 ]
+}
+
+case "${1:-}" in
+  --self-test|--selftest) self_test ;;
+  "") run_check "$ROOT" ;;
+  *) printf 'usage: %s [--self-test]\n' "$(basename "$0")" >&2; exit 2 ;;
+esac

--- a/scripts/lib/parity_block.py
+++ b/scripts/lib/parity_block.py
@@ -31,22 +31,67 @@ def _samples(path, key):
     return [r[key] for r in runs]
 
 
+def _runs(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)["runs"]
+
+
+def _request_latencies(path):
+    """Raw per-REQUEST latencies, in run order (§4.4.5).
+
+    This block used to read the BenchmarkReport's request_details and keep only
+    per-run summaries, so the raw samples died at this boundary and no
+    downstream consumer could re-derive a threshold from a parity block. The
+    quantities beside them are per-RUN and none of them is a substitute.
+    """
+    out = []
+    for run in _runs(path):
+        out.extend(d["latency_ms"] for d in run.get("request_details", []))
+    return out
+
+
 def _side(binary, sha, klass, path, install_source=None, feature_set=None):
     prov = {"binary_path": binary, "binary_sha256": sha,
             "resolution": "scripts/apr_bin.sh" if install_source else "scripts/llama_bin.sh",
             "compute_class": klass}
     if feature_set is not None:
         prov["feature_set"] = feature_set
+    runs = _runs(path)
     side = {"provenance": prov,
             "decode_tok_per_sec": _samples(path, "decode_tok_per_sec"),
             "prefill_tok_per_sec": _samples(path, "prefill_tok_per_sec"),
-            "ttft_p50_ms": _samples(path, "ttft_p50_ms")}
+            "ttft_p50_ms": _samples(path, "ttft_p50_ms"),
+            "samples_ms": _request_latencies(path),
+            # SGLang asserts completed == requested before it reads a
+            # throughput at all, and this block dropped both counts while
+            # reading the runs that hold them -- so a lane could report a ratio
+            # whose denominator had lost requests, and nothing downstream could
+            # tell. Carried on BOTH sides: a comparator that lost requests
+            # flatters the subject.
+            "requested": sum(r["total_requests"] for r in runs),
+            "completed": sum(r["successful"] for r in runs)}
     if install_source:
         side["install_source"] = install_source
     return side
 
 
 BANDS_DEFAULT = (1, 4, 8, 16)
+
+
+def _band_side(path):
+    """One side of one band: the two metrics, plus the counts SGLang asserts on.
+
+    The counts were dropped here while the runs holding them were being read, so
+    a band could report a ratio whose denominator had lost requests and nothing
+    downstream could tell. Carried on BOTH sides: a comparator that loses
+    requests flatters the subject.
+    """
+    runs = _runs(path)
+    return {"aggregate_tok_per_sec": _samples(path, "tokens_per_sec"),
+            "decode_tok_per_sec": _samples(path, "decode_tok_per_sec"),
+            "tokens_total": sum(r["completion_tokens_total"] for r in runs),
+            "requested": sum(r["total_requests"] for r in runs),
+            "completed": sum(r["successful"] for r in runs)}
 
 
 def _band_from(name, c, work):
@@ -56,10 +101,8 @@ def _band_from(name, c, work):
     if not (os.path.exists(a) and os.path.exists(l)):
         return None
     band = {"concurrency": c,
-            "subject": {"aggregate_tok_per_sec": _samples(a, "tokens_per_sec"),
-                        "decode_tok_per_sec": _samples(a, "decode_tok_per_sec")},
-            "comparator": {"aggregate_tok_per_sec": _samples(l, "tokens_per_sec"),
-                           "decode_tok_per_sec": _samples(l, "decode_tok_per_sec")}}
+            "subject": _band_side(a),
+            "comparator": _band_side(l)}
     ok = True
     for metric in ("aggregate_tok_per_sec", "decode_tok_per_sec"):
         ratio = (statistics.median(band["subject"][metric])

--- a/scripts/lib/parity_block.py
+++ b/scripts/lib/parity_block.py
@@ -77,6 +77,41 @@ def _side(binary, sha, klass, path, install_source=None, feature_set=None):
 
 BANDS_DEFAULT = (1, 4, 8, 16)
 
+# THE LANE-LEVEL SIDE IS THE c=1 BAND. It is not a separate measurement.
+#
+# THE DEFECT THIS REPLACES (PERF-004). This block used to read
+# `$WORK/apr-<lane>.json` and `$WORK/llama-<lane>.json` for the lane-level
+# samples. scripts/parity_host_receipt.sh -- its ONLY producer, which invokes
+# it directly at line 144 -- writes neither. Its run_lane() writes exactly
+# `apr-<lane>-c<N>.json`, `llama-<lane>-c<N>.json`, the two `.log` files and
+# `lanes.txt` (lines 96-124), and its own header comment claims a third
+# spelling, `$WORK/<class>.json`. So every complete run of the host receipt
+# script reached this file and died on
+#
+#     FAIL  lane cpu is missing a side; refusing to report half a comparison
+#
+# which reads as "the benchmark did not run" and is in fact "the consumer
+# requires an artifact no producer has ever written". The P2 chain has never
+# emitted a parity block.
+#
+# WHY THE CONSUMER MOVED AND NOT THE PRODUCER. Adding an unbanded run to
+# run_lane() would have made the producer emit it -- and that run would BE a
+# c=1 run: `apr test llm bench --concurrency` defaults to 1, and the
+# lane-level artifacts in the 2026-08-25 corpus (evidence/parity-http/
+# lambda-apr.json, lambda-llamacpp.json) are concurrency=[1] on every run. So
+# option (a) pays for a second, independently-measured copy of a number the
+# band sweep already has, and two independent copies of "the same" number is
+# how a receipt comes to disagree with itself. It also stops
+# llama_pin.toml's `http_concurrency_bands` from being the single statement of
+# what was measured, and nothing in the artifact would record that the
+# unbanded run was taken at c=1 rather than at some other concurrency.
+#
+# NO FALLBACK. If band c=1 is absent this refuses by name. Accepting either
+# layout would report a lane from whichever happened to be present and prove
+# neither contract.
+LANE_BAND = 1
+assert LANE_BAND in BANDS_DEFAULT
+
 
 def _band_side(path):
     """One side of one band: the two metrics, plus the counts SGLang asserts on.
@@ -115,12 +150,26 @@ def _band_from(name, c, work):
 
 
 def _lane_from(name, apr_class, comp_class, args, work):
-    """One lane, or None if a side is missing."""
-    apr_json = os.path.join(work, "apr-%s.json" % name)
-    cmp_json = os.path.join(work, "llama-%s.json" % name)
-    if not (os.path.exists(apr_json) and os.path.exists(cmp_json)):
-        sys.stderr.write("FAIL  lane %s is missing a side; refusing to report "
-                         "half a comparison\n" % name)
+    """One lane, or None if a side is missing.
+
+    The lane-level samples come from the c=1 band -- see LANE_BAND. The paths
+    named in the failure below are the ones run_lane() writes, so a missing
+    side names a file the producer was supposed to have produced rather than a
+    file nothing has ever produced.
+    """
+    apr_json = os.path.join(work, "apr-%s-c%d.json" % (name, LANE_BAND))
+    cmp_json = os.path.join(work, "llama-%s-c%d.json" % (name, LANE_BAND))
+    missing = [p for p in (apr_json, cmp_json) if not os.path.exists(p)]
+    if missing:
+        sys.stderr.write(
+            "FAIL  lane %s: the c=%d band is the lane-level measurement and "
+            "these are absent:\n" % (name, LANE_BAND))
+        for path in missing:
+            sys.stderr.write("        %s\n" % path)
+        sys.stderr.write("      Refusing to report half a comparison. There is "
+                         "no fallback to another band: a lane reported from "
+                         "c=4 while claiming the lane ratio would be a "
+                         "different measurement under the same name.\n")
         return None
     # feature_set is DERIVED from the class actually taken, so a cuda lane
     # cannot be claimed by a build that never took the cuda path.

--- a/scripts/lib/perf_receipt.py
+++ b/scripts/lib/perf_receipt.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Convert what this repo MEASURES into what scripts/perf_gate.sh READS.
+
+THE DEFECT THIS CLOSES (PERF-004). perf_gate.sh accepted no artifact any
+in-tree producer emitted. Four real inputs were tried and all four returned
+rc=1; only the gate's own synthetic fixture passed. Two incompatible band
+schemas had grown side by side:
+
+    parity_block.py   parity.lanes[].bands[].ratio_aggregate_tok_per_sec
+    perf_gate.sh                      bands[].agg_ratio
+
+THE RULE THIS OBEYS. Five fields the gate requires -- `requested`, `completed`,
+`timeouts`, `drain_ms`, `tokenization.method` -- looked like the same kind of
+gap. They are not. Two are DERIVABLE from counts the harness already records.
+Three are UNMEASURED: nothing in this tree measures them, and teaching this
+converter to emit a plausible value for them would hand-assign three numbers
+that no instrument produced, which is the exact defect APR-PERF-GATE-001 exists
+to remove.
+
+So this file derives the first two and REFUSES the last three. In their place it
+copies the UNMEASURED entries out of scripts/perf-receipt-fields.yaml into the
+receipt's `unmeasured` block, with each field's owning ticket and spec section.
+The gate then fails with "drain_ms absent -- the drain rule (§4.4.7) is not
+implemented in any client (owner PERF-004)" instead of "ArmC schema". A finding
+names the thing that has to be built; a schema error names nothing.
+
+USAGE
+
+  # from band artifacts: DIR/{prefix}-c{N}.json, each an `apr test llm bench
+  # --output` BenchmarkReport
+  perf_receipt.py --from-bands DIR --subject apr --comparator llamacpp \\
+                  --host lambda --workload W1 --out receipt.json \\
+                  --binary PATH --binary-sha256 HEX --compute-class cuda \\
+                  --model NAME --quantization Q4_K_M
+
+  # from a parity block, which already carries provenance for both sides
+  perf_receipt.py --from-parity parity.json --host lambda --workload W1 \\
+                  --out receipt.json
+
+  # derive and print, write nothing. The only mode that needs no provenance,
+  # and therefore the only one that can read a corpus whose binary digest was
+  # never recorded.
+  perf_receipt.py --from-bands DIR --subject apr --comparator llamacpp \\
+                  --derive-only
+
+Exit: 0 wrote (or printed) a receipt - 1 refused - 2 usage/read error
+"""
+import argparse
+import json
+import os
+import statistics
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bench_receipt  # noqa: E402
+
+SCRIPTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LEDGER = os.path.join(SCRIPTS, "perf-receipt-fields.yaml")
+BANDS_DEFAULT = (1, 4, 8, 16)
+
+
+# --------------------------------------------------------------- the ledger --
+def unmeasured_from_ledger(path=LEDGER):
+    """The UNMEASURED bucket, keyed by field, straight out of the map.
+
+    Read rather than restated so the receipt cannot drift from the ledger the
+    guard checks. A hand-copied list is a second definition, and a second
+    definition is how the two band schemas happened.
+    """
+    import yaml
+    with open(path, encoding="utf-8") as handle:
+        doc = yaml.safe_load(handle)
+    out = {}
+    for name, spec in (doc.get("fields") or {}).items():
+        if spec.get("class") != "UNMEASURED":
+            continue
+        out[name] = {"owner": spec.get("owner"), "spec": spec.get("spec"),
+                     "needs": " ".join((spec.get("needs") or "").split())}
+    return out
+
+
+# ------------------------------------------------------------ P1: bands dir --
+def _runs(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)["runs"]
+
+
+def _median(runs, key):
+    return statistics.median([r[key] for r in runs])
+
+
+def _band_paths(work, prefix, c):
+    return os.path.join(work, "%s-c%d.json" % (prefix, c))
+
+
+def _one_concurrency(runs):
+    """The concurrency this artifact was run at, or None if it disagrees.
+
+    A band file whose runs were taken at different concurrencies is not one
+    band, and averaging across it silently reports a mixture as a measurement.
+    """
+    levels = {r.get("concurrency") for r in runs}
+    return levels.pop() if len(levels) == 1 else None
+
+
+def _samples_ms(runs):
+    """Per-request latencies, retained per §4.4.5 so a bootstrap stays possible."""
+    out = []
+    for run in runs:
+        out.extend(d["latency_ms"] for d in run.get("request_details", []))
+    return out
+
+
+def _sides_for(work, subject, comparator, c, errors):
+    """Both sides of one band, or None with the reason recorded."""
+    s_path, c_path = _band_paths(work, subject, c), _band_paths(work, comparator, c)
+    if not os.path.exists(s_path):
+        return None
+    if not os.path.exists(c_path):
+        errors.append("band c=%d has a subject and no comparator; refusing to "
+                      "report half a comparison" % c)
+        return None
+    s_runs, c_runs = _runs(s_path), _runs(c_path)
+    if _one_concurrency(s_runs) != c or _one_concurrency(c_runs) != c:
+        errors.append("band c=%d: the artifact's own runs do not all report "
+                      "concurrency=%d" % (c, c))
+        return None
+    return s_runs, c_runs
+
+
+def _band_from_runs(c, s_runs, c_runs):
+    """One band, every value derived from the two artifacts' own samples."""
+    return {
+        "concurrency": c,
+        "aggregate_tok_per_sec": _median(s_runs, "tokens_per_sec"),
+        "decode_tok_per_sec": _median(s_runs, "decode_tok_per_sec"),
+        "tokens_total": sum(r["completion_tokens_total"] for r in s_runs),
+        "agg_ratio": _median(s_runs, "tokens_per_sec") / _median(c_runs, "tokens_per_sec"),
+        "decode_ratio": _median(s_runs, "decode_tok_per_sec") / _median(c_runs, "decode_tok_per_sec"),
+        # THE COMPARATOR'S OWN COMPLETION, carried rather than dropped.
+        # llama.cpp lost 3/80, 3/223, 6/302 and 10/522 requests on the
+        # 2026-08-25 corpus. Its tok/s counts tokens from SUCCESSFUL requests
+        # only over the same wall clock, so every lost request lowers the
+        # denominator of agg_ratio and flatters the subject. Arm C asserts
+        # completed == requested on the subject and never looked at the other
+        # side of its own ratio.
+        "comparator_requested": sum(r["total_requests"] for r in c_runs),
+        "comparator_completed": sum(r["successful"] for r in c_runs),
+    }
+
+
+def bands_from_dir(work, subject, comparator, errors):
+    """One band per concurrency for which BOTH sides exist."""
+    bands, samples, requested, completed = [], [], 0, 0
+    for c in BANDS_DEFAULT:
+        sides = _sides_for(work, subject, comparator, c, errors)
+        if sides is None:
+            continue
+        s_runs, c_runs = sides
+        bands.append(_band_from_runs(c, s_runs, c_runs))
+        samples.extend(_samples_ms(s_runs))
+        requested += sum(r["total_requests"] for r in s_runs)
+        completed += sum(r["successful"] for r in s_runs)
+    if not bands:
+        errors.append("no band had both sides present under %s" % work)
+    return bands, samples, requested, completed
+
+
+# --------------------------------------------------------- P2: parity block --
+def _lane_of(block, want, errors):
+    lanes = block.get("lanes") or []
+    if want:
+        lanes = [l for l in lanes if l.get("lane") == want]
+        if not lanes:
+            errors.append("no lane named %r in the parity block" % want)
+            return None
+    if len(lanes) != 1:
+        errors.append("the parity block carries %d lanes; name one with --lane"
+                      % len(lanes))
+        return None
+    return lanes[0]
+
+
+def _convert_parity_band(raw):
+    """THE RENAME AND THE RE-NESTING, in one place.
+
+        parity.lanes[].bands[].ratio_aggregate_tok_per_sec  ->  bands[].agg_ratio
+
+    Ratios are RE-DERIVED from the samples beside them and never copied: a
+    stated ratio is the one field that can be wrong while every field around it
+    is right, which is parity_block.py's own rule applied to its own output.
+    """
+    subj, comp = raw.get("subject") or {}, raw.get("comparator") or {}
+    band = {"concurrency": raw.get("concurrency"),
+            "aggregate_tok_per_sec": statistics.median(subj["aggregate_tok_per_sec"]),
+            "decode_tok_per_sec": statistics.median(subj["decode_tok_per_sec"])}
+    for src, dst in (("aggregate_tok_per_sec", "agg_ratio"),
+                     ("decode_tok_per_sec", "decode_ratio")):
+        band[dst] = statistics.median(subj[src]) / statistics.median(comp[src])
+    # Omitted rather than guessed when the block predates PERF-004: Arm C's
+    # zero-token check reads an absent count as "not zero", which is the honest
+    # reading of "this document never carried it".
+    for src, dst in (("tokens_total", "tokens_total"),):
+        if subj.get(src) is not None:
+            band[dst] = subj[src]
+    for src, dst in (("requested", "comparator_requested"),
+                     ("completed", "comparator_completed")):
+        if comp.get(src) is not None:
+            band[dst] = comp[src]
+    return band
+
+
+def bands_from_parity(path, lane_name, errors):
+    """Rename and re-nest P2's bands into the shape the gate reads.
+
+    Ratios are RE-DERIVED from the samples beside them rather than copied:
+    parity_block.py's own doctrine is that nothing accepts a ratio as input,
+    because a stated ratio is the one field that can be wrong while every field
+    around it is right.
+    """
+    with open(path, encoding="utf-8") as handle:
+        doc = json.load(handle)
+    block = doc.get("parity") if isinstance(doc.get("parity"), dict) else doc
+    lane = _lane_of(block, lane_name, errors)
+    if lane is None:
+        return None, None, None
+    if lane.get("comparability") == "cross-class-existence-only":
+        errors.append("lane %r is cross-class-existence-only. A cross-class row "
+                      "cannot arm Arm B's floor, and a receipt that merely MARKS "
+                      "it still walks into Arm A, which reads no comparator at "
+                      "all and would gate it happily. Refusing." % lane.get("lane"))
+        return None, None, None
+    bands = [_convert_parity_band(raw) for raw in (lane.get("bands") or [])]
+    if not bands:
+        errors.append("lane %r carries no bands" % lane.get("lane"))
+        return None, None, None
+    subject = lane.get("subject") or {}
+    return bands, subject, lane
+
+
+# --------------------------------------------------------------- assembling --
+def _provenance_from_args(args, errors):
+    prov = {"binary_path": args.binary, "binary_sha256": args.binary_sha256,
+            "resolution": args.resolution, "compute_class": args.compute_class}
+    for key, value in list(prov.items()):
+        if not value:
+            errors.append("provenance.%s is required and was not given. It is "
+                          "not derivable from a benchmark artifact: the harness "
+                          "never sees the binary it drove." % key)
+    for key, value in (("host", args.host), ("accelerator", args.accelerator),
+                       ("model", args.model), ("quantization", args.quantization)):
+        if value:
+            prov[key] = value
+    return prov
+
+
+def _print_table(bands, requested, completed):
+    base = next((b["aggregate_tok_per_sec"] for b in bands
+                 if b["concurrency"] == 1), None)
+    print("  c   agg_tok_s  scaling_eff   agg_ratio  decode_ratio   cmp completed")
+    for b in bands:
+        c = b["concurrency"]
+        eff = (b["aggregate_tok_per_sec"] / base) / c if base else float("nan")
+        cr, cc = b.get("comparator_requested"), b.get("comparator_completed")
+        comp = "%d/%d" % (cc, cr) if cr is not None else "-"
+        print("%3d  %10.2f  %11.4f  %10.4f  %12.4f  %14s"
+              % (c, b["aggregate_tok_per_sec"], eff, b["agg_ratio"],
+                 b["decode_ratio"], comp))
+    if requested is not None:
+        print("  subject completed/requested: %d/%d" % (completed, requested))
+
+
+def _fill_from_parity(args, receipt, errors):
+    bands, subject, _lane = bands_from_parity(args.from_parity, args.lane, errors)
+    if bands is None:
+        return None
+    prov = dict(subject.get("provenance") or {})
+    if args.host and not prov.get("host"):
+        prov["host"] = args.host
+    # §4.4.5's raw per-request latencies. A parity block written before
+    # PERF-004 does not carry them -- P2 read request_details and kept only
+    # per-RUN summaries -- and there is nothing on a parity side that can stand
+    # in for them. ttft_p50_ms is per-run and is a different quantity;
+    # substituting it would put a plausible list of numbers under a label that
+    # does not describe them.
+    if subject.get("samples_ms") is None:
+        errors.append("the subject side carries no samples_ms. A parity block "
+                      "written before PERF-004 kept only per-run summaries, and "
+                      "§4.4.5's raw per-request latencies cannot be recovered "
+                      "from it. Re-emit the block with parity_block.py, or use "
+                      "--from-bands.")
+        return None
+    receipt.update({"bands": bands, "provenance": prov,
+                    "samples_ms": list(subject["samples_ms"])})
+    if subject.get("requested") is not None:
+        receipt["requested"] = subject["requested"]
+        receipt["completed"] = subject.get("completed")
+    return receipt
+
+
+def _fill_from_bands(args, receipt, errors):
+    bands, samples, requested, completed = bands_from_dir(
+        args.from_bands, args.subject, args.comparator, errors)
+    if errors:
+        return None
+    receipt.update({"bands": bands, "requested": requested,
+                    "completed": completed, "samples_ms": samples})
+    if not args.derive_only:
+        receipt["provenance"] = _provenance_from_args(args, errors)
+    return receipt
+
+
+def build(args, errors):
+    receipt = {
+        "schema": "perf-receipt/v2.2-partial",
+        "host": args.host,
+        "workload": args.workload,
+        # WHAT THIS RECEIPT CANNOT SAY, said out loud. Every entry here is a
+        # field perf_gate.sh requires that no instrument in this tree produces.
+        # It is copied from scripts/perf-receipt-fields.yaml, never restated.
+        "unmeasured": unmeasured_from_ledger(),
+    }
+    fill = _fill_from_parity if args.from_parity else _fill_from_bands
+    if fill(args, receipt, errors) is None:
+        return None
+    if not receipt.get("samples_ms"):
+        errors.append("samples_ms came out empty. §4.4.5 keeps raw per-request "
+                      "samples so a threshold can be re-derived later; a receipt "
+                      "without them forecloses that permanently.")
+    return receipt
+
+
+# ----------------------------------------------------------------- selftest --
+# END TO END, not unit: the claim being proved is that a BenchmarkReport this
+# repo can actually produce reaches a verdict from scripts/perf_gate.sh, and
+# that what remains failing is the UNMEASURED bucket by name rather than a
+# schema error. A converter tested only against its own output would prove the
+# same thing the gate's synthetic fixture proved -- nothing.
+def _fake_run(concurrency, agg, decode, n_req, ok, tokens, latency0):
+    return {
+        "concurrency": concurrency, "tokens_per_sec": agg,
+        "decode_tok_per_sec": decode, "total_requests": n_req,
+        "successful": ok, "failed": n_req - ok,
+        "completion_tokens_total": tokens,
+        # A real timing distribution is not a constant; bench_receipt.py rejects
+        # a flat one as the fabricated-measurement shape, and it is right to.
+        "request_details": [{"latency_ms": latency0 + i * 1.7, "ttft_ms": 12.0,
+                             "completion_tokens": 128, "prompt_tokens": 100,
+                             "itl_ms": 9.0} for i in range(5)],
+    }
+
+
+def _write_report(path, runs):
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump({"runs": runs, "aggregate": {}, "regressions": []}, handle)
+
+
+def _fixture(work, agg_c4=360.0):
+    for c, agg, dec in ((1, 100.0, 110.0), (4, agg_c4, 112.0)):
+        _write_report(_band_paths(work, "apr", c),
+                      [_fake_run(c, agg, dec, 20, 20, 2560, 100.0),
+                       _fake_run(c, agg * 1.01, dec, 20, 20, 2560, 101.0)])
+        _write_report(_band_paths(work, "llamacpp", c),
+                      [_fake_run(c, agg / 0.9, dec / 1.1, 20, 20, 2560, 90.0),
+                       _fake_run(c, agg / 0.9, dec / 1.1, 20, 20, 2560, 91.0)])
+
+
+PROV_ARGS = ["--binary", "/opt/pinned", "--binary-sha256", "0" * 64,
+             "--compute-class", "cuda", "--resolution", "scripts/apr_bin.sh"]
+
+
+def _convert(work, out, extra=()):
+    return main(["--from-bands", work, "--host", "lambda", "--workload", "W1",
+                 "--out", out] + list(extra))
+
+
+def _edit_runs(work, mutate):
+    """Apply `mutate` to each band artifact's runs, in place."""
+    for c in (1, 4):
+        for side in ("apr", "llamacpp"):
+            path = _band_paths(work, side, c)
+            with open(path, encoding="utf-8") as handle:
+                doc = json.load(handle)
+            mutate(doc["runs"])
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(doc, handle)
+
+
+def _mutant(work, name, mutate):
+    """A fresh fixture with one thing wrong, converted; returns the rc."""
+    where = os.path.join(work, name)
+    os.makedirs(where, exist_ok=True)
+    _fixture(where)
+    _edit_runs(where, mutate)
+    return _convert(where, os.devnull, PROV_ARGS)
+
+
+def _selftest_verdict_rows(work, gate):
+    """Convert a fixture, run the real gate on it, and read the verdict."""
+    out = os.path.join(work, "receipt.json")
+    rc = _convert(work, out, PROV_ARGS + [
+        "--accelerator", "rtx-4090", "--model", "qwen2.5-coder-1.5b-instruct",
+        "--quantization", "Q4_K_M"])
+    import subprocess
+    proc = subprocess.run(["bash", gate, "--host", "lambda", "--phase", "merge",
+                           "--workload", "W1", "--receipt", out],
+                          capture_output=True, text=True, check=False)
+    text = proc.stdout + proc.stderr
+    return [
+        ("converts a real report shape", rc == 0),
+        # Arms A and B RUN. Before this converter they could not: the gate saw
+        # no bands at all and said so twice.
+        ("ArmA scores the converted receipt", "ArmA c=4" in text),
+        ("ArmB scores the converted receipt", "ArmB1 c=4" in text),
+        # The delegate ACCEPTS it -- provenance and raw samples are present, so
+        # the residual failure is not a schema rejection any more.
+        ("no schema rejection remains", "ArmC schema" not in text),
+        # ... and what does remain is named, with an owner.
+        ("drain_ms failure names the gap",
+         "drain_ms absent -- The drain rule is not implemented" in text),
+        ("drain_ms failure names its owner", "owner PERF-004)" in text),
+        ("verdict is still FAIL", proc.returncode == 1),
+    ]
+
+
+def _drop_samples(runs):
+    for run in runs:
+        run["request_details"] = []
+
+
+def _mix_concurrency(runs):
+    runs[-1]["concurrency"] = runs[-1]["concurrency"] + 4
+
+
+def _selftest_refusal_rows(work):
+    return [
+        # §4.4.5's raw samples are what a later threshold would be re-derived
+        # from; a receipt without them forecloses that permanently.
+        ("refuses a receipt with no raw samples",
+         _mutant(work, "stripped", _drop_samples) == 1),
+        # A band file whose runs disagree on concurrency is a mixture, and
+        # averaging across it reports the mixture as one band.
+        ("refuses a band that mixes concurrencies",
+         _mutant(work, "mixed", _mix_concurrency) == 1),
+        # The harness never sees the binary it drove, so provenance is not
+        # derivable and must not be defaulted. This is exactly why the
+        # 2026-08-25 corpus cannot produce a conformant receipt.
+        ("refuses a receipt with no provenance",
+         _convert(work, os.devnull) == 1),
+        # `--resolution` USED TO DEFAULT to "scripts/apr_bin.sh". That string
+        # is the provenance claim that matters -- never PATH, never a hardcoded
+        # absolute path -- so defaulting it wrote an assertion nothing checked
+        # into every receipt whose caller forgot the flag. It is now required,
+        # and this row is the proof that omitting it REFUSES rather than
+        # asserting on the caller's behalf.
+        ("refuses a receipt whose resolution is not stated",
+         _convert(work, os.devnull, [a for a in PROV_ARGS
+                                     if a not in ("--resolution",
+                                                  "scripts/apr_bin.sh")]) == 1),
+        # DISCRIMINATION -- the same tree, unmutated, still converts. Without
+        # this row every refusal above could come from a converter that refuses
+        # everything.
+        ("still converts an unmutated tree",
+         _convert(work, os.devnull, PROV_ARGS) == 0),
+    ]
+
+
+def selftest():
+    import shutil
+    import tempfile
+    gate = os.path.join(SCRIPTS, "perf_gate.sh")
+    work = tempfile.mkdtemp(prefix="perf-receipt-selftest-")
+    try:
+        _fixture(work)
+        rows = _selftest_verdict_rows(work, gate) + _selftest_refusal_rows(work)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+    bad = sum(1 for _name, ok in rows if not ok)
+    for name, ok in rows:
+        print("  %-5s %s" % ("ok" if ok else "BROKE", name))
+    print("  %d passed, %d broken" % (len(rows) - bad, bad))
+    return 1 if bad else 0
+
+
+def _parser():
+    ap = argparse.ArgumentParser()
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--from-bands", help="directory of per-concurrency BenchmarkReport artifacts")
+    src.add_argument("--from-parity", help="a parity block emitted by parity_block.py")
+    ap.add_argument("--subject", default="apr")
+    ap.add_argument("--comparator", default="llamacpp")
+    ap.add_argument("--lane", help="which lane of a multi-lane parity block")
+    ap.add_argument("--host")
+    ap.add_argument("--workload", default="W1")
+    ap.add_argument("--binary")
+    ap.add_argument("--binary-sha256")
+    # NO DEFAULT. This field asserts HOW the binary was resolved, and
+    # "scripts/apr_bin.sh" is the one claim that matters -- never PATH,
+    # never a hardcoded absolute path. A caller that omits it gets that
+    # assertion written into the receipt on its behalf, which is a
+    # provenance claim nothing checked: exactly this epic's defect at
+    # the scale of one argparse default. It is now required, and
+    # _provenance_from_args refuses an empty one by the same rule that
+    # refuses a missing digest.
+    ap.add_argument("--resolution")
+    ap.add_argument("--compute-class")
+    ap.add_argument("--accelerator")
+    ap.add_argument("--model")
+    ap.add_argument("--quantization")
+    ap.add_argument("--derive-only", action="store_true",
+                    help="print the derived table and write nothing")
+    ap.add_argument("--out", default="-")
+    return ap
+
+
+def _report_derived(receipt):
+    _print_table(receipt["bands"], receipt.get("requested"),
+                 receipt.get("completed"))
+    print("  wrote nothing: --derive-only")
+    for name in sorted(receipt["unmeasured"]):
+        entry = receipt["unmeasured"][name]
+        print("  UNMEASURED %-28s owner=%s %s"
+              % (name, entry["owner"], entry["spec"]))
+    return 0
+
+
+def _emit(receipt, out):
+    # SELF-VALIDATION, with the same code Arm C delegates to. A producer that
+    # writes something the gate rejects has moved the failure to release day,
+    # when the only cheap option is to weaken the gate.
+    schema_errors = bench_receipt.validate(receipt)
+    if schema_errors:
+        sys.stderr.write("perf_receipt: refusing to emit a receipt this repo's "
+                         "own gate would reject:\n")
+        for e in schema_errors:
+            sys.stderr.write("  %s\n" % e)
+        return 1
+    text = json.dumps(receipt, indent=2, sort_keys=True)
+    if out == "-":
+        print(text)
+    else:
+        with open(out, "w", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+        sys.stderr.write("wrote %s\n" % out)
+    return 0
+
+
+def main(argv=None):
+    if (argv if argv is not None else sys.argv[1:])[:1] == ["--selftest"]:
+        return selftest()
+    args = _parser().parse_args(argv)
+
+    errors = []
+    receipt = build(args, errors)
+    if receipt is None or errors:
+        sys.stderr.write("perf_receipt: refusing to emit a receipt:\n")
+        for e in errors:
+            sys.stderr.write("  %s\n" % e)
+        return 1
+
+    if args.derive_only:
+        return _report_derived(receipt)
+    return _emit(receipt, args.out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/perf_receipt.py
+++ b/scripts/lib/perf_receipt.py
@@ -44,6 +44,49 @@ USAGE
                   --derive-only
 
 Exit: 0 wrote (or printed) a receipt - 1 refused - 2 usage/read error
+
+REPRODUCING THE END-TO-END RUN, AND WHAT IT DOES NOT LICENSE
+------------------------------------------------------------
+The commit that added this file quotes a live run: band artifacts produced by
+`apr test llm bench`, converted here, and given a verdict by
+scripts/perf_gate.sh. State the instrument exactly, because a benchmark
+artifact is only as identified as the binary that made it.
+
+  subject     /home/noah/.cargo/bin/apr, `apr 0.64.0 (ce712eae0)`
+              sha256 964503625a69462e24964c5b8118b1b78a1c0cae8e4dbdf845b2da25281d01c9
+  comparator  /home/noah/src/llama.cpp/build/bin/llama-server
+              `version: 7746 (39173bcac)` == scripts/llama_pin.toml's pin
+  compute     cpu on BOTH sides, read from the runtimes' own logs rather than
+              from the flags: llama printed "offloaded 0/25 layers to GPU", and
+              apr printed no CUDA banner, which is what
+              parity_host_receipt.sh's apr_class_from_log() calls cpu.
+
+`. scripts/apr_bin.sh` REFUSES on that box -- rc=1, "STALE apr BINARY ...
+reports apr 0.64.0 (ce712eae0), HEAD a468eac4e". There is no apr built from
+HEAD anywhere on it, so no step could have used one, and saying so is the
+honest form. The binary that ran is three commits behind, and the other apr on
+PATH is worse: ~/.local/bin/apr is stamped `v0.64.0+no-git`, carrying no commit
+at all, so nothing could establish what source built it. It won a bare `apr`.
+
+WHY THAT RUN STILL PROVES WHAT IT CLAIMS, and only that. The subject under test
+is this converter and perf_gate.sh AT HEAD -- Python and Bash, run from this
+checkout. apr is the INSTRUMENT that produced the input artifact, and the
+receipt records which one by digest rather than by name. The Rust delta between
+ce712eae0 and HEAD is five files, all of them `apr profile` (PERF-016):
+commands/profile.rs plus the four it `include!`s, reached only through
+`ExtendedCommands::Profile`. Neither executed step -- `apr serve run` and
+`apr test llm bench` -- is in that path; the one cross-module consumer,
+serve_plan.rs, imports `detect_gpu_hardware` and `query_gpu_vram_mb`, and the
+delta touches neither.
+
+WHAT IT DOES NOT LICENSE: any statement about apr's speed. Those ratios are a
+CPU-only published binary against llama.cpp on a box at load 16-74, ten-second
+runs, two runs per band. They are not a parity result, they are not cited as
+one anywhere, and the receipt is deliberately left in scratch rather than
+committed under evidence/. Rebuilding to satisfy apr_bin.sh was declined
+rather than skipped: `cargo install --path crates/apr-cli --force` overwrites
+~/.cargo/bin/apr while other agents on this box may be running it, and it would
+not change a single thing the run establishes.
 """
 import argparse
 import json

--- a/scripts/lib/perf_receipt.py
+++ b/scripts/lib/perf_receipt.py
@@ -342,6 +342,10 @@ def _fake_run(concurrency, agg, decode, n_req, ok, tokens, latency0):
         "decode_tok_per_sec": decode, "total_requests": n_req,
         "successful": ok, "failed": n_req - ok,
         "completion_tokens_total": tokens,
+        # Read by parity_block._side for the lane-level samples. Present on
+        # every real BenchmarkReport; absent here until the P2 chain rows
+        # below started exercising that reader.
+        "prefill_tok_per_sec": agg * 0.9, "ttft_p50_ms": 30.0 + latency0 * 0.1,
         # A real timing distribution is not a constant; bench_receipt.py rejects
         # a flat one as the fabricated-measurement shape, and it is right to.
         "request_details": [{"latency_ms": latency0 + i * 1.7, "ttft_ms": 12.0,
@@ -465,6 +469,108 @@ def _selftest_refusal_rows(work):
     ]
 
 
+# ------------------------------------------- P2: the parity chain, end to end
+# scripts/parity_host_receipt.sh -> lib/parity_block.py -> --from-parity ->
+# scripts/perf_gate.sh.
+#
+# THIS BRANCH HAD NEVER RUN. `--from-parity` was reachable from no test, and
+# the join underneath it was broken in a way no unit test could see:
+# parity_block.py read `$WORK/apr-<lane>.json` and `$WORK/llama-<lane>.json`,
+# and parity_host_receipt.sh -- its only producer, which invokes it directly --
+# writes neither. run_lane() writes `apr-<lane>-c<N>.json`,
+# `llama-<lane>-c<N>.json`, two `.log` files and `lanes.txt`, and nothing else.
+# So every complete host run ended at
+#
+#     FAIL  lane cpu is missing a side; refusing to report half a comparison
+#
+# which reads as "the benchmark did not run". The chain had never produced a
+# parity block, and a receipt-schema epic had no test that ran it.
+#
+# The layout below is written from run_lane()'s own output targets, so a future
+# divergence between producer and consumer fails HERE rather than on a host at
+# 3am.
+PARITY_LANE = "cpu"
+PARITY_BANDS = (1, 4, 8, 16)   # llama_pin.toml [protocol.http] concurrency bands
+PARITY_RATIO = 1.05            # inside [0.80, 1.50], so the lane verdict is PASS
+
+
+def _parity_work(root, bands=PARITY_BANDS):
+    """A $WORK laid out exactly as parity_host_receipt.sh run_lane() writes it."""
+    work = os.path.join(root, "p2")
+    if os.path.isdir(work):
+        import shutil
+        shutil.rmtree(work)
+    os.makedirs(work)
+    for c in bands:
+        agg, dec = 100.0 + c, 110.0 + c
+        _write_report(os.path.join(work, "apr-%s-c%d.json" % (PARITY_LANE, c)),
+                      [_fake_run(c, agg, dec, 20, 20, 2560, 100.0),
+                       _fake_run(c, agg * 1.01, dec * 1.01, 20, 20, 2560, 103.0)])
+        _write_report(os.path.join(work, "llama-%s-c%d.json" % (PARITY_LANE, c)),
+                      [_fake_run(c, agg / PARITY_RATIO, dec / PARITY_RATIO,
+                                 20, 20, 2560, 90.0),
+                       _fake_run(c, agg * 1.01 / PARITY_RATIO,
+                                 dec * 1.01 / PARITY_RATIO, 20, 20, 2560, 93.0)])
+    with open(os.path.join(work, "lanes.txt"), "w", encoding="utf-8") as fh:
+        # run_lane: printf '%s %s %s\n' <klass> <apr class taken> <cmp taken>
+        fh.write("%s cpu cpu\n" % PARITY_LANE)
+    return work
+
+
+def _run_parity_block(work, out):
+    """parity_block.py with the argument set parity_host_receipt.sh passes."""
+    import subprocess
+    return subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS, "lib", "parity_block.py"),
+         "--work", work, "--apr", "/opt/apr", "--apr-sha", "1" * 64,
+         "--llama", "/opt/llama-server", "--llama-sha", "2" * 64,
+         "--llama-build", "39173bcac", "--model", "/models/q.gguf",
+         "--install-source", "crates.io", "--out", out],
+        capture_output=True, text=True, check=False)
+
+
+def _selftest_parity_chain_rows(root, gate):
+    import subprocess
+    work = _parity_work(root)
+    block = os.path.join(work, "parity.json")
+    emitted = _run_parity_block(work, block)
+
+    rows = [("P2 producer layout emits a parity block", emitted.returncode == 0)]
+    if emitted.returncode != 0:
+        # Say WHY here rather than leaving six rows failing with no reason.
+        rows.append(("P2 parity_block stderr: " + emitted.stderr.strip()
+                     .replace("\n", " ")[:160], False))
+        return rows
+
+    receipt = os.path.join(work, "receipt.json")
+    rc = main(["--from-parity", block, "--lane", PARITY_LANE,
+               "--host", "lambda", "--workload", "W1", "--out", receipt])
+    rows.append(("--from-parity converts that block", rc == 0))
+    if rc != 0:
+        return rows
+
+    proc = subprocess.run(["bash", gate, "--host", "lambda", "--phase", "merge",
+                           "--workload", "W1", "--receipt", receipt],
+                          capture_output=True, text=True, check=False)
+    text = proc.stdout + proc.stderr
+    rows += [
+        ("P2 chain reaches ArmA", "ArmA c=4" in text),
+        ("P2 chain reaches ArmB", "ArmB1 c=4" in text),
+        ("P2 chain hits no schema rejection", "ArmC schema" not in text),
+        ("P2 chain still FAILs on the unmeasured bucket",
+         proc.returncode == 1 and "drain_ms absent" in text),
+    ]
+
+    # RED, and NO FALLBACK. The lane-level side is the c=1 band; with c=1 gone
+    # the block must refuse by name rather than report the lane from c=4 under
+    # the same label.
+    starved = _parity_work(os.path.join(root, "starved"), bands=(4, 8, 16))
+    missing = _run_parity_block(starved, os.path.join(starved, "parity.json"))
+    rows.append(("refuses a lane whose c=1 band is absent",
+                 missing.returncode == 1 and "c=1 band" in missing.stderr))
+    return rows
+
+
 def selftest():
     import shutil
     import tempfile
@@ -472,7 +578,9 @@ def selftest():
     work = tempfile.mkdtemp(prefix="perf-receipt-selftest-")
     try:
         _fixture(work)
-        rows = _selftest_verdict_rows(work, gate) + _selftest_refusal_rows(work)
+        rows = (_selftest_verdict_rows(work, gate)
+                + _selftest_refusal_rows(work)
+                + _selftest_parity_chain_rows(work, gate))
     finally:
         shutil.rmtree(work, ignore_errors=True)
     bad = sum(1 for _name, ok in rows if not ok)

--- a/scripts/parity_host_receipt.sh
+++ b/scripts/parity_host_receipt.sh
@@ -87,7 +87,15 @@ BANDS=$(sed -n 's/^[[:space:]]*http_concurrency_bands[[:space:]]*=[[:space:]]*\[
         "$(dirname "$0")/llama_pin.toml" | tr -d ' ' | tr ',' ' ')
 [ -n "$BANDS" ] || { printf 'FAIL  llama_pin.toml declares no http_concurrency_bands\n' >&2; exit 1; }
 
-run_lane() { # run_lane <class> <apr-flags> <llama-ngl> -> writes $WORK/<class>.json
+# run_lane <class> <apr-flags> <llama-ngl>
+#   writes $WORK/{apr,llama}-<class>-c<N>.json for every declared band,
+#          $WORK/{apr,llama}-<class>.log, and one line into $WORK/lanes.txt.
+# The header used to claim `$WORK/<class>.json`, a THIRD spelling that
+# matched neither what it writes nor what lib/parity_block.py read. The
+# consumer wanted `$WORK/apr-<class>.json` and nothing has ever written
+# it, so this script has never emitted a parity block (PERF-004). The
+# lane-level side is now the c=1 band, which is what it always was.
+run_lane() {
     local klass="$1" apr_flags="$2" ngl="$3"
     local aport=8090 lport=8091
 

--- a/scripts/perf-receipt-fields.yaml
+++ b/scripts/perf-receipt-fields.yaml
@@ -1,0 +1,432 @@
+# perf-receipt-fields.yaml — THE THREE-WAY SCHEMA MAP (PERF-004).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# scripts/perf_gate.sh reads a receipt schema that NOTHING IN THIS TREE WRITES.
+# Four real artifacts were tried against it and all four returned rc=1:
+#
+#   evidence/parity-http/bands/apr-c1.json   a real `apr test llm bench --output`
+#   a valid bench receipt                    scripts/lib/bench_receipt.py's own shape
+#   a valid parity block                     scripts/lib/parity_block.py's own output
+#   evidence/parity-http/findings.json       the one real receipt in evidence/
+#
+# Only the gate's own synthetic selftest fixture passed. A gate whose only
+# passing input is a string literal inside itself measures the string literal.
+#
+# The instinct is to teach the gate to fill in what is missing. That is
+# forbidden here: `requested`, `completed`, `timeouts`, `drain_ms` and
+# `tokenization.method` would then be FIVE NUMBERS NOTHING MEASURES, wearing the
+# shape of measurements. This file exists so the difference between "nobody
+# wired it up" and "nobody instrumented it" is written down per field, in a form
+# a guard can check, instead of being rediscovered each time someone tries to
+# run the gate.
+#
+# THE THREE PRODUCERS
+# -------------------
+#   P1  `apr test llm bench --output`  -> crates/apr-cli/src/commands/test_llm.rs
+#       emits BenchmarkReport verbatim: {runs:[LoadTestResult], aggregate, regressions}
+#       (crates/aprender-test-lib/src/llm/benchmark.rs). No provenance, no
+#       tokenization, no scheduler block. This is the ONLY thing that measures.
+#   P2  scripts/lib/parity_block.py    -> {parity:{lanes:[{bands:[...]}]}}
+#       the designed consumer of P1. Ratios DERIVED from P1's samples.
+#   P3  scripts/lib/perf_receipt.py    -> the receipt scripts/perf_gate.sh reads.
+#       Converts P1 or P2. Derives what is derivable and REFUSES to write the
+#       rest, copying the UNMEASURED entries below into the receipt so the gate
+#       can name the gap and its owner instead of saying "ArmC schema".
+#
+# CLASSES
+# -------
+#   PRODUCED    a producer writes this exact field today.  needs: producer
+#   DERIVED     computable from a field a producer writes. needs: producer + formula
+#   POLICY      read from a committed decision file.       needs: policy
+#   UNMEASURED  nothing measures it. It would have to be   needs: owner + spec + needs
+#               invented. This bucket IS the finding.
+#
+# A field perf_gate.sh reads that is absent from this file is the defect that
+# produced this ticket, one more time.
+# scripts/check_perf_receipt_fields_have_producers.sh extracts the read set
+# mechanically and fails on the difference in either direction.
+schema_version: 1
+
+# Receivers in the two reader scripts that are NOT the receipt, and why. The
+# extractor includes a receiver by DEFAULT; forgetting to list a new non-receipt
+# receiver here is a loud false alarm, never a silent miss.
+non_receipt_receivers:
+  perf_gate.sh:
+    m: scripts/perf-matrix.yaml, the expected cell set
+    bl: a baseline cell inside that matrix
+    environ: process environment (PERF_GATE_TODAY, the injectable clock)
+    fielddoc: this file, read by Arm C to name an absent field's owner
+    e: one entry of this file
+  bench_receipt.py:
+    band: the PARITY-lane band schema, a different document
+    block: a parity block
+    comp: a parity lane's comparator side
+    lane: a parity lane
+    side: one side of a parity lane
+    bench: the bench sub-block of a host receipt, already covered by the top level
+
+# Mode-dispatch keys: `_bench_of` and `_parity_of` probe these to decide WHICH
+# document they were handed. They are not receipt content and carry no verdict.
+dispatch_keys: [bench, parity]
+
+fields:
+
+  # ---------------------------------------------------------------- Arm A ---
+  # Arm A is comparator-free and PRIMARY. Everything it needs is derivable from
+  # P1 today: the derivation over evidence/parity-http/bands/ reproduces the
+  # spec's own carried figures (c=4 0.310, c=8 0.152, c=16 0.075) to 3 decimals.
+  # Arm A was never blocked on measurement. It was blocked on this file.
+  bands:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/benchmark.rs, symbol: "pub runs: Vec<LoadTestResult>"}
+    formula: one entry per concurrency artifact handed to perf_receipt.py
+
+  bands[].concurrency:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "pub concurrency: usize"}
+    formula: runs[0].concurrency, asserted equal across every run of one band
+
+  bands[].aggregate_tok_per_sec:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "let tokens_per_sec"}
+    formula: median(runs[].tokens_per_sec)
+    caveat: >-
+      P1 computes it as (tokens over SUCCESSFUL requests) / elapsed_secs, where
+      elapsed_secs spans until every worker joined -- so the denominator already
+      covers the drain overshoot §4.4.7 asks for. It does NOT apply §4.4.3's
+      "non-truncated" exclusion. On the 2026-08-25 corpus truncated_pct is 100.0
+      on BOTH sides (max_tokens=128 on every request), so applying that exclusion
+      literally makes the numerator zero. Resolve what the exclusion means under
+      a fixed-output workload before committing an Arm A ratchet from it.
+
+  bands[].tokens_total:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "completion_tokens_total: total_tokens"}
+    formula: sum(runs[].completion_tokens_total)
+
+  # ---------------------------------------------------------------- Arm B ---
+  # Both ratios are derivable from P1 on both sides, and P2 already computes
+  # exactly them under different names. The whole of Arm B's gap is a rename
+  # plus a re-nesting:
+  #   P2  parity.lanes[].bands[].ratio_aggregate_tok_per_sec
+  #   P3  bands[].agg_ratio
+  bands[].agg_ratio:
+    class: DERIVED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: 'band["ratio_" + metric]'}
+    formula: median(subject runs[].tokens_per_sec) / median(comparator runs[].tokens_per_sec)
+
+  bands[].decode_ratio:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "let decode_tok_per_sec"}
+    formula: median(subject runs[].decode_tok_per_sec) / median(comparator runs[].decode_tok_per_sec)
+
+  bands[].comparator_status:
+    class: POLICY
+    required: conditional
+    policy: scripts/perf-matrix.yaml
+    formula: cell_exceptions entry matching (host, band, arm B); absent means the cell is gated
+
+  # THE OTHER SIDE OF THE RATIO. Arm C asserted completed == requested on the
+  # SUBJECT and never looked at the comparator, whose tok/s counts tokens from
+  # successful requests only over the same wall clock -- so every request the
+  # comparator loses lowers the denominator and flatters us. On the 2026-08-25
+  # corpus it lost 3/80, 3/223, 6/302 and 10/522. Reported, never failed: the
+  # comparator's loss rate has no committed threshold and inventing one here
+  # would be the defect this gate exists to stop.
+  bands[].comparator_requested:
+    class: DERIVED
+    required: conditional
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "total_requests: total"}
+    formula: sum(comparator runs[].total_requests) for this band
+
+  bands[].comparator_completed:
+    class: DERIVED
+    required: conditional
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "let successful"}
+    formula: sum(comparator runs[].successful) for this band
+
+  # ---------------------------------------------------------------- Arm C ---
+  requested:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "total_requests: total"}
+    formula: sum(runs[].total_requests) over the subject's bands
+    caveat: >-
+      Exact under the closed-loop client: run_phase_max stops ISSUING at T, so
+      every counted request started inside the window. It stops being exact the
+      moment an open-loop rate mode is used for a gated band.
+
+  completed:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "let successful"}
+    formula: sum(runs[].successful) over the subject's bands
+
+  timeouts:
+    class: UNMEASURED
+    required: always
+    owner: PERF-004
+    spec: "§4.4.3"
+    needs: >-
+      The 120 s per-request bound §4.4.3 names ALREADY EXISTS -- client.rs sets
+      a 120-second reqwest timeout. What is missing is the discriminant:
+      loadtest.rs collapses every failure to `Err(_) => failed_record()`, so a
+      timed-out request, a refused connection and a malformed response all land
+      in the same `failed` counter. `failed` is a SUPERSET of `timeouts`, and
+      substituting it would report a broken server as a slow one. Classify the
+      error at both call sites (reqwest exposes is_timeout()) and carry the
+      count through to LoadTestResult.
+
+  drain_ms:
+    class: UNMEASURED
+    required: always
+    owner: PERF-004
+    spec: "§4.4.7"
+    needs: >-
+      The drain rule is not implemented in any client. run_phase_max -- the path
+      the benchmark subcommand actually takes -- has no drain phase at all:
+      workers loop `while Instant::now() < deadline` and the last request of each
+      worker simply overruns T. run_phase_rate (open-loop, unused by the gate)
+      polls a semaphore against a hardcoded 30 s deadline and records nothing.
+      Neither measures the overshoot, so §4.4.7's `drain_ms > 0.5 x window =>
+      SUSPECT` rule cannot be evaluated on any artifact this repo can produce.
+      Implement the drain phase in the closed-loop client and record its length.
+
+  tokenization:
+    class: UNMEASURED
+    required: always
+    owner: PERF-004
+    spec: "§4.4.6"
+    needs: the block below; no producer emits a tokenization block of any shape
+
+  tokenization.method:
+    class: UNMEASURED
+    required: always
+    owner: PERF-004
+    spec: "§4.4.6"
+    needs: >-
+      The harness counts tokens from the server's own `usage.completion_tokens`
+      (loadtest.rs, send_one_request), which is §4.4.6's `server_usage` -- the
+      method the spec says is NOT canonical, because two servers' usage fields
+      are two implementations' opinions. Writing "server_usage" here would be
+      accurate about today and would silently arm a ratio §4.4.6 refuses. The
+      canonical `client_tokenizer` path does not exist, and the three sibling
+      fields the block requires (tokenizer_sha256, counts_special_tokens,
+      counts_prompt_echo) have no producer and nothing that could infer them.
+      SGLang RFC #9808 is the cited prior art for getting this wrong.
+
+  # ---------------------------------------------------------------- Arm D ---
+  # §4.4.9's scheduler block. REPORTING today, blocking with PERF-001 -- and the
+  # arm exists so a batching implementation's own failure modes are visible in
+  # the PR that lands it, which requires these fields to exist BEFORE it lands.
+  kv:
+    class: UNMEASURED
+    required: at-release
+    owner: PERF-018
+    spec: "§4.4.9"
+    needs: the four counters below, read from the server rather than computed by the harness
+
+  kv.bytes_used:
+    class: UNMEASURED
+    required: at-release
+    owner: PERF-018
+    spec: "§4.4.9"
+    needs: KV bytes actually populated, reported by the server through /health and the receipt
+
+  kv.bytes_reserved:
+    class: UNMEASURED
+    required: at-release
+    owner: PERF-018
+    spec: "§4.4.9"
+    needs: KV bytes reserved at admission; under contiguous allocation this is the max_seq_len reservation
+
+  kv.admission_rejected:
+    class: UNMEASURED
+    required: at-release
+    owner: PERF-018
+    spec: "§4.4.9"
+    needs: count of requests refused for capacity, taken from the admission path
+
+  kv.preempted_swap:
+    class: UNMEASURED
+    required: at-release
+    owner: PERF-018
+    spec: "§4.4.9"
+    needs: >-
+      sequences whose KV moved to host DRAM. There is no preemption today, so
+      the honest value is zero -- but writing zero from the HARNESS rather than
+      from the scheduler pins the field at zero across the PR that introduces
+      preemption, which is the exact PR it exists to observe.
+
+  # ---------------------------------------------------------------- Arm E ---
+  itl:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.5 Arm E"
+    needs: the two percentiles below, pooled per §4.4.3
+
+  itl.p95_w1_ms:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.4.3"
+    needs: >-
+      §4.4.3 defines itl_ms as all inter-token gaps POOLED across requests, p50
+      and p95. LoadTestResult carries itl_p50_ms only -- there is no itl p95 at
+      all -- and even that p50 is a median of per-request means, not a pooled
+      percentile. tpot_p95_ms exists and is a different quantity (per-request
+      mean time per output token). Pool the gaps and emit the p95.
+
+  itl.p95_w2_ms:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.4.3"
+    needs: >-
+      the same pooled percentile measured on the W2 workload. The prompts exist
+      (crates/aprender-serve/benchmarks/qwen-coder/prompts-w2.jsonl); the pooled
+      p95 does not.
+
+  injector:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.5 Arm E"
+    needs: a long-prefill injector; W2 today is a prompt file, not an injector with a schedule
+
+  injector.stall_p95_ms:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.5 Arm E"
+    needs: p95 decode stall observed while a long prefill runs; requires the injector to exist first
+
+  injector.arrival_index:
+    class: UNMEASURED
+    required: at-release-w2
+    owner: PERF-017
+    spec: "§4.5 Arm E"
+    needs: which sampled request the long prefill was injected at; requires the injector to exist first
+
+  # ---------------------- delegated to scripts/lib/bench_receipt.py ---------
+  # Arm C calls bench_receipt.py, so these are required transitively. They are
+  # the reason a raw benchmark artifact can never pass on its own: a
+  # BenchmarkReport carries no provenance object of any kind.
+  provenance:
+    class: PRODUCED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: '"binary_path": binary'}
+
+  provenance.binary_path:
+    class: PRODUCED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: '"binary_path": binary'}
+
+  provenance.binary_sha256:
+    class: PRODUCED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: '"binary_sha256": sha'}
+    caveat: >-
+      Supplied by the CALLER (scripts/apr_bin.sh, scripts/llama_bin.sh), never by
+      the harness. The 2026-08-25 band corpus in evidence/parity-http/bands/
+      records no binary digest at all, so that corpus cannot produce a
+      conformant receipt however good its numbers are. perf_receipt.py refuses
+      to invent one; --derive-only prints the table and writes nothing.
+
+  provenance.resolution:
+    class: PRODUCED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: '"resolution":'}
+
+  provenance.compute_class:
+    class: PRODUCED
+    required: always
+    producer: {file: scripts/lib/parity_block.py, symbol: '"compute_class": klass'}
+
+  provenance.feature_set:
+    class: PRODUCED
+    required: conditional
+    producer: {file: scripts/lib/parity_block.py, symbol: 'prov["feature_set"] = feature_set'}
+
+  provenance.host:
+    class: DERIVED
+    required: conditional
+    producer: {file: scripts/perf-matrix.yaml, symbol: "hosts:"}
+    formula: "the --host argument, which must name a key under hosts: in the matrix"
+
+  provenance.accelerator:
+    class: DERIVED
+    required: conditional
+    producer: {file: scripts/perf-matrix.yaml, symbol: "accelerator:"}
+    formula: hosts[host].accelerator
+
+  provenance.model:
+    class: DERIVED
+    required: conditional
+    producer: {file: scripts/lib/parity_block.py, symbol: "os.path.basename(args.model)"}
+    formula: basename of the model path handed to the harness
+
+  provenance.quantization:
+    class: UNMEASURED
+    required: conditional
+    owner: PERF-004
+    spec: "§4.4 join key"
+    needs: >-
+      Nothing reads the quantization out of the model file. It is part of the
+      join key precisely so a Q4_K_M row cannot be compared with an F16 one, and
+      today it can only be typed in by hand. `apr inspect` already reports it;
+      read it from the artifact instead of accepting it as an argument.
+
+  samples_ms:
+    class: DERIVED
+    required: always
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "pub latency_ms: f64"}
+    formula: concat(runs[].request_details[].latency_ms) across the subject's bands
+    caveat: >-
+      request_details is skipped when empty, so a run that produced none yields
+      an empty samples_ms, which bench_receipt.py rejects as a vacuous pass --
+      the correct outcome, and worth knowing before a release night rather than
+      during one. It is present on the 2026-08-25 corpus.
+
+  n:
+    class: DERIVED
+    required: conditional
+    producer: {file: crates/aprender-test-lib/src/llm/loadtest.rs, symbol: "pub latency_ms: f64"}
+    formula: len(samples_ms); perf_receipt.py omits it rather than restating a length
+
+  runs_discarded:
+    class: UNMEASURED
+    required: conditional
+    owner: PERF-004
+    spec: "§4.4.5"
+    needs: >-
+      The harness discards nothing today, so omitting the field is honest. It
+      becomes required the moment any run is dropped, and its companion
+      discard_reason is blocked on the same failure classification `timeouts`
+      needs.
+
+  discard_reason:
+    class: UNMEASURED
+    required: conditional
+    owner: PERF-004
+    spec: "§4.4.5"
+    needs: one of early_eos/negative_delta/nonzero_exit/timeout, which needs the failure classification `timeouts` also needs
+
+  comparability:
+    class: POLICY
+    required: conditional
+    policy: scripts/lib/bench_receipt.py
+    formula: >-
+      cross-class-existence-only when the subject and comparator compute_class
+      differ. perf_receipt.py REFUSES to build a receipt from such a lane rather
+      than marking it: a cross-class row cannot arm Arm B's floor, and a receipt
+      carrying the mark still walks into Arm A, which reads no comparator at all
+      and would gate it happily.

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -17,6 +17,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MATRIX="$ROOT/scripts/perf-matrix.yaml"
+# THE SCHEMA MAP (PERF-004). Every field below is classified there as PRODUCED,
+# DERIVED, POLICY or UNMEASURED, and the UNMEASURED entries carry an owning
+# ticket. Arm C reads it so an absent field is reported as the instrumentation
+# gap it is -- "drain_ms absent: the drain rule is not implemented in any
+# client (§4.4.7, owner PERF-004)" -- rather than as a schema error, which
+# names nothing and leaves the reader to guess whether the fix is a converter
+# or a measurement.
+FIELDS="$ROOT/scripts/perf-receipt-fields.yaml"
 
 die() { printf 'perf_gate: %s\n' "$*" >&2; exit 2; }
 
@@ -26,24 +34,61 @@ die() { printf 'perf_gate: %s\n' "$*" >&2; exit 2; }
 
 arm_c_integrity() {
   local receipt="$1" rc=0
-  python3 "$ROOT/scripts/lib/bench_receipt.py" "$receipt" >/dev/null 2>&1 \
-    || { echo "FAIL ArmC schema: bench_receipt.py rejected the receipt"; rc=1; }
-  python3 - "$receipt" <<'PY' || rc=1
-import json,sys
+  # The delegate's errors are PRINTED, not swallowed. They used to go to
+  # /dev/null behind "bench_receipt.py rejected the receipt", so the one line a
+  # reader got named neither the field nor the rule -- and every real artifact
+  # in the tree fails here, so that line was the whole diagnosis.
+  local schema_out
+  if ! schema_out="$(python3 "$ROOT/scripts/lib/bench_receipt.py" "$receipt" 2>&1)"; then
+    printf 'FAIL ArmC schema: %s\n' "$schema_out"
+    rc=1
+  fi
+  python3 - "$receipt" "$FIELDS" <<'PY' || rc=1
+import json,sys,yaml
 r=json.load(open(sys.argv[1]))
+fielddoc=yaml.safe_load(open(sys.argv[2])) or {}
+ledger=fielddoc.get("fields") or {}
+
+def why(field):
+    """The instrumentation gap behind an absent field, with its owner.
+
+    A gate that says 'absent' has told the reader the shape of the receipt. A
+    gate that says WHAT WOULD HAVE TO BE BUILT and WHO OWNS IT has told them
+    the shape of the work. The five fields that made every real artifact fail
+    here split two ways -- two derivable, three unmeasured -- and only this
+    lookup makes the difference visible at the point of failure.
+    """
+    e=ledger.get(field) or {}
+    if e.get("class")!="UNMEASURED":
+        return ""
+    needs=" ".join((e.get("needs") or "").split())
+    return f" -- {needs} ({e.get('spec')}, owner {e.get('owner')})"
+
 bad=[]
 req,comp=r.get("requested"),r.get("completed")
 if req is None or comp is None or req!=comp:
-    bad.append(f"completed({comp}) != requested({req})")
-if r.get("timeouts",0)!=0:
+    bad.append(f"completed({comp}) != requested({req}){why('completed')}")
+if r.get("timeouts") is None:
+    bad.append(f"timeouts absent{why('timeouts')}")
+elif r.get("timeouts")!=0:
     bad.append(f"timeouts={r.get('timeouts')} (fatal to this host's ratio)")
 if not (r.get("tokenization") or {}).get("method"):
-    bad.append("tokenization.method absent")
+    bad.append(f"tokenization.method absent{why('tokenization.method')}")
 if r.get("drain_ms") is None:
-    bad.append("drain_ms absent")
+    bad.append(f"drain_ms absent{why('drain_ms')}")
 for b in (r.get("bands") or []):
     if b.get("tokens_total",1)==0:
         bad.append(f"band {b.get('concurrency')}: zero-token response is a failure, not a fast request")
+    # THE OTHER SIDE OF THE RATIO. Arm C asserts completed == requested on the
+    # SUBJECT and never looked at the comparator, whose tok/s counts tokens
+    # from successful requests only over the same wall clock -- so every
+    # request the comparator loses lowers the denominator and flatters us.
+    # Reported, not failed: the comparator's loss rate has no committed
+    # threshold, and inventing one here is the defect this gate exists to stop.
+    cr,cc=b.get("comparator_requested"),b.get("comparator_completed")
+    if cr is not None and cc is not None and cc!=cr:
+        print(f"REPORT ArmC c={b.get('concurrency')} comparator completed {cc}/{cr} "
+              f"-- its lost requests lower the denominator of agg_ratio")
 for m in bad: print(f"FAIL ArmC {m}")
 sys.exit(1 if bad else 0)
 PY
@@ -296,6 +341,14 @@ selftest() {
   _case baseline_healthy               "$OK" pass
   _case completed_lt_requested         "${OK/\"completed\":16/\"completed\":15}" fail
   _case a_timeout_is_fatal             "${OK/\"timeouts\":0/\"timeouts\":1}" fail
+  # AN ABSENT COUNTER IS NOT A ZERO COUNTER. This read `r.get("timeouts",0)`,
+  # so a receipt that never counted timeouts was indistinguishable from one
+  # that counted none -- and no producer in this tree counts them at all
+  # (loadtest.rs collapses every failure to one `failed` tally), so the default
+  # was doing all the work on every real artifact. That is the same shape as a
+  # missing measurement reading as a passing one, which is what this gate is
+  # for.
+  _case timeouts_absent_is_not_zero    "${OK/\"timeouts\":0,/}" fail
   _case tokenization_absent            "${OK/\"method\":\"hf-tokenizers\"/\"method\":\"\"}" fail
   _case drain_ms_absent                "${OK/\"drain_ms\":12/\"drain_ms\":null}" fail
   _case zero_token_response            "${OK/\"tokens_total\":900,\"agg_ratio\":0.9,\"decode_ratio\":1.1}]}/\"tokens_total\":0,\"agg_ratio\":0.9,\"decode_ratio\":1.1}]}}" fail


### PR DESCRIPTION
Epic #2706 (the receipt rule). PERF-004-SCHEMA was **held back last round on a refuted proof** — the commit claimed an end-to-end run that could not have executed. The rework found that the refutation's diagnosis was also wrong, in its object.

## The chain has never emitted a parity block

The earlier refutation said `parity_block.py` needs a `lanes.txt` the corpus does not contain. That is false: `scripts/parity_host_receipt.sh:124` writes `lanes.txt`, and it is the only caller of `parity_block.py`. The corpus under `evidence/parity-http/bands/` is a *different* artifact set, whose consumer is `perf_receipt.py --from-bands` — which reads `llamacpp-cN.json` correctly and always did.

Enumerating both sides mechanically found the actual break. Verified on `origin/main`:

| producer writes (`run_lane`, :96–124) | consumer reads (`parity_block._lane_from`) |
|---|---|
| `apr-<lane>-c<N>.json`, `llama-<lane>-c<N>.json` (`:104`) | ✔ band path, `:54-55` |
| `lanes.txt` (`:124`) | ✔ |
| — nothing — | **`apr-<lane>.json`, `llama-<lane>.json`** (`:76-77`) ✗ |

And `run_lane`'s own header comment at `:90` claims a **third** spelling, `$WORK/<class>.json`, matching neither side.

So every complete host run died on `FAIL lane cpu is missing a side` — which reads to an operator as *"the benchmark didn't run."* **The P2 chain has never emitted a parity block**, and `--from-parity` was reachable from no test.

**Fixed on the consumer side.** The lane-level side is the c=1 band, which is what it always was: `--concurrency` defaults to 1, and the corpus's own lane-level files are `concurrency=[1]` on every run. Moving the producer instead would buy a second independently-measured copy of a number the band sweep already has, and would stop `llama_pin.toml`'s `http_concurrency_bands` being the single statement of what was measured. **No fallback** — c=1 absent refuses by name and never silently promotes c=4.

## Run to a real verdict, and the verdict is FAIL

```
python3 scripts/lib/perf_receipt.py --from-bands <live>/bands --subject apr \
  --comparator llamacpp --host lambda-vector --workload W1 --binary-sha256 9645036…1d01c9 …
  -> rc=0, receipt4.json, 8158 bytes

bash scripts/perf_gate.sh --host lambda-vector --phase merge --workload W1 --receipt receipt4.json
  -> rc=1
  FAIL ArmC completed(26) != requested(58)
  FAIL ArmC band 16: zero-token response is a failure, not a fast request
  FAIL ArmC timeouts / tokenization.method / drain_ms absent  (each named, owner PERF-004)
  VERDICT FAIL host=lambda-vector phase=merge workload=W1
```

Read back out of the artifact: `requested/completed = 58/26`, `len(samples_ms) = 26`, `provenance.binary_sha256` matches `sha256sum`.

Before and after the fix on the same artifacts, the failure **moved** — which is the evidence that the fix reached the data:
- pre-fix: `FAIL lane cpu is missing a side` (never reached the data)
- post-fix: `FAIL band[16] contains a non-positive rate` (reached it, refused correctly — apr timed out 16/16 at c=16, `elapsed_secs = 120.0`, exactly the reqwest bound)

A live P2 `rc=0` was **not** obtained and is not claimed. The `rc=0` path is proven by the selftest running the real scripts as subprocesses.

**The ratios here are not a parity result and are cited as one nowhere.** CPU-only binary, box at load 16–74, 10 s runs. The receipt is deliberately left in scratch, **not** under `evidence/`.

## The three landmines, checked rather than assumed

- **`perf_gate.sh`'s real mode is invoked by nothing.** #2709 wired `--selftest`. The real mode (`--host/--phase/--workload/--receipt`) still has no caller, and neither does `parity_host_receipt.sh`. Every remaining reference is inside `check_no_competing_harnesses.sh`, which allowlists it as *"THE entrypoint"* — the canonical measurement entrypoint is referenced only by the guard that declares it canonical. A join between two scripts nothing runs together is exactly why the spelling mismatch survived.
- **`drain_ms` and `tokenization.method` fail ALWAYS, deliberately.** Both are `class: UNMEASURED, required: always` with zero producers. Proven by the live gate FAILing on all three. Not a mirror defect, because only `--selftest` is in a required check.
- **8/8 `perf-matrix.yaml` cells `UNMEASURED`** — confirmed.

## Two defects fixed that this work itself created or exposed

- The cherry-pick predated #2709 and added a **second** `perf_gate.sh --selftest` CI step under a different name. Removed.
- **`--resolution` defaulted to `"scripts/apr_bin.sh"`** — writing the one provenance claim that matters into every receipt whose caller forgot the flag. A default that fabricates provenance is worse than a missing field, because it is indistinguishable from a real answer. Now required, with a RED row.

## Mutation table

| mutation | result |
|---|---|
| restore the pre-fix `apr-%s.json` read | **RED** 2 broke / 12 passed |
| add a silent fallback to any present band | **RED** 1 broke / 18 passed |
| unmutated | GREEN 19/19 |
| omit `--resolution` | RED, refuses |
| `perf_gate.sh --selftest` | 18/18, incl. `timeouts_absent_is_not_zero` |
| schema-map guard `--self-test` | 8/8, 5 RED + 3 discrimination |

`--from-bands` rows stay green under both P2 mutations, so the RED is discrimination rather than blanket refusal.

## Binary provenance

`bash scripts/apr_bin.sh` → **rc=1, STALE**: there is no HEAD-built `apr` on this box, so no step could have used one. `~/.local/bin/apr` is `v0.64.0+no-git` — no commit at all — and wins a bare `apr`. Executed steps used `/home/noah/.cargo/bin/apr`, `0.64.0 (ce712eae0)`, sha256 recorded in the receipt; comparator `llama-server` `7746 (39173bcac)` = the pin.

The bound on what that licenses was verified, not asserted: the subject under test is the converter and gate **at HEAD** (the Python and Bash in this checkout); apr is the *instrument*, recorded by digest. The Rust delta `ce712eae0..HEAD` is five files, all `apr profile` (PERF-016), reached only via `ExtendedCommands::Profile`; neither executed step is in that path. Rebuilding was **declined with a reason, not skipped** — `cargo install --force` overwrites `~/.cargo/bin/apr` while other agents are running it, and would change nothing this run establishes.

**Any statement about apr's speed from this run is unproven, and is made nowhere.**

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
