### PR TITLE
feat(perf): the perf gate requires drain_ms, and nothing on earth writes drain_ms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "chrono",
  "criterion 0.5.1",
  "crossterm 0.28.1",
+ "flate2",
  "futures",
  "gif 0.13.3",
  "image",

--- a/crates/aprender-test-lib/Cargo.toml
+++ b/crates/aprender-test-lib/Cargo.toml
@@ -59,6 +59,12 @@ mp4 = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 regex = { workspace = true }
 sha2 = { workspace = true }
+# PERF-024 (APR-PERF-GATE-001 v2.2 §4.4.5): raw per-request samples are retained
+# as gzipped JSONL beside every receipt -- a summary-only receipt cannot be
+# resampled and is rejected. Not feature-gated: `src/perf/` must compile (and
+# its tests must RUN) under default features, because CI is
+# `cargo nextest run --profile ci --workspace --lib` with no --features.
+flate2 = "1"
 serde_yaml_ng = { workspace = true }
 
 # Tracing and UUID (available on all targets)

--- a/crates/aprender-test-lib/src/lib.rs
+++ b/crates/aprender-test-lib/src/lib.rs
@@ -564,6 +564,14 @@ pub mod animation;
 )]
 pub mod presentar;
 
+/// APR-PERF-GATE-001 v2.2 §4.4 — the serving-performance measurement protocol.
+///
+/// Termination rule, metric definitions, bootstrap CI, and raw-sample retention
+/// for `apr test llm bench`. Ungated on purpose: CI runs
+/// `cargo nextest run --profile ci --workspace --lib` with no `--features`, so a
+/// protocol placed behind the `llm` feature would never be tested in CI.
+pub mod perf_gate;
+
 /// LLM Testing: Correctness assertions and load testing for OpenAI-compatible APIs.
 ///
 /// Feature-gated behind `llm`. Provides HTTP client, assertion builders,

--- a/crates/aprender-test-lib/src/llm/band.rs
+++ b/crates/aprender-test-lib/src/llm/band.rs
@@ -1,0 +1,772 @@
+//! APR-PERF-GATE-001 v2.2 §4.4 — the protocol, driven through the existing
+//! `apr test llm bench` request path.
+//!
+//! This is **not a second harness.** It drives [`LlmClient`] — the one HTTP
+//! client [`super::loadtest::LoadTest`] drives, and the one
+//! `scripts/parity_host_receipt.sh` points at both `apr serve` and
+//! `llama-server` (§4.4.8: one client, both servers, or the ratio is refused).
+//! What it adds is the part `LoadTest` never had:
+//! the §4.4.2 termination rule, the §4.4.2 warmup-then-quiesce, the §4.4.3
+//! metric definitions, §4.4.4's interval, §4.4.5 retention, and §4.4.7's
+//! `drain_ms`.
+//!
+//! `LoadTest::run` stays exactly as it is. It answers a different question — "how
+//! does this server behave for `duration` seconds" — and a great deal of tooling
+//! reads its `LoadTestResult`. Changing its termination rule underneath those
+//! readers would silently change every number they have ever recorded.
+//!
+//! `loadtest::send_one_request` is the sibling adapter: it maps the same client's
+//! responses into `LoadTestResult`'s `RequestRecord`. This module maps them into
+//! [`RequestSample`] instead, because `RequestRecord` carries no absolute timing
+//! and cannot distinguish a timeout from a transport error — both of which §4.4.3
+//! requires.
+
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use crate::perf_gate::bootstrap::{bootstrap_agg_tok_s_ci, BootstrapCi};
+use crate::perf_gate::metrics::{BandMetrics, RequestSample};
+use crate::perf_gate::protocol::{BandConfig, ClientModel, Outcome, Tokenization, REPLICATES};
+use crate::perf_gate::window::{WindowController, WindowReport};
+
+use super::client::{ChatRequest, LlmClient, LlmClientError};
+use super::client::{ChatResponse, Usage};
+
+/// One §4.4-conformant band measurement.
+#[derive(Debug, Clone)]
+pub struct BandRun {
+    /// The protocol parameters actually used.
+    pub config: BandConfig,
+    /// §4.4.1 — recorded, not assumed.
+    pub client_model: ClientModel,
+    /// §4.4.6 — required, supplied by the caller because only the caller knows
+    /// how its tokens were counted.
+    pub tokenization: Tokenization,
+    /// §4.4.3 metrics.
+    pub metrics: BandMetrics,
+    /// §4.4.2/§4.4.7 window and drain accounting.
+    pub window: WindowReport,
+    /// §4.4.5 raw per-request samples, for retention and resampling.
+    pub samples: Vec<RequestSample>,
+    /// §4.4.4 bootstrap percentile CI on `agg_tok_s`.
+    pub agg_ci: Option<BootstrapCi>,
+    /// Warmup requests actually completed (discarded, never in `samples`).
+    pub warmup_completed: usize,
+    /// Every reason this run is not §4.4-conformant. Empty means conformant.
+    /// A run that shrank its window says so here rather than looking identical
+    /// to one that did not.
+    pub protocol_violations: Vec<String>,
+}
+
+impl BandRun {
+    /// True when nothing departed from §4.4 and no `SUSPECT` annotation fired.
+    #[must_use]
+    pub fn is_conformant(&self) -> bool {
+        self.protocol_violations.is_empty() && self.window.suspect.is_empty()
+    }
+}
+
+type Shared = Arc<Mutex<WindowController>>;
+
+/// `(index, in-flight including this request)`, as returned by the admission gate.
+type Admitted = (usize, usize);
+
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// §4.4.2 warmup: every worker completes at least one request, `2 × c` in total,
+/// all discarded. Returns how many actually completed.
+async fn warmup(
+    client: &LlmClient,
+    prompts: &[ChatRequest],
+    band: &BandConfig,
+    stream: bool,
+) -> usize {
+    let per_worker = band.warmup_requests.div_ceil(band.concurrency).max(1);
+    let mut handles = Vec::with_capacity(band.concurrency);
+    for worker in 0..band.concurrency {
+        let client = client.clone();
+        let prompts = prompts.to_vec();
+        handles.push(tokio::spawn(async move {
+            let mut done = 0_usize;
+            for k in 0..per_worker {
+                let prompt = &prompts[(worker + k) % prompts.len()];
+                if issue(&client, prompt, stream).await.is_some() {
+                    done += 1;
+                }
+            }
+            done
+        }));
+    }
+    let mut total = 0;
+    for h in handles {
+        total += h.await.unwrap_or(0);
+    }
+    total
+}
+
+/// Everything one closed-loop worker needs. A struct rather than eight cloned
+/// locals per spawn: the worker body is the part that has to stay readable,
+/// because it is where "concurrent" is either true or a comfortable fiction.
+struct Worker {
+    id: usize,
+    client: LlmClient,
+    prompts: Vec<ChatRequest>,
+    controller: Shared,
+    samples: Arc<Mutex<Vec<RequestSample>>>,
+    timeout: Duration,
+    origin: Instant,
+    stream: bool,
+}
+
+/// What one request revealed, in the terms §4.4.3 is written in.
+///
+/// Deliberately NOT `loadtest::RequestRecord`. That type reports a `latency` and
+/// a `success` flag; §4.4.3 needs token arrival offsets and a four-valued
+/// outcome, and a timeout there is indistinguishable from a transport error.
+struct Observed {
+    /// Token arrival offsets from THIS request's start. Empty when not streaming.
+    token_offsets: Vec<Duration>,
+    generated_tokens: u32,
+    prompt_tokens: u32,
+}
+
+fn usage_counts(usage: Option<&Usage>, fallback_tokens: u32) -> (u32, u32) {
+    usage.map_or((fallback_tokens, 0), |u| {
+        (u.completion_tokens, u.prompt_tokens)
+    })
+}
+
+fn observe_blocking(response: &ChatResponse) -> Observed {
+    let (generated_tokens, prompt_tokens) = usage_counts(response.usage.as_ref(), 0);
+    Observed {
+        // A non-streaming response has no per-token arrival information at all.
+        // Empty rather than synthesised: §4.4.3's `itl_ms` and `decode_tok_s` are
+        // undefined here, and inventing evenly-spaced timestamps would make an
+        // unmeasured quantity look measured.
+        token_offsets: Vec::new(),
+        generated_tokens,
+        prompt_tokens,
+    }
+}
+
+/// Issue one request through the shared [`LlmClient`] — the same client
+/// `LoadTest`/`send_one_request` uses, so both drive one transport (§4.4.8).
+async fn issue(client: &LlmClient, prompt: &ChatRequest, stream: bool) -> Option<Observed> {
+    if stream {
+        let streamed = client.chat_completion_stream(prompt).await.ok()?;
+        let observed_tokens = u32::try_from(streamed.token_timestamps.len()).unwrap_or(u32::MAX);
+        let (generated_tokens, prompt_tokens) =
+            usage_counts(streamed.usage.as_ref(), observed_tokens);
+        return Some(Observed {
+            token_offsets: streamed.token_timestamps,
+            generated_tokens,
+            prompt_tokens,
+        });
+    }
+    let timed = client.send(prompt).await.ok()?;
+    Some(observe_blocking(&timed.response))
+}
+
+/// Turn one completed (or timed-out) request into its §4.4.5 retained sample.
+fn sample_from(
+    slot: Admitted,
+    worker: usize,
+    span: (f64, f64),
+    drained: bool,
+    observed: Option<&Observed>,
+) -> RequestSample {
+    let (start_s, end_s) = span;
+    let (index, in_flight_at_start) = slot;
+    let Some(observed) = observed else {
+        // §4.4.3 — a request that hit the 120 s hard timeout, or failed. Any
+        // partial output is discarded: it is not a completed request and must
+        // not be credited to `agg_tok_s`'s numerator.
+        return RequestSample {
+            index,
+            worker,
+            start_s,
+            end_s,
+            token_times_s: Vec::new(),
+            generated_tokens: 0,
+            prompt_tokens: 0,
+            outcome: Outcome::Error,
+            in_flight_at_start,
+            drained,
+        };
+    };
+    RequestSample {
+        index,
+        worker,
+        start_s,
+        end_s,
+        // Token offsets are relative to THIS request's start; §4.4.3 needs a
+        // band-wide origin so spans are comparable across workers.
+        token_times_s: observed
+            .token_offsets
+            .iter()
+            .map(|d| start_s + d.as_secs_f64())
+            .collect(),
+        generated_tokens: observed.generated_tokens,
+        prompt_tokens: observed.prompt_tokens,
+        outcome: Outcome::Completed,
+        in_flight_at_start,
+        drained,
+    }
+}
+
+/// One closed-loop worker: admit, issue, wait for completion, immediately try to
+/// admit again (§4.4.1). Exits when the shared gate closes.
+async fn worker_loop(w: Worker) {
+    loop {
+        // §4.4.2/§4.4.7 — one shared admission decision. The gate closes once,
+        // stamping T; no worker issues at or after it.
+        let admitted = {
+            let mut c = lock(&w.controller);
+            c.try_admit_with_in_flight(w.origin.elapsed().as_secs_f64())
+        };
+        let Some(slot) = admitted else { break };
+
+        let prompt = &w.prompts[slot.0 % w.prompts.len()];
+        let start_s = w.origin.elapsed().as_secs_f64();
+        // §4.4.3 — the 120 s hard per-request timeout, classified as a TIMEOUT
+        // in its own counter rather than folded into a generic failure count.
+        let timed_out = tokio::time::timeout(w.timeout, issue(&w.client, prompt, w.stream)).await;
+        let end_s = w.origin.elapsed().as_secs_f64();
+
+        let drained = lock(&w.controller).complete(end_s);
+        let mut sample = match &timed_out {
+            Ok(observed) => sample_from(slot, w.id, (start_s, end_s), drained, observed.as_ref()),
+            Err(_elapsed) => sample_from(slot, w.id, (start_s, end_s), drained, None),
+        };
+        if timed_out.is_err() {
+            sample.outcome = Outcome::Timeout;
+        }
+        lock(&w.samples).push(sample);
+    }
+}
+
+/// Every reason this run departs from §4.4, for the receipt.
+fn violations(
+    band: &BandConfig,
+    warmup_completed: usize,
+    m: &BandMetrics,
+    win: &WindowReport,
+) -> Vec<String> {
+    let mut out = band.conformance_violations();
+    if warmup_completed < band.warmup_requests {
+        out.push(format!(
+            "§4.4.2 warmup completed {warmup_completed} of {} required requests",
+            band.warmup_requests
+        ));
+    }
+    if m.completed < band.min_samples {
+        out.push(format!(
+            "§4.4.2 only {} of {} required sampled requests completed",
+            m.completed, band.min_samples
+        ));
+    }
+    out.extend(win.suspect.iter().cloned());
+    out
+}
+
+/// Run one §4.4-conformant band against `client`.
+///
+/// The caller supplies `tokenization` because §4.4.6 gives `method` no default:
+/// a harness that guessed it would be asserting something it does not know.
+///
+/// # Errors
+/// When `prompts` is empty, which makes the workload undefined rather than
+/// merely small, or when the §4.4.6 block does not validate.
+pub async fn run_band(
+    client: &LlmClient,
+    prompts: &[ChatRequest],
+    band: &BandConfig,
+    tokenization: Tokenization,
+    stream: bool,
+) -> Result<BandRun, LlmClientError> {
+    if prompts.is_empty() {
+        return Err(LlmClientError::HealthCheckFailed(
+            "run_band: the prompt corpus is empty; §4.3 requires a fixed workload".to_string(),
+        ));
+    }
+    tokenization
+        .validate()
+        .map_err(LlmClientError::HealthCheckFailed)?;
+
+    // §4.4.2 — warmup, discarded, then a 5 s quiesce before the first sampled
+    // request. Without the quiesce the first sampled requests are measured on a
+    // server still finishing warmup work, which is the opposite of what warmup
+    // was for.
+    let warmup_completed = warmup(client, prompts, band, stream).await;
+    tokio::time::sleep(band.quiesce).await;
+
+    let controller: Shared = Arc::new(Mutex::new(WindowController::new(band)));
+    let samples: Arc<Mutex<Vec<RequestSample>>> = Arc::new(Mutex::new(Vec::new()));
+    let origin = Instant::now();
+
+    let mut handles = Vec::with_capacity(band.concurrency);
+    for id in 0..band.concurrency {
+        handles.push(tokio::spawn(worker_loop(Worker {
+            id,
+            client: client.clone(),
+            prompts: prompts.to_vec(),
+            controller: Arc::clone(&controller),
+            samples: Arc::clone(&samples),
+            timeout: band.request_timeout,
+            origin,
+            stream,
+        })));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let window = lock(&controller).report();
+    let mut collected = std::mem::take(&mut *lock(&samples));
+    collected.sort_by_key(|s| s.index);
+
+    let metrics = BandMetrics::from_samples(band.concurrency, &collected);
+    let agg_ci = bootstrap_agg_tok_s_ci(&collected, 0.95);
+    let protocol_violations = violations(band, warmup_completed, &metrics, &window);
+
+    Ok(BandRun {
+        config: band.clone(),
+        client_model: band.client_model,
+        tokenization,
+        metrics,
+        window,
+        samples: collected,
+        agg_ci,
+        warmup_completed,
+        protocol_violations,
+    })
+}
+
+/// §4.4.2 — `N = 3` full band replicates per cell.
+///
+/// Three separate runs, each with its own warmup and quiesce, because a
+/// replicate that shares a warmup is not an independent run of the protocol.
+///
+/// # Errors
+/// Propagates the first failing replicate.
+pub async fn run_cell(
+    client: &LlmClient,
+    prompts: &[ChatRequest],
+    band: &BandConfig,
+    tokenization: &Tokenization,
+    stream: bool,
+) -> Result<Vec<BandRun>, LlmClientError> {
+    let mut runs = Vec::with_capacity(REPLICATES);
+    for _ in 0..REPLICATES {
+        runs.push(run_band(client, prompts, band, tokenization.clone(), stream).await?);
+    }
+    Ok(runs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf_gate::protocol::TokenizationMethod;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    const BODY: &str = concat!(
+        r#"{"id":"c","object":"chat.completion","created":0,"model":"m","#,
+        r#""choices":[{"index":0,"message":{"role":"assistant","content":"a b c"},"#,
+        r#""finish_reason":"length"}],"#,
+        r#""usage":{"prompt_tokens":512,"completion_tokens":128,"total_tokens":640}}"#
+    );
+
+    /// A minimal OpenAI-shaped server that holds each request open for
+    /// `service_ms` and records the peak number of connections it was serving at
+    /// once. That peak is measured on the SERVER side, so it cannot be faked by
+    /// the client's own bookkeeping.
+    struct Probe {
+        url: String,
+        peak: Arc<AtomicUsize>,
+        served: Arc<AtomicUsize>,
+    }
+
+    /// Consume one HTTP request head and its body, so the client is not left
+    /// waiting on a half-read socket.
+    async fn consume_request(sock: &mut tokio::net::TcpStream) {
+        let mut buf = vec![0_u8; 8192];
+        let mut seen = Vec::new();
+        while let Ok(n) = sock.read(&mut buf).await {
+            if n == 0 {
+                return;
+            }
+            seen.extend_from_slice(&buf[..n]);
+            let text = String::from_utf8_lossy(&seen).to_string();
+            let Some(head_end) = text.find("\r\n\r\n") else {
+                continue;
+            };
+            if seen.len() >= head_end + 4 + content_length(&text) {
+                return;
+            }
+        }
+    }
+
+    fn content_length(head: &str) -> usize {
+        head.to_lowercase()
+            .split("content-length:")
+            .nth(1)
+            .and_then(|t| t.split("\r\n").next())
+            .and_then(|t| t.trim().parse::<usize>().ok())
+            .unwrap_or(0)
+    }
+
+    /// Serve one connection: count it in, hold it open for `service_ms`, answer.
+    async fn serve_one(mut sock: tokio::net::TcpStream, service_ms: u64, counters: Counters) {
+        let now = counters.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        counters.peak.fetch_max(now, Ordering::SeqCst);
+
+        consume_request(&mut sock).await;
+        tokio::time::sleep(Duration::from_millis(service_ms)).await;
+
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n{BODY}",
+            BODY.len()
+        );
+        let _ = sock.write_all(resp.as_bytes()).await;
+        let _ = sock.flush().await;
+        let _ = sock.shutdown().await;
+
+        counters.served.fetch_add(1, Ordering::SeqCst);
+        counters.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    #[derive(Clone)]
+    struct Counters {
+        in_flight: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        served: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_probe(service_ms: u64) -> Probe {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let counters = Counters {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            peak: Arc::new(AtomicUsize::new(0)),
+            served: Arc::new(AtomicUsize::new(0)),
+        };
+        let (peak, served) = (Arc::clone(&counters.peak), Arc::clone(&counters.served));
+
+        tokio::spawn(async move {
+            while let Ok((sock, _)) = listener.accept().await {
+                tokio::spawn(serve_one(sock, service_ms, counters.clone()));
+            }
+        });
+
+        Probe {
+            url: format!("http://{addr}"),
+            peak,
+            served,
+        }
+    }
+
+    /// An SSE server that emits `tokens` chunks `gap_ms` apart, so TTFT and the
+    /// inter-token gaps have known values the client must be able to recover.
+    async fn serve_sse(mut sock: tokio::net::TcpStream, tokens: usize, gap_ms: u64) {
+        consume_request(&mut sock).await;
+        let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                    Cache-Control: no-cache\r\nConnection: close\r\n\r\n";
+        if sock.write_all(head.as_bytes()).await.is_err() {
+            return;
+        }
+        for i in 0..tokens {
+            tokio::time::sleep(Duration::from_millis(gap_ms)).await;
+            let chunk = format!(
+                "data: {{\"choices\":[{{\"index\":0,\"delta\":{{\"content\":\"t{i} \"}}}}]}}\n\n"
+            );
+            if sock.write_all(chunk.as_bytes()).await.is_err() {
+                return;
+            }
+            let _ = sock.flush().await;
+        }
+        let _ = sock.write_all(b"data: [DONE]\n\n").await;
+        let _ = sock.flush().await;
+        let _ = sock.shutdown().await;
+    }
+
+    async fn spawn_sse_probe(tokens: usize, gap_ms: u64) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            while let Ok((sock, _)) = listener.accept().await {
+                tokio::spawn(serve_sse(sock, tokens, gap_ms));
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    fn prompts() -> Vec<ChatRequest> {
+        vec![ChatRequest {
+            model: "m".to_string(),
+            messages: vec![super::super::client::ChatMessage {
+                role: super::super::client::Role::User,
+                content: "hello".to_string(),
+            }],
+            temperature: Some(0.0),
+            max_tokens: Some(128),
+            stream: Some(false),
+        }]
+    }
+
+    fn tokenization() -> Tokenization {
+        Tokenization::server_usage(false, false)
+    }
+
+    /// A band short enough to run in a test, and it must report that it is not
+    /// conformant — the shrunken window is visible in the result, not hidden.
+    fn tiny_band(c: usize, samples: usize) -> BandConfig {
+        BandConfig::relaxed(c, samples, Duration::ZERO, Duration::ZERO)
+    }
+
+    /// THE end-to-end proof: `c = 8` workers, driven through the same
+    /// `send_one_request` path `apr test llm bench` uses, over real loopback
+    /// HTTP, are concurrent **as observed by the server**.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn eight_workers_are_concurrent_over_real_http() {
+        let probe = spawn_probe(60).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let band = tiny_band(8, 32);
+
+        let run = run_band(&client, &prompts(), &band, tokenization(), false)
+            .await
+            .expect("band runs");
+
+        let server_peak = probe.peak.load(Ordering::SeqCst);
+        let client_peak = run.window.client_peak_in_flight;
+        eprintln!(
+            "run_band c=8: server_peak={server_peak} client_peak={client_peak} \
+             requested={} completed={} window_ms={:.1} drain_ms={:.1} served={}",
+            run.window.requested,
+            run.metrics.completed,
+            run.window.window_ms,
+            run.window.drain_ms,
+            probe.served.load(Ordering::SeqCst)
+        );
+
+        assert_eq!(client_peak, 8, "the client must admit 8 at once");
+        assert!(
+            server_peak >= 4,
+            "the SERVER saw only {server_peak} concurrent connections; a client that \
+             says c=8 and is secretly sequential shows 1"
+        );
+        assert!(run.metrics.completed >= 32, "{:?}", run.metrics);
+        // §4.4.3 sanity: 128 tokens per completed request, wall-clock aggregate.
+        assert!(run.metrics.agg_tok_s > 0.0);
+        assert_eq!(run.metrics.timeouts, 0);
+    }
+
+    /// The negative control that makes the assertion above mean something: the
+    /// same code at `c = 1` must show a server peak of exactly 1, and must take
+    /// several times longer for the same request count.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn c1_is_sequential_and_slower_for_the_same_work() {
+        let requests = 16;
+        let service_ms = 40;
+
+        let p1 = spawn_probe(service_ms).await;
+        let c1 = LlmClient::new(&p1.url, "m");
+        let t1 = Instant::now();
+        let r1 = run_band(
+            &c1,
+            &prompts(),
+            &tiny_band(1, requests),
+            tokenization(),
+            false,
+        )
+        .await
+        .expect("c=1 band runs");
+        let wall1 = t1.elapsed();
+
+        let p8 = spawn_probe(service_ms).await;
+        let c8 = LlmClient::new(&p8.url, "m");
+        let t8 = Instant::now();
+        let r8 = run_band(
+            &c8,
+            &prompts(),
+            &tiny_band(8, requests),
+            tokenization(),
+            false,
+        )
+        .await
+        .expect("c=8 band runs");
+        let wall8 = t8.elapsed();
+
+        let speedup = wall1.as_secs_f64() / wall8.as_secs_f64();
+        eprintln!(
+            "same {requests} requests: c=1 wall={wall1:?} server_peak={} | \
+             c=8 wall={wall8:?} server_peak={} | speedup={speedup:.2}x",
+            p1.peak.load(Ordering::SeqCst),
+            p8.peak.load(Ordering::SeqCst)
+        );
+
+        assert_eq!(p1.peak.load(Ordering::SeqCst), 1, "c=1 must never overlap");
+        assert_eq!(r1.window.client_peak_in_flight, 1);
+        assert!(r8.window.client_peak_in_flight > 1);
+        assert!(
+            speedup > 2.0,
+            "c=8 must beat c=1 on the same work; got {speedup:.2}x \
+             (c=1 {wall1:?}, c=8 {wall8:?})"
+        );
+    }
+
+    /// §4.4.3 end to end: TTFT and the pooled inter-token gaps are recovered
+    /// from a real SSE stream with known spacing. Without this, `ttft_ms` and
+    /// `itl_ms` are only ever tested on synthetic samples, and a wiring bug
+    /// between the client and the sample would be invisible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ttft_and_itl_are_recovered_from_a_real_sse_stream() {
+        // 6 tokens, 25 ms apart: TTFT ~25 ms, five gaps of ~25 ms each.
+        let url = spawn_sse_probe(6, 25).await;
+        let client = LlmClient::new(&url, "m");
+        let run = run_band(&client, &prompts(), &tiny_band(2, 8), tokenization(), true)
+            .await
+            .expect("band runs");
+
+        eprintln!(
+            "sse band: ttft_p50={:.1}ms ttft_p95={:.1}ms itl_p50={:.1}ms itl_p95={:.1}ms \
+             decode={:.1}tok/s completed={}",
+            run.metrics.ttft_p50_ms,
+            run.metrics.ttft_p95_ms,
+            run.metrics.itl_p50_ms,
+            run.metrics.itl_p95_ms,
+            run.metrics.decode_tok_s,
+            run.metrics.completed
+        );
+
+        assert!(run.metrics.completed >= 8, "{:?}", run.metrics);
+        // Generous bounds: loopback plus a loaded runner, but a broken wiring
+        // reports 0.0 and a chunk-count bug reports a wildly different spacing.
+        assert!(
+            (10.0..200.0).contains(&run.metrics.ttft_p50_ms),
+            "ttft_p50={} ms, expected ~25",
+            run.metrics.ttft_p50_ms
+        );
+        assert!(
+            (10.0..200.0).contains(&run.metrics.itl_p50_ms),
+            "itl_p50={} ms, expected ~25",
+            run.metrics.itl_p50_ms
+        );
+        assert!(run.metrics.decode_tok_s > 0.0);
+        // Five gaps per request, pooled -- not one mean per request.
+        let pooled: usize = run.samples.iter().map(|s| s.itl_gaps_ms().len()).sum();
+        assert_eq!(
+            pooled,
+            5 * run.samples.len(),
+            "every gap must be pooled, not one summary per request"
+        );
+    }
+
+    /// §4.4.2 — a shrunken band must SAY it is shrunken. A relaxed run that
+    /// reported itself conformant is the fabricated-baseline shape.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_relaxed_band_reports_its_own_non_conformance() {
+        let probe = spawn_probe(5).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let run = run_band(&client, &prompts(), &tiny_band(2, 8), tokenization(), false)
+            .await
+            .expect("band runs");
+        assert!(!run.is_conformant());
+        assert!(
+            run.protocol_violations
+                .iter()
+                .any(|v| v.contains("min_wall_clock")),
+            "{:?}",
+            run.protocol_violations
+        );
+        assert!(
+            run.protocol_violations
+                .iter()
+                .any(|v| v.contains("quiesce")),
+            "{:?}",
+            run.protocol_violations
+        );
+    }
+
+    /// §4.4.7 — `drain_ms` is produced. It had zero producers in this repo while
+    /// `perf_gate.sh` has always failed a receipt that omits it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn drain_ms_and_window_ms_are_produced() {
+        let probe = spawn_probe(30).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let run = run_band(
+            &client,
+            &prompts(),
+            &tiny_band(4, 16),
+            tokenization(),
+            false,
+        )
+        .await
+        .expect("band runs");
+        assert!(run.window.window_ms > 0.0, "{:?}", run.window);
+        assert!(run.window.drain_ms >= 0.0, "{:?}", run.window);
+        // The last admissions are still in flight when T is stamped, so a
+        // concurrent band always has a non-zero drain.
+        assert!(run.window.drain_ms > 0.0, "{:?}", run.window);
+    }
+
+    /// §4.4.6 — the tokenization block travels with the run and is validated.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_invalid_tokenization_block_refuses_the_run() {
+        let probe = spawn_probe(1).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let bad = Tokenization {
+            method: TokenizationMethod::ClientTokenizer,
+            tokenizer_sha256: None,
+            counts_special_tokens: true,
+            counts_prompt_echo: false,
+        };
+        let r = run_band(&client, &prompts(), &tiny_band(1, 1), bad, false).await;
+        assert!(
+            r.is_err(),
+            "a run must not start without a valid §4.4.6 block"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_empty_prompt_corpus_refuses_the_run() {
+        let probe = spawn_probe(1).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let r = run_band(&client, &[], &tiny_band(1, 1), tokenization(), false).await;
+        assert!(r.is_err());
+    }
+
+    /// §4.4.4/§4.4.5 — the run carries an interval and the raw samples that
+    /// re-derive it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_run_carries_samples_and_a_reproducible_interval() {
+        let probe = spawn_probe(5).await;
+        let client = LlmClient::new(&probe.url, "m");
+        let run = run_band(
+            &client,
+            &prompts(),
+            &tiny_band(4, 24),
+            tokenization(),
+            false,
+        )
+        .await
+        .expect("band runs");
+
+        assert_eq!(run.samples.len(), run.window.requested);
+        assert!(run.samples.iter().any(|s| s.in_flight_at_start > 1));
+        let ci = run.agg_ci.as_ref().expect("n >= 2");
+        assert_eq!(ci.seed, 2026);
+        assert_eq!(ci.resamples, 10_000);
+        assert_eq!(ci.resampling_unit, "whole_request");
+        let again = bootstrap_agg_tok_s_ci(&run.samples, 0.95).expect("n >= 2");
+        assert_eq!(&again, ci, "the interval must re-derive from the samples");
+    }
+}

--- a/crates/aprender-test-lib/src/llm/mod.rs
+++ b/crates/aprender-test-lib/src/llm/mod.rs
@@ -8,6 +8,10 @@
 //! - **Reporting**: JSON and Markdown report generation with historical tracking (feature: `llm`)
 
 pub mod assertion;
+/// APR-PERF-GATE-001 v2.2 §4.4 band protocol, driven through this module's
+/// existing request path (PERF-024).
+#[cfg(feature = "llm")]
+pub mod band;
 #[cfg(feature = "llm")]
 pub mod benchmark;
 pub mod client;
@@ -25,6 +29,8 @@ pub mod score;
 pub mod training_scorecard;
 
 pub use assertion::{LlmAssertion, LlmAssertionError, LlmAssertionResult};
+#[cfg(feature = "llm")]
+pub use band::{run_band, run_cell, BandRun};
 pub use client::{
     BrickTrace, BrickTraceOp, ChatMessage, ChatRequest, ChatResponse, ChatResponseChoice, Role,
     StreamChunk, StreamedChatResponse, TimedChatResponse, Usage,

--- a/crates/aprender-test-lib/src/perf_gate/bootstrap.rs
+++ b/crates/aprender-test-lib/src/perf_gate/bootstrap.rs
@@ -1,0 +1,327 @@
+//! §4.4.4 — bootstrap percentile confidence intervals.
+//!
+//! Percentile method, 10 000 resamples, seed 2026, resampling **whole
+//! requests**. Tokens within a request are not independent, so resampling
+//! tokens (or per-token latencies) would understate the interval by pretending
+//! each token is its own observation.
+//!
+//! BCa is deliberately not implemented: §4.4.4 rejects it as an undocumented
+//! degree of freedom at this dispersion.
+//!
+//! The PRNG is a `SplitMix64` written out in full rather than taken from a
+//! crate. §4.4.4 requires the interval to be *reproducible from the retained
+//! samples*, and a dependency's internal stream is free to change across a
+//! semver-compatible bump — which would silently move every published interval.
+//! The stream is pinned by [`tests::splitmix64_stream_is_pinned`].
+
+use serde::{Deserialize, Serialize};
+
+use super::metrics::{percentile, RequestSample};
+use super::protocol::{BOOTSTRAP_RESAMPLES, BOOTSTRAP_SEED};
+
+/// `SplitMix64`, exactly as published by Steele et al. Deterministic across
+/// platforms: `u64` wrapping arithmetic only, no floats in the state.
+#[derive(Debug, Clone)]
+pub struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    /// Seed the generator.
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    /// Next 64 bits.
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform index in `[0, n)` by Lemire's multiply-shift. Unbiased enough for
+    /// resampling and, unlike modulo, free of the low-bit bias that would skew
+    /// which requests get picked.
+    pub fn index_below(&mut self, n: usize) -> usize {
+        debug_assert!(n > 0, "index_below(0) is undefined");
+        ((u128::from(self.next_u64()) * n as u128) >> 64) as usize
+    }
+}
+
+/// A bootstrap percentile interval, with everything needed to re-derive it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BootstrapCi {
+    /// The statistic on the observed sample.
+    pub point: f64,
+    /// Lower percentile bound.
+    pub lower: f64,
+    /// Upper percentile bound.
+    pub upper: f64,
+    /// Nominal coverage, e.g. 0.95.
+    pub confidence: f64,
+    /// Resamples drawn.
+    pub resamples: usize,
+    /// The seed. In the receipt, per §4.4.4.
+    pub seed: u64,
+    /// Whole requests, always. Recorded so the unit of resampling is on the page.
+    pub resampling_unit: &'static str,
+    /// Observations resampled.
+    pub n: usize,
+}
+
+/// A statistic of a set of whole requests, e.g. [`super::metrics::agg_tok_s`].
+///
+/// A function pointer rather than a generic `F: Fn(..)`: a fn item passed to a
+/// generic higher-ranked bound makes rustc infer a fresh lifetime and reject the
+/// call, so every call site would need a wrapping closure — which clippy then
+/// correctly flags as redundant. The pointer type takes the fn item directly.
+pub type Statistic = fn(&[RequestSample]) -> f64;
+
+/// §4.4.4 — bootstrap percentile CI for any statistic of a set of whole requests.
+///
+/// `statistic` is applied to the observed samples for the point estimate and to
+/// each resample for the distribution. Passing
+/// [`super::metrics::agg_tok_s`] gives the aggregate's interval; passing a
+/// median gives the median's.
+///
+/// Returns `None` for fewer than two observations, where a bootstrap interval is
+/// not defined. Returning a degenerate `[x, x]` there would read as a
+/// measurement of impossible precision.
+pub fn bootstrap_ci(
+    samples: &[RequestSample],
+    confidence: f64,
+    statistic: Statistic,
+) -> Option<BootstrapCi> {
+    bootstrap_ci_with(
+        samples,
+        confidence,
+        BOOTSTRAP_RESAMPLES,
+        BOOTSTRAP_SEED,
+        statistic,
+    )
+}
+
+/// [`bootstrap_ci`] with the resample count and seed spelled out. The public
+/// entry point pins both to the §4.4.4 values; this exists for the tests that
+/// prove the pinning matters.
+pub fn bootstrap_ci_with(
+    samples: &[RequestSample],
+    confidence: f64,
+    resamples: usize,
+    seed: u64,
+    statistic: Statistic,
+) -> Option<BootstrapCi> {
+    let n = samples.len();
+    if n < 2 || resamples == 0 || !(0.0..1.0).contains(&confidence) {
+        return None;
+    }
+
+    let mut rng = SplitMix64::new(seed);
+    let mut draws = Vec::with_capacity(resamples);
+    // One reusable buffer: resampling WHOLE requests means cloning records, and
+    // 10 000 fresh allocations of n records is the difference between a CI that
+    // is cheap enough to always compute and one people turn off.
+    let mut resample: Vec<RequestSample> = Vec::with_capacity(n);
+    for _ in 0..resamples {
+        resample.clear();
+        for _ in 0..n {
+            resample.push(samples[rng.index_below(n)].clone());
+        }
+        draws.push(statistic(&resample));
+    }
+    draws.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let alpha = 1.0 - confidence;
+    let lower = percentile(&draws, alpha / 2.0)?;
+    let upper = percentile(&draws, 1.0 - alpha / 2.0)?;
+
+    Some(BootstrapCi {
+        point: statistic(samples),
+        lower,
+        upper,
+        confidence,
+        resamples,
+        seed,
+        resampling_unit: "whole_request",
+        n,
+    })
+}
+
+/// [`bootstrap_ci`] specialised to §4.4.3's `agg_tok_s`.
+///
+/// A named wrapper rather than a bare function reference at each call site:
+/// passing `agg_tok_s` directly makes rustc infer a fresh lifetime instead of
+/// the higher-ranked one the bound wants, and the resulting error is opaque.
+///
+/// Returns `None` under the same conditions as [`bootstrap_ci`].
+#[must_use]
+pub fn bootstrap_agg_tok_s_ci(samples: &[RequestSample], confidence: f64) -> Option<BootstrapCi> {
+    bootstrap_ci(samples, confidence, super::metrics::agg_tok_s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf_gate::metrics::agg_tok_s;
+    use crate::perf_gate::protocol::Outcome;
+
+    fn sample(index: usize, start_s: f64, end_s: f64, tokens: u32) -> RequestSample {
+        RequestSample {
+            index,
+            worker: index % 4,
+            start_s,
+            end_s,
+            token_times_s: vec![start_s + 0.01, end_s],
+            generated_tokens: tokens,
+            prompt_tokens: 512,
+            outcome: Outcome::Completed,
+            in_flight_at_start: 4,
+            drained: false,
+        }
+    }
+
+    fn deck(n: usize) -> Vec<RequestSample> {
+        (0..n)
+            .map(|i| {
+                let start = i as f64 * 0.25;
+                let jitter = f64::from((i % 7) as u32) * 0.05;
+                sample(i, start, start + 1.0 + jitter, 100 + (i % 5) as u32)
+            })
+            .collect()
+    }
+
+    /// The stream is pinned. If this reds, every previously published interval
+    /// moved, and that must be a deliberate, versioned decision.
+    #[test]
+    fn splitmix64_stream_is_pinned() {
+        let mut r = SplitMix64::new(2026);
+        let got: Vec<u64> = (0..4).map(|_| r.next_u64()).collect();
+        assert_eq!(
+            got,
+            vec![
+                15_824_617_304_438_902_051,
+                8_699_989_649_721_214_301,
+                12_310_341_597_754_734_734,
+                7_097_835_237_234_771_186,
+            ],
+            "SplitMix64(2026) stream changed"
+        );
+    }
+
+    #[test]
+    fn index_below_stays_in_range_and_covers_it() {
+        let mut r = SplitMix64::new(BOOTSTRAP_SEED);
+        let mut seen = [false; 5];
+        for _ in 0..500 {
+            let i = r.index_below(5);
+            assert!(i < 5, "index {i} out of range");
+            seen[i] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "every index must be reachable");
+    }
+
+    /// §4.4.4's whole point: same samples + seed 2026 => the identical interval,
+    /// bit for bit, twice.
+    #[test]
+    fn same_samples_and_seed_give_the_identical_interval_twice() {
+        let s = deck(40);
+        let a = bootstrap_agg_tok_s_ci(&s, 0.95).expect("n >= 2");
+        let b = bootstrap_agg_tok_s_ci(&s, 0.95).expect("n >= 2");
+        assert_eq!(
+            a, b,
+            "the CI must be reproducible from the retained samples"
+        );
+        assert_eq!(a.seed, 2026);
+        assert_eq!(a.resamples, 10_000);
+        assert_eq!(a.resampling_unit, "whole_request");
+        assert_eq!(a.n, 40);
+    }
+
+    /// And the seed is load-bearing, not decoration: a different seed must move
+    /// the interval, or "seed 2026" would be an unfalsifiable claim.
+    #[test]
+    fn a_different_seed_gives_a_different_interval() {
+        let s = deck(40);
+        let a = bootstrap_ci_with(&s, 0.95, 10_000, 2026, agg_tok_s).expect("n >= 2");
+        let b = bootstrap_ci_with(&s, 0.95, 10_000, 2027, agg_tok_s).expect("n >= 2");
+        assert_eq!(
+            a.point, b.point,
+            "the point estimate does not depend on the seed"
+        );
+        assert!(
+            (a.lower - b.lower).abs() > f64::EPSILON || (a.upper - b.upper).abs() > f64::EPSILON,
+            "seed had no effect: {a:?} vs {b:?}"
+        );
+    }
+
+    #[test]
+    fn the_interval_brackets_the_point_estimate() {
+        let s = deck(60);
+        let ci = bootstrap_agg_tok_s_ci(&s, 0.95).expect("n >= 2");
+        assert!(ci.lower <= ci.point, "{ci:?}");
+        assert!(ci.point <= ci.upper, "{ci:?}");
+        assert!(
+            ci.lower < ci.upper,
+            "a non-degenerate sample needs width: {ci:?}"
+        );
+    }
+
+    /// Whole requests, not tokens. Resampling n whole records from n records
+    /// must be able to draw the same record twice — that is what makes it a
+    /// bootstrap. A permutation would give zero width.
+    #[test]
+    fn resampling_is_with_replacement_over_whole_requests() {
+        let mut rng = SplitMix64::new(BOOTSTRAP_SEED);
+        let n = 8;
+        let mut counts = vec![0_usize; n];
+        for _ in 0..n {
+            counts[rng.index_below(n)] += 1;
+        }
+        assert!(
+            counts.iter().any(|&c| c >= 2),
+            "a with-replacement draw of n from n must duplicate: {counts:?}"
+        );
+    }
+
+    /// A wider spread of per-request behaviour must widen the interval. An
+    /// undersized or noisy `n` should FAIL a gate by widening, never pass
+    /// silently (§4.4.2).
+    #[test]
+    fn more_dispersion_widens_the_interval() {
+        let tight: Vec<RequestSample> = (0..40)
+            .map(|i| sample(i, i as f64 * 0.25, i as f64 * 0.25 + 1.0, 100))
+            .collect();
+        let loose: Vec<RequestSample> = (0..40)
+            .map(|i| {
+                let start = i as f64 * 0.25;
+                let dur = if i % 2 == 0 { 0.2 } else { 4.0 };
+                sample(i, start, start + dur, 100)
+            })
+            .collect();
+        let a = bootstrap_agg_tok_s_ci(&tight, 0.95).expect("n >= 2");
+        let b = bootstrap_agg_tok_s_ci(&loose, 0.95).expect("n >= 2");
+        assert!(
+            (b.upper - b.lower) > (a.upper - a.lower),
+            "dispersed: {:?} must be wider than tight: {:?}",
+            b,
+            a
+        );
+    }
+
+    #[test]
+    fn fewer_than_two_observations_has_no_interval() {
+        assert!(bootstrap_agg_tok_s_ci(&[], 0.95).is_none());
+        assert!(bootstrap_agg_tok_s_ci(&deck(1), 0.95).is_none());
+        assert!(bootstrap_agg_tok_s_ci(&deck(2), 0.95).is_some());
+    }
+
+    #[test]
+    fn a_nonsense_confidence_has_no_interval() {
+        let s = deck(10);
+        assert!(bootstrap_ci(&s, 1.0, agg_tok_s).is_none());
+        assert!(bootstrap_ci(&s, -0.1, agg_tok_s).is_none());
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/metrics.rs
+++ b/crates/aprender-test-lib/src/perf_gate/metrics.rs
@@ -1,0 +1,447 @@
+//! §4.4.3 — the metric definitions, computed from retained per-request samples.
+//!
+//! The whole point of this file is that `agg_tok_s` is a **wall-clock** quantity
+//! and the mean of per-request rates is a different number. `mean_of_rates` is
+//! implemented here *deliberately*, next to it, so the difference is asserted in
+//! a test rather than argued about in review. It is never used to produce a
+//! receipt figure.
+
+use serde::{Deserialize, Serialize};
+
+use super::protocol::Outcome;
+
+/// One retained per-request sample (§4.4.5). Every time is an offset in seconds
+/// from a single band-wide origin, so the wall-clock span is computable across
+/// workers without reconstructing anything.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequestSample {
+    /// Monotone index in issue order.
+    pub index: usize,
+    /// Which closed-loop worker issued it.
+    pub worker: usize,
+    /// Offset of the request start from the band origin.
+    pub start_s: f64,
+    /// Offset of the request's completion (or abandonment) from the band origin.
+    pub end_s: f64,
+    /// Arrival offsets of each streamed token. Empty when not streaming.
+    #[serde(default)]
+    pub token_times_s: Vec<f64>,
+    /// Generated (completion) tokens, counted per the receipt's `tokenization` block.
+    pub generated_tokens: u32,
+    /// Prompt tokens, when the server reports them.
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    /// How the request ended.
+    pub outcome: Outcome,
+    /// Concurrent requests in flight at the instant this one was issued.
+    /// The direct, per-request evidence that the client was actually concurrent.
+    #[serde(default)]
+    pub in_flight_at_start: usize,
+    /// True when this request completed after the measurement window closed,
+    /// i.e. during the §4.4.7 drain.
+    #[serde(default)]
+    pub drained: bool,
+}
+
+impl RequestSample {
+    /// §4.4.3 `ttft_ms` — request start to first token byte at the client.
+    /// `None` when no token was ever observed.
+    #[must_use]
+    pub fn ttft_ms(&self) -> Option<f64> {
+        self.token_times_s
+            .first()
+            .map(|t| (t - self.start_s) * 1000.0)
+    }
+
+    /// §4.4.3 `decode_tok_s` for this request:
+    /// `(generated tokens - 1) / (last token time - first token time)`.
+    ///
+    /// `None` when fewer than two tokens were observed, where the quantity is
+    /// undefined rather than zero.
+    #[must_use]
+    pub fn decode_tok_s(&self) -> Option<f64> {
+        if self.token_times_s.len() < 2 || self.generated_tokens < 2 {
+            return None;
+        }
+        let first = self.token_times_s[0];
+        let last = self.token_times_s[self.token_times_s.len() - 1];
+        let span = last - first;
+        if span <= 0.0 {
+            return None;
+        }
+        Some(f64::from(self.generated_tokens - 1) / span)
+    }
+
+    /// §4.4.3 `itl_ms` — this request's inter-token gaps, for pooling.
+    #[must_use]
+    pub fn itl_gaps_ms(&self) -> Vec<f64> {
+        self.token_times_s
+            .windows(2)
+            .map(|w| (w[1] - w[0]) * 1000.0)
+            .collect()
+    }
+
+    /// True when this sample contributes to `agg_tok_s`'s numerator (§4.4.3:
+    /// completed and non-truncated).
+    #[must_use]
+    pub fn counts_toward_aggregate(&self) -> bool {
+        self.outcome == Outcome::Completed
+    }
+}
+
+/// §4.4.3 — one band's metrics.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BandMetrics {
+    /// Fixed concurrency `c`.
+    pub concurrency: usize,
+    /// (Σ generated tokens over completed, non-truncated sampled requests)
+    /// ÷ (last completion − first request start). **Wall-clock.**
+    pub agg_tok_s: f64,
+    /// Median across sampled requests of per-request `(tokens-1)/(last-first)`.
+    pub decode_tok_s: f64,
+    /// p50 of `ttft_ms`.
+    pub ttft_p50_ms: f64,
+    /// p95 of `ttft_ms`.
+    pub ttft_p95_ms: f64,
+    /// p50 of the pooled inter-token gaps.
+    pub itl_p50_ms: f64,
+    /// p95 of the pooled inter-token gaps.
+    pub itl_p95_ms: f64,
+    /// Requests issued inside the window.
+    pub requested: usize,
+    /// Requests that completed.
+    pub completed: usize,
+    /// Requests that hit the 120 s hard timeout.
+    pub timeouts: usize,
+    /// Requests abandoned at the drain deadline (§4.4.7).
+    pub truncated: usize,
+    /// Requests that failed for any other reason.
+    pub errors: usize,
+    /// Σ generated tokens over the requests in the numerator.
+    pub tokens_total: u64,
+    /// The denominator actually used, in seconds. Present so a reader can
+    /// re-derive `agg_tok_s` without the samples.
+    pub span_s: f64,
+}
+
+/// Percentile by linear interpolation between order statistics, on an
+/// ascending-sorted slice. Defined here once so `ttft_p95` means the same thing
+/// in every receipt this repo produces.
+///
+/// Returns `None` for an empty slice — a percentile of nothing is undefined,
+/// and returning `0.0` there is how an empty band reads as a fast one.
+#[must_use]
+pub fn percentile(sorted_ascending: &[f64], p: f64) -> Option<f64> {
+    match sorted_ascending.len() {
+        0 => None,
+        1 => Some(sorted_ascending[0]),
+        n => {
+            let idx = (n as f64 - 1.0) * p;
+            let lo = idx.floor() as usize;
+            let hi = (lo + 1).min(n - 1);
+            let frac = idx - lo as f64;
+            Some(sorted_ascending[lo].mul_add(1.0 - frac, sorted_ascending[hi] * frac))
+        }
+    }
+}
+
+fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    v
+}
+
+fn median(values: Vec<f64>) -> f64 {
+    percentile(&sorted(values), 0.50).unwrap_or(0.0)
+}
+
+/// §4.4.3 `agg_tok_s`, exactly as specified.
+///
+/// Numerator: generated tokens over completed, non-truncated samples.
+/// Denominator: last completion minus first request start, where "first request
+/// start" is over **every** sampled request (§4.4.7) — including ones that
+/// timed out, because they occupied the server for that time.
+///
+/// Returns `0.0` when the span is non-positive; a band with no elapsed time
+/// produced no evidence and must not read as infinite throughput.
+#[must_use]
+pub fn agg_tok_s(samples: &[RequestSample]) -> f64 {
+    let (tokens, span) = aggregate_terms(samples);
+    if span <= 0.0 {
+        return 0.0;
+    }
+    tokens as f64 / span
+}
+
+/// The numerator and denominator of [`agg_tok_s`], separately, so a receipt can
+/// carry both and a reader can check the division.
+#[must_use]
+pub fn aggregate_terms(samples: &[RequestSample]) -> (u64, f64) {
+    if samples.is_empty() {
+        return (0, 0.0);
+    }
+    let tokens: u64 = samples
+        .iter()
+        .filter(|s| s.counts_toward_aggregate())
+        .map(|s| u64::from(s.generated_tokens))
+        .sum();
+    let first_start = samples
+        .iter()
+        .map(|s| s.start_s)
+        .fold(f64::INFINITY, f64::min);
+    let last_end = samples
+        .iter()
+        .filter(|s| s.counts_toward_aggregate())
+        .map(|s| s.end_s)
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !first_start.is_finite() || !last_end.is_finite() {
+        return (tokens, 0.0);
+    }
+    (tokens, last_end - first_start)
+}
+
+/// The arithmetic mean of per-request token rates.
+///
+/// **This is not `agg_tok_s` and must never be reported as it.** It exists so
+/// the test `agg_tok_s_is_wall_clock_not_the_mean_of_rates` can assert the two
+/// differ on a fixture with hand-computed values. Under a
+/// serialising server with idle gaps between requests, this number can be many
+/// times the true aggregate.
+#[must_use]
+pub fn mean_of_rates(samples: &[RequestSample]) -> f64 {
+    let rates: Vec<f64> = samples
+        .iter()
+        .filter(|s| s.counts_toward_aggregate())
+        .filter_map(|s| {
+            let dur = s.end_s - s.start_s;
+            if dur > 0.0 {
+                Some(f64::from(s.generated_tokens) / dur)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if rates.is_empty() {
+        return 0.0;
+    }
+    rates.iter().sum::<f64>() / rates.len() as f64
+}
+
+impl BandMetrics {
+    /// Compute every §4.4.3 metric from one band's retained samples.
+    #[must_use]
+    pub fn from_samples(concurrency: usize, samples: &[RequestSample]) -> Self {
+        let (tokens_total, span_s) = aggregate_terms(samples);
+        let agg = if span_s > 0.0 {
+            tokens_total as f64 / span_s
+        } else {
+            0.0
+        };
+
+        let ttfts = sorted(samples.iter().filter_map(RequestSample::ttft_ms).collect());
+        let itls = sorted(
+            samples
+                .iter()
+                .flat_map(RequestSample::itl_gaps_ms)
+                .collect::<Vec<f64>>(),
+        );
+        let decodes: Vec<f64> = samples
+            .iter()
+            .filter_map(RequestSample::decode_tok_s)
+            .collect();
+
+        let count = |o: Outcome| samples.iter().filter(|s| s.outcome == o).count();
+
+        Self {
+            concurrency,
+            agg_tok_s: agg,
+            decode_tok_s: median(decodes),
+            ttft_p50_ms: percentile(&ttfts, 0.50).unwrap_or(0.0),
+            ttft_p95_ms: percentile(&ttfts, 0.95).unwrap_or(0.0),
+            itl_p50_ms: percentile(&itls, 0.50).unwrap_or(0.0),
+            itl_p95_ms: percentile(&itls, 0.95).unwrap_or(0.0),
+            requested: samples.len(),
+            completed: count(Outcome::Completed),
+            timeouts: count(Outcome::Timeout),
+            truncated: count(Outcome::Truncated),
+            errors: count(Outcome::Error),
+            tokens_total,
+            span_s,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a sample whose token arrivals are evenly spaced across
+    /// `[start, end]`, so `decode_tok_s` and `itl` are hand-computable.
+    fn sample(index: usize, start_s: f64, end_s: f64, tokens: u32) -> RequestSample {
+        let n = tokens as usize;
+        let token_times_s = if n == 0 {
+            Vec::new()
+        } else {
+            let step = (end_s - start_s) / n as f64;
+            (1..=n).map(|i| start_s + step * i as f64).collect()
+        };
+        RequestSample {
+            index,
+            worker: 0,
+            start_s,
+            end_s,
+            token_times_s,
+            generated_tokens: tokens,
+            prompt_tokens: 0,
+            outcome: Outcome::Completed,
+            in_flight_at_start: 1,
+            drained: false,
+        }
+    }
+
+    /// THE fixture this ticket exists for.
+    ///
+    /// Four requests, 100 tokens each, run two-at-a-time:
+    ///   r0 [0,1]  r1 [0,2]  r2 [1,3]  r3 [2,4]
+    /// Wall-clock span = 4.0 s, tokens = 400  =>  agg_tok_s = 100.0
+    /// Per-request rates = 100, 50, 50, 50    =>  mean       =  62.5
+    #[test]
+    fn agg_tok_s_is_wall_clock_not_the_mean_of_rates() {
+        let s = vec![
+            sample(0, 0.0, 1.0, 100),
+            sample(1, 0.0, 2.0, 100),
+            sample(2, 1.0, 3.0, 100),
+            sample(3, 2.0, 4.0, 100),
+        ];
+        let (tokens, span) = aggregate_terms(&s);
+        assert_eq!(tokens, 400);
+        assert!((span - 4.0).abs() < 1e-12, "span={span}");
+
+        let agg = agg_tok_s(&s);
+        let mean = mean_of_rates(&s);
+        assert!((agg - 100.0).abs() < 1e-9, "agg={agg}, want 100.0");
+        assert!((mean - 62.5).abs() < 1e-9, "mean={mean}, want 62.5");
+        assert!(
+            (agg - mean).abs() > 1.0,
+            "agg {agg} and mean-of-rates {mean} must not coincide"
+        );
+    }
+
+    /// The dangerous direction: a serialising server with idle gaps. The mean of
+    /// per-request rates reports 100 tok/s; the machine actually delivered 57.1.
+    /// This is the shape of the number the epic exists to refuse.
+    #[test]
+    fn mean_of_rates_overstates_a_serialising_server() {
+        let s = vec![
+            sample(0, 0.0, 1.0, 100),
+            sample(1, 2.0, 3.0, 100),
+            sample(2, 4.0, 5.0, 100),
+            sample(3, 6.0, 7.0, 100),
+        ];
+        let agg = agg_tok_s(&s);
+        let mean = mean_of_rates(&s);
+        assert!((agg - 400.0 / 7.0).abs() < 1e-9, "agg={agg}");
+        assert!((mean - 100.0).abs() < 1e-9, "mean={mean}");
+        assert!(mean > agg * 1.7, "mean {mean} must overstate agg {agg}");
+    }
+
+    /// §4.4.3: the numerator counts only completed, non-truncated requests, but
+    /// the denominator starts at the FIRST request start whatever its outcome.
+    #[test]
+    fn timeouts_lengthen_the_span_but_add_no_tokens() {
+        let mut timed_out = sample(0, 0.0, 1.0, 100);
+        timed_out.outcome = Outcome::Timeout;
+        timed_out.generated_tokens = 100; // partial output must not be credited
+        let s = vec![timed_out, sample(1, 0.5, 2.5, 100)];
+
+        let (tokens, span) = aggregate_terms(&s);
+        assert_eq!(tokens, 100, "a timed-out request contributes no tokens");
+        assert!(
+            (span - 2.5).abs() < 1e-12,
+            "span must start at 0.0, got {span}"
+        );
+
+        let m = BandMetrics::from_samples(2, &s);
+        assert_eq!(m.requested, 2);
+        assert_eq!(m.completed, 1);
+        assert_eq!(m.timeouts, 1);
+        assert!((m.agg_tok_s - 40.0).abs() < 1e-9, "{}", m.agg_tok_s);
+    }
+
+    #[test]
+    fn decode_tok_s_is_the_median_of_per_request_rates() {
+        // Token arrivals evenly spaced: 100 tokens over a 1.0 s request means
+        // step 0.01 s, first at 0.01, last at 1.00 -> span 0.99, rate 99/0.99 = 100.
+        let one = sample(0, 0.0, 1.0, 100);
+        assert!((one.decode_tok_s().expect("two+ tokens") - 100.0).abs() < 1e-9);
+
+        // Three requests at 100, 50, 25 tok/s -> median 50.
+        let s = vec![
+            sample(0, 0.0, 1.0, 100),
+            sample(1, 0.0, 2.0, 100),
+            sample(2, 0.0, 4.0, 100),
+        ];
+        let m = BandMetrics::from_samples(1, &s);
+        assert!((m.decode_tok_s - 50.0).abs() < 1e-9, "{}", m.decode_tok_s);
+    }
+
+    #[test]
+    fn single_token_request_has_no_decode_rate_and_no_gaps() {
+        let s = sample(0, 0.0, 1.0, 1);
+        assert_eq!(s.decode_tok_s(), None);
+        assert!(s.itl_gaps_ms().is_empty());
+        assert!(s.ttft_ms().is_some(), "one token still has a TTFT");
+    }
+
+    #[test]
+    fn ttft_is_start_to_first_token() {
+        let s = sample(0, 10.0, 11.0, 4); // step 0.25 -> first at 10.25
+        assert!((s.ttft_ms().expect("has tokens") - 250.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn itl_gaps_are_pooled_across_requests() {
+        // r0: 4 tokens over 1.0 s -> 3 gaps of 250 ms
+        // r1: 3 tokens over 3.0 s -> 2 gaps of 1000 ms
+        let s = vec![sample(0, 0.0, 1.0, 4), sample(1, 0.0, 3.0, 3)];
+        let pooled: Vec<f64> = s.iter().flat_map(RequestSample::itl_gaps_ms).collect();
+        assert_eq!(
+            pooled.len(),
+            5,
+            "3 + 2 gaps pooled, not 2 per-request means"
+        );
+        let m = BandMetrics::from_samples(2, &s);
+        // sorted: 250,250,250,1000,1000 -> p50 = 250
+        assert!((m.itl_p50_ms - 250.0).abs() < 1e-9, "{}", m.itl_p50_ms);
+        assert!(m.itl_p95_ms > 900.0, "{}", m.itl_p95_ms);
+    }
+
+    #[test]
+    fn percentile_of_nothing_is_none_not_zero() {
+        assert_eq!(percentile(&[], 0.5), None);
+        assert_eq!(percentile(&[7.0], 0.95), Some(7.0));
+    }
+
+    #[test]
+    fn percentile_interpolates_between_order_statistics() {
+        let v = vec![0.0, 10.0, 20.0, 30.0];
+        assert_eq!(percentile(&v, 0.0), Some(0.0));
+        assert_eq!(percentile(&v, 1.0), Some(30.0));
+        assert_eq!(percentile(&v, 0.5), Some(15.0));
+    }
+
+    #[test]
+    fn empty_band_is_zero_not_infinite() {
+        let m = BandMetrics::from_samples(4, &[]);
+        assert_eq!(m.agg_tok_s, 0.0);
+        assert_eq!(m.requested, 0);
+        assert_eq!(m.span_s, 0.0);
+    }
+
+    #[test]
+    fn samples_round_trip_as_jsonl_rows() {
+        let s = sample(3, 1.5, 2.5, 8);
+        let line = serde_json::to_string(&s).expect("serialize");
+        let back: RequestSample = serde_json::from_str(&line).expect("deserialize");
+        assert_eq!(back, s);
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/mod.rs
+++ b/crates/aprender-test-lib/src/perf_gate/mod.rs
@@ -1,0 +1,159 @@
+//! APR-PERF-GATE-001 v2.2 §4.4 — the measurement protocol, as code.
+//!
+//! # What this is, and what it is not
+//!
+//! This is **not a benchmarking harness.** The harness is
+//! [`crate::llm::loadtest::LoadTest`], reached from `apr test llm bench`, and it
+//! already drives `c` concurrent workers over external HTTP against both `apr
+//! serve` and `llama-server`. A second harness would be a
+//! `check_no_competing_harnesses.sh` violation and a PERF-009 regression.
+//!
+//! This module is the **protocol** the harness was missing: the termination
+//! rule, the metric definitions, the confidence interval, and the sample
+//! retention that turn a load test into a §4.4-conformant *measurement*. Every
+//! decision lives here as a pure function so it can be tested in microseconds
+//! and, crucially, so it is compiled under **default features**. `aprender-test-lib`'s
+//! `llm` feature is not default and CI runs
+//! `cargo nextest run --profile ci --workspace --lib` with no `--features`, so a
+//! test placed inside `llm/` never executes in CI. The protocol had to sit
+//! outside that gate to be gated at all.
+//!
+//! # §4.4 requirement → code, and what is NOT implemented
+//!
+//! | Clause | Requirement | Status | Where |
+//! |---|---|---|---|
+//! | §4.4.1 | closed-loop, `c` workers, issue → wait → immediately reissue | pre-existing | `llm/loadtest.rs` `run_phase_max` |
+//! | §4.4.1 | external HTTP on the same host, never in-process | pre-existing | `llm/client.rs` (reqwest to a URL) |
+//! | §4.4.1 | record `client_model: closed_loop` | **added** | [`protocol::ClientModel`] |
+//! | §4.4.2 | warmup `2 × c` requests, discarded | **added** | [`protocol::warmup_requests`], [`window::WindowController::with_bounds`] |
+//! | §4.4.2 | 5 s quiesce before the first sampled request | **added** | [`protocol::QUIESCE`], [`protocol::BandConfig::quiesce`] |
+//! | §4.4.2 | minimum sampled requests `max(30, 8 × c)` | **added** | [`protocol::min_sampled_requests`] |
+//! | §4.4.2 | minimum 60 s wall-clock per band | **added** | [`protocol::MIN_WALL_CLOCK`] |
+//! | §4.4.2 | termination = whichever bound is satisfied **last** | **added** | [`window::WindowController::try_admit`] |
+//! | §4.4.2 | `N = 3` full band replicates | **added** (constant + assertion) | [`protocol::REPLICATES`] |
+//! | §4.4.3 | `agg_tok_s` **wall-clock**, not the mean of per-request rates | **added** | [`metrics::agg_tok_s`], with [`metrics::mean_of_rates`] beside it purely so a test asserts they differ |
+//! | §4.4.3 | `decode_tok_s` = median of per-request `(tok-1)/(last-first)` | **added** | [`metrics::RequestSample::decode_tok_s`] |
+//! | §4.4.3 | `ttft_ms` p50/p95 | **added** (p95 was absent) | [`metrics::BandMetrics`] |
+//! | §4.4.3 | `itl_ms` **pooled** gaps, p50/p95 | **added** | [`metrics::RequestSample::itl_gaps_ms`] |
+//! | §4.4.3 | counts `completed`/`requested`/`timeouts`/`truncated` | **added** | [`protocol::Outcome`], [`metrics::BandMetrics`] |
+//! | §4.4.3 | 120 s hard per-request timeout | pre-existing | `llm/client.rs:213` |
+//! | §4.4.4 | bootstrap percentile, 10 000 resamples, seed 2026, **whole requests** | **added** | [`bootstrap::bootstrap_ci`] |
+//! | §4.4.5 | raw samples retained as gzipped JSONL | **added** | [`samples::write_samples_gz`] |
+//! | §4.4.5 | `receipt_size_budget_bytes` | **deliberately unset** | [`samples::SamplesFile::exceeds_budget`] takes the budget as an argument; the spec forbids the literal until a full receipt is measured |
+//! | §4.4.6 | `tokenization` block, `method` with no default | **added** | [`protocol::Tokenization`] |
+//! | §4.4.7 | no new request at or after `T`; drain to completion | pre-existing + **formalised** | [`window::WindowController`] |
+//! | §4.4.7 | `drain_ms` recorded | **added** | [`window::WindowReport::drain_ms`] |
+//! | §4.4.7 | `drain_ms > 0.5 × window` annotated `SUSPECT` | **added** | [`window::WindowReport::suspect`] |
+//!
+//! ## NOT implemented by this module — stated plainly
+//!
+//! - **§4.4.8 comparator harness.** One client driving both `apr serve` and
+//!   `llama-server` already exists (`scripts/parity_host_receipt.sh` runs the
+//!   same `apr test llm bench` against both). Nothing here changes or verifies
+//!   that, and the `tokenization`-block-must-match-across-lanes rule is a
+//!   *receipt validator's* job, not this module's.
+//! - **§4.4.9 scheduler observability.** `max_in_flight`, `admission_rejected`,
+//!   `preempted_*`, `kv_blocks_*`, `gpu_layers_*`, `backend_loaded[]`,
+//!   `autofit_applied[]` are all **server**-reported. A client cannot synthesise
+//!   them, and a client-side guess would be worse than a null.
+//!   [`window::WindowReport::client_peak_in_flight`] is the client's own
+//!   observation and is named so it can never be mistaken for the server's
+//!   `max_in_flight`.
+//! - **Receipt emission.** Nothing here writes `receipt.json`.
+//!   `scripts/lib/bench_receipt.py` is the single schema authority and the
+//!   serialiser that feeds it is a separate ticket.
+//! - **W1/W2 workload construction** (§4.3), prompt corpora, and the
+//!   `prompt_tokens = 512 ± 8` assertion. Note in passing that
+//!   `crates/aprender-serve/benchmarks/qwen-coder/` contains `prompts-w2.jsonl`
+//!   but **no `prompts-w1.jsonl`**, which §4.3.1 names as W1's corpus.
+//! - **Running any band.** No baseline is measured or committed by this ticket.
+//!   Every cell in `scripts/perf-matrix.yaml` stays `UNMEASURED`.
+
+pub mod bootstrap;
+pub mod metrics;
+pub mod protocol;
+pub mod samples;
+pub mod window;
+
+pub use bootstrap::{bootstrap_agg_tok_s_ci, bootstrap_ci, BootstrapCi, SplitMix64, Statistic};
+pub use metrics::{agg_tok_s, aggregate_terms, percentile, BandMetrics, RequestSample};
+pub use protocol::{
+    min_sampled_requests, warmup_requests, BandConfig, ClientModel, Outcome, Tokenization,
+    TokenizationMethod, BOOTSTRAP_RESAMPLES, BOOTSTRAP_SEED, MIN_WALL_CLOCK, QUIESCE, REPLICATES,
+    REQUEST_TIMEOUT,
+};
+pub use samples::{read_samples_gz, write_samples_gz, SamplesFile};
+pub use window::{WindowController, WindowReport};
+
+#[cfg(test)]
+mod conformance_tests {
+    use super::*;
+
+    /// §4.4.2 — `N = 3` full band runs per cell. The constant exists so a
+    /// harness can assert against it rather than defaulting to 1 and calling a
+    /// single run a measurement.
+    #[test]
+    fn replicates_is_three() {
+        assert_eq!(REPLICATES, 3);
+    }
+
+    /// The four bands of §4.5, and the sample floor each one owes.
+    #[test]
+    fn every_declared_band_has_a_conformant_config() {
+        for (c, want_samples) in [(1_usize, 30_usize), (4, 32), (8, 64), (16, 128)] {
+            let cfg = BandConfig::conformant(c);
+            assert!(
+                cfg.is_conformant(),
+                "c={c}: {:?}",
+                cfg.conformance_violations()
+            );
+            assert_eq!(cfg.min_samples, want_samples, "c={c}");
+            assert_eq!(cfg.warmup_requests, 2 * c, "c={c}");
+            assert_eq!(cfg.client_model, ClientModel::ClosedLoop);
+        }
+    }
+
+    /// End to end over the pure protocol: admit under the real termination rule,
+    /// build samples, compute §4.4.3 metrics, and bound them with the §4.4.4 CI.
+    #[test]
+    fn protocol_composes_end_to_end() {
+        let cfg = BandConfig::conformant(4);
+        let mut w = WindowController::new(&cfg);
+        let mut samples = Vec::new();
+        // Four workers, each request taking 1 s, stepping the clock by 0.25 s.
+        let mut now = 0.0_f64;
+        while let Some(index) = w.try_admit(now) {
+            let start = now;
+            let end = now + 1.0;
+            let drained = w.complete(end);
+            samples.push(RequestSample {
+                index,
+                worker: index % 4,
+                start_s: start,
+                end_s: end,
+                token_times_s: (1..=8).map(|k| start + f64::from(k) * 0.125).collect(),
+                generated_tokens: 8,
+                prompt_tokens: 512,
+                outcome: Outcome::Completed,
+                in_flight_at_start: 4,
+                drained,
+            });
+            now += 0.25;
+        }
+        let report = w.report();
+        // 60 s at one admission per 0.25 s is 240 requests, well past max(30, 32).
+        assert!(report.requested >= cfg.min_samples, "{report:?}");
+        assert!(report.window_ms >= 60_000.0, "{report:?}");
+
+        let m = BandMetrics::from_samples(cfg.concurrency, &samples);
+        assert_eq!(m.requested, samples.len());
+        assert_eq!(m.completed, samples.len());
+        assert_eq!(m.timeouts, 0);
+        assert!(m.agg_tok_s > 0.0);
+
+        let ci = bootstrap_agg_tok_s_ci(&samples, 0.95).expect("n >= 2");
+        assert_eq!(ci.seed, BOOTSTRAP_SEED);
+        assert_eq!(ci.resamples, BOOTSTRAP_RESAMPLES);
+        assert!(ci.lower <= ci.point && ci.point <= ci.upper, "{ci:?}");
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/protocol.rs
+++ b/crates/aprender-test-lib/src/perf_gate/protocol.rs
@@ -1,0 +1,426 @@
+//! §4.4.1, §4.4.2, §4.4.6 — protocol constants, band configuration, and the
+//! conformance predicate that makes a shrunken run say so.
+//!
+//! Every literal here is quoted from `docs/specifications/APR-PERF-GATE-001-v2.2.md`.
+//! Nothing in this file is a threshold; they are all protocol parameters.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// §4.4.1 — the client model. Closed-loop is the only model this module
+/// implements, and it is *recorded* rather than assumed so the choice is
+/// falsifiable from the receipt alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientModel {
+    /// `c` workers; each issues a request, waits for completion, immediately
+    /// issues the next.
+    ClosedLoop,
+}
+
+/// §4.4.2 — warmup requests are `WARMUP_MULTIPLIER × c`, discarded.
+pub const WARMUP_MULTIPLIER: usize = 2;
+/// §4.4.2 — quiesce between warmup completion and the first sampled request.
+pub const QUIESCE: Duration = Duration::from_secs(5);
+/// §4.4.2 — minimum sampled requests is `max(MIN_SAMPLES_FLOOR, MIN_SAMPLES_PER_WORKER × c)`.
+pub const MIN_SAMPLES_FLOOR: usize = 30;
+/// §4.4.2 — the per-worker term of the minimum-sample rule.
+pub const MIN_SAMPLES_PER_WORKER: usize = 8;
+/// §4.4.2 — minimum wall-clock per band.
+pub const MIN_WALL_CLOCK: Duration = Duration::from_secs(60);
+/// §4.4.3 — hard per-request timeout. A request exceeding this increments `timeouts`.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+/// §4.4.2 — full band replicates per cell.
+pub const REPLICATES: usize = 3;
+/// §4.4.4 — bootstrap resamples.
+pub const BOOTSTRAP_RESAMPLES: usize = 10_000;
+/// §4.4.4 — bootstrap seed. Goes in the receipt; the interval is reproducible
+/// from the retained samples with this value and no other.
+pub const BOOTSTRAP_SEED: u64 = 2026;
+/// §4.4.7 — `drain_ms > DRAIN_SUSPECT_FRACTION × window` is annotated `SUSPECT`.
+pub const DRAIN_SUSPECT_FRACTION: f64 = 0.5;
+
+/// §4.4.2 — `max(30, 8 × c)`.
+#[must_use]
+pub fn min_sampled_requests(concurrency: usize) -> usize {
+    MIN_SAMPLES_FLOOR.max(MIN_SAMPLES_PER_WORKER * concurrency)
+}
+
+/// §4.4.2 — `2 × c`.
+#[must_use]
+pub fn warmup_requests(concurrency: usize) -> usize {
+    WARMUP_MULTIPLIER * concurrency
+}
+
+/// One band's measurement parameters.
+///
+/// [`BandConfig::conformant`] is the only constructor that produces §4.4-legal
+/// values. [`BandConfig::relaxed`] exists so unit tests can exercise the driver
+/// in milliseconds instead of minutes — and every run carries
+/// [`BandConfig::conformance_violations`] into its receipt, so a relaxed run is
+/// self-identifying rather than indistinguishable from a real one. A knob that
+/// lets you shrink the window without saying so is how a gate stops being able
+/// to fail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BandConfig {
+    /// Fixed concurrency `c`.
+    pub concurrency: usize,
+    /// Warmup requests, discarded and never written to the receipt.
+    pub warmup_requests: usize,
+    /// Quiesce between warmup completion and the first sampled request.
+    pub quiesce: Duration,
+    /// Minimum sampled requests to issue before the window may close.
+    pub min_samples: usize,
+    /// Minimum wall-clock the window must stay open.
+    pub min_wall_clock: Duration,
+    /// Hard per-request timeout.
+    pub request_timeout: Duration,
+    /// Recorded, not assumed.
+    pub client_model: ClientModel,
+}
+
+impl BandConfig {
+    /// The §4.4-conformant configuration for concurrency `c`.
+    ///
+    /// # Panics
+    /// Never; `concurrency` of 0 is clamped to 1 so the worker pool always has
+    /// a worker. A zero-worker band is unrepresentable rather than empty.
+    #[must_use]
+    pub fn conformant(concurrency: usize) -> Self {
+        let concurrency = concurrency.max(1);
+        Self {
+            concurrency,
+            warmup_requests: warmup_requests(concurrency),
+            quiesce: QUIESCE,
+            min_samples: min_sampled_requests(concurrency),
+            min_wall_clock: MIN_WALL_CLOCK,
+            request_timeout: REQUEST_TIMEOUT,
+            client_model: ClientModel::ClosedLoop,
+        }
+    }
+
+    /// A shrunken configuration for tests and smoke runs. **Never conformant**:
+    /// [`Self::conformance_violations`] is non-empty by construction unless the
+    /// caller happens to pass the spec values back in.
+    #[must_use]
+    pub fn relaxed(
+        concurrency: usize,
+        min_samples: usize,
+        min_wall_clock: Duration,
+        quiesce: Duration,
+    ) -> Self {
+        let concurrency = concurrency.max(1);
+        Self {
+            concurrency,
+            warmup_requests: warmup_requests(concurrency),
+            quiesce,
+            min_samples,
+            min_wall_clock,
+            request_timeout: REQUEST_TIMEOUT,
+            client_model: ClientModel::ClosedLoop,
+        }
+    }
+
+    /// Every way this configuration departs from §4.4.2, in prose, for the receipt.
+    #[must_use]
+    pub fn conformance_violations(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        let want_warmup = warmup_requests(self.concurrency);
+        if self.warmup_requests < want_warmup {
+            out.push(format!(
+                "§4.4.2 warmup_requests={} < 2*c={want_warmup}",
+                self.warmup_requests
+            ));
+        }
+        if self.quiesce < QUIESCE {
+            out.push(format!("§4.4.2 quiesce={:?} < 5s", self.quiesce));
+        }
+        let want_samples = min_sampled_requests(self.concurrency);
+        if self.min_samples < want_samples {
+            out.push(format!(
+                "§4.4.2 min_samples={} < max(30, 8*c)={want_samples}",
+                self.min_samples
+            ));
+        }
+        if self.min_wall_clock < MIN_WALL_CLOCK {
+            out.push(format!(
+                "§4.4.2 min_wall_clock={:?} < 60s",
+                self.min_wall_clock
+            ));
+        }
+        if self.request_timeout != REQUEST_TIMEOUT {
+            out.push(format!(
+                "§4.4.3 request_timeout={:?} != 120s",
+                self.request_timeout
+            ));
+        }
+        out
+    }
+
+    /// True when [`Self::conformance_violations`] is empty.
+    #[must_use]
+    pub fn is_conformant(&self) -> bool {
+        self.conformance_violations().is_empty()
+    }
+}
+
+/// §4.4.3 / §4.4.7 — how one request ended. The four values are the four
+/// counters the receipt must carry, and they are mutually exclusive so
+/// `requested = completed + timeouts + truncated + errors` holds by construction.
+///
+/// **`Truncated` means "abandoned at the drain deadline" (§4.4.7), NOT
+/// `finish_reason == "length"`.** Under W1 every request stops at
+/// `max_tokens = 128` with EOS ignored, so reading `truncated` as the
+/// finish-reason sense would exclude the entire workload from `agg_tok_s`'s
+/// numerator and report zero throughput for a healthy server. The two senses are
+/// named differently on purpose; conflating them is how two conformant harnesses
+/// produce incomparable receipts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// Finished inside the window or during the drain, with a usable response.
+    Completed,
+    /// Hit the 120 s hard per-request timeout (§4.4.3).
+    Timeout,
+    /// Abandoned at the drain deadline (§4.4.7).
+    Truncated,
+    /// Failed for any other reason (transport, non-2xx, unparseable body).
+    Error,
+}
+
+/// §4.4.6 — how tokens were counted. **No `Default` impl, deliberately:** the
+/// spec says `method` has no default and its absence is schema-fatal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenizationMethod {
+    /// Token counts taken from the server's own `usage` fields.
+    ServerUsage,
+    /// Token counts computed client-side with the model's tokenizer. Canonical.
+    ClientTokenizer,
+}
+
+/// §4.4.6 — the `tokenization` block, required in every receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tokenization {
+    /// REQUIRED, no default.
+    pub method: TokenizationMethod,
+    /// REQUIRED when `method = client_tokenizer`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokenizer_sha256: Option<String>,
+    /// REQUIRED.
+    pub counts_special_tokens: bool,
+    /// REQUIRED.
+    pub counts_prompt_echo: bool,
+}
+
+impl Tokenization {
+    /// The canonical method: the model's own tokenizer, applied identically to
+    /// the measured server and its comparator.
+    ///
+    /// # Errors
+    /// When `tokenizer_sha256` is not a 64-character lowercase hex digest.
+    pub fn client_tokenizer(
+        tokenizer_sha256: impl Into<String>,
+        counts_special_tokens: bool,
+        counts_prompt_echo: bool,
+    ) -> Result<Self, String> {
+        let sha = tokenizer_sha256.into();
+        let block = Self {
+            method: TokenizationMethod::ClientTokenizer,
+            tokenizer_sha256: Some(sha),
+            counts_special_tokens,
+            counts_prompt_echo,
+        };
+        block.validate()?;
+        Ok(block)
+    }
+
+    /// Server-reported `usage` counts. Legal, but two servers' `usage` fields
+    /// are two implementations' opinions — §4.4.6 prefers `client_tokenizer`.
+    #[must_use]
+    pub fn server_usage(counts_special_tokens: bool, counts_prompt_echo: bool) -> Self {
+        Self {
+            method: TokenizationMethod::ServerUsage,
+            tokenizer_sha256: None,
+            counts_special_tokens,
+            counts_prompt_echo,
+        }
+    }
+
+    /// §4.4.6 schema check.
+    ///
+    /// # Errors
+    /// When `client_tokenizer` carries no digest, or the digest is malformed,
+    /// or `server_usage` carries a digest it cannot have produced.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.method {
+            TokenizationMethod::ClientTokenizer => {
+                let sha = self.tokenizer_sha256.as_deref().ok_or_else(|| {
+                    "tokenization.tokenizer_sha256 is REQUIRED when method = client_tokenizer"
+                        .to_string()
+                })?;
+                if sha.len() != 64 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    return Err(format!(
+                        "tokenization.tokenizer_sha256 must be 64 hex characters, got {:?}",
+                        sha
+                    ));
+                }
+                Ok(())
+            }
+            TokenizationMethod::ServerUsage => {
+                if self.tokenizer_sha256.is_some() {
+                    return Err(
+                        "tokenization.tokenizer_sha256 is meaningless when method = server_usage"
+                            .to_string(),
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Poka-yoke for transports: a declared method the transport cannot honour
+    /// is refused at construction, not silently downgraded at measure time.
+    ///
+    /// # Errors
+    /// When the declared method and the available counting machinery disagree.
+    pub fn require_counter(&self, has_client_counter: bool) -> Result<(), String> {
+        match (self.method, has_client_counter) {
+            (TokenizationMethod::ClientTokenizer, false) => Err(
+                "tokenization.method = client_tokenizer but no client TokenCounter was supplied"
+                    .to_string(),
+            ),
+            (TokenizationMethod::ServerUsage, true) => Err(
+                "tokenization.method = server_usage but a client TokenCounter was supplied; \
+                 declare client_tokenizer or drop the counter"
+                    .to_string(),
+            ),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_sampled_requests_is_max_30_or_8c() {
+        assert_eq!(min_sampled_requests(1), 30);
+        assert_eq!(min_sampled_requests(3), 30);
+        assert_eq!(min_sampled_requests(4), 32);
+        assert_eq!(min_sampled_requests(8), 64);
+        assert_eq!(min_sampled_requests(16), 128);
+    }
+
+    #[test]
+    fn warmup_is_two_per_worker() {
+        for c in [1_usize, 4, 8, 16] {
+            assert_eq!(warmup_requests(c), 2 * c);
+        }
+    }
+
+    /// The shipped defaults ARE the spec values. If someone edits a constant,
+    /// this is the test that reds.
+    #[test]
+    fn conformant_config_matches_the_spec_literals() {
+        for c in [1_usize, 4, 8, 16] {
+            let cfg = BandConfig::conformant(c);
+            assert_eq!(cfg.concurrency, c);
+            assert_eq!(cfg.warmup_requests, 2 * c);
+            assert_eq!(cfg.quiesce, Duration::from_secs(5));
+            assert_eq!(cfg.min_samples, 30.max(8 * c));
+            assert_eq!(cfg.min_wall_clock, Duration::from_secs(60));
+            assert_eq!(cfg.request_timeout, Duration::from_secs(120));
+            assert_eq!(cfg.client_model, ClientModel::ClosedLoop);
+            assert!(
+                cfg.is_conformant(),
+                "violations: {:?}",
+                cfg.conformance_violations()
+            );
+        }
+    }
+
+    /// The escape hatch must be visible from the receipt. A relaxed run that
+    /// reported itself conformant is exactly the fabricated-baseline class.
+    #[test]
+    fn relaxed_config_reports_every_departure() {
+        let cfg = BandConfig::relaxed(4, 8, Duration::from_millis(50), Duration::ZERO);
+        assert!(!cfg.is_conformant());
+        let v = cfg.conformance_violations();
+        assert_eq!(
+            v.len(),
+            3,
+            "expected quiesce+min_samples+min_wall, got {v:?}"
+        );
+        assert!(v.iter().any(|s| s.contains("quiesce")));
+        assert!(v.iter().any(|s| s.contains("min_samples")));
+        assert!(v.iter().any(|s| s.contains("min_wall_clock")));
+    }
+
+    #[test]
+    fn client_model_serializes_as_closed_loop() {
+        let j =
+            serde_json::to_string(&ClientModel::ClosedLoop).expect("ClientModel must serialize");
+        assert_eq!(j, "\"closed_loop\"");
+    }
+
+    #[test]
+    fn client_tokenizer_without_a_digest_is_refused() {
+        let bad = Tokenization {
+            method: TokenizationMethod::ClientTokenizer,
+            tokenizer_sha256: None,
+            counts_special_tokens: true,
+            counts_prompt_echo: false,
+        };
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn client_tokenizer_digest_must_be_hex64() {
+        assert!(Tokenization::client_tokenizer("deadbeef", true, false).is_err());
+        let good = "a".repeat(64);
+        assert!(Tokenization::client_tokenizer(good, true, false).is_ok());
+    }
+
+    #[test]
+    fn server_usage_may_not_carry_a_tokenizer_digest() {
+        let bad = Tokenization {
+            method: TokenizationMethod::ServerUsage,
+            tokenizer_sha256: Some("b".repeat(64)),
+            counts_special_tokens: false,
+            counts_prompt_echo: false,
+        };
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn declared_method_and_available_counter_must_agree() {
+        let ct = Tokenization::client_tokenizer("c".repeat(64), true, false).expect("valid digest");
+        assert!(ct.require_counter(false).is_err());
+        assert!(ct.require_counter(true).is_ok());
+
+        let su = Tokenization::server_usage(true, false);
+        assert!(su.require_counter(true).is_err());
+        assert!(su.require_counter(false).is_ok());
+    }
+
+    #[test]
+    fn tokenization_block_round_trips_with_method_present() {
+        let t = Tokenization::server_usage(true, false);
+        let j = serde_json::to_string(&t).expect("serialize");
+        assert!(j.contains("\"method\":\"server_usage\""), "{j}");
+        assert!(!j.contains("tokenizer_sha256"), "{j}");
+        let back: Tokenization = serde_json::from_str(&j).expect("deserialize");
+        assert_eq!(back, t);
+    }
+
+    /// `method` has no default: a block missing it must fail to deserialize.
+    #[test]
+    fn tokenization_without_method_is_schema_fatal() {
+        let j = r#"{"counts_special_tokens":true,"counts_prompt_echo":false}"#;
+        let r: Result<Tokenization, _> = serde_json::from_str(j);
+        assert!(r.is_err(), "absent method must be fatal, not defaulted");
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/samples.rs
+++ b/crates/aprender-test-lib/src/perf_gate/samples.rs
@@ -1,0 +1,222 @@
+//! §4.4.5 — raw per-request sample retention.
+//!
+//! "Raw per-request samples are retained on every cell — a summary-only receipt
+//! cannot be resampled and is rejected (I-4)." Gzipped JSONL inside the receipt
+//! directory, with its `sha256` and byte size recorded so the receipt names what
+//! it points at.
+//!
+//! The `receipt_size_budget_bytes` assertion §4.4.5 asks for is **not** given a
+//! literal here. The spec says "measure one full receipt, commit its size as
+//! `receipt_size_budget_bytes` … No literal until measured `[U]`", and no
+//! conformant band has been run yet. [`SamplesFile::exceeds_budget`] takes the
+//! budget as an argument so the check can be armed the day the number is
+//! measured, without a plausible-looking placeholder being committed today.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::metrics::RequestSample;
+
+/// Where the raw samples went, and what they hash to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SamplesFile {
+    /// Path relative to the receipt directory.
+    pub path: PathBuf,
+    /// `sha256` of the gzipped bytes on disk.
+    pub sha256: String,
+    /// Size of the gzipped bytes.
+    pub bytes: u64,
+    /// Rows written — one JSON object per request, one request per line.
+    pub rows: usize,
+}
+
+impl SamplesFile {
+    /// §4.4.5 budget check. The budget is an argument, not a constant, because
+    /// the spec forbids inventing the literal before a full receipt is measured.
+    #[must_use]
+    pub fn exceeds_budget(&self, budget_bytes: u64) -> bool {
+        self.bytes > budget_bytes
+    }
+}
+
+/// Write `samples` as gzipped JSONL to `path`, returning its digest and size.
+///
+/// One JSON object per line, in issue order. JSONL rather than a JSON array so
+/// a truncated file still yields every complete row: a receipt that cannot be
+/// partially read is a receipt that gets discarded whole.
+///
+/// # Errors
+/// On any I/O or serialisation failure. A retention failure is returned, never
+/// swallowed — a receipt whose samples silently failed to write is exactly the
+/// summary-only receipt §4.4.5 rejects.
+pub fn write_samples_gz(path: &Path, samples: &[RequestSample]) -> std::io::Result<SamplesFile> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    {
+        let file = File::create(path)?;
+        let mut gz = GzEncoder::new(BufWriter::new(file), Compression::default());
+        for s in samples {
+            let line = serde_json::to_string(s)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            gz.write_all(line.as_bytes())?;
+            gz.write_all(b"\n")?;
+        }
+        gz.finish()?.flush()?;
+    }
+
+    let bytes = std::fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(SamplesFile {
+        path: path
+            .file_name()
+            .map_or_else(|| path.to_path_buf(), PathBuf::from),
+        sha256: format!("{:x}", hasher.finalize()),
+        bytes: bytes.len() as u64,
+        rows: samples.len(),
+    })
+}
+
+/// Read back gzipped JSONL samples. The receipt is only re-derivable if this
+/// round-trips, so it ships alongside the writer rather than being left to the
+/// consumer to reimplement.
+///
+/// # Errors
+/// On any I/O or parse failure.
+pub fn read_samples_gz(path: &Path) -> std::io::Result<Vec<RequestSample>> {
+    use std::io::BufRead;
+    let file = File::open(path)?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let reader = std::io::BufReader::new(gz);
+    let mut out = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        out.push(
+            serde_json::from_str(&line)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf_gate::bootstrap::bootstrap_agg_tok_s_ci;
+    use crate::perf_gate::protocol::Outcome;
+
+    fn deck(n: usize) -> Vec<RequestSample> {
+        (0..n)
+            .map(|i| RequestSample {
+                index: i,
+                worker: i % 4,
+                start_s: i as f64 * 0.25,
+                end_s: i as f64 * 0.25 + 1.0 + f64::from((i % 3) as u32) * 0.1,
+                token_times_s: vec![i as f64 * 0.25 + 0.05, i as f64 * 0.25 + 0.9],
+                generated_tokens: 128,
+                prompt_tokens: 512,
+                outcome: Outcome::Completed,
+                in_flight_at_start: 4,
+                drained: false,
+            })
+            .collect()
+    }
+
+    fn tmpdir(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("perf024-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        d
+    }
+
+    #[test]
+    fn samples_round_trip_through_gzip() {
+        let dir = tmpdir("roundtrip");
+        let path = dir.join("samples.jsonl.gz");
+        let want = deck(25);
+        let meta = write_samples_gz(&path, &want).expect("write");
+        assert_eq!(meta.rows, 25);
+        assert!(meta.bytes > 0);
+        assert_eq!(meta.sha256.len(), 64);
+        assert_eq!(meta.path, PathBuf::from("samples.jsonl.gz"));
+
+        let got = read_samples_gz(&path).expect("read");
+        assert_eq!(got, want, "retained samples must survive the round trip");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The reason retention is mandatory: the CI must be re-derivable from the
+    /// file alone, by someone who never saw the run.
+    #[test]
+    fn the_ci_is_reproducible_from_the_retained_file_alone() {
+        let dir = tmpdir("rederive");
+        let path = dir.join("samples.jsonl.gz");
+        let original = deck(40);
+        write_samples_gz(&path, &original).expect("write");
+
+        let from_disk = read_samples_gz(&path).expect("read");
+        let a = bootstrap_agg_tok_s_ci(&original, 0.95).expect("n >= 2");
+        let b = bootstrap_agg_tok_s_ci(&from_disk, 0.95).expect("n >= 2");
+        assert_eq!(a, b, "a receipt is only evidence if its CI re-derives");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// It really is gzip, not a JSONL file with a misleading name.
+    #[test]
+    fn the_file_is_actually_gzip() {
+        let dir = tmpdir("magic");
+        let path = dir.join("samples.jsonl.gz");
+        write_samples_gz(&path, &deck(3)).expect("write");
+        let bytes = std::fs::read(&path).expect("read raw");
+        assert_eq!(&bytes[..2], &[0x1f, 0x8b], "gzip magic bytes absent");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn digest_matches_the_bytes_on_disk() {
+        let dir = tmpdir("digest");
+        let path = dir.join("samples.jsonl.gz");
+        let meta = write_samples_gz(&path, &deck(5)).expect("write");
+        let bytes = std::fs::read(&path).expect("read raw");
+        let mut h = Sha256::new();
+        h.update(&bytes);
+        assert_eq!(meta.sha256, format!("{:x}", h.finalize()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// One line per request: a partially-truncated file still yields whole rows.
+    #[test]
+    fn one_json_object_per_line() {
+        let dir = tmpdir("lines");
+        let path = dir.join("samples.jsonl.gz");
+        write_samples_gz(&path, &deck(7)).expect("write");
+        let file = File::open(&path).expect("open");
+        let mut text = String::new();
+        std::io::Read::read_to_string(&mut flate2::read::GzDecoder::new(file), &mut text)
+            .expect("decode");
+        assert_eq!(text.lines().count(), 7);
+        for line in text.lines() {
+            let _: RequestSample = serde_json::from_str(line).expect("each line stands alone");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn budget_check_takes_the_budget_as_an_argument() {
+        let dir = tmpdir("budget");
+        let path = dir.join("samples.jsonl.gz");
+        let meta = write_samples_gz(&path, &deck(10)).expect("write");
+        assert!(meta.exceeds_budget(0));
+        assert!(!meta.exceeds_budget(u64::MAX));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/window.rs
+++ b/crates/aprender-test-lib/src/perf_gate/window.rs
@@ -1,0 +1,398 @@
+//! §4.4.2 termination and §4.4.7 boundary effects, as a pure state machine.
+//!
+//! The measurement window is a *shared admission decision*, not a per-worker
+//! deadline check. Written as a deadline test inside each worker's loop, the
+//! sample-count bound cannot be expressed at all (no worker knows the total),
+//! and there is no single instant `T` to measure `drain_ms` from. Both of those
+//! are why this is a controller rather than an `if` in the loop.
+//!
+//! It is deliberately clock-free: every method takes the current offset in
+//! seconds. That is what lets the whole termination rule be unit-tested in
+//! microseconds instead of the 60 s it governs.
+
+use serde::{Deserialize, Serialize};
+
+use super::protocol::{BandConfig, DRAIN_SUSPECT_FRACTION};
+
+/// Shared admission gate for one band's closed-loop workers.
+#[derive(Debug, Clone)]
+pub struct WindowController {
+    min_samples: usize,
+    min_wall_s: f64,
+    issued: usize,
+    closed_at_s: Option<f64>,
+    last_completion_s: f64,
+    in_flight: usize,
+    peak_in_flight: usize,
+}
+
+impl WindowController {
+    /// Build the controller for `config`. The window opens at offset `0.0`;
+    /// callers pass offsets measured from the first sampled request's origin.
+    #[must_use]
+    pub fn new(config: &BandConfig) -> Self {
+        Self {
+            min_samples: config.min_samples,
+            min_wall_s: config.min_wall_clock.as_secs_f64(),
+            issued: 0,
+            closed_at_s: None,
+            last_completion_s: 0.0,
+            in_flight: 0,
+            peak_in_flight: 0,
+        }
+    }
+
+    /// A controller with explicit bounds, for the warmup phase (§4.4.2: exactly
+    /// `2 × c` requests, no wall-clock floor) and for tests.
+    #[must_use]
+    pub fn with_bounds(min_samples: usize, min_wall_s: f64) -> Self {
+        Self {
+            min_samples,
+            min_wall_s,
+            issued: 0,
+            closed_at_s: None,
+            last_completion_s: 0.0,
+            in_flight: 0,
+            peak_in_flight: 0,
+        }
+    }
+
+    /// §4.4.2 — "termination is whichever bound is satisfied **last**".
+    ///
+    /// Returns the index reserved for a new request, or `None` once the window
+    /// has closed. §4.4.7: **no new request is issued at or after `T`**, and `T`
+    /// is stamped here, once, at the first refusal.
+    pub fn try_admit(&mut self, now_s: f64) -> Option<usize> {
+        self.try_admit_with_in_flight(now_s).map(|(index, _)| index)
+    }
+
+    /// [`Self::try_admit`], also returning the in-flight count **including this
+    /// request**, read under the same lock that made the admission decision.
+    ///
+    /// A caller that admits, unlocks, and then asks for `in_flight()` reads a
+    /// number from a different instant. The per-request in-flight figure is the
+    /// evidence that the client was concurrent, so it must not be a racy guess.
+    pub fn try_admit_with_in_flight(&mut self, now_s: f64) -> Option<(usize, usize)> {
+        if self.closed_at_s.is_some() {
+            return None;
+        }
+        if self.issued >= self.min_samples && now_s >= self.min_wall_s {
+            self.closed_at_s = Some(now_s);
+            return None;
+        }
+        let index = self.issued;
+        self.issued += 1;
+        self.in_flight += 1;
+        self.peak_in_flight = self.peak_in_flight.max(self.in_flight);
+        Some((index, self.in_flight))
+    }
+
+    /// Record a completion at `now_s`. Returns `true` when this request
+    /// completed during the drain, i.e. after the window closed.
+    pub fn complete(&mut self, now_s: f64) -> bool {
+        self.in_flight = self.in_flight.saturating_sub(1);
+        self.last_completion_s = self.last_completion_s.max(now_s);
+        self.closed_at_s.is_some_and(|t| now_s > t)
+    }
+
+    /// Peak concurrent requests the client had in flight. This is the *client's*
+    /// number and is named as such: `max_in_flight` in §4.4.9 is what the
+    /// **server** admitted, which only the server can report.
+    #[must_use]
+    pub fn peak_in_flight(&self) -> usize {
+        self.peak_in_flight
+    }
+
+    /// Requests admitted so far.
+    #[must_use]
+    pub fn issued(&self) -> usize {
+        self.issued
+    }
+
+    /// Requests currently outstanding.
+    #[must_use]
+    pub fn in_flight(&self) -> usize {
+        self.in_flight
+    }
+
+    /// Whether the window has closed.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.closed_at_s.is_some()
+    }
+
+    /// Finalise the band. `window_close_s` defaults to the last completion when
+    /// the window never closed (a run cut short), which yields `drain_ms = 0`
+    /// rather than a negative number.
+    #[must_use]
+    pub fn report(&self) -> WindowReport {
+        let close = self.closed_at_s.unwrap_or(self.last_completion_s);
+        let drain_ms = ((self.last_completion_s - close).max(0.0)) * 1000.0;
+        let window_ms = close * 1000.0;
+        let mut suspect = Vec::new();
+        if window_ms > 0.0 && drain_ms > DRAIN_SUSPECT_FRACTION * window_ms {
+            suspect.push(format!(
+                "§4.4.7 drain_ms={drain_ms:.1} > 0.5 x window_ms={window_ms:.1}: one request \
+                 dominated the window; re-run this band with a longer window"
+            ));
+        }
+        if self.closed_at_s.is_none() {
+            suspect.push(
+                "§4.4.2 the window never closed: neither termination bound was reached, so this \
+                 band did not run the protocol"
+                    .to_string(),
+            );
+        }
+        WindowReport {
+            requested: self.issued,
+            window_ms,
+            drain_ms,
+            client_peak_in_flight: self.peak_in_flight,
+            suspect,
+        }
+    }
+}
+
+/// What the controller observed, for the receipt.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WindowReport {
+    /// Requests admitted before `T`.
+    pub requested: usize,
+    /// `T` minus window open, in milliseconds.
+    pub window_ms: f64,
+    /// §4.4.7 — last drained completion minus `T`, in milliseconds.
+    pub drain_ms: f64,
+    /// Peak concurrent requests **the client** had outstanding.
+    pub client_peak_in_flight: usize,
+    /// §4.4.7 `SUSPECT` annotations, empty when the band is clean.
+    pub suspect: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The sample bound alone must not close the window: §4.4.2 says the last
+    /// bound wins. A fast host that hit 30 samples in 2 s still owes 60 s.
+    #[test]
+    fn sample_bound_alone_does_not_close_the_window() {
+        let mut w = WindowController::with_bounds(3, 60.0);
+        for i in 0..3 {
+            assert_eq!(w.try_admit(0.1 * f64::from(i)), Some(i as usize));
+        }
+        assert_eq!(w.try_admit(0.4), Some(3), "still open: 0.4s < 60s");
+        assert!(!w.is_closed());
+    }
+
+    /// And the wall-clock bound alone must not close it either: a slow host that
+    /// burned 60 s on 4 requests still owes `max(30, 8c)` samples.
+    #[test]
+    fn wall_clock_bound_alone_does_not_close_the_window() {
+        let mut w = WindowController::with_bounds(30, 1.0);
+        for _ in 0..4 {
+            assert!(
+                w.try_admit(100.0).is_some(),
+                "still open: only 4 of 30 samples"
+            );
+        }
+        assert!(!w.is_closed());
+    }
+
+    #[test]
+    fn window_closes_only_when_both_bounds_are_satisfied() {
+        let mut w = WindowController::with_bounds(3, 10.0);
+        assert!(w.try_admit(0.0).is_some());
+        assert!(w.try_admit(1.0).is_some());
+        assert!(w.try_admit(2.0).is_some());
+        assert!(!w.is_closed());
+        assert_eq!(w.try_admit(10.0), None, "3 samples AND 10s -> closed");
+        assert!(w.is_closed());
+    }
+
+    /// §4.4.7 — once closed, the gate stays closed. A late worker must not
+    /// sneak a request in after `T`.
+    #[test]
+    fn no_new_request_is_admitted_at_or_after_t() {
+        let mut w = WindowController::with_bounds(1, 1.0);
+        assert!(w.try_admit(0.0).is_some());
+        assert_eq!(w.try_admit(1.0), None);
+        assert_eq!(w.try_admit(1.0001), None);
+        assert_eq!(w.try_admit(500.0), None);
+        assert_eq!(w.issued(), 1, "exactly one request was ever admitted");
+    }
+
+    /// The drain is measured from `T`, not from the last admission.
+    #[test]
+    fn drain_ms_is_measured_from_window_close() {
+        let mut w = WindowController::with_bounds(2, 4.0);
+        assert!(w.try_admit(0.0).is_some());
+        assert!(w.try_admit(1.0).is_some());
+        assert!(!w.complete(2.0), "completed inside the window");
+        assert_eq!(w.try_admit(4.0), None, "T = 4.0");
+        assert!(w.complete(5.5), "completed during the drain");
+        let r = w.report();
+        assert!((r.window_ms - 4000.0).abs() < 1e-9, "{}", r.window_ms);
+        assert!((r.drain_ms - 1500.0).abs() < 1e-9, "{}", r.drain_ms);
+        assert!(r.suspect.is_empty(), "{:?}", r.suspect);
+    }
+
+    /// §4.4.7 — `drain_ms > 0.5 x window` is annotated SUSPECT.
+    #[test]
+    fn a_dominating_request_is_annotated_suspect() {
+        let mut w = WindowController::with_bounds(1, 2.0);
+        assert!(w.try_admit(0.0).is_some());
+        assert_eq!(w.try_admit(2.0), None);
+        assert!(w.complete(20.0));
+        let r = w.report();
+        assert!((r.drain_ms - 18000.0).abs() < 1e-9);
+        assert_eq!(r.suspect.len(), 1, "{:?}", r.suspect);
+        assert!(r.suspect[0].contains("drain_ms"));
+    }
+
+    /// A band whose window never closed did not run the protocol, and must say
+    /// so rather than reporting a clean `drain_ms = 0`.
+    #[test]
+    fn an_unclosed_window_is_suspect_not_clean() {
+        let mut w = WindowController::with_bounds(100, 60.0);
+        assert!(w.try_admit(0.0).is_some());
+        assert!(!w.complete(1.0));
+        let r = w.report();
+        assert_eq!(r.drain_ms, 0.0);
+        assert!(
+            r.suspect.iter().any(|s| s.contains("never closed")),
+            "{:?}",
+            r.suspect
+        );
+    }
+
+    /// The controller is the only place that knows how many requests were in
+    /// flight at once, and it is the evidence that `c` workers really overlapped.
+    #[test]
+    fn peak_in_flight_tracks_concurrent_admissions() {
+        let mut w = WindowController::with_bounds(100, 100.0);
+        for _ in 0..8 {
+            assert!(w.try_admit(0.0).is_some());
+        }
+        assert_eq!(w.in_flight(), 8);
+        assert_eq!(w.peak_in_flight(), 8);
+        for _ in 0..8 {
+            w.complete(1.0);
+        }
+        assert_eq!(w.in_flight(), 0);
+        assert_eq!(w.peak_in_flight(), 8, "peak is a high-water mark");
+    }
+
+    #[test]
+    fn controller_reads_its_bounds_from_the_band_config() {
+        let cfg = BandConfig::conformant(8);
+        let w = WindowController::new(&cfg);
+        assert_eq!(w.min_samples, 64, "max(30, 8*8)");
+        assert!((w.min_wall_s - 60.0).abs() < 1e-9);
+        assert_eq!(cfg.quiesce, Duration::from_secs(5));
+    }
+}
+
+/// A closed-loop concurrency proof over real OS threads.
+///
+/// Not `#[cfg(test)]`: this is the falsifier for the defect class that produced
+/// this ticket — a client that *says* concurrency `c` and issues requests one at
+/// a time. It is exported so any harness can run it against its own admission
+/// path, and it is exercised by [`concurrency_proof_tests`] under default
+/// features, where CI can actually see it.
+///
+/// `c` threads each loop: admit, "work" for `work` , complete. Returns the
+/// observed peak in flight and the wall time. A serialising implementation
+/// yields `peak == 1` and `wall ≈ requests × work`; a concurrent one yields
+/// `peak == c` and `wall ≈ requests / c × work`.
+#[must_use]
+pub fn closed_loop_probe(
+    concurrency: usize,
+    requests: usize,
+    work: std::time::Duration,
+) -> (usize, std::time::Duration) {
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    let controller = Mutex::new(WindowController::with_bounds(requests, 0.0));
+    let origin = Instant::now();
+    std::thread::scope(|scope| {
+        for _ in 0..concurrency {
+            scope.spawn(|| loop {
+                let admitted = {
+                    let mut c = controller
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    c.try_admit(origin.elapsed().as_secs_f64())
+                };
+                if admitted.is_none() {
+                    break;
+                }
+                std::thread::sleep(work);
+                let mut c = controller
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                c.complete(origin.elapsed().as_secs_f64());
+            });
+        }
+    });
+    let peak = controller
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .peak_in_flight();
+    (peak, origin.elapsed())
+}
+
+#[cfg(test)]
+mod concurrency_proof_tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The direct claim: `c` workers are in flight at the same time.
+    #[test]
+    fn eight_workers_are_actually_concurrent() {
+        let (peak, _) = closed_loop_probe(8, 64, Duration::from_millis(20));
+        assert_eq!(
+            peak, 8,
+            "peak in-flight must reach c; a serialising client gives 1"
+        );
+    }
+
+    /// The indirect claim, which a fake concurrent client cannot also satisfy:
+    /// the same request count must finish far faster at c=8 than at c=1.
+    ///
+    /// The bound is deliberately loose (4x, not 8x) so scheduler noise on a
+    /// loaded CI runner cannot red it, while a secretly-sequential client — which
+    /// would score 1.0x — still fails by a wide margin.
+    #[test]
+    fn wall_time_at_c8_is_not_eight_times_the_c1_time() {
+        let requests = 32;
+        let work = Duration::from_millis(20);
+        let (peak1, wall1) = closed_loop_probe(1, requests, work);
+        let (peak8, wall8) = closed_loop_probe(8, requests, work);
+
+        assert_eq!(peak1, 1);
+        assert_eq!(peak8, 8);
+        let speedup = wall1.as_secs_f64() / wall8.as_secs_f64();
+        eprintln!(
+            "closed_loop_probe: {requests} requests x {work:?} -- \
+             c=1 peak={peak1} wall={wall1:?}; c=8 peak={peak8} wall={wall8:?}; speedup={speedup:.2}x"
+        );
+        assert!(
+            speedup > 4.0,
+            "c=1 took {wall1:?}, c=8 took {wall8:?} (speedup {speedup:.2}x); \
+             a concurrent client must be much faster, a sequential one scores ~1.0x"
+        );
+    }
+
+    /// And the probe can tell the difference — a c=1 run is the negative control.
+    #[test]
+    fn the_probe_reports_one_for_a_sequential_client() {
+        let (peak, wall) = closed_loop_probe(1, 8, Duration::from_millis(10));
+        assert_eq!(peak, 1);
+        assert!(
+            wall >= Duration::from_millis(70),
+            "8 x 10ms sequential must take ~80ms, got {wall:?}"
+        );
+    }
+}

--- a/docs/perf-024-measurement-protocol.md
+++ b/docs/perf-024-measurement-protocol.md
@@ -1,0 +1,133 @@
+# PERF-024 — §4.4 measurement protocol: what was missing, and where it now lives
+
+Ticket: PERF-024, epic APR-PERF-GATE-001 (paiml/aprender#2706).
+Spec: `docs/specifications/APR-PERF-GATE-001-v2.2.md` §4.4.
+Audited against `origin/main` at `de8fbc407`.
+
+## The thing that already existed
+
+`crates/aprender-test-lib/src/llm/loadtest.rs` — reached from `apr test llm bench`
+(`crates/apr-cli/src/commands/test_llm.rs` → `apr_test::llm::benchmark::Benchmark`
+→ `LoadTest::run`) — is the project's comparator client. It is genuinely
+concurrent, genuinely external HTTP, and its aggregate is genuinely wall-clock:
+
+| Claim | Verdict | Evidence on `origin/main` |
+|---|---|---|
+| No concurrency | **FALSE** | `loadtest.rs:568` `for worker_id in 0..self.config.concurrency`, each worker `while Instant::now() < deadline { send_one_request(..).await }` |
+| `agg` is the mean of per-request rates | **FALSE** | `loadtest.rs:519-521` `measure_start.elapsed()`; `:834` `tokens_per_sec = total_tokens / elapsed_secs` — Σ tokens ÷ wall-clock |
+| No TTFT/ITL | **FALSE** | `ttft_p50/p90/p95/p99_ms`, `itl_p50_ms`, `tpot_p*_ms` on `LoadTestResult` |
+
+`crates/aprender-serve/src/http_client/benchmark_runner.rs` is **not** that client.
+It is reachable only from `http_client/tests/*` and `benches/external_matrix.rs`,
+and it is a byte-identical duplicate of `crates/aprender-serve/src/http_client/preflight.rs`
+(`diff -q` rc=0, 370 lines each) of which only `benchmark_runner.rs` is `include!`d.
+See "Separate defect" below.
+
+## What was genuinely missing, and where it is now
+
+Everything new is under `crates/aprender-test-lib/src/perf_gate/`, deliberately
+**outside** the `llm` feature so its tests compile and run under the crate's
+default features. `llm/band.rs` drives it through the *existing* request path.
+
+| Clause | Requirement | Status | Code |
+|---|---|---|---|
+| §4.4.1 | closed-loop, `c` workers, issue → wait → reissue | pre-existing | `llm/loadtest.rs:568`; `llm/band.rs::worker_loop` |
+| §4.4.1 | external HTTP, same host, never in-process | pre-existing | `llm/client.rs`, driven by `llm/band.rs::issue` |
+| §4.4.1 | record `client_model: closed_loop` | **added** | `perf_gate/protocol.rs::ClientModel` |
+| §4.4.2 | warmup `2 × c` requests, discarded | **added** | `perf_gate/protocol.rs::warmup_requests`; `llm/band.rs::warmup` |
+| §4.4.2 | 5 s quiesce before the first sampled request | **added** | `perf_gate/protocol.rs::QUIESCE`; `band.rs` `sleep(band.quiesce)` |
+| §4.4.2 | minimum sampled requests `max(30, 8 × c)` | **added** | `perf_gate/protocol.rs::min_sampled_requests` |
+| §4.4.2 | minimum 60 s wall-clock per band | **added** | `perf_gate/protocol.rs::MIN_WALL_CLOCK` |
+| §4.4.2 | termination = whichever bound is satisfied **last** | **added** | `perf_gate/window.rs::WindowController::try_admit` |
+| §4.4.2 | `N = 3` replicates per cell | **added** | `perf_gate/protocol.rs::REPLICATES`; `llm/band.rs::run_cell` |
+| §4.4.3 | `agg_tok_s` **wall-clock**, not the mean of rates | pre-existing, **restated exactly** | `perf_gate/metrics.rs::agg_tok_s` |
+| §4.4.3 | `decode_tok_s` = median of per-request `(tok-1)/(last−first)` | **added** | `perf_gate/metrics.rs::RequestSample::decode_tok_s` |
+| §4.4.3 | `ttft_ms` p50 **and p95** | **added** (p95 absent before) | `perf_gate/metrics.rs::BandMetrics` |
+| §4.4.3 | `itl_ms` **pooled gaps**, p50/p95 | **added** | `perf_gate/metrics.rs::RequestSample::itl_gaps_ms` |
+| §4.4.3 | `completed`/`requested`/`timeouts`/`truncated` | **added** | `perf_gate/protocol.rs::Outcome`, `metrics.rs::BandMetrics` |
+| §4.4.3 | 120 s hard per-request timeout | pre-existing, **now classified** | `llm/client.rs:213`; `band.rs::worker_loop` `tokio::time::timeout` → `Outcome::Timeout` |
+| §4.4.4 | bootstrap percentile, 10 000 resamples, seed 2026, **whole requests** | **added** | `perf_gate/bootstrap.rs::bootstrap_ci` |
+| §4.4.5 | raw samples retained as gzipped JSONL | **added** | `perf_gate/samples.rs::write_samples_gz` |
+| §4.4.6 | `tokenization` block, `method` with no default | **added** | `perf_gate/protocol.rs::Tokenization` |
+| §4.4.7 | no new request at or after `T`; drain to completion | pre-existing, **formalised** | `perf_gate/window.rs::WindowController` |
+| §4.4.7 | `drain_ms` recorded | **added** | `perf_gate/window.rs::WindowReport::drain_ms` |
+| §4.4.7 | `drain_ms > 0.5 × window` → `SUSPECT` | **added** | `perf_gate/window.rs::WindowReport::suspect` |
+
+### Pre-existing but not §4.4-exact — differences worth knowing
+
+- `LoadTestResult::decode_tok_per_sec` is `1000 / itl_p50_ms`: the reciprocal of a
+  median ITL, **not** the median of per-request decode rates. Different statistic.
+  `BandMetrics::decode_tok_s` implements the §4.4.3 one.
+- `LoadTestResult::itl_p50_ms` pools **one value per request** (that request's mean
+  ITL). §4.4.3 pools **every gap**. `BandMetrics` implements the §4.4.3 one.
+- `LoadTestResult::truncated_pct` counts `finish_reason == "length"`. §4.4.7's
+  `truncated` means "abandoned at the drain deadline". Under W1 — `max_tokens=128`,
+  EOS ignored — *every* request has `finish_reason == "length"`, so conflating the
+  two would exclude the whole workload from `agg_tok_s`'s numerator and report zero
+  throughput for a healthy server. `perf_gate::protocol::Outcome` documents the split.
+- `LoadTest::run` is **unchanged**, and so is every byte of `llm/loadtest.rs`. It
+  answers a different question and a lot of tooling reads its output; changing its
+  termination rule underneath those readers would silently move every number they
+  have recorded. `llm/band.rs` therefore drives `LlmClient` directly — the same
+  HTTP client `send_one_request` drives, so §4.4.8's one-client rule still holds —
+  and maps its responses into `RequestSample` rather than into `RequestRecord`,
+  which carries no absolute timing and cannot distinguish a timeout from a
+  transport error.
+- **Non-streaming requests yield no `ttft_ms`, `itl_ms`, or `decode_tok_s`.** The
+  offsets are left empty rather than synthesised: inventing evenly-spaced token
+  times would make an unmeasured quantity look measured. A conformant band must
+  run with `stream = true`.
+
+## NOT implemented — stated plainly
+
+- **§4.4.8 comparator harness.** One client already drives both servers
+  (`scripts/parity_host_receipt.sh`). Nothing here verifies that, and the
+  "tokenization blocks must match across lanes or the ratio is refused" rule is a
+  receipt-validator job.
+- **§4.4.9 scheduler observability.** `max_in_flight`, `admission_rejected`,
+  `preempted_*`, `kv_blocks_*`, `gpu_layers_*`, `backend_loaded[]`,
+  `autofit_applied[]` are **server**-reported. A client cannot synthesise them and a
+  client-side guess is worse than a null. `WindowReport::client_peak_in_flight` is
+  the client's own observation and is named so it cannot be mistaken for the
+  server's `max_in_flight`.
+- **Receipt emission.** Nothing here writes `receipt.json`.
+  `scripts/lib/bench_receipt.py` is the single schema authority; serialising a
+  `BandRun` into it is a separate ticket.
+- **`receipt_size_budget_bytes`.** §4.4.5 forbids the literal until a full receipt
+  is measured. `SamplesFile::exceeds_budget` takes the budget as an argument so the
+  check arms the day the number exists, with no placeholder committed today.
+- **CLI wiring.** `apr test llm bench` still calls `LoadTest::run`. Nothing invokes
+  `run_band`/`run_cell` outside tests yet.
+- **W1/W2 workload construction** (§4.3) and the `prompt_tokens = 512 ± 8` check.
+  Note: `crates/aprender-serve/benchmarks/qwen-coder/` contains `prompts-w2.jsonl`
+  but **no `prompts-w1.jsonl`**, which §4.3.1 names as W1's corpus.
+- **Any measured baseline.** Every cell in `scripts/perf-matrix.yaml` is untouched
+  and stays `UNMEASURED`.
+
+## Verification
+
+Every new decision was mutation-verified, since a gate nobody proved can fail is
+this epic's recurring defect:
+
+| Mutation | Tests turned RED |
+|---|---|
+| `agg_tok_s` returns `mean_of_rates` | 2 |
+| termination `AND` → `OR` (either bound closes the window) | 5 |
+| bootstrap seed → wall clock | 3 |
+| `for id in 0..band.concurrency` → `0..1` | 4, including the real-HTTP proof |
+
+Concurrency is proved from the **server** side: a loopback probe counts its own
+concurrent connections. At `c = 8` it reports peak 8; at `c = 1`, peak 1. The same
+16 requests take 770 ms at `c = 1` and 186 ms at `c = 8` (4.14x).
+
+TTFT and ITL are proved end to end against an SSE probe emitting 6 tokens 25 ms
+apart: measured `ttft_p50 = 26.7 ms`, `itl_p50 = 26.2 ms`, `decode = 38.2 tok/s`,
+with five pooled gaps per request rather than one summary per request.
+
+## Separate defect worth its own ticket
+
+`crates/aprender-serve/src/http_client/preflight.rs` and
+`crates/aprender-serve/src/http_client/benchmark_runner.rs` are byte-identical
+370-line files; only the latter is `include!`d, so `preflight.rs` is dead. It reads
+like the production benchmark client and is not one. That duplicate is what caused
+this ticket to be filed on a false premise.


### PR DESCRIPTION
Epic #2706 (the receipt rule). PERF-024 was filed by me on a **false premise** — I audited `benchmark_runner.rs`, which turned out to be a dead byte-identical duplicate of `preflight.rs`, reachable only from benches and tests. The ticket was re-aimed mid-flight from "build a client" to "audit `LoadTest::run()` against §4.4 and close what is actually missing."

## The finding that matters: the perf gate has never rendered a verdict on a real receipt

Two defects, each harmless-looking alone, that conceal each other:

```
scripts/perf_gate.sh:42     if r.get("drain_ms") is None: bad.append("drain_ms absent")
drain_ms producers, repo-wide, outside the spec/gate/matrix:   0
```

**`perf_gate.sh` fails any receipt omitting `drain_ms`, and nothing anywhere writes `drain_ms`.** No real receipt can satisfy the gate. And per #2716, `perf_gate.sh`'s real mode (`--host/--phase/--workload/--receipt`) has **no caller** — every remaining reference is inside `check_no_competing_harnesses.sh`, which allowlists it as *"THE entrypoint."*

A gate that cannot pass is invisible while nothing runs it. A gate nothing runs looks fine if you assume it would pass. Together: the epic's central enforcement mechanism has never judged a real measurement, and neither half would have shown that on its own.

## The §4.4 audit of `LoadTest::run` at `de8fbc407`

My three original claims, tested against both files:

| claim | `benchmark_runner.rs` | the real client (`loadtest.rs`) |
|---|---|---|
| zero concurrency primitives | **confirmed** | refuted — `:568` `for worker_id in 0..self.config.concurrency` |
| `mean_throughput` = mean of rates | **confirmed** (`:327`) | refuted — `:519-521`, `:834` `total_tokens / elapsed_secs`, wall-clock |
| no ttft/itl | **confirmed** | refuted — `ttft_p50/p90/p95/p99_ms`, `itl_p50_ms`, `tpot_p*_ms` |

**Genuinely missing**, and now implemented: `client_model` record; warmup as `2×c` *requests* (it was a duration, defaulting to zero); the **5 s quiesce** (Phase 2 → Phase 3 with no sleep); the min-sample bound; last-bound-wins termination; `timeouts` as its own counter; §4.4.4 bootstrap (it used a t-distribution over N run-level means).

**Partial, and worth knowing:** `decode_tok_per_sec` was `1000/median-ITL` rather than the median of per-request rates; `itl_p50_ms` pooled one *mean per request* instead of every gap; no `ttft` p95. And `truncated_pct` means `finish_reason=="length"` — a different thing from §4.4.7's "abandoned at drain". Conflating them would zero out W1's entire numerator, since W1 ignores EOS.

## Proofs

**Concurrency proved from the server side.** A loopback probe counts its *own* concurrent connections, so client-side bookkeeping cannot fake it: c=8 → server_peak **8**; c=1 → server_peak **1**. Same 16 requests: c=1 770 ms, c=8 186 ms, **4.14×**.

**`agg_tok_s` fixture, both directions.** Requests spanning [0,1] [0,2] [1,3] [2,4], 100 tokens each → span 4.0 s, 400 tokens → **agg = 100.0**; mean-of-rates = **62.5**. A second fixture that serialises with idle gaps gives agg **57.1** against mean-of-rates **100.0** — the overstatement direction, asserted explicitly so the two can never be confused again.

**TTFT/ITL end-to-end** against an SSE probe emitting 6 tokens 25 ms apart: `ttft_p50=26.7ms`, `itl_p50=26.2ms`, five *pooled* gaps per request.

**Bootstrap determinism**: same samples + seed 2026 → byte-identical CI twice; seed 2027 moves the interval while the point estimate holds.

**Mutations**, each reverted with the tree clean: `agg_tok_s := mean_of_rates` → 2 RED · termination `AND := OR` → 5 RED · seed := clock → 3 RED · `0..concurrency := 0..1` → 4 RED including the real-HTTP proof.

## Not proven — read this before relying on it

- **Nothing calls `run_band` outside tests.** `apr test llm bench` still calls `LoadTest::run`. CLI wiring and receipt serialisation are follow-ups, and the protocol was **not** verified against a real model server.
- **§4.4.9's scheduler block is not implemented and cannot be by a client** — those fields are server-reported. `WindowReport::client_peak_in_flight` is named so it cannot be mistaken for `max_in_flight`.
- **`receipt_size_budget_bytes` is deliberately unset** — §4.4.5 forbids the literal until a full receipt is measured.
- **Non-streaming requests yield no ttft/itl/decode.** Left empty, never synthesised. A conformant band must use `stream = true`; no guard yet refuses `stream = false`.
- No baseline was measured or committed. `scripts/perf-matrix.yaml` is untouched, all 8 cells still `UNMEASURED`.

No `apr` binary was invoked at all — every result is source-level analysis of `origin/main` plus `cargo test` compiled from this worktree, so nothing here depends on an installed binary.

## Three findings to file separately

1. **`preflight.rs` is a dead byte-identical duplicate of `benchmark_runner.rs`** (`diff -q` rc=0, 370 lines, only the latter `include!`d). It reads exactly like the production client and is unreachable — it is what caused this ticket to be filed on a false premise.
2. **`aprender-test-lib`'s `llm` tests are dark under `cargo test -p aprender-test-lib`** (non-default feature) but **do** run under CI's `cargo nextest run --workspace --lib`, because `apr-cli` pulls `apr-test` with `features=["llm"]` and workspace feature unification turns it on. Drop that one edge and 700+ tests go dark **silently**. The new protocol is placed outside the feature so it is gated either way.
3. **The PMAT pre-commit complexity gate makes `loadtest.rs` uneditable** — 157/171 on `origin/main`, identical before and after, so the gate blocks *any* commit touching it, including a pure visibility change. `band.rs` was reworked to use `LlmClient` directly so `loadtest.rs` is untouched to the byte, but the next person who must edit it will be blocked and may reach for `--no-verify`.

## Verification

`cargo test -p aprender-test-lib --lib` 6356 pass (52 `perf_gate`) · `--features llm --lib` 6533 pass (52 + 8 `band`) · `cargo check -p apr-cli --lib` rc=0 · `cargo fmt --all -- --check` rc=0 · `cargo clippy -p aprender-test-lib --features llm --all-targets -- -D warnings` rc=0.

One incident worth recording: an initial `src/perf/` clobbered two existing files there; both were restored from git (`git diff` clean) and the work relocated to `src/perf_gate/`.

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
