### PR TITLE
ci(cuda-nightly): each matrix leg names its own silicon (paiml/infra#342)

### DIFF
--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -80,7 +80,7 @@ jobs:
           - name: blackwell-gb10
             arch: ARM64
             select: blackwell
-    runs-on: [self-hosted, Linux, "${{ matrix.arch }}", cuda]
+    runs-on: [self-hosted, Linux, "${{ matrix.arch }}", cuda, "${{ matrix.select }}"]
     timeout-minutes: 90
     env:
       APR_PARITY_MODEL: ${{ vars.APR_PARITY_MODEL || '/home/noah/models/qwen2.5-coder-1.5b-instruct-q4k.apr' }}


### PR DESCRIPTION
Prerequisite for [paiml/infra#342](https://github.com/paiml/infra/issues/342), which makes `gx10` selectable across the org — **opt-in only, never a default**.

## The problem with the current selector

```yaml
runs-on: [self-hosted, Linux, "${{ matrix.arch }}", cuda]
```

That describes a **category** — "a Linux CUDA box of this architecture" — not a machine. It resolves to the two runners we mean today, but only by coincidence of there being exactly two.

`gx10`'s labels are `self-hosted, Linux, ARM64, cuda, blackwell, gb10`, and the first three are GitHub defaults that cannot be removed. So the ARM64 leg reaches gx10 **without ever naming it**, and would equally accept any future aarch64 CUDA runner the org registers — silently, at dispatch time.

## The fix costs nothing

This workflow already computes the discriminator: `matrix.select` is `ada` / `blackwell`, used a few lines below for the silicon filter. Putting it in `runs-on` makes each leg name its own box:

| leg | resolves to | matches |
|---|---|---|
| `X64` | `[self-hosted, Linux, X64, cuda, ada]` | `lambda-4090` only |
| `ARM64` | `[self-hosted, Linux, ARM64, cuda, blackwell]` | `gx10` only |

Neither leg can drift onto the other, and neither can pick up a machine that merely happens to have a GPU.

## Verification

Both the current selector and this one are committed as fixtures in `paiml/infra` (`machines/clean-room/fixtures/gx10-opt-in-guard/`): the current form as a **defect** the guard must flag, this form as **clean**. The guard runs both before it is allowed to report on anything real.

No behaviour change today — the same two runners are selected. It removes the coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)