### PR TITLE
perf(beat): run the speed lane on perf-solo and make it name its own runner (Refs PERF-031)

### DIFF
--- a/.github/workflows/beat-speed-nightly.yml
+++ b/.github/workflows/beat-speed-nightly.yml
@@ -41,7 +41,16 @@ concurrency:
 
 jobs:
   beat-speed:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    # PERF-013/PERF-031. `perf-solo` is carried by exactly ONE runner
+    # (intel-clean-room-16; paiml/infra#338), so two speed runs can never
+    # overlap and time each other. Verified server-side: this five-label
+    # selector resolves to 1 agent, the four-label one resolves to 16.
+    # Cardinality is enforced by `make -C machines/intel verify-perf-solo-lane`
+    # in paiml/infra, not here.
+    #
+    # TRADE-OFF: this lane is one agent wide, so the job can QUEUE behind
+    # general clean-room work on that runner. See timeout-minutes below.
+    runs-on: [self-hosted, X64, Linux, clean-room, perf-solo]
     timeout-minutes: 45
     env:
       # Every beat step tees here; the final step audits it for completeness.
@@ -55,6 +64,41 @@ jobs:
       BEAT_LOG: ${{ github.workspace }}/beat-speed-measurements.log
     steps:
       - uses: actions/checkout@v7
+
+      # PERF-031 measurement-environment receipt.
+      #
+      # What `perf-solo` buys: this job is alone in its LANE. What it cannot
+      # buy: a quiet BOX. `intel` runs 16 runners by design (over-subscription
+      # is provisioned deliberately), so the label removes perf-vs-perf
+      # contention only. Any absolute number taken here must therefore carry
+      # its neighbour count as part of the receipt. A ratio cancels steady
+      # load, but not a neighbour arriving or leaving mid-run - which is why
+      # the count is recorded at BOTH ends and compared.
+      #
+      # RUNNER_NAME, not hostname: all 16 agents report the same hostname
+      # (mac-server), so hostname cannot say which agent served this job.
+      # The runner name is the only field that identifies the lane, and it is
+      # the whole point of the receipt.
+      #
+      # Match the `comm` field, NOT an args regex: runner 2.336 installs the
+      # worker under a versioned directory (bin.2.336.0/Runner.Worker), so a
+      # "bin/Runner.Worker" pattern counts ZERO while 16 jobs are running.
+      # Subtract one for this job's own worker. Zombies are excluded.
+      #
+      # This step is a RECEIPT, never a gate: it records the environment and
+      # cannot fail the build. Asserting on neighbour count would put an
+      # environment-dependent red in a lane that exists to measure code.
+      - name: Receipt — measurement environment (before)
+        id: env_before
+        run: |
+          set -uo pipefail
+          n=$(ps -eo stat=,comm= | awk '$1 !~ /^Z/ && $2 == "Runner.Worker" { c++ } END { print c+0 }')
+          neighbours=$(( n > 0 ? n - 1 : 0 ))
+          echo "neighbours=$neighbours" >> "$GITHUB_OUTPUT"
+          printf 'BEAT-ENV before runner=%s neighbours=%s load=%s host=%s\n' \
+            "${RUNNER_NAME:-unknown}" "$neighbours" \
+            "$(cut -d' ' -f1-3 /proc/loadavg)" "$(hostname)" \
+            | tee -a "$BEAT_LOG"
 
       - name: Ensure uv is available (for scikit-learn baselines)
         run: |
@@ -154,3 +198,24 @@ jobs:
       - name: Every beat must have reported a measurement
         if: ${{ !cancelled() }}
         run: bash scripts/check_beat_measurements.sh "$BEAT_LOG"
+
+      # Closing half of the receipt. The neighbour count is passed in through
+      # `env:` rather than spliced into the script body: Actions substitutes
+      # expressions TEXTUALLY, so a value that happened to contain a newline
+      # would become script. Same reason no expression appears in any comment
+      # above - `#` does not protect a comment from substitution.
+      - name: Receipt — measurement environment (after)
+        if: ${{ !cancelled() }}
+        env:
+          BEFORE_NEIGHBOURS: ${{ steps.env_before.outputs.neighbours }}
+        run: |
+          set -uo pipefail
+          n=$(ps -eo stat=,comm= | awk '$1 !~ /^Z/ && $2 == "Runner.Worker" { c++ } END { print c+0 }')
+          after=$(( n > 0 ? n - 1 : 0 ))
+          printf 'BEAT-ENV after runner=%s neighbours=%s (before %s)\n' \
+            "${RUNNER_NAME:-unknown}" "$after" "${BEFORE_NEIGHBOURS:-unknown}" \
+            | tee -a "$BEAT_LOG"
+          if [ "$after" != "${BEFORE_NEIGHBOURS:-unknown}" ]; then
+            printf 'BEAT-ENV UNSTABLE: neighbour count moved %s -> %s during the run\n' \
+              "${BEFORE_NEIGHBOURS:-unknown}" "$after" | tee -a "$BEAT_LOG"
+          fi


### PR DESCRIPTION
## What

PERF-013 (paiml/infra#338) shipped the `perf-solo` label at cardinality 1 on
`intel-clean-room-16` and closed with one item explicitly unproven:

> **No job has actually run on the label** — that needs a workflow commit, which was out of scope.

This is that commit. It puts `perf-solo` on the BEAT speed lane's `runs-on` and
makes the job **name its own runner**, so the claim stops resting on config and
starts resting on a job's own output.

## Why `RUNNER_NAME` is the load-bearing line

All 16 agents on `intel` report the same `hostname` (`mac-server`). Hostname
therefore cannot say *which agent served a job* — and that is the entire claim
the lane makes. `RUNNER_NAME` is the only field that identifies the lane.

PERF-013's proposed receipt recorded neighbours, load, and hostname. It did not
record the runner name, which means it could not actually have proven the thing
it was for. That field is the substantive addition here.

## What the lane does NOT buy — recorded in the file

A label cannot make the box quiet. `intel` runs 16 runners **by design** and
over-subscription is provisioned deliberately, so `perf-solo` removes
**perf-vs-perf** contention only. The job is alone in its **lane**, never alone
on the **box**.

So the neighbour count is part of the receipt, sampled at **both ends**: a ratio
cancels steady load, but not a neighbour arriving or leaving mid-run. A reader
who takes an absolute number from this lane can now see whether the box was
steady while it was taken.

## Receipt, not gate

Neither step can fail the build. Asserting on neighbour count would put an
environment-dependent red into a lane that exists to measure code — against the
standing rule about wall-clock/environment assertions in checks.

## Trade-off the reviewer owns

The lane is now **one agent wide**, so this job can QUEUE behind general
clean-room work on `intel-clean-room-16`. `timeout-minutes` is unchanged at 45.
Whether 45 still fits, or the 05:45 UTC schedule should move, is a judgement
call left to review rather than made silently here.

## Safety notes

- **No `${{ }}` in any added comment.** Actions substitutes expressions
  textually and does not honour `#`; a comment quoting one has broken a job in
  this repo before. The single value crossing between steps travels via `env:`,
  never spliced into a script body.
- **`comm` match, not an args regex.** Runner 2.336 installs the worker under a
  versioned directory (`bin.2.336.0/Runner.Worker`), so a `bin/Runner.Worker`
  pattern counts **zero** while 16 jobs run. Verified live on `intel`: `comm`
  form = 16, args-regex form = 0, at the same instant.
- **No collision with the blackout auditor.** `check_beat_measurements.sh`
  derives its markers from the `--test beat_*` references, not from log text, so
  the `BEAT-ENV` lines are invisible to it.
- Nothing about the runner fleet is changed by this PR. Cardinality stays
  enforced in `paiml/infra` by `make -C machines/intel verify-perf-solo-lane`,
  not duplicated here, so the two cannot drift.

## Verification

Repo guards, run against the patched file:

| guard | rc |
|---|---|
| `check_beats_gated.sh` | 0 — all 26 beats execute |
| `check_workflow_env_defined.sh` | 0 — 12 workflows |
| `check_workflow_path_filters.sh` | 0 |
| `check_beat_baseline_env.sh` | 0 — 4 incumbents importable |

Plus: YAML parses, and a scan asserts zero comment lines contain an Actions
expression.

**End-to-end**: `beat-speed-nightly.yml` is `workflow_dispatch`-able, so this
branch's version was dispatched against its own ref to land a real job on the
lane without merging anything first. The result is reported in PERF-031.

Refs PERF-031 · paiml/infra#338
