### PR TITLE
fix(lint): clear the clippy 1.98 ceiling drift Toolchain Ceiling has been reporting since 08-20

### DIFF
--- a/crates/apr-format/src/v2/reader_impl.rs
+++ b/crates/apr-format/src/v2/reader_impl.rs
@@ -310,9 +310,17 @@ impl AprV2Reader {
         }
 
         let data = self.get_tensor_data(name)?;
+        // `as_chunks::<4>()` rather than `chunks_exact(4)`: same semantics
+        // (the ragged tail is the discarded `.1`), but it yields `&[u8; 4]`,
+        // so `from_le_bytes` takes the array directly instead of a
+        // reassembled one. clippy::chunks_exact_to_as_chunks (new in 1.98)
+        // flags the old form; caught by the Toolchain Ceiling lane, which is
+        // exactly the drift it exists to catch.
         let floats: Vec<f32> = data
-            .chunks_exact(4)
-            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect();
 
         Some(floats)
@@ -440,9 +448,17 @@ impl<'a> AprV2ReaderRef<'a> {
         }
 
         let data = self.get_tensor_data(name)?;
+        // `as_chunks::<4>()` rather than `chunks_exact(4)`: same semantics
+        // (the ragged tail is the discarded `.1`), but it yields `&[u8; 4]`,
+        // so `from_le_bytes` takes the array directly instead of a
+        // reassembled one. clippy::chunks_exact_to_as_chunks (new in 1.98)
+        // flags the old form; caught by the Toolchain Ceiling lane, which is
+        // exactly the drift it exists to catch.
         let floats: Vec<f32> = data
-            .chunks_exact(4)
-            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect();
 
         Some(floats)

--- a/crates/aprender-compute/src/hash/mod.rs
+++ b/crates/aprender-compute/src/hash/mod.rs
@@ -45,12 +45,13 @@ pub fn hash_bytes(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0;
 
     // Process 8 bytes at a time
-    let chunks = bytes.chunks_exact(8);
-    let remainder = chunks.remainder();
+    // `as_chunks::<8>()` yields `&[u8; 8]` directly, so the fallible
+    // `try_into().expect(...)` below is gone: the 8-byte width is now a type,
+    // not a runtime claim. clippy::chunks_exact_to_as_chunks (new in 1.98).
+    let (chunks, remainder) = bytes.as_chunks::<8>();
 
     for chunk in chunks {
-        let word =
-            u64::from_le_bytes(chunk.try_into().expect("chunks_exact(8) guarantees 8 bytes"));
+        let word = u64::from_le_bytes(*chunk);
         hash = hash.rotate_left(5).bitxor(word).wrapping_mul(K);
     }
 

--- a/crates/aprender-contracts-cli/src/commands/certify.rs
+++ b/crates/aprender-contracts-cli/src/commands/certify.rs
@@ -221,7 +221,7 @@ fn print_summary(
         "✗"
     };
     eprintln!();
-    eprintln!("pv certify — {icon} {edges_satisfied}/{edges_total} composition edges satisfied",);
+    eprintln!("pv certify — {icon} {edges_satisfied}/{edges_total} composition edges satisfied");
     if let Some(cfg) = config_proof {
         if let Some(tensors) = cfg.get("expected_tensors") {
             eprintln!("  Config: {tensors} expected tensors");
@@ -317,7 +317,7 @@ pub fn analyze_config(cfg_path: &Path) -> Result<serde_json::Value, Box<dyn std:
         .unwrap_or(nh);
     let v = json.get("vocab_size").and_then(Value::as_u64).unwrap_or(0);
 
-    let head_dim = if nh > 0 { h / nh } else { 0 };
+    let head_dim = h.checked_div(nh).unwrap_or(0);
     let expected_tensors = if l > 0 { 1 + l * 9 + 2 } else { 0 };
 
     let checks = [

--- a/crates/aprender-contracts-cli/src/commands/score.rs
+++ b/crates/aprender-contracts-cli/src/commands/score.rs
@@ -212,7 +212,7 @@ fn run_directory(
 
     if let Some(threshold) = min_score {
         if mean < threshold {
-            return Err(format!("Mean score {mean:.2} below threshold {threshold:.2}",).into());
+            return Err(format!("Mean score {mean:.2} below threshold {threshold:.2}").into());
         }
     }
 

--- a/crates/aprender-core/src/format/converter/write.rs
+++ b/crates/aprender-core/src/format/converter/write.rs
@@ -270,7 +270,9 @@ fn add_f32_tensor_to_writer(
         // The loader stored an empty placeholder in `data` for passthrough tensors,
         // so we reconstruct F32 values from the raw bytes here.
         let f32_data: Vec<f32> = raw_bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| {
                 let bits = u16::from_le_bytes([c[0], c[1]]);
                 if *is_bf16 {

--- a/crates/aprender-core/src/format/dequant_ext.rs
+++ b/crates/aprender-core/src/format/dequant_ext.rs
@@ -77,14 +77,18 @@ fn decode_tensor_bytes(dtype: TensorDType, data: &[u8], element_count: usize) ->
     match dtype {
         TensorDType::F32 => {
             let floats: Vec<f32> = data
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
                 .collect();
             Some(floats)
         }
         TensorDType::F16 => {
             let floats: Vec<f32> = data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| apr_format::f16_to_f32(u16::from_le_bytes([chunk[0], chunk[1]])))
                 .collect();
             Some(floats)
@@ -103,7 +107,9 @@ fn decode_tensor_bytes(dtype: TensorDType, data: &[u8], element_count: usize) ->
         TensorDType::AprQ4 => Some(dequantize_q4(data, element_count)),
         TensorDType::BF16 => {
             let floats: Vec<f32> = data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| {
                     let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                     f32::from_bits(u32::from(bits) << 16)

--- a/crates/aprender-core/src/format/gguf/shape.rs
+++ b/crates/aprender-core/src/format/gguf/shape.rs
@@ -56,7 +56,9 @@ impl GgufReader {
                 }
                 let bytes = &self.data[tensor_start..tensor_start + byte_size];
                 bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                     .collect()
             }
@@ -76,7 +78,9 @@ impl GgufReader {
                 }
                 let bytes = &self.data[tensor_start..tensor_start + byte_size];
                 bytes
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
                     .collect()
             }

--- a/crates/aprender-core/src/format/onnx/mod.rs
+++ b/crates/aprender-core/src/format/onnx/mod.rs
@@ -105,12 +105,16 @@ impl OnnxTensor {
         match self.data_type {
             OnnxDataType::Float => self
                 .raw_data
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
                 .collect(),
             OnnxDataType::Float16 => self
                 .raw_data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|b| {
                     let bits = u16::from_le_bytes([b[0], b[1]]);
                     f16_to_f32(bits)
@@ -118,7 +122,9 @@ impl OnnxTensor {
                 .collect(),
             OnnxDataType::Double => self
                 .raw_data
-                .chunks_exact(8)
+                .as_chunks::<8>()
+                .0
+                .iter()
                 .map(|b| {
                     f64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]) as f32
                 })
@@ -127,12 +133,16 @@ impl OnnxTensor {
             OnnxDataType::Uint8 => self.raw_data.iter().map(|&b| b as f32).collect(),
             OnnxDataType::Int32 => self
                 .raw_data
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f32)
                 .collect(),
             OnnxDataType::Int64 => self
                 .raw_data
-                .chunks_exact(8)
+                .as_chunks::<8>()
+                .0
+                .iter()
                 .map(|b| {
                     i64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]) as f32
                 })

--- a/crates/aprender-core/src/format/onnx/reader.rs
+++ b/crates/aprender-core/src/format/onnx/reader.rs
@@ -437,7 +437,7 @@ impl<'a> ProtobufReader<'a> {
     /// Read a packed repeated field of little-endian f32 values.
     fn read_packed_f32_into(&mut self, out: &mut Vec<f32>) -> Result<()> {
         let packed = self.read_bytes()?;
-        for chunk in packed.chunks_exact(4) {
+        for chunk in packed.as_chunks::<4>().0 {
             out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
         }
         Ok(())
@@ -446,7 +446,7 @@ impl<'a> ProtobufReader<'a> {
     /// Read a packed repeated field of little-endian f64 values.
     fn read_packed_f64_into(&mut self, out: &mut Vec<f64>) -> Result<()> {
         let packed = self.read_bytes()?;
-        for chunk in packed.chunks_exact(8) {
+        for chunk in packed.as_chunks::<8>().0 {
             out.push(f64::from_le_bytes([
                 chunk[0], chunk[1], chunk[2], chunk[3],
                 chunk[4], chunk[5], chunk[6], chunk[7],
@@ -464,9 +464,7 @@ pub fn is_onnx_file(path: &Path) -> bool {
     }
     // Check protobuf magic (ONNX starts with varint tag for field 1, wire type 0)
     // Field 1 (ir_version) with varint wire type = tag byte 0x08
-    std::fs::read(path)
-        .ok()
-        .is_some_and(|data| data.len() > 4 && data[0] == 0x08)
+    std::fs::read(path).is_ok_and(|data| data.len() > 4 && data[0] == 0x08)
 }
 
 /// Check if a file is a NeMo archive (.nemo = tar.gz)

--- a/crates/aprender-core/src/format/safetensors.rs
+++ b/crates/aprender-core/src/format/safetensors.rs
@@ -316,18 +316,24 @@ fn list_tensors_safetensors(data: &[u8], options: TensorListOptions) -> Result<T
 fn safetensors_bytes_to_f32(bytes: &[u8], dtype: &str) -> Vec<f32> {
     match dtype {
         "F32" => bytes
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
         "F16" => bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| {
                 let bits = u16::from_le_bytes([c[0], c[1]]);
                 f16_to_f32(bits)
             })
             .collect(),
         "BF16" => bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| {
                 let bits = u16::from_le_bytes([c[0], c[1]]);
                 bf16_to_f32(bits)

--- a/crates/aprender-core/src/inspect/safetensors.rs
+++ b/crates/aprender-core/src/inspect/safetensors.rs
@@ -242,14 +242,18 @@ impl HfSafetensors {
         match dtype {
             Dtype::F32 => {
                 let floats: Vec<f32> = bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
                     .collect();
                 Ok(floats)
             }
             Dtype::F16 => {
                 let floats: Vec<f32> = bytes
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|chunk| {
                         let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                         half::f16::from_bits(bits).to_f32()
@@ -259,7 +263,9 @@ impl HfSafetensors {
             }
             Dtype::BF16 => {
                 let floats: Vec<f32> = bytes
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|chunk| {
                         let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                         half::bf16::from_bits(bits).to_f32()

--- a/crates/aprender-core/src/serialization/apr/mod.rs
+++ b/crates/aprender-core/src/serialization/apr/mod.rs
@@ -45,6 +45,108 @@ pub struct AprReader {
     data_offset: usize,
 }
 
+/// Flatten an APR v2 binary header's typed metadata into the string-keyed
+/// `AprMetadata` map.
+///
+/// Split out of `AprReader::from_bytes`, which the repo's own pre-commit gate
+/// reports at Cognitive 26 > 25 — on `origin/main` as well as here, since this
+/// is 20 straight `if let Some(..)` field copies and none of the decisions
+/// interact. The gate only inspects STAGED files, so the debt was invisible
+/// until an unrelated line in this file was touched.
+fn v2_metadata_to_flat(meta: &crate::format::v2::AprV2Metadata) -> AprMetadata {
+    // Build flat metadata from typed + custom fields
+    let mut metadata = AprMetadata::new();
+    if !meta.model_type.is_empty() {
+        metadata.insert(
+            "model_type".to_string(),
+            JsonValue::String(meta.model_type.clone()),
+        );
+    }
+    if let Some(ref name) = meta.name {
+        metadata.insert("model_name".to_string(), JsonValue::String(name.clone()));
+    }
+    if let Some(ref desc) = meta.description {
+        metadata.insert("description".to_string(), JsonValue::String(desc.clone()));
+    }
+    if let Some(ref author) = meta.author {
+        metadata.insert("author".to_string(), JsonValue::String(author.clone()));
+    }
+    if let Some(ref license) = meta.license {
+        metadata.insert("license".to_string(), JsonValue::String(license.clone()));
+    }
+    if let Some(ref version) = meta.version {
+        metadata.insert("version".to_string(), JsonValue::String(version.clone()));
+    }
+    if let Some(ref arch) = meta.architecture {
+        metadata.insert("architecture".to_string(), JsonValue::String(arch.clone()));
+    }
+    // Transformer config fields (V2 binary header → flat metadata)
+    if let Some(v) = meta.hidden_size {
+        metadata.insert(
+            "hidden_size".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.num_layers {
+        metadata.insert(
+            "num_layers".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.num_heads {
+        metadata.insert(
+            "num_heads".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.num_kv_heads {
+        metadata.insert(
+            "num_kv_heads".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.vocab_size {
+        metadata.insert(
+            "vocab_size".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.intermediate_size {
+        metadata.insert(
+            "intermediate_size".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.max_position_embeddings {
+        metadata.insert(
+            "max_position_embeddings".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    if let Some(v) = meta.rope_theta {
+        if let Some(n) = serde_json::Number::from_f64(v as f64) {
+            metadata.insert("rope_theta".into(), JsonValue::Number(n));
+        }
+    }
+    if let Some(v) = meta.rms_norm_eps {
+        if let Some(n) = serde_json::Number::from_f64(v as f64) {
+            metadata.insert("rms_norm_eps".into(), JsonValue::Number(n));
+        }
+    }
+    if let Some(v) = meta.head_dim {
+        metadata.insert(
+            "head_dim".into(),
+            JsonValue::Number(serde_json::Number::from(v)),
+        );
+    }
+    // Include custom fields
+    for (k, v) in &meta.custom {
+        metadata.insert(k.clone(), v.clone());
+    }
+
+    metadata
+}
+
 impl AprReader {
     /// Load APR file from path
     ///
@@ -67,95 +169,7 @@ impl AprReader {
 
         let meta = reader.metadata();
 
-        // Build flat metadata from typed + custom fields
-        let mut metadata = AprMetadata::new();
-        if !meta.model_type.is_empty() {
-            metadata.insert(
-                "model_type".to_string(),
-                JsonValue::String(meta.model_type.clone()),
-            );
-        }
-        if let Some(ref name) = meta.name {
-            metadata.insert("model_name".to_string(), JsonValue::String(name.clone()));
-        }
-        if let Some(ref desc) = meta.description {
-            metadata.insert("description".to_string(), JsonValue::String(desc.clone()));
-        }
-        if let Some(ref author) = meta.author {
-            metadata.insert("author".to_string(), JsonValue::String(author.clone()));
-        }
-        if let Some(ref license) = meta.license {
-            metadata.insert("license".to_string(), JsonValue::String(license.clone()));
-        }
-        if let Some(ref version) = meta.version {
-            metadata.insert("version".to_string(), JsonValue::String(version.clone()));
-        }
-        if let Some(ref arch) = meta.architecture {
-            metadata.insert("architecture".to_string(), JsonValue::String(arch.clone()));
-        }
-        // Transformer config fields (V2 binary header → flat metadata)
-        if let Some(v) = meta.hidden_size {
-            metadata.insert(
-                "hidden_size".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.num_layers {
-            metadata.insert(
-                "num_layers".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.num_heads {
-            metadata.insert(
-                "num_heads".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.num_kv_heads {
-            metadata.insert(
-                "num_kv_heads".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.vocab_size {
-            metadata.insert(
-                "vocab_size".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.intermediate_size {
-            metadata.insert(
-                "intermediate_size".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.max_position_embeddings {
-            metadata.insert(
-                "max_position_embeddings".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        if let Some(v) = meta.rope_theta {
-            if let Some(n) = serde_json::Number::from_f64(v as f64) {
-                metadata.insert("rope_theta".into(), JsonValue::Number(n));
-            }
-        }
-        if let Some(v) = meta.rms_norm_eps {
-            if let Some(n) = serde_json::Number::from_f64(v as f64) {
-                metadata.insert("rms_norm_eps".into(), JsonValue::Number(n));
-            }
-        }
-        if let Some(v) = meta.head_dim {
-            metadata.insert(
-                "head_dim".into(),
-                JsonValue::Number(serde_json::Number::from(v)),
-            );
-        }
-        // Include custom fields
-        for (k, v) in &meta.custom {
-            metadata.insert(k.clone(), v.clone());
-        }
+        let metadata = v2_metadata_to_flat(meta);
 
         // Build tensor descriptors
         let tensor_names = reader.tensor_names();
@@ -264,7 +278,9 @@ impl AprReader {
             ));
         }
         Ok(bytes
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect())
     }
@@ -284,15 +300,21 @@ impl AprReader {
 
         match desc.dtype.as_str() {
             "F32" => Ok(bytes
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                 .collect()),
             "F16" => Ok(bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|c| trueno::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
                 .collect()),
             "BF16" => Ok(bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|c| {
                     let bits = u16::from_le_bytes([c[0], c[1]]);
                     f32::from_bits(u32::from(bits) << 16)

--- a/crates/aprender-core/src/serialization/safetensors_reader.rs
+++ b/crates/aprender-core/src/serialization/safetensors_reader.rs
@@ -130,11 +130,12 @@ pub(super) fn extract_f32(tensor_bytes: &[u8]) -> Result<Vec<f32>, String> {
     }
 
     let values: Vec<f32> = tensor_bytes
-        .chunks_exact(4)
-        .map(|chunk| {
-            let bytes: [u8; 4] = chunk.try_into().expect("chunk is 4 bytes");
-            f32::from_le_bytes(bytes)
-        })
+        .as_chunks::<4>()
+        .0
+        .iter()
+        // `as_chunks::<4>()` yields `&[u8; 4]`, so the width is a type rather
+        // than a runtime claim and the `try_into().expect(..)` is gone.
+        .map(|chunk| f32::from_le_bytes(*chunk))
         .collect();
 
     Ok(values)
@@ -150,11 +151,10 @@ pub(crate) fn extract_bf16_to_f32(tensor_bytes: &[u8]) -> Result<Vec<f32>, Strin
     }
 
     let values: Vec<f32> = tensor_bytes
-        .chunks_exact(2)
-        .map(|chunk| {
-            let bytes: [u8; 2] = chunk.try_into().expect("chunk is 2 bytes");
-            bf16_to_f32(bytes)
-        })
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| bf16_to_f32(*chunk))
         .collect();
 
     Ok(values)
@@ -170,11 +170,10 @@ pub(crate) fn extract_f16_to_f32(tensor_bytes: &[u8]) -> Result<Vec<f32>, String
     }
 
     let values: Vec<f32> = tensor_bytes
-        .chunks_exact(2)
-        .map(|chunk| {
-            let bytes: [u8; 2] = chunk.try_into().expect("chunk is 2 bytes");
-            f16_to_f32(bytes)
-        })
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| f16_to_f32(*chunk))
         .collect();
 
     Ok(values)

--- a/crates/aprender-core/src/verify/ground_truth.rs
+++ b/crates/aprender-core/src/verify/ground_truth.rs
@@ -87,7 +87,9 @@ impl GroundTruth {
     pub fn from_bin_file<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let bytes = std::fs::read(path)?;
         let data: Vec<f32> = bytes
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
             .collect();
         Ok(Self::from_slice(&data))

--- a/crates/aprender-db/src/kv/memory.rs
+++ b/crates/aprender-db/src/kv/memory.rs
@@ -6,6 +6,7 @@
 use super::KvStore;
 use crate::Result;
 use dashmap::DashMap;
+use std::future::Future;
 
 /// In-memory key-value store using lock-free concurrent hashmap.
 ///
@@ -66,21 +67,27 @@ impl Default for MemoryKvStore {
 }
 
 impl KvStore for MemoryKvStore {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
-        Ok(self.store.get(key).map(|v| v.value().clone()))
+    // NOT `async fn`: every operation here is a synchronous DashMap access, so
+    // the futures resolve on their first poll. `std::future::ready` says that
+    // in the type instead of leaving an `async` block with nothing to suspend
+    // on. `+ Send` is carried over from the trait's own declaration in
+    // kv/mod.rs, which clippy's suggestion drops.
+    // clippy::unused_async_trait_impl (new in 1.98).
+    fn get(&self, key: &str) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send {
+        std::future::ready(Ok(self.store.get(key).map(|v| v.value().clone())))
     }
 
-    async fn set(&self, key: &str, value: Vec<u8>) -> Result<()> {
+    fn set(&self, key: &str, value: Vec<u8>) -> impl Future<Output = Result<()>> + Send {
         self.store.insert(key.to_string(), value);
-        Ok(())
+        std::future::ready(Ok(()))
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    fn delete(&self, key: &str) -> impl Future<Output = Result<()>> + Send {
         self.store.remove(key);
-        Ok(())
+        std::future::ready(Ok(()))
     }
 
-    async fn exists(&self, key: &str) -> Result<bool> {
-        Ok(self.store.contains_key(key))
+    fn exists(&self, key: &str) -> impl Future<Output = Result<bool>> + Send {
+        std::future::ready(Ok(self.store.contains_key(key)))
     }
 }

--- a/crates/aprender-explain/src/compare.rs
+++ b/crates/aprender-explain/src/compare.rs
@@ -145,7 +145,7 @@ pub fn format_comparison_text(report: &ComparisonReport) -> String {
 
     output.push_str(&format!(
         "{:<25} {:>12} {:>12} {:>8}\n",
-        "Metric", &report.report_a_name, &report.report_b_name, "Winner"
+        "Metric", report.report_a_name, report.report_b_name, "Winner"
     ));
     output.push_str(&format!("{}\n", "─".repeat(60)));
 

--- a/crates/aprender-gpu/src/driver/ptx_cache.rs
+++ b/crates/aprender-gpu/src/driver/ptx_cache.rs
@@ -116,7 +116,7 @@ pub(crate) fn sha256(data: &[u8]) -> [u8; 32] {
     padded.extend_from_slice(&bit_len.to_be_bytes());
 
     // Process each 512-bit (64-byte) block
-    for block in padded.chunks_exact(64) {
+    for block in padded.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
         for i in 0..16 {
             w[i] = u32::from_be_bytes([

--- a/crates/aprender-gpu/src/kernels/backward/nf4_tensor_core.rs
+++ b/crates/aprender-gpu/src/kernels/backward/nf4_tensor_core.rs
@@ -196,7 +196,7 @@ impl Kernel for Nf4TensorCoreGemmBackwardAKernel {
                 // Global B coordinates: B[tile_k + k_out_in_tile, n_offset + n_shared_in_tile]
                 let global_k_out = ctx.add_u32_reg(tile_k, k_out_in_tile);
                 let global_n_shared = ctx.add_u32_reg(n_offset, n_shared_in_tile);
-                let ck = ctx.min_u32(global_k_out, k_minus_1);
+                let _ck = ctx.min_u32(global_k_out, k_minus_1);
                 let cn_b = ctx.min_u32(global_n_shared, n_minus_1);
 
                 // NF4 addressing: block_idx = global_k_out / 64

--- a/crates/aprender-gpu/src/kernels/gemm/basic/tensor_core/cta128_wmma.rs
+++ b/crates/aprender-gpu/src/kernels/gemm/basic/tensor_core/cta128_wmma.rs
@@ -109,9 +109,9 @@ pub fn build_cta128_wmma_fp16_cpasync(m: u32, n: u32, k: u32) -> PtxKernel {
             // Thread t loads: elements [t*8..t*8+7], i.e., row = (t*8)/16 = t/2, col = (t*8)%16
             // cp.async 0: smem_off = t*16, global_off = row*K + col
             // cp.async 1: smem_off = t*16 + 8, global_off = row*K + col + 4
-            let a_row_in_tile = ctx.shr_u32(tid, c_2); // t/4 (covers 0..63 for first half)
-                                                       // But we need rows 0..127 with 256 threads loading 8 elements each
-                                                       // Better: t*8/16 = t/2 for the row
+            let _a_row_in_tile = ctx.shr_u32(tid, c_2); // t/4 (covers 0..63 for first half)
+                                                        // But we need rows 0..127 with 256 threads loading 8 elements each
+                                                        // Better: t*8/16 = t/2 for the row
             let a_elem_start = ctx.mul_u32_reg(tid, c_8); // t * 8
             let a_row0 = ctx.shr_u32(a_elem_start, c_4); // (t*8) / 16
             let c_mask15 = ctx.mov_u32_imm(15);
@@ -241,8 +241,8 @@ pub fn build_cta128_wmma_fp16_cpasync(m: u32, n: u32, k: u32) -> PtxKernel {
             {
                 // A fragment addresses: warp_m_off + {0, 16} rows, compute_off
                 // B fragment addresses: warp_n_off + {0, 16} cols, compute_off
-                let stride_a = ctx.mov_u32_imm(16); // A leading dim in smem = tile_k=16
-                let stride_b = ctx.mov_u32_imm(128); // B leading dim in smem = tile_n=128
+                let _stride_a = ctx.mov_u32_imm(16); // A leading dim in smem = tile_k=16
+                let _stride_b = ctx.mov_u32_imm(128); // B leading dim in smem = tile_n=128
 
                 // Top-left (0,0): A at warp_m_off, B at warp_n_off
                 let a00_bytes = ctx.mul_u32_reg(warp_m_off, c_16);

--- a/crates/aprender-gpu/src/kernels/gemm/basic/tensor_core/cta64_wmma.rs
+++ b/crates/aprender-gpu/src/kernels/gemm/basic/tensor_core/cta64_wmma.rs
@@ -73,7 +73,7 @@ pub fn build_cta64_wmma_fp16_cpasync(m: u32, n: u32, k: u32) -> PtxKernel {
             let c_4 = ctx.mov_u32_imm(4);
             let c_5 = ctx.mov_u32_imm(5);
             let c_16 = ctx.mov_u32_imm(16);
-            let c_63 = ctx.mov_u32_imm(63);
+            let _c_63 = ctx.mov_u32_imm(63);
             let c_64 = ctx.mov_u32_imm(64);
             let c_256 = ctx.mov_u32_imm(a_threads);
             let c_a_smem = ctx.mov_u32_imm(a_smem_bytes as u32);
@@ -352,7 +352,7 @@ pub fn build_cta64_mma_fp16_cpasync(_m: u32, n: u32, k: u32) -> PtxKernel {
             let warp_m_off = ctx.mul_u32_reg(warp_row, c_16);
             let warp_n_off = ctx.mul_u32_reg(warp_col, c_16);
 
-            let smem_base = ctx.shared_base_addr();
+            let _smem_base = ctx.shared_base_addr();
             let is_a_thread = ctx.setp_lt_u32(tid, c_256);
 
             // === cp.async load offsets (IDENTICAL to wmma version) ===
@@ -659,7 +659,7 @@ pub fn build_cta64x128_mma_fp16_cpasync(_m: u32, n: u32, k: u32) -> PtxKernel {
             let warp_m_off = ctx.mul_u32_reg(warp_row, c_16); // 0, 16, 32, 48
             let warp_n_off = ctx.mul_u32_reg(warp_col, c_32); // 0, 32, 64, 96
 
-            let smem_base = ctx.shared_base_addr();
+            let _smem_base = ctx.shared_base_addr();
             let is_a_thread = ctx.setp_lt_u32(tid, c_256);
 
             // === cp.async load offsets ===
@@ -675,16 +675,16 @@ pub fn build_cta64x128_mma_fp16_cpasync(_m: u32, n: u32, k: u32) -> PtxKernel {
             // local = tid-256, row = local/8, col = (local%8)*16 (16 FP16 = 32 bytes per chunk)
             // Wait: 256 threads × 16 bytes = 4096 bytes. B = 16×128×2 = 4096. OK!
             let b_local = ctx.sub_u32_reg(tid, c_256);
-            let b_row_in_tile = ctx.shr_u32(b_local, c_3); // local/8 (32 rows across 256 threads? No...)
-                                                           // 256 threads, 4096 bytes: each thread loads 16 bytes
-                                                           // B has 16 rows × 128 cols × 2 bytes = 4096 bytes
-                                                           // Arrange: thread loads 8 consecutive FP16 elements
-                                                           // local*8 gives element index, row = local*8/128, col = (local*8)%128
-                                                           // Actually: 256 threads × 16 bytes = 4096 bytes total.
-                                                           // Each thread loads 16 contiguous bytes = 8 FP16 elements.
-                                                           // Element index start = local * 8
-                                                           // Row = (local * 8) / 128 = local / 16
-                                                           // Col = (local * 8) % 128 = (local % 16) * 8
+            let _b_row_in_tile = ctx.shr_u32(b_local, c_3); // local/8 (32 rows across 256 threads? No...)
+                                                            // 256 threads, 4096 bytes: each thread loads 16 bytes
+                                                            // B has 16 rows × 128 cols × 2 bytes = 4096 bytes
+                                                            // Arrange: thread loads 8 consecutive FP16 elements
+                                                            // local*8 gives element index, row = local*8/128, col = (local*8)%128
+                                                            // Actually: 256 threads × 16 bytes = 4096 bytes total.
+                                                            // Each thread loads 16 contiguous bytes = 8 FP16 elements.
+                                                            // Element index start = local * 8
+                                                            // Row = (local * 8) / 128 = local / 16
+                                                            // Col = (local * 8) % 128 = (local % 16) * 8
             let c_mask15 = ctx.mov_u32_imm(15);
             let b_row_in_tile = ctx.shr_u32(b_local, c_4); // local/16
             let b_col_mod = ctx.and_u32(b_local, c_mask15); // local%16

--- a/crates/aprender-gpu/src/kernels/quantize/nf4_cpu.rs
+++ b/crates/aprender-gpu/src/kernels/quantize/nf4_cpu.rs
@@ -145,7 +145,7 @@ pub fn quantize_nf4(values: &[f32], rows: usize, cols: usize) -> Nf4Quantized {
         // Quantize: normalize to [-1, 1], find nearest codebook entry
         let inv_scale = if absmax > 0.0 { 1.0 / absmax } else { 0.0 };
 
-        for pair in block.chunks_exact(2) {
+        for pair in block.as_chunks::<2>().0 {
             let idx_lo = nearest_nf4_index(pair[0] * inv_scale);
             let idx_hi = nearest_nf4_index(pair[1] * inv_scale);
             data.push(idx_lo | (idx_hi << 4));

--- a/crates/aprender-graph/src/storage/parquet.rs
+++ b/crates/aprender-graph/src/storage/parquet.rs
@@ -30,7 +30,12 @@ impl CsrGraph {
     /// # Errors
     ///
     /// Returns error if file I/O fails or Arrow conversion fails
-    #[allow(clippy::unused_async)] // Async API for future I/O operations
+    // Inherent impl, not a trait impl, despite the lint's name: dropping the
+    // `async` and returning `std::future::ready(..)` would run the whole
+    // parquet write EAGERLY at call time instead of at await time, which is a
+    // behaviour change, not a cleanup. Same reason as the `unused_async` allow
+    // that has been here since this was written.
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)] // Async API for future I/O operations
     pub async fn write_parquet<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let base_path = path.as_ref();
 
@@ -48,7 +53,7 @@ impl CsrGraph {
     /// # Errors
     ///
     /// Returns error if files don't exist or Arrow conversion fails
-    #[allow(clippy::unused_async)] // Async API for future I/O operations
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)] // Async API for future I/O operations
     pub async fn read_parquet<P: AsRef<Path>>(path: P) -> Result<Self> {
         let base_path = path.as_ref();
 

--- a/crates/aprender-orchestrate/src/analyzer.rs
+++ b/crates/aprender-orchestrate/src/analyzer.rs
@@ -356,9 +356,7 @@ fn calculate_tdg_fallback(path: &Path) -> Option<f64> {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "rs"))
             .take(10)
             .any(|e| {
-                std::fs::read_to_string(e.path())
-                    .ok()
-                    .is_some_and(|content| content.contains("#[test]"))
+                std::fs::read_to_string(e.path()).is_ok_and(|content| content.contains("#[test]"))
             });
 
     if !has_tests {

--- a/crates/aprender-orchestrate/src/cli/agent_helpers.rs
+++ b/crates/aprender-orchestrate/src/cli/agent_helpers.rs
@@ -12,7 +12,7 @@ pub(super) fn try_auto_pull(manifest: &batuta::agent::AgentManifest) -> anyhow::
         println!("  Quantization: {}, Timeout: 600s", quant);
         match manifest.model.auto_pull(600) {
             Ok(path) => {
-                println!("{} Model downloaded: {}", "✓".green(), path.display(),);
+                println!("{} Model downloaded: {}", "✓".green(), path.display());
             }
             Err(e) => {
                 anyhow::bail!("auto-pull failed: {e}");

--- a/crates/aprender-orchestrate/src/cli/agent_pool_cmds.rs
+++ b/crates/aprender-orchestrate/src/cli/agent_pool_cmds.rs
@@ -24,7 +24,7 @@ pub(super) fn cmd_agent_pool(
 
     println!("{} Multi-Agent Pool", "🔀".bright_cyan().bold());
     println!("{}", "═".repeat(60).dimmed());
-    println!("  Agents: {}  Concurrency: {}", manifests.len(), max_concurrent,);
+    println!("  Agents: {}  Concurrency: {}", manifests.len(), max_concurrent);
     println!("  Prompt: {}", prompt.bright_yellow());
     println!();
 
@@ -48,25 +48,25 @@ pub(super) fn cmd_agent_pool(
     rt.block_on(async {
         let mut pool = AgentPool::new(driver, max_concurrent).with_memory(memory);
 
-        println!("{} Spawning {} agents...", "▶".bright_green(), agent_count,);
+        println!("{} Spawning {} agents...", "▶".bright_green(), agent_count);
 
         let ids = pool.fan_out(configs).map_err(|e| anyhow::anyhow!("pool fan-out: {e}"))?;
         for id in &ids {
-            println!("  {} Agent {id} spawned", "•".bright_blue(),);
+            println!("  {} Agent {id} spawned", "•".bright_blue());
         }
         println!();
 
-        println!("{} Waiting for results...", "⏳".bright_blue(),);
+        println!("{} Waiting for results...", "⏳".bright_blue());
         let results = pool.join_all().await;
 
         println!();
-        println!("{} Results ({}/{})", "✓".green(), results.len(), ids.len(),);
+        println!("{} Results ({}/{})", "✓".green(), results.len(), ids.len());
         println!("{}", "─".repeat(60).dimmed());
 
         for (id, result) in &results {
             match result {
                 Ok(r) => {
-                    println!("  {} Agent {id}: {}", "✓".green(), r.text,);
+                    println!("  {} Agent {id}: {}", "✓".green(), r.text);
                     println!(
                         "    {}",
                         format!(
@@ -77,7 +77,7 @@ pub(super) fn cmd_agent_pool(
                     );
                 }
                 Err(e) => {
-                    println!("  {} Agent {id}: {e}", "✗".bright_red(),);
+                    println!("  {} Agent {id}: {e}", "✗".bright_red());
                 }
             }
         }

--- a/crates/aprender-orchestrate/src/cli/bug_hunter_output.rs
+++ b/crates/aprender-orchestrate/src/cli/bug_hunter_output.rs
@@ -439,7 +439,7 @@ fn output_text(result: &HuntResult) {
 
     // Severity summary
 
-    println!("Severity: {}", severity_summary_line(&result.stats),);
+    println!("Severity: {}", severity_summary_line(&result.stats));
     println!();
 
     // Category distribution chart

--- a/crates/aprender-orchestrate/src/falsification/invariants.rs
+++ b/crates/aprender-orchestrate/src/falsification/invariants.rs
@@ -179,8 +179,7 @@ fn has_rust_tests(project_path: &Path) -> bool {
             .map(|entries| {
                 entries.flatten().any(|p| {
                     std::fs::read_to_string(&p)
-                        .ok()
-                        .is_some_and(|c| c.contains("#[test]") || c.contains("#[cfg(test)]"))
+                        .is_ok_and(|c| c.contains("#[test]") || c.contains("#[cfg(test)]"))
                 })
             })
             .unwrap_or(false)

--- a/crates/aprender-orchestrate/src/falsification/safety.rs
+++ b/crates/aprender-orchestrate/src/falsification/safety.rs
@@ -707,8 +707,7 @@ fn scan_validation_patterns(project_path: &Path) -> (bool, Vec<&'static str>) {
 fn has_validator_crate(project_path: &Path) -> bool {
     let cargo_toml = project_path.join("Cargo.toml");
     std::fs::read_to_string(cargo_toml)
-        .ok()
-        .is_some_and(|c| c.contains("validator") || c.contains("garde"))
+        .is_ok_and(|c| c.contains("validator") || c.contains("garde"))
 }
 
 /// SF-09: Input Validation

--- a/crates/aprender-orchestrate/src/pipeline/stages/validation.rs
+++ b/crates/aprender-orchestrate/src/pipeline/stages/validation.rs
@@ -30,7 +30,10 @@ impl ValidationStage {
     }
 
     /// Trace syscalls from both binaries and compare them for semantic equivalence
-    pub async fn trace_and_compare(
+    // Not `async`: every call in this body is blocking (`Self::trace_binary`
+    // shells out and waits). The `async` bought nothing and could not suspend.
+    // clippy::unused_async_trait_impl (new in 1.98).
+    pub fn trace_and_compare(
         &self,
         original_binary: &std::path::Path,
         transpiled_binary: &std::path::Path,
@@ -113,7 +116,7 @@ impl PipelineStage for ValidationStage {
             let transpiled_binary = ctx.output_path.join("target/release/transpiled");
 
             if original_binary.exists() && transpiled_binary.exists() {
-                match self.trace_and_compare(&original_binary, &transpiled_binary).await {
+                match self.trace_and_compare(&original_binary, &transpiled_binary) {
                     Ok(equivalent) => {
                         ctx.validation_results.push(ValidationResult {
                             stage: self.name().to_string(),

--- a/crates/aprender-orchestrate/src/stack/quality_checker.rs
+++ b/crates/aprender-orchestrate/src/stack/quality_checker.rs
@@ -178,6 +178,15 @@ impl QualityChecker {
     }
 
     /// Estimate rust project score when pmat is not available
+    // LEFT `async` DELIBERATELY. clippy is right that nothing here awaits — but
+    // nothing awaits anywhere in `QualityChecker`: every leaf shells out through
+    // a blocking `std::process::Command`, and the chain reaches the PUBLIC
+    // `check_component`. Measured by de-asyncing the two estimate_* helpers:
+    // the lint simply moved up to `run_rust_project_score` / `run_repo_score`,
+    // and de-asyncing those moves it to `check_component`, whose signature is
+    // this crate's API. Making that module honestly synchronous is worth doing
+    // and is not a toolchain-drift fix; it needs its own change.
+    #[allow(unknown_lints, clippy::unused_async_trait_impl)]
     async fn estimate_rust_score(&self, path: &Path) -> Result<Score> {
         let mut score = 50u32; // Base score
 
@@ -252,6 +261,8 @@ impl QualityChecker {
     }
 
     /// Estimate repo and readme scores when pmat is not available
+    // See estimate_rust_score above for why this stays `async`.
+    #[allow(unknown_lints, clippy::unused_async_trait_impl)]
     async fn estimate_repo_scores(&self, path: &Path) -> Result<(Score, Score)> {
         let mut repo_score = 40u32; // Base score
         let mut readme_score = 0u32;

--- a/crates/aprender-present-core/src/binding.rs
+++ b/crates/aprender-present-core/src/binding.rs
@@ -779,8 +779,10 @@ impl BindingManager {
         let mut widget_updates = Vec::new();
         let mut state_updates = Vec::new();
 
-        // Drain into separate Vec to avoid borrow issues
-        let updates: Vec<PendingUpdate> = self.pending_updates.drain(..).collect();
+        // Take, rather than drain-and-collect, to avoid borrow issues: same
+        // effect (self.pending_updates left empty), one fewer allocation.
+        // clippy::drain_collect (new in 1.98).
+        let updates: Vec<PendingUpdate> = std::mem::take(&mut self.pending_updates);
 
         for update in updates {
             match update.source {

--- a/crates/aprender-present-core/src/lifecycle.rs
+++ b/crates/aprender-present-core/src/lifecycle.rs
@@ -230,7 +230,9 @@ impl LifecycleManager {
 
     /// Dispatch all pending events.
     pub fn flush(&mut self) {
-        let events: Vec<LifecycleEvent> = self.pending_events.drain(..).collect();
+        // See binding.rs::flush — `mem::take` is the allocation-free spelling
+        // of `drain(..).collect()`. clippy::drain_collect (new in 1.98).
+        let events: Vec<LifecycleEvent> = std::mem::take(&mut self.pending_events);
 
         for event in events {
             let widget_hooks = self

--- a/crates/aprender-present-core/src/simd.rs
+++ b/crates/aprender-present-core/src/simd.rs
@@ -595,9 +595,11 @@ pub fn batch_sum_f64(values: &[f64]) -> f64 {
         return values.iter().sum();
     }
 
-    // 4-way accumulator for ILP and auto-vectorization
-    let chunks = values.chunks_exact(4);
-    let remainder = chunks.remainder();
+    // 4-way accumulator for ILP and auto-vectorization.
+    // `as_chunks::<4>()` is `chunks_exact(4)` plus its remainder, as one
+    // destructuring, and yields `&[f64; 4]` so the fixed indexing below is
+    // bounds-checked at compile time. clippy::chunks_exact_to_as_chunks (1.98).
+    let (chunks, remainder) = values.as_chunks::<4>();
 
     let mut acc = [0.0f64; 4];
     for chunk in chunks {
@@ -663,9 +665,8 @@ pub fn batch_min_max_f64(values: &[f64]) -> Option<(f64, f64)> {
         return Some((min, max));
     }
 
-    // 4-way min/max for auto-vectorization
-    let chunks = values.chunks_exact(4);
-    let remainder = chunks.remainder();
+    // 4-way min/max for auto-vectorization. See batch_sum_f64 on as_chunks.
+    let (chunks, remainder) = values.as_chunks::<4>();
 
     let mut min_acc = [f64::INFINITY; 4];
     let mut max_acc = [f64::NEG_INFINITY; 4];
@@ -852,14 +853,12 @@ pub fn weighted_sum_f64(values: &[f64], weights: &[f64]) -> f64 {
             .sum();
     }
 
-    // 4-way accumulator
-    let v_chunks = values.chunks_exact(4);
-    let w_chunks = weights.chunks_exact(4);
-    let v_rem = v_chunks.remainder();
-    let w_rem = w_chunks.remainder();
+    // 4-way accumulator. See batch_sum_f64 on as_chunks.
+    let (v_chunks, v_rem) = values.as_chunks::<4>();
+    let (w_chunks, w_rem) = weights.as_chunks::<4>();
 
     let mut acc = [0.0f64; 4];
-    for (vc, wc) in v_chunks.zip(w_chunks) {
+    for (vc, wc) in v_chunks.iter().zip(w_chunks.iter()) {
         acc[0] = vc[0].mul_add(wc[0], acc[0]);
         acc[1] = vc[1].mul_add(wc[1], acc[1]);
         acc[2] = vc[2].mul_add(wc[2], acc[2]);

--- a/crates/aprender-present-test/src/snapshot.rs
+++ b/crates/aprender-present-test/src/snapshot.rs
@@ -263,7 +263,7 @@ impl Image {
     pub fn histogram(&self) -> [[u32; 256]; 4] {
         let mut hist = [[0u32; 256]; 4];
 
-        for chunk in self.data.chunks_exact(4) {
+        for chunk in self.data.as_chunks::<4>().0 {
             for (i, &val) in chunk.iter().enumerate() {
                 hist[i][val as usize] += 1;
             }
@@ -282,7 +282,7 @@ impl Image {
 
         let mut sums = [0.0f64; 4];
 
-        for chunk in self.data.chunks_exact(4) {
+        for chunk in self.data.as_chunks::<4>().0 {
             for (i, &val) in chunk.iter().enumerate() {
                 sums[i] += f64::from(val);
             }

--- a/crates/aprender-present-widgets/src/checkbox.rs
+++ b/crates/aprender-present-widgets/src/checkbox.rs
@@ -326,11 +326,9 @@ impl Widget for Checkbox {
             Event::MouseDown {
                 position,
                 button: MouseButton::Left,
-            } => {
-                if self.bounds.contains_point(position) {
-                    self.state = self.state.toggle();
-                    return Some(Box::new(CheckboxChanged { state: self.state }));
-                }
+            } if self.bounds.contains_point(position) => {
+                self.state = self.state.toggle();
+                return Some(Box::new(CheckboxChanged { state: self.state }));
             }
             _ => {}
         }

--- a/crates/aprender-present-widgets/src/column.rs
+++ b/crates/aprender-present-widgets/src/column.rs
@@ -141,7 +141,7 @@ impl Widget for Column {
             child_sizes.push(size);
         }
 
-        let gaps_height = self.gap * (self.children.len() - 1).max(0) as f32;
+        let gaps_height = self.gap * (self.children.len() - 1) as f32;
         let content_height = total_height + gaps_height;
         let remaining_space = (bounds.height - content_height).max(0.0);
 

--- a/crates/aprender-present-widgets/src/row.rs
+++ b/crates/aprender-present-widgets/src/row.rs
@@ -171,7 +171,7 @@ impl Widget for Row {
             child_sizes.push(size);
         }
 
-        let gaps_width = self.gap * (self.children.len() - 1).max(0) as f32;
+        let gaps_width = self.gap * (self.children.len() - 1) as f32;
         let content_width = total_width + gaps_width;
         let remaining_space = (bounds.width - content_width).max(0.0);
 

--- a/crates/aprender-present-widgets/src/slider.rs
+++ b/crates/aprender-present-widgets/src/slider.rs
@@ -310,14 +310,12 @@ impl Widget for Slider {
             } => {
                 self.dragging = false;
             }
-            Event::MouseMove { position } => {
-                if self.dragging {
-                    let normalized = self.value_from_x(position.x);
-                    let old_value = self.value;
-                    self.set_from_normalized(normalized);
-                    if (self.value - old_value).abs() > f32::EPSILON {
-                        return Some(Box::new(SliderChanged { value: self.value }));
-                    }
+            Event::MouseMove { position } if self.dragging => {
+                let normalized = self.value_from_x(position.x);
+                let old_value = self.value;
+                self.set_from_normalized(normalized);
+                if (self.value - old_value).abs() > f32::EPSILON {
+                    return Some(Box::new(SliderChanged { value: self.value }));
                 }
             }
             _ => {}

--- a/crates/aprender-present-widgets/src/tabs.rs
+++ b/crates/aprender-present-widgets/src/tabs.rs
@@ -355,7 +355,7 @@ impl Tabs {
         if self.items.is_empty() {
             return self.min_tab_width;
         }
-        let total_spacing = self.spacing * (self.items.len() - 1).max(0) as f32;
+        let total_spacing = self.spacing * (self.items.len() - 1) as f32;
         let per_tab = (available_width - total_spacing) / self.items.len() as f32;
         per_tab.max(self.min_tab_width)
     }

--- a/crates/aprender-qa-cli/src/main_tickets_and_parity.rs
+++ b/crates/aprender-qa-cli/src/main_tickets_and_parity.rs
@@ -400,7 +400,7 @@ fn load_logits_from_file(logits_path: &std::path::Path) -> Vec<f32> {
         );
         std::process::exit(1);
     }
-    data.chunks_exact(4)
+    data.as_chunks::<4>().0.iter()
         .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
         .collect()
 }

--- a/crates/aprender-qa-gen/src/hf_parity_oracle_impl.rs
+++ b/crates/aprender-qa-gen/src/hf_parity_oracle_impl.rs
@@ -86,7 +86,7 @@ impl HfParityOracle {
 
         let logits: Vec<f32> = logits_view
             .data()
-            .chunks_exact(4)
+            .as_chunks::<4>().0.iter()
             .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
             .collect();
 
@@ -224,7 +224,7 @@ impl HfParityOracle {
 
         let actual: Vec<f32> = logits_view
             .data()
-            .chunks_exact(4)
+            .as_chunks::<4>().0.iter()
             .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
             .collect();
 

--- a/crates/aprender-qa-runner/src/diagnostics_markdown_gen.rs
+++ b/crates/aprender-qa-runner/src/diagnostics_markdown_gen.rs
@@ -180,9 +180,7 @@ fn get_git_branch() -> String {
 fn get_git_dirty() -> bool {
     Command::new("git")
         .args(["status", "--porcelain"])
-        .output()
-        .ok()
-        .is_some_and(|o| !o.stdout.is_empty())
+        .output().is_ok_and(|o| !o.stdout.is_empty())
 }
 
 /// Get the rustc compiler version string

--- a/crates/aprender-qa-runner/src/executor_serve_battery.rs
+++ b/crates/aprender-qa-runner/src/executor_serve_battery.rs
@@ -771,9 +771,7 @@ impl Executor {
         }
 
         // Response should contain tokens (array or count)
-        let has_tokens = serde_json::from_str::<serde_json::Value>(&output.stdout)
-            .ok()
-            .is_some_and(|v| v.get("tokens").is_some() || v.get("count").is_some());
+        let has_tokens = serde_json::from_str::<serde_json::Value>(&output.stdout).is_ok_and(|v| v.get("tokens").is_some() || v.get("count").is_some());
 
         if has_tokens {
             Evidence::corroborated(&gate_id, scenario.clone(), &output.stdout, duration)

--- a/crates/aprender-rag-cli/src/extract.rs
+++ b/crates/aprender-rag-cli/src/extract.rs
@@ -130,7 +130,7 @@ fn extract_frames_ffmpeg(video: &Path, threshold: f64, min_interval: f64) -> Res
     fs::create_dir_all(&frames_dir)?;
 
     // Use ffmpeg select filter for scene detection + fps filter for minimum interval
-    let select_filter = format!("select='gt(scene\\,{threshold})',fps=1/{min_interval}",);
+    let select_filter = format!("select='gt(scene\\,{threshold})',fps=1/{min_interval}");
 
     let output_pattern = frames_dir
         .join("frame_%04d.png")

--- a/crates/aprender-serve/src/apr/dequant.rs
+++ b/crates/aprender-serve/src/apr/dequant.rs
@@ -13,7 +13,7 @@ pub fn f16_to_f32(bits: u16) -> f32 {
 /// Dequantize F16 data to F32
 pub fn dequantize_f16(bytes: &[u8], num_elements: usize) -> Vec<f32> {
     let mut result = Vec::with_capacity(num_elements);
-    for chunk in bytes.chunks_exact(2) {
+    for chunk in bytes.as_chunks::<2>().0 {
         let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
         result.push(f16_to_f32(bits));
     }

--- a/crates/aprender-serve/src/apr/loading_mmap.rs
+++ b/crates/aprender-serve/src/apr/loading_mmap.rs
@@ -369,7 +369,9 @@ impl AprV2Model {
         match entry.dtype.as_str() {
             "F32" | "f32" => {
                 let floats: Vec<f32> = bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
                     .collect();
                 Ok(floats)

--- a/crates/aprender-serve/src/apr_transformer/loader.rs
+++ b/crates/aprender-serve/src/apr_transformer/loader.rs
@@ -251,7 +251,9 @@ impl MmapAprTransformer {
 
         // Convert bytes to f32 (could be zero-copy if aligned)
         let floats: Vec<f32> = bytes
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
             .collect();
 

--- a/crates/aprender-serve/src/apr_transformer/mod_dequant_q4k_apr.rs
+++ b/crates/aprender-serve/src/apr_transformer/mod_dequant_q4k_apr.rs
@@ -69,19 +69,25 @@ fn dequant_by_dtype(tensor_data: &[u8], dims: &[usize], dtype: u8) -> Vec<f32> {
             dequantize_apr_q8_native(tensor_data, num_elements)
         },
         1 => tensor_data
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
             .collect(),
         // GH-369: BF16 (GGML type 30) — 2 bytes per element, upper 16 bits of F32
         30 => tensor_data
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| {
                 let bits = u16::from_le_bytes([c[0], c[1]]);
                 f32::from_bits((bits as u32) << 16)
             })
             .collect(),
         _ => tensor_data
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
     }

--- a/crates/aprender-serve/src/gguf/embedding.rs
+++ b/crates/aprender-serve/src/gguf/embedding.rs
@@ -82,7 +82,9 @@ fn dequantize_embedding(
 ) -> Result<Vec<f32>> {
     match dtype {
         "F32" | "f32" => Ok(embed_data
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect()),
         "BF16" | "bf16" => Ok(crate::inference::simd_bf16_to_f32(embed_data)),

--- a/crates/aprender-serve/src/gguf/inference/forward/acceleration.rs
+++ b/crates/aprender-serve/src/gguf/inference/forward/acceleration.rs
@@ -143,7 +143,7 @@ impl OwnedQuantizedModel {
             GGUF_TYPE_F32 => {
                 let num_floats = weight.data.len() / 4;
                 let mut output = vec![0.0f32; num_floats];
-                for (i, chunk) in weight.data.chunks_exact(4).enumerate() {
+                for (i, chunk) in weight.data.as_chunks::<4>().0.iter().enumerate() {
                     output[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
                 }
                 Ok(output)
@@ -151,13 +151,17 @@ impl OwnedQuantizedModel {
             // F16 weights — widen each little-endian half to f32.
             GGUF_TYPE_F16 => Ok(weight
                 .data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|b| half::f16::from_le_bytes([b[0], b[1]]).to_f32())
                 .collect()),
             // BF16 weights — left-shift the 16 mantissa/exponent bits into f32.
             GGUF_TYPE_BF16 => Ok(weight
                 .data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|b| {
                     let bits = u16::from_le_bytes([b[0], b[1]]);
                     f32::from_bits((bits as u32) << 16)

--- a/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
+++ b/crates/aprender-serve/src/gguf/loader_apr_quantized.rs
@@ -241,16 +241,22 @@ fn apr_decode_dense_float(
 
     let values: Vec<f32> = match dtype {
         "F32" => raw
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
         "F16" => raw
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| half::f16::from_le_bytes([c[0], c[1]]).to_f32())
             .collect(),
         // BF16 is the upper 16 bits of the F32 bit pattern.
         _ => raw
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| half::bf16::from_le_bytes([c[0], c[1]]).to_f32())
             .collect(),
     };

--- a/crates/aprender-serve/src/gguf/metadata.rs
+++ b/crates/aprender-serve/src/gguf/metadata.rs
@@ -74,7 +74,9 @@ impl GGUFModel {
 
                 let bytes = &file_data[offset..offset + byte_size];
                 let values = bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
                     .collect();
                 Ok(values)

--- a/crates/aprender-serve/src/gpu/adapters/wgpu_adapter.rs
+++ b/crates/aprender-serve/src/gpu/adapters/wgpu_adapter.rs
@@ -312,12 +312,16 @@ pub fn dequant_tensor_public(tensor: &crate::gguf::OwnedQuantizedTensor) -> Resu
         GGUF_TYPE_Q5_K => dequantize_q5_k(&tensor.data),
         GGUF_TYPE_F32 => Ok(tensor
             .data
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect()),
         GGUF_TYPE_F16 => Ok(tensor
             .data
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| {
                 let bits = u16::from_le_bytes([c[0], c[1]]);
                 half::f16::from_bits(bits).to_f32()

--- a/crates/aprender-serve/src/gpu/scheduler/linear_attn.rs
+++ b/crates/aprender-serve/src/gpu/scheduler/linear_attn.rs
@@ -109,9 +109,7 @@ impl LinearAttnState {
         for b in &mut self.conv_buf {
             b.fill(0.0);
         }
-        for c in &mut self.conv_steps {
-            *c = 0;
-        }
+        self.conv_steps.fill(0);
     }
 }
 

--- a/crates/aprender-serve/src/inference/simd.rs
+++ b/crates/aprender-serve/src/inference/simd.rs
@@ -332,7 +332,7 @@ fn simd_bf16_to_f32_avx2(input: &[u8], count: usize) -> Vec<f32> {
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
 fn bf16_to_f32_fast(input: &[u8], count: usize) -> Vec<f32> {
     let mut output = Vec::with_capacity(count);
-    for chunk in input.chunks_exact(2) {
+    for chunk in input.as_chunks::<2>().0 {
         let bits = u16::from_le_bytes([chunk[0], chunk[1]]) as u32;
         output.push(f32::from_bits(bits << 16));
     }
@@ -365,7 +365,9 @@ fn bf16_to_f32_fast(input: &[u8], count: usize) -> Vec<f32> {
 #[must_use]
 pub fn simd_f16_to_f32(input: &[u8]) -> Vec<f32> {
     input
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| {
             let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
             half::f16::from_bits(bits).to_f32()

--- a/crates/aprender-serve/src/inference_trace/save_tensor.rs
+++ b/crates/aprender-serve/src/inference_trace/save_tensor.rs
@@ -185,7 +185,7 @@ pub fn read_tensor_file<R: Read>(r: &mut R) -> Result<(TensorHeader, Vec<f32>), 
     r.read_exact(&mut body)?;
 
     let mut values = Vec::with_capacity(n);
-    for chunk in body.chunks_exact(4) {
+    for chunk in body.as_chunks::<4>().0 {
         let mut v = [0u8; 4];
         v.copy_from_slice(chunk);
         values.push(f32::from_le_bytes(v));

--- a/crates/aprender-serve/src/quantize/dequant.rs
+++ b/crates/aprender-serve/src/quantize/dequant.rs
@@ -176,7 +176,7 @@ pub fn dequantize_f16(data: &[u8]) -> Result<Vec<f32>> {
     let num_values = data.len() / 2;
     let mut result = Vec::with_capacity(num_values);
 
-    for chunk in data.chunks_exact(2) {
+    for chunk in data.as_chunks::<2>().0 {
         let h = u16::from_le_bytes([chunk[0], chunk[1]]);
         result.push(f16_to_f32(h));
     }

--- a/crates/aprender-serve/src/quantize/mod.rs
+++ b/crates/aprender-serve/src/quantize/mod.rs
@@ -232,7 +232,7 @@ pub fn quantize_activations_q8k_into(
         });
     }
 
-    for (sb_idx, chunk) in activations.chunks_exact(256).enumerate() {
+    for (sb_idx, chunk) in activations.as_chunks::<256>().0.iter().enumerate() {
         Q8KSuperBlock::quantize_into(
             chunk,
             &mut scales[sb_idx],
@@ -264,11 +264,12 @@ pub fn quantize_to_q8_blocks(values: &[f32]) -> Result<Vec<Q8_0Block>> {
     }
 
     let blocks: Vec<Q8_0Block> = values
-        .chunks_exact(32)
-        .map(|chunk| {
-            let arr: [f32; 32] = chunk.try_into().expect("chunk is exactly 32 elements");
-            Q8_0Block::quantize(&arr)
-        })
+        .as_chunks::<32>()
+        .0
+        .iter()
+        // `as_chunks::<32>()` yields `&[f32; 32]`, so the width is a type and
+        // the fallible conversion is gone.
+        .map(Q8_0Block::quantize)
         .collect();
 
     Ok(blocks)

--- a/crates/aprender-serve/src/quantize/parallel_dequant.rs
+++ b/crates/aprender-serve/src/quantize/parallel_dequant.rs
@@ -201,7 +201,7 @@ unsafe fn dequantize_q4_k_avx2_parallel(data: &[u8]) -> Result<Vec<f32>> {
         .par_chunks(CHUNK_BYTES)
         .flat_map(|chunk| {
             let mut chunk_result = Vec::with_capacity(chunk.len() / SUPER_BLOCK_BYTES * QK_K);
-            for sb_data in chunk.chunks_exact(SUPER_BLOCK_BYTES) {
+            for sb_data in chunk.as_chunks::<SUPER_BLOCK_BYTES>().0 {
                 // SAFETY: AVX2 availability verified by caller
                 chunk_result.extend(unsafe { dequantize_q4_k_superblock_avx2(sb_data) });
             }

--- a/crates/aprender-serve/src/safetensors/mapped_model.rs
+++ b/crates/aprender-serve/src/safetensors/mapped_model.rs
@@ -275,14 +275,12 @@ impl MappedSafeTensorsModel {
         }
 
         let values = bytes
-            .chunks_exact(4)
-            .map(|chunk| {
-                f32::from_le_bytes(
-                    chunk
-                        .try_into()
-                        .expect("chunks_exact(4) guarantees 4-byte slices"),
-                )
-            })
+            .as_chunks::<4>()
+            .0
+            .iter()
+            // `as_chunks::<4>()` yields `&[u8; 4]`, so the width is a type and
+            // the fallible conversion is gone.
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect();
 
         Ok(values)
@@ -382,7 +380,9 @@ impl MappedSafeTensorsModel {
     pub fn get_tensor_f16_native(&self, name: &str) -> Result<Vec<u16>> {
         let bytes = self.get_tensor_f16_bytes(name)?;
         let values: Vec<u16> = bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
             .collect();
         Ok(values)
@@ -393,7 +393,9 @@ impl MappedSafeTensorsModel {
         let bytes = self.get_tensor_f16_bytes(name)?;
 
         let values: Vec<f32> = bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| {
                 let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                 half::f16::from_bits(bits).to_f32()

--- a/crates/aprender-serve/src/safetensors/safetensors_parser.rs
+++ b/crates/aprender-serve/src/safetensors/safetensors_parser.rs
@@ -114,14 +114,12 @@ impl SafetensorsModel {
         }
 
         let values = bytes
-            .chunks_exact(4)
-            .map(|chunk| {
-                f32::from_le_bytes(
-                    chunk
-                        .try_into()
-                        .expect("chunks_exact(4) guarantees 4-byte slices"),
-                )
-            })
+            .as_chunks::<4>()
+            .0
+            .iter()
+            // `as_chunks::<4>()` yields `&[u8; 4]`, so the width is a type and
+            // the fallible conversion is gone.
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect();
 
         Ok(values)
@@ -247,7 +245,9 @@ impl SafetensorsModel {
 
         // Convert F16 bytes to F32
         let values: Vec<f32> = bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| {
                 let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
                 half::f16::from_bits(bits).to_f32()

--- a/crates/aprender-serve/src/stats.rs
+++ b/crates/aprender-serve/src/stats.rs
@@ -411,7 +411,7 @@ fn normal_cdf(x: f64) -> f64 {
     let t = 1.0 / (1.0 + p * x);
     let y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * (-x * x).exp();
 
-    0.5 * (1.0 + sign * y)
+    f64::midpoint(1.0, sign * y)
 }
 
 include!("stats_assign_ranks.rs");

--- a/crates/aprender-simulate/src/domains/monte_carlo.rs
+++ b/crates/aprender-simulate/src/domains/monte_carlo.rs
@@ -512,9 +512,7 @@ impl WorkStealingMonteCarlo {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            num_workers: std::thread::available_parallelism()
-                .map(std::num::NonZero::get)
-                .unwrap_or(4),
+            num_workers: std::thread::available_parallelism().map_or(4, std::num::NonZero::get),
         }
     }
 

--- a/crates/aprender-test-cli/src/config.rs
+++ b/crates/aprender-test-cli/src/config.rs
@@ -160,9 +160,7 @@ impl CliConfig {
     #[allow(clippy::redundant_closure_for_method_calls)] // Cannot use NonZero::get directly due to MSRV 1.75 (stable in 1.79)
     pub fn effective_jobs(&self) -> usize {
         if self.parallel_jobs == 0 {
-            std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1)
+            std::thread::available_parallelism().map_or(1, |n| n.get())
         } else {
             self.parallel_jobs
         }

--- a/crates/aprender-test-cli/src/handlers/build.rs
+++ b/crates/aprender-test-cli/src/handlers/build.rs
@@ -33,14 +33,12 @@ pub fn scan_files_recursive(dir: &Path, extension: &str, files: &mut Vec<PathBuf
 /// Check if an HTML file references WASM
 #[must_use]
 pub fn html_references_wasm(html_path: &Path) -> bool {
-    std::fs::read_to_string(html_path)
-        .map(|content| {
-            content.contains(".wasm")
-                || content.contains("WebAssembly")
-                || content.contains("wasm-bindgen")
-                || content.contains("wasm_bindgen")
-        })
-        .unwrap_or(false)
+    std::fs::read_to_string(html_path).is_ok_and(|content| {
+        content.contains(".wasm")
+            || content.contains("WebAssembly")
+            || content.contains("wasm-bindgen")
+            || content.contains("wasm_bindgen")
+    })
 }
 
 /// Find which HTML files reference WASM

--- a/crates/aprender-test-cli/src/handlers/comply.rs
+++ b/crates/aprender-test-cli/src/handlers/comply.rs
@@ -357,9 +357,9 @@ pub fn check_c002_console_errors() -> ComplianceResult {
 pub fn check_c003_custom_elements(path: &Path) -> ComplianceResult {
     let html_files = find_html_files_in_dir(path);
     let has_custom_elements = html_files.iter().any(|f| {
-        std::fs::read_to_string(f)
-            .map(|content| content.contains("customElements.define") || content.contains("<wasm-"))
-            .unwrap_or(false)
+        std::fs::read_to_string(f).is_ok_and(|content| {
+            content.contains("customElements.define") || content.contains("<wasm-")
+        })
     });
 
     if has_custom_elements {

--- a/crates/aprender-test-cli/src/handlers/coverage.rs
+++ b/crates/aprender-test-cli/src/handlers/coverage.rs
@@ -130,7 +130,7 @@ pub fn calculate_coverage(row: usize, col: usize, rows: usize, cols: usize) -> f
     }
     let x_factor = col as f32 / (cols - 1) as f32;
     let y_factor = row as f32 / (rows - 1) as f32;
-    (x_factor + y_factor) / 2.0
+    f32::midpoint(x_factor, y_factor)
 }
 
 /// Create sample coverage data for demonstration

--- a/crates/aprender-test-cli/src/main.rs
+++ b/crates/aprender-test-cli/src/main.rs
@@ -729,7 +729,7 @@ fn run_build(args: &probador::BuildArgs) -> CliResult<()> {
             args.profiling,
         )
         .await
-        .map_err(|e| probador::CliError::test_execution(e))
+        .map_err(probador::CliError::test_execution)
     })
 }
 
@@ -774,7 +774,7 @@ fn run_brick_generation(args: &probador::BuildArgs) -> CliResult<()> {
     println!("Generating artifacts...");
 
     let result = generate_from_bricks(Some(&worker), Some(&events), None, &config)
-        .map_err(|e| probador::CliError::test_execution(e))?;
+        .map_err(probador::CliError::test_execution)?;
 
     println!("\nGenerated files:");
     for file in &result.files_written {
@@ -824,7 +824,7 @@ fn run_watch(args: &probador::WatchArgs) -> CliResult<()> {
     rt.block_on(async {
         run_wasm_pack_build(&path, &target, release, None, false)
             .await
-            .map_err(|e| probador::CliError::test_execution(e))
+            .map_err(probador::CliError::test_execution)
     })?;
 
     // Start server if requested

--- a/crates/aprender-test-cli/src/runner.rs
+++ b/crates/aprender-test-cli/src/runner.rs
@@ -89,7 +89,7 @@ impl TestResults {
 
     /// Get total number of tests
     #[must_use]
-    pub fn total(&self) -> usize {
+    pub const fn total(&self) -> usize {
         self.results.len()
     }
 

--- a/crates/aprender-test-cli/src/score.rs
+++ b/crates/aprender-test-cli/src/score.rs
@@ -1177,8 +1177,7 @@ impl ScoreCalculator {
     fn find_files(&self, pattern: &str) -> usize {
         let full_pattern = self.root.join(pattern);
         glob(full_pattern.to_string_lossy().as_ref())
-            .map(|paths| paths.filter_map(Result::ok).count())
-            .unwrap_or(0)
+            .map_or(0, |paths| paths.filter_map(Result::ok).count())
     }
 
     /// Generate recommendations from category scores

--- a/crates/aprender-test-cli/src/simulation.rs
+++ b/crates/aprender-test-cli/src/simulation.rs
@@ -201,7 +201,7 @@ impl ParameterVariation {
             distribution: Distribution::Uniform,
             min,
             max,
-            base: (min + max) / 2.0,
+            base: f64::midpoint(min, max),
         }
     }
 

--- a/crates/aprender-test-cli/src/wasm_testing.rs
+++ b/crates/aprender-test-cli/src/wasm_testing.rs
@@ -188,8 +188,7 @@ impl Recording {
             viewport: Viewport::default(),
             start_time: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_millis() as u64),
             duration_ms: 0,
             events: Vec::new(),
             metadata: RecordingMetadata::default(),
@@ -464,8 +463,7 @@ impl PerformanceBaseline {
             commit: commit.into(),
             timestamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
             metrics: Vec::new(),
         }
     }

--- a/crates/aprender-test-lib/src/av_sync/extraction.rs
+++ b/crates/aprender-test-lib/src/av_sync/extraction.rs
@@ -67,7 +67,9 @@ pub fn extract_audio(video_path: &Path, sample_rate: u32) -> Result<Vec<f32>, Pr
     }
 
     let samples: Vec<f32> = bytes
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|chunk| {
             let arr: [u8; 4] = [chunk[0], chunk[1], chunk[2], chunk[3]];
             f32::from_le_bytes(arr)

--- a/crates/aprender-test-lib/src/brick/compute.rs
+++ b/crates/aprender-test-lib/src/brick/compute.rs
@@ -757,16 +757,19 @@ impl Brick for ComputeBrick {
                         ));
                     }
                 }
-                TileOp::StoreShared { dst } => {
-                    if !tensor_names.contains(&dst.as_str()) {
-                        failed.push((
-                            BrickAssertion::Custom {
-                                name: "tensor_exists".into(),
-                                validator_id: 4,
-                            },
-                            format!("StoreShared references unknown tensor: {}", dst),
-                        ));
-                    }
+                // Guard rather than a nested `if`: a false guard falls through
+                // to `_ => {}`, which is what the empty `if` body did.
+                // clippy::collapsible_match (fires here and not on the
+                // identically-shaped LoadShared arm above, which is not the
+                // last named arm).
+                TileOp::StoreShared { dst } if !tensor_names.contains(&dst.as_str()) => {
+                    failed.push((
+                        BrickAssertion::Custom {
+                            name: "tensor_exists".into(),
+                            validator_id: 4,
+                        },
+                        format!("StoreShared references unknown tensor: {}", dst),
+                    ));
                 }
                 _ => {}
             }

--- a/crates/aprender-test-lib/src/brick/distributed.rs
+++ b/crates/aprender-test-lib/src/brick/distributed.rs
@@ -845,7 +845,7 @@ impl WorkerQueue {
         let mut queue = self.local_queue.write().expect("lock poisoned");
         queue.push(task);
         // Sort by priority (higher first)
-        queue.sort_by(|a, b| b.priority.cmp(&a.priority));
+        queue.sort_by_key(|a| std::cmp::Reverse(a.priority));
     }
 
     /// Pop a task from the local queue (highest priority first)
@@ -1024,7 +1024,7 @@ impl WorkStealingScheduler {
         }
 
         // Sort by queue length (steal from busiest)
-        candidates.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        candidates.sort_by_key(|a| std::cmp::Reverse(a.1.len()));
 
         // Try to steal from the busiest queue
         for (_, queue) in candidates {

--- a/crates/aprender-test-lib/src/brick/web_sys_gen.rs
+++ b/crates/aprender-test-lib/src/brick/web_sys_gen.rs
@@ -261,7 +261,12 @@ impl FetchClient {
 
     /// Fetch bytes from a URL (native fallback - returns error)
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(clippy::unused_async)] // Must be async for API compatibility with WASM target
+    // Same reason as the `unused_async` allow that has been here since this
+    // fallback was written: the wasm32 sibling of this method IS async, and the
+    // two must have the same signature. clippy::unused_async_trait_impl is new
+    // in 1.98 and fires here despite `FetchClient` being an inherent impl, not
+    // a trait impl.
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)] // Must be async for API compatibility with WASM target
     pub async fn fetch_bytes(&self, _url: &str) -> Result<Vec<u8>, WebSysError> {
         Err(WebSysError::NotInBrowser)
     }

--- a/crates/aprender-test-lib/src/coverage/memory.rs
+++ b/crates/aprender-test-lib/src/coverage/memory.rs
@@ -66,9 +66,11 @@ impl<'a> CoverageMemoryView<'a> {
     pub fn read_all_counters(&self) -> Vec<u64> {
         let slice = &self.memory[self.counter_base..];
         slice
-            .chunks_exact(8)
+            .as_chunks::<8>()
+            .0
+            .iter()
             .take(self.block_count)
-            .map(|b| u64::from_le_bytes(b.try_into().unwrap_or([0; 8])))
+            .map(|b| u64::from_le_bytes(*b))
             .collect()
     }
 

--- a/crates/aprender-test-lib/src/coverage/superblock.rs
+++ b/crates/aprender-test-lib/src/coverage/superblock.rs
@@ -175,11 +175,9 @@ impl SuperblockBuilder {
 
         let effective_size = self.target_size.min(self.max_size);
         let mut superblocks = Vec::new();
-        let mut next_id = self.next_id;
 
-        for chunk in blocks.chunks(effective_size) {
+        for (next_id, chunk) in (self.next_id..).zip(blocks.chunks(effective_size)) {
             let id = SuperblockId::new(next_id);
-            next_id += 1;
             superblocks.push(Superblock::new(id, chunk.to_vec(), function));
         }
 

--- a/crates/aprender-test-lib/src/fixture.rs
+++ b/crates/aprender-test-lib/src/fixture.rs
@@ -196,7 +196,7 @@ impl FixtureManager {
             .iter()
             .map(|(id, e)| (*id, e.priority))
             .collect();
-        ordered.sort_by(|a, b| b.1.cmp(&a.1));
+        ordered.sort_by_key(|a| std::cmp::Reverse(a.1));
 
         self.setup_order.clear();
 

--- a/crates/aprender-test-lib/src/llm/gpu_telemetry.rs
+++ b/crates/aprender-test-lib/src/llm/gpu_telemetry.rs
@@ -66,6 +66,13 @@ impl GpuTelemetryCollector {
     }
 
     /// Start collecting GPU telemetry in the background.
+    // `GpuTelemetryCollector` is an inherent impl, not a trait impl, and this is
+    // a public `async fn` that callers `.await`; dropping the `async` would be a
+    // breaking API change to satisfy a lint whose own suggestion does not apply
+    // here (it proposes wrapping one branch of the `if` in
+    // `std::future::ready`, which does not compile). clippy::
+    // unused_async_trait_impl, new in 1.98.
+    #[allow(unknown_lints, clippy::unused_async_trait_impl)]
     pub async fn start(&mut self) -> Result<(), String> {
         let interval = self.poll_interval_s;
         let nvsmi_args = format!(

--- a/crates/aprender-train/src/monitor/inference/collector/stream.rs
+++ b/crates/aprender-train/src/monitor/inference/collector/stream.rs
@@ -101,7 +101,7 @@ impl<P: DecisionPath + Serialize, W: Write + Send + Sync> TraceCollector<P>
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        let traces: Vec<_> = self.buffer.drain(..).collect();
+        let traces: Vec<_> = std::mem::take(&mut self.buffer);
         for trace in traces {
             self.write_trace(&trace)?;
         }

--- a/crates/aprender-train/src/optim/dp/accountant.rs
+++ b/crates/aprender-train/src/optim/dp/accountant.rs
@@ -55,9 +55,7 @@ impl RdpAccountant {
 
     /// Reset the accountant
     pub fn reset(&mut self) {
-        for r in &mut self.rdp {
-            *r = 0.0;
-        }
+        self.rdp.fill(0.0);
         self.steps = 0;
     }
 }

--- a/crates/aprender-verify-ml/src/mutator/ast_mutator.rs
+++ b/crates/aprender-verify-ml/src/mutator/ast_mutator.rs
@@ -502,28 +502,26 @@ impl AstMutator {
                     }
                 }
             }
-            PythonNode::FuncDef { name, args, body } => {
-                if body.len() > 1 {
-                    for i in 0..body.len() {
-                        let mut new_body = body.clone();
-                        new_body.remove(i);
+            PythonNode::FuncDef { name, args, body } if body.len() > 1 => {
+                for i in 0..body.len() {
+                    let mut new_body = body.clone();
+                    new_body.remove(i);
 
-                        let mutated = PythonNode::FuncDef {
-                            name: name.clone(),
-                            args: args.clone(),
-                            body: new_body,
-                        };
+                    let mutated = PythonNode::FuncDef {
+                        name: name.clone(),
+                        args: args.clone(),
+                        body: new_body,
+                    };
 
-                        let mut del_path = path.clone();
-                        del_path.push(i);
+                    let mut del_path = path.clone();
+                    del_path.push(i);
 
-                        mutations.push(AstMutation {
-                            operator: MutationOperator::Sdl,
-                            path: del_path,
-                            description: format!("Delete function body statement {}", i + 1),
-                            mutated_ast: mutated,
-                        });
-                    }
+                    mutations.push(AstMutation {
+                        operator: MutationOperator::Sdl,
+                        path: del_path,
+                        description: format!("Delete function body statement {}", i + 1),
+                        mutated_ast: mutated,
+                    });
                 }
             }
             _ => {}

--- a/crates/aprender-zram-core/src/samefill.rs
+++ b/crates/aprender-zram-core/src/samefill.rs
@@ -146,8 +146,12 @@ unsafe fn page_same_filled_avx512(page: &[u8; PAGE_SIZE]) -> Option<u64> {
 pub fn fill_page_word(page: &mut [u8; PAGE_SIZE], value: u64) {
     // Convert u64 to bytes and fill - safe regardless of alignment
     let bytes = value.to_ne_bytes();
-    for chunk in page.chunks_exact_mut(8) {
-        chunk.copy_from_slice(&bytes);
+    // `as_chunks_mut::<8>()` yields `&mut [u8; 8]`, so this is a whole-array
+    // assignment instead of a length-checked `copy_from_slice`.
+    // clippy::chunks_exact_to_as_chunks (new in 1.98).
+    let (chunks, _rest) = page.as_chunks_mut::<8>();
+    for chunk in chunks {
+        *chunk = bytes;
     }
 }
 
@@ -175,12 +179,13 @@ pub fn detect_same_fill(page: &[u8; PAGE_SIZE]) -> SameFillResult {
     let fill_word = u64::from_ne_bytes([first_byte; 8]);
 
     // Check 8 bytes at a time
-    let chunks = page.chunks_exact(8);
-    let remainder = chunks.remainder();
+    // `as_chunks::<8>()` yields `&[u8; 8]` directly, so the fallible
+    // `try_into().expect(...)` below is gone: the 8-byte width is now a type,
+    // not a runtime claim. clippy::chunks_exact_to_as_chunks (new in 1.98).
+    let (chunks, remainder) = page.as_chunks::<8>();
 
     for chunk in chunks {
-        // chunks_exact guarantees exactly 8-byte chunks, so try_into always succeeds
-        let word = u64::from_ne_bytes(chunk.try_into().expect("chunks_exact guarantees 8 bytes"));
+        let word = u64::from_ne_bytes(*chunk);
         if word != fill_word {
             return SameFillResult::NotSameFill;
         }


### PR DESCRIPTION
## The defect

`aprender/Toolchain Ceiling` is one of the seven lanes the infra nightly audit's
`lane-liveness` dead-man's switch reported dead on 2026-08-27
(infra run 33071842506):

    aprender/Toolchain Ceiling   DEAD no-healthy 8d (>3d) — not allowlisted

The lane is doing precisely what aprender#2370 built it to do. It was green
through 2026-08-19 and has failed every scheduled run since 2026-08-20 — Rust
1.98.0 was released 2026-08-18 — with the message it exists to print:

    ✗ TOOLCHAIN CEILING DRIFT: the tree does NOT pass clippy on current stable
      (1.98.0). It still passes on the pinned 1.93.0, which is why no PR
      gate caught this - see aprender#2370.

## 71 findings, not 2

`cargo clippy --all-targets -- -D warnings` stops at the first crate that fails,
so the nightly log only ever showed the first wave (two `chunks_exact` hits in
`apr-format`). Each fix revealed the next. **Ten passes to reach zero**, nine
lints, all new in 1.98:

| count | lint |
|---|---|
| 57 | `chunks_exact_to_as_chunks` |
| 6 | `unused_async_trait_impl` |
| 3 | `unnecessary_sort_by` |
| 2 | `unnecessary_trailing_comma` |
| 1 each | `manual_slice_fill`, `manual_midpoint`, `manual_is_variant_and`, `manual_checked_ops`, `explicit_counter_loop`, `collapsible_match` |

`as_chunks::<N>()` is the bulk, and it is a real improvement rather than a
respelling: it yields `&[T; N]`, so the chunk width is a **type** instead of a
runtime claim, and nine `chunk.try_into().expect("chunk is N bytes")` calls
simply disappear.

## What is not mechanical, and why

Six `unused_async_trait_impl` hits. Two fixed, four left `async` behind a
documented `#[allow]`, for four different reasons:

- **aprender-db `MemoryKvStore` — FIXED, not allowed.** The trait already
  declares `-> impl Future<..> + Send`, every operation is a synchronous DashMap
  access, and clippy is right. (`+ Send` is carried over from the trait —
  clippy's suggestion drops it, which would not compile.)
- **aprender-orchestrate `estimate_rust_score` / `estimate_repo_scores` —
  allowed, having tried the fix.** De-asyncing them moved the lint up to
  `run_rust_project_score` / `run_repo_score`; de-asyncing those moves it to the
  **public** `check_component`. Nothing in `QualityChecker` ever awaits — every
  leaf is a blocking `std::process::Command`. Making that module honestly
  synchronous is worth doing and is not a toolchain-drift fix.
- **aprender-graph `read_parquet`/`write_parquet`, aprender-test-lib
  `fetch_bytes` — allowed.** All three already carried
  `#[allow(clippy::unused_async)]` with an author-written reason; this is the
  same finding under a new lint name. For the parquet pair, the suggestion would
  additionally run the write **eagerly at call time** instead of at await time.
- **aprender-test-lib `GpuTelemetryCollector::start` — allowed.** Public `async
  fn` that callers `.await`, and clippy's own suggestion does not compile here
  (it proposes wrapping one branch of an `if` in `std::future::ready`).

Every one of those allows is written `#[allow(unknown_lints,
clippy::unused_async_trait_impl)]`. **Without `unknown_lints` the pinned 1.93
toolchain fails** with `error: unknown lint: clippy::unused_async_trait_impl` —
a ceiling fix that breaks the floor. Caught by running both, not by reading.

## A defect introduced by clippy's own autofix

`manual_slice_fill`'s machine-applicable suggestion is
`&mut self.rdp.fill(0.0);` — a borrow of `()`. `cargo clippy --fix` applied it;
the next pass caught it with `unnecessary_operation` + `unused borrow that must
be used`. It is fixed here, and it is why every pass was re-run rather than
trusted.

## One extraction that is not a clippy finding

`AprReader::from_bytes` is split, because the repo's own pre-commit gate refused
the commit:

    Complexity check... ❌
      crates/aprender-core/src/serialization/apr/mod.rs
      from_bytes (line 62) - Cognitive 26 > 25

That is **pre-existing** debt, not caused by this change — verified by running
`pmat analyze complexity` against `git show HEAD:` of the same file, which
reports the identical 26 > 25. The hook only inspects staged files, so touching
four unrelated lines is what made it visible. `--no-verify` is not an option, so
the 20 straight `if let Some(..)` metadata copies move to `v2_metadata_to_flat`
— a pure code move. The file now reports no function over either threshold.

## Verification

Every gate this lane and the normal CI lint job run, measured locally:

    $ cargo +1.98.0 clippy --all-targets -- -D warnings     # the ceiling gate
      Finished ... EXIT=0                                   # was: 71 findings
    $ cargo +1.93.0 clippy --all-targets -- -D warnings     # the pin, normal CI
      Finished ... EXIT=0
    $ bash scripts/check_msrv.sh                            # the lane's msrv-floor job
      ✓ workspace builds on its declared MSRV 1.91
    $ cargo fmt --all -- --check                            # exit 0
    $ pmat analyze complexity --file .../apr/mod.rs --max-cognitive 25
      no functions found exceeding the thresholds

Tests, on the pinned 1.93 toolchain, over the nine crates carrying the
behavioural rewrites (`apr-format`, `aprender-core`, `aprender-compute`,
`aprender-zram-core`, `aprender-present-core`, `aprender-db`,
`aprender-orchestrate`, `aprender-contracts-cli`, `aprender-graph`):

    26,414 passed; 0 failed; 13 ignored

Honest caveat: that test run predates the `from_bytes` extraction (a pure code
move made afterwards to satisfy the complexity gate); the re-run of
`aprender-core`'s suite had not finished when this PR was opened. `Toolchain
Ceiling` was also dispatched on this branch (run 33163324585) but the intel pool
was saturated — 16/16 runners busy — so its result is not in this description.
Read both before merging.

Note also that local `stable` on the box I used is 1.97.1, so
`check_clippy_current_stable.sh` would have linted the wrong toolchain here;
1.98.0 was named explicitly, which is what CI's `rustup toolchain install
stable` resolves to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)