### PR TITLE
fix(perf): the gate's selftest was green on a hand-typed drain_ms, red on every real measurement

### DIFF
--- a/crates/aprender-test-lib/src/lib.rs
+++ b/crates/aprender-test-lib/src/lib.rs
@@ -564,6 +564,25 @@ pub mod animation;
 )]
 pub mod presentar;
 
+/// APR-PERF-GATE-001 v2.2 §4.4.6 / §4.4.7 — the receipt producers.
+///
+/// `scripts/perf_gate.sh` fails any receipt whose `drain_ms` or
+/// `tokenization` block is absent, and until PERF-026 nothing in the workspace
+/// produced either: `grep -rn "drain_ms" --include="*.rs" crates` returned zero
+/// lines, so the gate was green on its own hand-typed fixture and red on every
+/// measurement that could ever be taken.
+///
+/// Compiled under DEFAULT features on purpose. CI runs
+/// `cargo nextest run --workspace --lib` with no `--features`, so a producer
+/// placed behind the non-default `llm` feature would never be gated.
+#[allow(
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
+    clippy::missing_const_for_fn,
+    clippy::doc_markdown
+)]
+pub mod perf_gate;
+
 /// LLM Testing: Correctness assertions and load testing for OpenAI-compatible APIs.
 ///
 /// Feature-gated behind `llm`. Provides HTTP client, assertion builders,

--- a/crates/aprender-test-lib/src/perf_gate/drain.rs
+++ b/crates/aprender-test-lib/src/perf_gate/drain.rs
@@ -1,0 +1,778 @@
+//! §4.4.7 boundary effects and drain — the producer for `drain_ms`, and for the
+//! four request counters that must never be conflated.
+//!
+//! # Why this exists
+//!
+//! `scripts/perf_gate.sh:42` fails any receipt whose `drain_ms` is absent. On
+//! `62d23d8d1`, `grep -rn "drain_ms" --include="*.rs" crates` returned **zero
+//! lines**: nothing in the workspace could produce the field, so Arm C rejected
+//! every receipt that could ever be measured. A gate that can only fail is the
+//! mirror of one that can only pass.
+//!
+//! # What `drain_ms` MEANS (§4.4.7), stated before it is computed
+//!
+//! The measurement window opens at offset `0` and **closes at `T`**. No new
+//! request is issued at or after `T` (I-14). Every request issued before `T` is
+//! then *drained* — allowed to run on past `T` to completion or timeout.
+//!
+//! > `drain_ms` = (last settlement of any pre-`T` request) − `T`, clamped at 0.
+//!
+//! It is the length of the **drain phase**, not a property of any one request,
+//! and it is `0` when nothing was still in flight at `T`. §4.4.7's `SUSPECT`
+//! rule reads it exactly that way: `drain_ms > 0.5 × window` means one request
+//! dominated the window and the band must be re-run longer.
+//!
+//! # The conflation this module refuses to make
+//!
+//! §4.4.7: "A request that timed out during drain increments `timeouts`; one
+//! **abandoned at drain deadline** increments `truncated`."
+//!
+//! `truncated` therefore means *the drain deadline arrived while this request
+//! was still running*. It does **not** mean `finish_reason == "length"`.
+//! W1 (§4.3.1) generates with `max_tokens = 128` and **EOS ignored**, so every
+//! single healthy W1 request ends with `finish_reason == "length"`. §4.4.3 puts
+//! `agg_tok_s`'s numerator over "completed, **non-truncated**" requests — so
+//! reading `truncated` in the finish-reason sense empties the numerator and
+//! reports `0 tok/s` for a perfectly healthy server. The two senses are named
+//! apart here on purpose: [`Outcome::AbandonedAtDrain`] is the §4.4.7 sense and
+//! is the only thing that increments `truncated`.
+//!
+//! # Timeouts are their own counter, and it is checked, not just named
+//!
+//! §4.4.3 fixes a hard **120 s per request**. [`Outcome::Timeout`] and
+//! [`Outcome::Failed`] are distinct counters (I-5 makes `timeouts > 0` fatal to
+//! a host's ratio, while a transport error is a different fault), and
+//! [`BandInput::derive`] *verifies* the label against the request's own
+//! duration: a `Timeout` that did not reach the timeout, or a `Failed` that
+//! exceeded it, is refused rather than counted.
+//!
+//! # Nothing here is defaulted
+//!
+//! Every number below is derived from per-request timestamps supplied by the
+//! caller. There is no constructor that accepts a `drain_ms` scalar, because a
+//! caller-supplied `drain_ms` is indistinguishable from a fabricated one — the
+//! same rule `scripts/lib/bench_receipt.py` already applies to ratios ("a stated
+//! ratio that its own samples do not produce is a fabricated measurement").
+
+use serde::{Deserialize, Serialize};
+
+/// §4.4.3 — the hard per-request timeout, in milliseconds.
+pub const REQUEST_TIMEOUT_MS: f64 = 120_000.0;
+
+/// §4.4.7 — `drain_ms > DRAIN_SUSPECT_FRACTION × window_ms` is annotated `SUSPECT`.
+pub const DRAIN_SUSPECT_FRACTION: f64 = 0.5;
+
+/// How one sampled request ended. The four variants are mutually exclusive, so
+/// `requested == completed + timeouts + truncated + errors` holds by
+/// construction rather than by convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// Returned a usable response, inside the window or during the drain.
+    Completed,
+    /// Reached the §4.4.3 hard 120 s timeout.
+    Timeout,
+    /// Still running when the drain deadline arrived (§4.4.7). Increments
+    /// `truncated`. **Not** `finish_reason == "length"` — see the module docs.
+    AbandonedAtDrain,
+    /// Any other fault: transport, non-2xx, unparseable body. Counted apart
+    /// from [`Outcome::Timeout`] because they are different defects.
+    Failed,
+}
+
+/// One sampled request's terminal record. All offsets are milliseconds from the
+/// window opening at `0`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequestOutcome {
+    /// When the client issued the request.
+    pub issued_ms: f64,
+    /// When the request reached its terminal state.
+    pub settled_ms: f64,
+    /// How it ended.
+    pub outcome: Outcome,
+    /// Generated (completion) tokens. Must be non-zero for a completion:
+    /// Arm C treats a zero-token response as a failure, not a fast request.
+    pub generated_tokens: u32,
+    /// Time to first token, when the transport streamed. `None` for a
+    /// non-streaming client, which genuinely cannot observe it.
+    pub ttft_ms: Option<f64>,
+    /// Absolute arrival offsets of each generated token, when the transport
+    /// streamed. Empty for a non-streaming client.
+    pub token_times_ms: Vec<f64>,
+}
+
+impl RequestOutcome {
+    /// Wall-clock duration of the request.
+    #[must_use]
+    pub fn duration_ms(&self) -> f64 {
+        self.settled_ms - self.issued_ms
+    }
+
+    /// §4.4.3 — per-request `decode_tok_s = (tokens − 1) / (last − first)`.
+    /// `None` unless the transport streamed at least two tokens.
+    #[must_use]
+    pub fn decode_tok_per_sec(&self) -> Option<f64> {
+        let (first, last) = (self.token_times_ms.first()?, self.token_times_ms.last()?);
+        let span_s = (last - first) / 1000.0;
+        let n = self.token_times_ms.len();
+        if n < 2 || span_s <= 0.0 {
+            return None;
+        }
+        Some((n as f64 - 1.0) / span_s)
+    }
+
+    /// §4.4.3 — this request's inter-token gaps, in milliseconds.
+    #[must_use]
+    pub fn itl_gaps_ms(&self) -> Vec<f64> {
+        self.token_times_ms
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .collect()
+    }
+}
+
+/// §4.7.1 — a band's comparator posture.
+///
+/// There is deliberately **no `Measured` variant**. A comparator ratio needs a
+/// baseline object that itself passes every receipt rule (I-3) and a comparator
+/// lane driven by the same client binary (I-15, PERF-019). This producer cannot
+/// derive one, so it cannot emit one: an unbacked `agg_ratio` is the exact
+/// fabrication this epic exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComparatorStatus {
+    /// Permanent exclusion. Needs the decision recorded, per §4.7.1.
+    NotApplicable {
+        /// Who decided, e.g. `perf-matrix.yaml`.
+        decided_by: String,
+        /// Why the comparator cannot exist for this cell.
+        reason: String,
+    },
+    /// Temporary. Counted against the denominator; needs an owner.
+    Unmeasured {
+        /// Who owes the measurement.
+        owner: String,
+        /// Why it has not been measured yet.
+        reason: String,
+    },
+}
+
+impl ComparatorStatus {
+    /// The wire token `perf_gate.sh` reads from `band.comparator_status`.
+    #[must_use]
+    pub fn wire_token(&self) -> &'static str {
+        match self {
+            Self::NotApplicable { .. } => "NOT_APPLICABLE",
+            Self::Unmeasured { .. } => "UNMEASURED",
+        }
+    }
+}
+
+/// One band's raw input: the window it ran, and every request it sampled.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BandInput {
+    /// Fixed concurrency `c`.
+    pub concurrency: u32,
+    /// `T` — the window close, in milliseconds from window open.
+    pub window_ms: f64,
+    /// Every sampled request's terminal record.
+    pub requests: Vec<RequestOutcome>,
+    /// This cell's comparator posture.
+    pub comparator: ComparatorStatus,
+}
+
+/// Everything §4.4.7 and §4.4.3 derive from a [`BandInput`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DerivedBand {
+    /// Fixed concurrency `c`.
+    pub concurrency: u32,
+    /// `T`, in milliseconds.
+    pub window_ms: f64,
+    /// §4.4.7 — length of the drain phase, in milliseconds.
+    pub drain_ms: f64,
+    /// §4.4.7 `SUSPECT` annotations; empty when the band is clean.
+    pub suspect: Vec<String>,
+    /// Requests issued before `T`.
+    pub requested: usize,
+    /// Requests that returned a usable response.
+    pub completed: usize,
+    /// Requests that reached the 120 s hard timeout.
+    pub timeouts: usize,
+    /// Requests abandoned at the drain deadline (§4.4.7 sense).
+    pub truncated: usize,
+    /// Requests that failed for any other reason.
+    pub errors: usize,
+    /// Σ generated tokens over completed requests — `agg_tok_s`'s numerator.
+    pub tokens_total: u64,
+    /// `agg_tok_s`'s denominator: last completion − first request start, in ms.
+    pub span_ms: f64,
+    /// §4.4.3 — wall-clock aggregate throughput.
+    pub aggregate_tok_per_sec: f64,
+    /// §4.4.3 — median per-request decode rate. `None` without streaming.
+    pub decode_tok_per_sec: Option<f64>,
+    /// p50 time-to-first-token. `None` without streaming.
+    pub ttft_p50_ms: Option<f64>,
+    /// p95 time-to-first-token. `None` without streaming.
+    pub ttft_p95_ms: Option<f64>,
+    /// p50 of the pooled inter-token gaps. `None` without streaming.
+    pub itl_p50_ms: Option<f64>,
+    /// p95 of the pooled inter-token gaps. `None` without streaming.
+    pub itl_p95_ms: Option<f64>,
+    /// Per-request end-to-end latencies of completed requests (§4.4.5, I-4).
+    pub latencies_ms: Vec<f64>,
+    /// §4.5 fields this client could not produce, each with its reason. Never
+    /// silently omitted and never filled with a plausible number.
+    pub unproduced: Vec<String>,
+    /// This cell's comparator posture.
+    pub comparator: ComparatorStatus,
+}
+
+impl BandInput {
+    /// Derive every §4.4.3/§4.4.7 quantity from the sampled requests.
+    ///
+    /// # Errors
+    /// When the band violates the measurement protocol: an empty band, a
+    /// non-positive window, a request issued at or after `T` (I-14), a
+    /// settlement before its issue, a zero-token completion, an abandonment
+    /// that did not happen during the drain, or a `Timeout`/`Failed` label that
+    /// the request's own duration contradicts.
+    pub fn derive(&self) -> Result<DerivedBand, String> {
+        self.validate()?;
+        let drain_ms = self.drain_ms();
+        let span_ms = self.span_ms();
+        let tokens_total = self.tokens_total();
+        Ok(DerivedBand {
+            concurrency: self.concurrency,
+            window_ms: self.window_ms,
+            drain_ms,
+            suspect: self.suspect(drain_ms),
+            requested: self.requests.len(),
+            completed: self.count(Outcome::Completed),
+            timeouts: self.count(Outcome::Timeout),
+            truncated: self.count(Outcome::AbandonedAtDrain),
+            errors: self.count(Outcome::Failed),
+            tokens_total,
+            span_ms,
+            aggregate_tok_per_sec: rate_per_sec(tokens_total as f64, span_ms),
+            decode_tok_per_sec: self.decode_median(),
+            ttft_p50_ms: self.ttft_percentile(0.50),
+            ttft_p95_ms: self.ttft_percentile(0.95),
+            itl_p50_ms: self.itl_percentile(0.50),
+            itl_p95_ms: self.itl_percentile(0.95),
+            latencies_ms: self.latencies_ms(),
+            unproduced: self.unproduced(),
+            comparator: self.comparator.clone(),
+        })
+    }
+
+    fn completed_iter(&self) -> impl Iterator<Item = &RequestOutcome> {
+        self.requests
+            .iter()
+            .filter(|r| r.outcome == Outcome::Completed)
+    }
+
+    fn count(&self, outcome: Outcome) -> usize {
+        self.requests
+            .iter()
+            .filter(|r| r.outcome == outcome)
+            .count()
+    }
+
+    fn tokens_total(&self) -> u64 {
+        self.completed_iter()
+            .map(|r| u64::from(r.generated_tokens))
+            .sum()
+    }
+
+    /// §4.4.7 — last settlement of any request, minus `T`, clamped at 0.
+    fn drain_ms(&self) -> f64 {
+        let last = self
+            .requests
+            .iter()
+            .map(|r| r.settled_ms)
+            .fold(f64::NEG_INFINITY, f64::max);
+        (last - self.window_ms).max(0.0)
+    }
+
+    /// §4.4.3 — last completion minus first request start.
+    fn span_ms(&self) -> f64 {
+        let first = self
+            .requests
+            .iter()
+            .map(|r| r.issued_ms)
+            .fold(f64::INFINITY, f64::min);
+        let last = self
+            .completed_iter()
+            .map(|r| r.settled_ms)
+            .fold(f64::NEG_INFINITY, f64::max);
+        (last - first).max(0.0)
+    }
+
+    fn suspect(&self, drain_ms: f64) -> Vec<String> {
+        if self.window_ms > 0.0 && drain_ms > DRAIN_SUSPECT_FRACTION * self.window_ms {
+            return vec![format!(
+                "SUSPECT §4.4.7 c={}: drain_ms={drain_ms:.1} > 0.5 x window_ms={:.1} — one \
+                 request dominated the window; re-run this band with a longer window",
+                self.concurrency, self.window_ms
+            )];
+        }
+        Vec::new()
+    }
+
+    fn latencies_ms(&self) -> Vec<f64> {
+        self.completed_iter()
+            .map(RequestOutcome::duration_ms)
+            .collect()
+    }
+
+    fn decode_median(&self) -> Option<f64> {
+        let rates: Vec<f64> = self
+            .completed_iter()
+            .filter_map(RequestOutcome::decode_tok_per_sec)
+            .collect();
+        percentile(&sorted(rates), 0.50)
+    }
+
+    fn ttft_percentile(&self, p: f64) -> Option<f64> {
+        let v: Vec<f64> = self.completed_iter().filter_map(|r| r.ttft_ms).collect();
+        percentile(&sorted(v), p)
+    }
+
+    fn itl_percentile(&self, p: f64) -> Option<f64> {
+        let v: Vec<f64> = self
+            .completed_iter()
+            .flat_map(RequestOutcome::itl_gaps_ms)
+            .collect();
+        percentile(&sorted(v), p)
+    }
+
+    /// §4.5 fields this client could not observe, named rather than invented.
+    fn unproduced(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if self.ttft_percentile(0.50).is_none() {
+            out.push(format!(
+                "§4.5 c={}: ttft_ms p50/p95 — the transport did not stream, so the client never \
+                 observed a first-token instant",
+                self.concurrency
+            ));
+        }
+        if self.itl_percentile(0.50).is_none() {
+            out.push(format!(
+                "§4.5 c={}: itl_ms p50/p95 and decode_tok_per_sec — the transport did not stream, \
+                 so there are no per-token arrival times to pool",
+                self.concurrency
+            ));
+        }
+        out
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.requests.is_empty() {
+            return Err(format!(
+                "band c={}: no sampled requests — a band over zero requests is a vacuous pass, \
+                 not a measurement",
+                self.concurrency
+            ));
+        }
+        // NaN is caught explicitly: a negated `>` would let it through.
+        if self.window_ms.is_nan() || self.window_ms <= 0.0 {
+            return Err(format!(
+                "band c={}: window_ms={} — the window must have positive length or `drain_ms` \
+                 and the SUSPECT fraction are both undefined",
+                self.concurrency, self.window_ms
+            ));
+        }
+        for (i, r) in self.requests.iter().enumerate() {
+            validate_request(self.concurrency, i, r, self.window_ms)?;
+        }
+        Ok(())
+    }
+}
+
+/// Every per-request rule of §4.4.3 and §4.4.7, applied to one record.
+fn validate_request(c: u32, i: usize, r: &RequestOutcome, window_ms: f64) -> Result<(), String> {
+    let at = format!("band c={c} request[{i}]");
+    if r.issued_ms >= window_ms {
+        return Err(format!(
+            "{at}: issued_ms={} >= T={window_ms} — I-14: no request is issued at or after the \
+             window close, and its tokens are never counted",
+            r.issued_ms
+        ));
+    }
+    if r.settled_ms < r.issued_ms {
+        return Err(format!(
+            "{at}: settled_ms={} precedes issued_ms={}",
+            r.settled_ms, r.issued_ms
+        ));
+    }
+    validate_outcome(&at, r, window_ms)
+}
+
+/// The label a request carries must agree with the clock (§4.4.3, §4.4.7).
+fn validate_outcome(at: &str, r: &RequestOutcome, window_ms: f64) -> Result<(), String> {
+    let d = r.duration_ms();
+    match r.outcome {
+        Outcome::Completed if r.generated_tokens == 0 => Err(format!(
+            "{at}: completed with zero generated tokens — Arm C: a zero-token response is a \
+             failure, not a fast request"
+        )),
+        Outcome::Timeout if d < REQUEST_TIMEOUT_MS => Err(format!(
+            "{at}: labelled Timeout but ran {d:.1} ms < the {REQUEST_TIMEOUT_MS} ms hard timeout \
+             (§4.4.3) — that is a Failed, and the two are separate counters"
+        )),
+        Outcome::Failed if d >= REQUEST_TIMEOUT_MS => Err(format!(
+            "{at}: labelled Failed but ran {d:.1} ms >= the {REQUEST_TIMEOUT_MS} ms hard timeout \
+             — that is a Timeout, which I-5 makes fatal to this host's ratio"
+        )),
+        Outcome::AbandonedAtDrain if r.settled_ms < window_ms => Err(format!(
+            "{at}: labelled AbandonedAtDrain but settled at {}, before T={window_ms} — a request \
+             can only be abandoned during the drain",
+            r.settled_ms
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn rate_per_sec(count: f64, span_ms: f64) -> f64 {
+    if span_ms <= 0.0 {
+        return 0.0;
+    }
+    count / (span_ms / 1000.0)
+}
+
+fn sorted(mut v: Vec<f64>) -> Vec<f64> {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    v
+}
+
+/// Percentile by linear interpolation between order statistics.
+///
+/// Returns `None` for an empty slice: a percentile of nothing is undefined, and
+/// returning `0.0` there is how an empty band reads as an instant one.
+#[must_use]
+pub fn percentile(sorted_ascending: &[f64], p: f64) -> Option<f64> {
+    match sorted_ascending.len() {
+        0 => None,
+        1 => Some(sorted_ascending[0]),
+        n => {
+            let idx = (n as f64 - 1.0) * p;
+            let lo = idx.floor() as usize;
+            let hi = (lo + 1).min(n - 1);
+            let frac = idx - lo as f64;
+            Some(sorted_ascending[lo].mul_add(1.0 - frac, sorted_ascending[hi] * frac))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A completed request that generated `tokens`, issued at `issued_ms` and
+    /// settling `dur_ms` later. Non-streaming: no ttft, no token times.
+    fn done(issued_ms: f64, dur_ms: f64, tokens: u32) -> RequestOutcome {
+        RequestOutcome {
+            issued_ms,
+            settled_ms: issued_ms + dur_ms,
+            outcome: Outcome::Completed,
+            generated_tokens: tokens,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        }
+    }
+
+    fn unmeasured() -> ComparatorStatus {
+        ComparatorStatus::Unmeasured {
+            owner: "perf-gate".to_string(),
+            reason: "no comparator lane on this cell yet (PERF-019)".to_string(),
+        }
+    }
+
+    fn band(window_ms: f64, requests: Vec<RequestOutcome>) -> BandInput {
+        BandInput {
+            concurrency: 4,
+            window_ms,
+            requests,
+            comparator: unmeasured(),
+        }
+    }
+
+    /// THE POINT OF THE TICKET, half one: nothing in flight at `T` means the
+    /// drain phase had zero length. `0.0` here is a measurement, not a default.
+    #[test]
+    fn drain_ms_is_zero_when_nothing_straddles_the_window_close() {
+        let d = band(1000.0, vec![done(0.0, 100.0, 128), done(200.0, 100.0, 128)])
+            .derive()
+            .expect("valid band");
+        assert_eq!(d.drain_ms, 0.0);
+        assert!(d.suspect.is_empty(), "{:?}", d.suspect);
+    }
+
+    /// THE POINT OF THE TICKET, half two: the SAME code path over a band whose
+    /// last request ran past `T` yields a DIFFERENT, non-zero `drain_ms`. A
+    /// defaulted field cannot do this.
+    #[test]
+    fn drain_ms_varies_with_actual_drain_behaviour() {
+        let quiet = band(1000.0, vec![done(0.0, 100.0, 128), done(900.0, 50.0, 128)])
+            .derive()
+            .expect("valid band");
+        let straggler = band(1000.0, vec![done(0.0, 100.0, 128), done(900.0, 350.0, 128)])
+            .derive()
+            .expect("valid band");
+        assert_eq!(quiet.drain_ms, 0.0);
+        assert!((straggler.drain_ms - 250.0).abs() < 1e-9, "{straggler:?}");
+        assert_ne!(quiet.drain_ms, straggler.drain_ms);
+    }
+
+    /// §4.4.7 — `drain_ms > 0.5 x window` is annotated SUSPECT.
+    #[test]
+    fn a_dominating_request_is_annotated_suspect() {
+        let d = band(1000.0, vec![done(0.0, 50.0, 128), done(900.0, 700.0, 128)])
+            .derive()
+            .expect("valid band");
+        assert!((d.drain_ms - 600.0).abs() < 1e-9, "{d:?}");
+        assert_eq!(d.suspect.len(), 1, "{:?}", d.suspect);
+        assert!(d.suspect[0].contains("drain_ms"), "{:?}", d.suspect);
+    }
+
+    /// And the annotation discriminates: just under the fraction stays clean.
+    #[test]
+    fn a_drain_just_under_half_the_window_is_not_suspect() {
+        let d = band(1000.0, vec![done(0.0, 50.0, 128), done(900.0, 599.0, 128)])
+            .derive()
+            .expect("valid band");
+        assert!((d.drain_ms - 499.0).abs() < 1e-9, "{d:?}");
+        assert!(d.suspect.is_empty(), "{:?}", d.suspect);
+    }
+
+    /// I-14, the registered mutation: "issue one request after `T` and count its
+    /// tokens". The band is refused, so the tokens can never be counted.
+    #[test]
+    fn a_request_issued_at_or_after_t_is_refused() {
+        let at_t = band(1000.0, vec![done(0.0, 10.0, 8), done(1000.0, 10.0, 8)]).derive();
+        let after_t = band(1000.0, vec![done(0.0, 10.0, 8), done(1500.0, 10.0, 8)]).derive();
+        for (label, got) in [("at T", at_t), ("after T", after_t)] {
+            let err = got.expect_err(label);
+            assert!(err.contains("I-14"), "{label}: {err}");
+        }
+    }
+
+    /// THE CONFLATION THIS TICKET EXISTS TO PREVENT. Every W1 request stops at
+    /// `max_tokens = 128` with EOS ignored, i.e. every one has
+    /// `finish_reason == "length"`. Read in the finish-reason sense, `truncated`
+    /// would be 8 and §4.4.3's "completed, non-truncated" numerator would be
+    /// EMPTY. In the §4.4.7 sense it is 0 and the numerator is 1024 tokens.
+    #[test]
+    fn max_tokens_truncation_is_not_drain_truncation() {
+        let reqs: Vec<RequestOutcome> = (0..8)
+            .map(|i| done(f64::from(i) * 100.0, 90.0, 128))
+            .collect();
+        let d = band(1000.0, reqs).derive().expect("valid band");
+        assert_eq!(
+            d.truncated, 0,
+            "no request was abandoned at the drain deadline"
+        );
+        assert_eq!(d.completed, 8);
+        assert_eq!(d.tokens_total, 1024, "the numerator must not be emptied");
+        assert!(d.aggregate_tok_per_sec > 0.0, "{d:?}");
+    }
+
+    /// The §4.4.7 sense: a request still running at the drain deadline.
+    #[test]
+    fn an_abandoned_request_increments_truncated_not_completed() {
+        let abandoned = RequestOutcome {
+            issued_ms: 900.0,
+            settled_ms: 1400.0,
+            outcome: Outcome::AbandonedAtDrain,
+            generated_tokens: 12,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let d = band(1000.0, vec![done(0.0, 100.0, 128), abandoned])
+            .derive()
+            .expect("valid band");
+        assert_eq!(d.truncated, 1);
+        assert_eq!(d.completed, 1);
+        assert_eq!(
+            d.tokens_total, 128,
+            "an abandoned request contributes no tokens"
+        );
+        assert!((d.drain_ms - 400.0).abs() < 1e-9, "{d:?}");
+    }
+
+    /// An abandonment that happened before `T` is a contradiction, not a count.
+    #[test]
+    fn an_abandonment_before_the_window_close_is_refused() {
+        let bogus = RequestOutcome {
+            issued_ms: 100.0,
+            settled_ms: 200.0,
+            outcome: Outcome::AbandonedAtDrain,
+            generated_tokens: 1,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let err = band(1000.0, vec![done(0.0, 10.0, 8), bogus])
+            .derive()
+            .expect_err("settled before T");
+        assert!(err.contains("only be abandoned during the drain"), "{err}");
+    }
+
+    /// §4.4.3 — `timeouts` is its own counter, and the label is checked against
+    /// the clock rather than trusted.
+    #[test]
+    fn timeouts_and_failures_are_separate_and_both_are_verified() {
+        let timeout = RequestOutcome {
+            issued_ms: 10.0,
+            settled_ms: 10.0 + REQUEST_TIMEOUT_MS,
+            outcome: Outcome::Timeout,
+            generated_tokens: 0,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let failure = RequestOutcome {
+            issued_ms: 20.0,
+            settled_ms: 45.0,
+            outcome: Outcome::Failed,
+            generated_tokens: 0,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let d = band(1000.0, vec![done(0.0, 10.0, 8), timeout, failure])
+            .derive()
+            .expect("valid band");
+        assert_eq!(d.timeouts, 1);
+        assert_eq!(d.errors, 1);
+        assert_eq!(
+            d.requested,
+            d.completed + d.timeouts + d.truncated + d.errors,
+            "the four counters must partition the requests"
+        );
+    }
+
+    /// A `Timeout` that did not reach 120 s is a mislabelled failure. I-5 makes
+    /// `timeouts > 0` fatal to a host's ratio, so the label must be earned.
+    #[test]
+    fn a_short_request_cannot_be_labelled_a_timeout() {
+        let liar = RequestOutcome {
+            issued_ms: 0.0,
+            settled_ms: 50.0,
+            outcome: Outcome::Timeout,
+            generated_tokens: 0,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let err = band(1000.0, vec![done(500.0, 10.0, 8), liar])
+            .derive()
+            .expect_err("50 ms is not a timeout");
+        assert!(err.contains("hard timeout"), "{err}");
+    }
+
+    /// And the converse: a request that ran past the hard timeout is a timeout,
+    /// not a generic error that would leave `timeouts == 0`.
+    #[test]
+    fn an_over_long_request_cannot_be_labelled_a_plain_failure() {
+        let liar = RequestOutcome {
+            issued_ms: 0.0,
+            settled_ms: REQUEST_TIMEOUT_MS + 1.0,
+            outcome: Outcome::Failed,
+            generated_tokens: 0,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let err = band(1000.0, vec![done(500.0, 10.0, 8), liar])
+            .derive()
+            .expect_err("past the hard timeout");
+        assert!(err.contains("I-5"), "{err}");
+    }
+
+    /// Arm C: "a zero-token response is a failure, not a fast request".
+    #[test]
+    fn a_zero_token_completion_is_refused() {
+        let err = band(1000.0, vec![done(0.0, 10.0, 0)])
+            .derive()
+            .expect_err("zero tokens");
+        assert!(err.contains("zero-token"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_band_is_refused() {
+        let err = band(1000.0, Vec::new()).derive().expect_err("no requests");
+        assert!(err.contains("vacuous"), "{err}");
+    }
+
+    #[test]
+    fn a_non_positive_window_is_refused() {
+        let err = band(0.0, vec![done(-10.0, 5.0, 8)])
+            .derive()
+            .expect_err("zero window");
+        assert!(err.contains("window_ms"), "{err}");
+    }
+
+    /// §4.4.3 — the denominator is wall-clock (last completion − first start),
+    /// never the mean of per-request rates.
+    #[test]
+    fn aggregate_is_wall_clock_over_the_whole_span() {
+        // Two requests, 100 tokens each, spanning 0 -> 2000 ms.
+        let d = band(
+            2500.0,
+            vec![done(0.0, 500.0, 100), done(1000.0, 1000.0, 100)],
+        )
+        .derive()
+        .expect("valid band");
+        assert!((d.span_ms - 2000.0).abs() < 1e-9, "{d:?}");
+        assert!(
+            (d.aggregate_tok_per_sec - 100.0).abs() < 1e-9,
+            "200 tokens over 2 s = 100 tok/s, got {}",
+            d.aggregate_tok_per_sec
+        );
+    }
+
+    /// A non-streaming client cannot observe TTFT or ITL. It says so instead of
+    /// emitting a plausible number.
+    #[test]
+    fn a_non_streaming_band_names_what_it_could_not_produce() {
+        let d = band(1000.0, vec![done(0.0, 100.0, 128)])
+            .derive()
+            .expect("valid band");
+        assert_eq!(d.ttft_p50_ms, None);
+        assert_eq!(d.itl_p95_ms, None);
+        assert_eq!(d.decode_tok_per_sec, None);
+        assert_eq!(d.unproduced.len(), 2, "{:?}", d.unproduced);
+        assert!(d.unproduced.iter().all(|s| s.contains("did not stream")));
+    }
+
+    /// A streaming client produces them, and then `unproduced` is empty.
+    #[test]
+    fn a_streaming_band_produces_ttft_itl_and_decode() {
+        let streamed = RequestOutcome {
+            issued_ms: 0.0,
+            settled_ms: 500.0,
+            outcome: Outcome::Completed,
+            generated_tokens: 5,
+            ttft_ms: Some(100.0),
+            token_times_ms: vec![100.0, 200.0, 300.0, 400.0, 500.0],
+        };
+        let d = band(1000.0, vec![streamed]).derive().expect("valid band");
+        assert_eq!(d.ttft_p50_ms, Some(100.0));
+        assert_eq!(d.itl_p50_ms, Some(100.0));
+        // (5 - 1) tokens over (500 - 100) ms = 10 tok/s.
+        assert_eq!(d.decode_tok_per_sec, Some(10.0));
+        assert!(d.unproduced.is_empty(), "{:?}", d.unproduced);
+    }
+
+    #[test]
+    fn percentile_of_nothing_is_undefined_not_zero() {
+        assert_eq!(percentile(&[], 0.5), None);
+        assert_eq!(percentile(&[7.0], 0.95), Some(7.0));
+        assert_eq!(percentile(&[0.0, 10.0], 0.5), Some(5.0));
+    }
+
+    #[test]
+    fn comparator_status_renders_the_token_the_gate_reads() {
+        assert_eq!(unmeasured().wire_token(), "UNMEASURED");
+        let na = ComparatorStatus::NotApplicable {
+            decided_by: "perf-matrix.yaml".to_string(),
+            reason: "vLLM has no aarch64 build".to_string(),
+        };
+        assert_eq!(na.wire_token(), "NOT_APPLICABLE");
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/mod.rs
+++ b/crates/aprender-test-lib/src/perf_gate/mod.rs
@@ -1,0 +1,546 @@
+//! APR-PERF-GATE-001 v2.2 §4.4.6 / §4.4.7 — the receipt producers.
+//!
+//! # The defect this closes (PERF-026)
+//!
+//! `scripts/perf_gate.sh:42` fails any receipt whose `drain_ms` is absent:
+//!
+//! ```text
+//! if r.get("drain_ms") is None:
+//!     bad.append("drain_ms absent")
+//! ```
+//!
+//! On `62d23d8d1`, `grep -rn "drain_ms" --include="*.rs" crates` returned
+//! **rc=1, zero lines**. The only `drain_ms` anywhere in the repo were the
+//! spec, this line of the gate, a matrix comment, and the gate's own hand-typed
+//! selftest fixture `"drain_ms":12`. So Arm C was **green on a string literal
+//! and red on every measurement that could ever be taken** — a gate that cannot
+//! pass, which is the exact mirror of the cannot-fail gates §5 catalogues.
+//!
+//! The same held for §4.4.6's `tokenization` block, which the spec marks
+//! REQUIRED with no default.
+//!
+//! # What is here
+//!
+//! - [`drain`] — the §4.4.7 producer. `drain_ms`, the four request counters,
+//!   and the `SUSPECT` annotation, all **derived from per-request terminal
+//!   records**. There is no constructor that accepts a `drain_ms` scalar.
+//! - [`receipt`] — the emitter. Turns those records plus a §4.4.6 tokenization
+//!   declaration and §4.2 provenance into the JSON `scripts/perf_gate.sh` and
+//!   `scripts/lib/bench_receipt.py` actually read.
+//!
+//! # The definition that had to be right first (§4.4.7)
+//!
+//! > `drain_ms` is the length of the **drain phase**: the last settlement of any
+//! > pre-`T` request, minus `T`, clamped at zero.
+//!
+//! and, load-bearing:
+//!
+//! > `truncated` counts requests **abandoned at the drain deadline**, never
+//! > `finish_reason == "length"`.
+//!
+//! W1 generates with `max_tokens = 128` and **EOS ignored** (§4.3.1), so every
+//! healthy W1 request carries `finish_reason == "length"`. §4.4.3 puts
+//! `agg_tok_s`'s numerator over "completed, non-truncated" requests, so the
+//! finish-reason reading empties the numerator and reports `0 tok/s` for a
+//! working server. [`drain::Outcome::AbandonedAtDrain`] is the §4.4.7 sense and
+//! is the only thing that increments `truncated`;
+//! `drain::tests::max_tokens_truncation_is_not_drain_truncation` is the guard.
+//!
+//! # What a client cannot produce, said rather than synthesised
+//!
+//! §4.4.9's scheduler block is **server**-reported: I-16 requires
+//! `max_in_flight` come from the server rather than be inferred by the harness,
+//! and I-2 requires `gpu_layers_resolved` be read from the loader. Arm D's `kv`
+//! block is the same. Neither is emitted from client-side data. They are named
+//! in the receipt's `unproduced_fields` with the reason, because a default that
+//! invents provenance is worse than a missing field — it is indistinguishable
+//! from a real answer.
+//!
+//! # MERGE NOTE — PERF-024 on `feat/n1-band-cli`
+//!
+//! That branch adds `window.rs`, `protocol.rs`, `metrics.rs`, `samples.rs` and
+//! `bootstrap.rs` to this same directory: the §4.4.1/§4.4.2 admission and
+//! termination rule, the §4.4.3 metric set, and the §4.4.4 bootstrap. The two
+//! halves compose — its `WindowController` decides *when* `T` falls and hands
+//! over per-request records; [`drain::BandInput`] derives the §4.4.7 numbers
+//! from those records and [`receipt::ReceiptInput`] writes them out, which
+//! PERF-024's own docs list as explicitly out of its scope ("Receipt emission.
+//! Nothing here writes `receipt.json`").
+//!
+//! Two overlaps must be resolved in the integration commit rather than left to
+//! drift: `protocol::Tokenization` and [`receipt::TokenizationBlock`] are the
+//! same §4.4.6 block, and `protocol::Outcome` and [`drain::Outcome`] are the
+//! same four counters. Keep one of each.
+
+pub mod drain;
+pub mod receipt;
+
+pub use drain::{
+    percentile, BandInput, ComparatorStatus, DerivedBand, Outcome, RequestOutcome,
+    DRAIN_SUSPECT_FRACTION, REQUEST_TIMEOUT_MS,
+};
+pub use receipt::{
+    ComputeClass, KvBlock, Provenance, ReceiptInput, TokenCountingMethod, TokenizationBlock,
+    Workload, SERVER_ONLY_FIELDS,
+};
+
+#[cfg(test)]
+mod gate_conformance_tests {
+    //! Does a receipt this producer emits satisfy `scripts/perf_gate.sh`?
+    //!
+    //! # Why these tests do not run the gate
+    //!
+    //! The obvious test shells out to `bash scripts/perf_gate.sh --receipt …`.
+    //! It cannot live here. `workspace-test` — the job that runs
+    //! `cargo nextest run --workspace --lib` — executes inside
+    //! `localhost:5000/sovereign-ci:stable`, and **that image has no python3 at
+    //! all** (probed 2026-08-28: `ls /usr/bin | grep -c ^python` → `0`,
+    //! `command -v python3` → nothing). `perf_gate.sh` is a bash wrapper around
+    //! five embedded python programs, so a subprocess test would have gone RED
+    //! on every PR for a reason having nothing to do with the receipt. The gate
+    //! runs today only in the `ci` job (`ci.yml:981`, `--selftest`), whose
+    //! environment is a different one.
+    //!
+    //! So the coupling here is **textual, against the gate's own source**: the
+    //! set of fields the gate reads is extracted from `perf_gate.sh` at test
+    //! time and checked against what the producer emits. That is stronger than a
+    //! hardcoded key list — when the gate starts requiring a new field, this
+    //! goes red until the field is either produced or explicitly classified as
+    //! one a client cannot produce.
+    //!
+    //! The end-to-end run against the real gate was performed by hand for
+    //! PERF-026 and is recorded in the ticket's mutation table. Wiring a caller
+    //! for the gate's real (non-selftest) mode is a separate ticket.
+
+    use super::*;
+    use serde_json::Value;
+    use std::path::{Path, PathBuf};
+
+    /// Top-level fields the gate reads that a **client** cannot produce, each
+    /// with the reason it is declared rather than invented.
+    const RECEIPT_SCOPE_UNPRODUCIBLE: &[(&str, &str)] = &[
+        (
+            "kv",
+            "Arm D's memory block is server-reported (§4.4.9). Supplied only via \
+             KvBlock::from_server_report; absent otherwise.",
+        ),
+        (
+            "itl",
+            "Arm E's itl.p95_w1_ms / p95_w2_ms is a ratio ACROSS two workloads. A single \
+             host x workload receipt cannot hold it (PERF-020).",
+        ),
+        (
+            "injector",
+            "Arm E's out-of-band injector is a W2 construct (§4.3.2) this producer does not \
+             model (PERF-020).",
+        ),
+    ];
+
+    /// Per-band fields the gate reads that this producer refuses to derive.
+    const BAND_SCOPE_UNPRODUCIBLE: &[(&str, &str)] = &[
+        (
+            "agg_ratio",
+            "A comparator ratio needs a baseline object that itself passes every receipt rule \
+             (I-3) and a lane driven by the same client binary (I-15, PERF-019).",
+        ),
+        ("decode_ratio", "As agg_ratio (I-3, I-15, PERF-019)."),
+    ];
+
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .canonicalize()
+            .expect("workspace root is two levels above this crate")
+    }
+
+    fn gate_source() -> String {
+        let path = repo_root().join("scripts").join("perf_gate.sh");
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()))
+    }
+
+    /// Every `<receiver>.get("<field>")` the gate performs, as (receiver, field).
+    fn gate_field_reads(source: &str) -> Vec<(String, String)> {
+        let re =
+            regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_]*(?:\[[a-z]\])?)\.get\("([a-z0-9_]+)""#)
+                .expect("static regex");
+        re.captures_iter(source)
+            .map(|c| (c[1].to_string(), c[2].to_string()))
+            .collect()
+    }
+
+    fn band(concurrency: u32, requests: Vec<RequestOutcome>) -> BandInput {
+        BandInput {
+            concurrency,
+            window_ms: 60_000.0,
+            requests,
+            comparator: ComparatorStatus::Unmeasured {
+                owner: "perf-gate".to_string(),
+                reason: "no same-client comparator lane on this cell yet (I-15, PERF-019)"
+                    .to_string(),
+            },
+        }
+    }
+
+    /// A §4.4-shaped band: `max(30, 8c)` requests in a 60 s window, with the
+    /// final request deliberately straddling `T` so `drain_ms` is non-zero and
+    /// demonstrably came from the data rather than from a constant.
+    fn synthetic_band(concurrency: u32) -> BandInput {
+        let window_ms = 60_000.0;
+        let n = 30.max(8 * concurrency as usize);
+        let step = (window_ms - 1_000.0) / n as f64;
+        let mut requests: Vec<RequestOutcome> = (0..n)
+            .map(|i| {
+                let issued = i as f64 * step;
+                // Varying durations: a constant distribution is F12.
+                let dur = 400.0 + (i % 7) as f64 * 13.0;
+                RequestOutcome {
+                    issued_ms: issued,
+                    settled_ms: issued + dur,
+                    outcome: Outcome::Completed,
+                    generated_tokens: 128,
+                    ttft_ms: Some(40.0 + (i % 5) as f64),
+                    token_times_ms: (0..128)
+                        .map(|k| issued + 40.0 + k as f64 * (dur - 40.0) / 128.0)
+                        .collect(),
+                }
+            })
+            .collect();
+        let last = requests.last_mut().expect("n >= 30");
+        last.issued_ms = window_ms - 100.0;
+        last.settled_ms = window_ms + 250.0;
+        last.token_times_ms = (0..128)
+            .map(|k| window_ms - 60.0 + k as f64 * 310.0 / 128.0)
+            .collect();
+        band(concurrency, requests)
+    }
+
+    fn provenance() -> Provenance {
+        Provenance {
+            binary_path: "/opt/clean-room/bin/apr".to_string(),
+            binary_sha256: "a".repeat(64),
+            resolution: "scripts/apr_bin.sh".to_string(),
+            compute_class: ComputeClass::Cuda,
+            host: "lambda".to_string(),
+            accelerator: "rtx-4090".to_string(),
+            model: "qwen2.5-coder-7b-apache-q4k-v1".to_string(),
+            quantization: "Q4_K_M".to_string(),
+            feature_set: vec!["inference".to_string(), "cuda".to_string()],
+        }
+    }
+
+    fn receipt_input(kv: Option<KvBlock>) -> ReceiptInput {
+        ReceiptInput {
+            provenance: provenance(),
+            tokenization: TokenizationBlock::ClientTokenizer {
+                tokenizer_sha256: "b".repeat(64),
+                counts_special_tokens: false,
+                counts_prompt_echo: false,
+            },
+            workload: Workload::W1,
+            commit: "62d23d8d1".to_string(),
+            bands: vec![
+                synthetic_band(1),
+                synthetic_band(4),
+                synthetic_band(8),
+                synthetic_band(16),
+            ],
+            kv,
+        }
+    }
+
+    fn rendered() -> Value {
+        receipt_input(None).render().expect("valid receipt")
+    }
+
+    fn unproducible(table: &[(&str, &str)], field: &str) -> bool {
+        table.iter().any(|(name, _)| *name == field)
+    }
+
+    /// THE RATCHET. The universe is derived from the gate's own source, so a new
+    /// required field cannot be added to `perf_gate.sh` without this test going
+    /// red until it is either produced or explicitly classified.
+    #[test]
+    fn every_field_the_gate_reads_is_produced_or_declared_unproducible() {
+        let receipt = rendered();
+        let bands = receipt["bands"].as_array().expect("bands array");
+        let mut checked = 0_usize;
+        for (receiver, field) in gate_field_reads(&gate_source()) {
+            match receiver.as_str() {
+                "r" => {
+                    checked += 1;
+                    assert!(
+                        receipt.get(&field).is_some()
+                            || unproducible(RECEIPT_SCOPE_UNPRODUCIBLE, &field),
+                        "perf_gate.sh reads receipt field `{field}` and the producer neither \
+                         emits it nor declares it unproducible"
+                    );
+                }
+                "b" | "bands[c]" => {
+                    checked += 1;
+                    let missing: Vec<u64> = bands
+                        .iter()
+                        .filter(|b| b.get(&field).is_none())
+                        .filter_map(|b| b["concurrency"].as_u64())
+                        .collect();
+                    assert!(
+                        missing.is_empty() || unproducible(BAND_SCOPE_UNPRODUCIBLE, &field),
+                        "perf_gate.sh reads band field `{field}`, absent at bands {missing:?} \
+                         and not declared unproducible"
+                    );
+                }
+                // `bl`/`m` read perf-matrix.yaml, and `kv`/`itl`/`inj` read
+                // inside blocks already classified above.
+                _ => {}
+            }
+        }
+        assert!(
+            checked >= 10,
+            "only {checked} field reads found in perf_gate.sh — the extractor stopped matching, \
+             so this test is no longer checking anything"
+        );
+    }
+
+    /// And the ratchet discriminates: a field the gate reads that the producer
+    /// does not emit and has not classified must fail the check above.
+    #[test]
+    fn the_field_ratchet_rejects_an_unclassified_new_requirement() {
+        let receipt = rendered();
+        assert!(
+            receipt.get("max_in_flight").is_none()
+                && !unproducible(RECEIPT_SCOPE_UNPRODUCIBLE, "max_in_flight"),
+            "control: max_in_flight is neither emitted nor classified, so were the gate to start \
+             reading it the test above would go red"
+        );
+    }
+
+    /// Every rule Arm C applies, as a property of what the producer emits.
+    /// `perf_gate.sh` remains the authority; this states the guarantee.
+    #[test]
+    fn a_produced_receipt_satisfies_every_arm_c_rule() {
+        let r = rendered();
+        assert_eq!(
+            r["requested"], r["completed"],
+            "Arm C: completed == requested"
+        );
+        assert_eq!(
+            r["timeouts"], 0,
+            "I-5: a timeout is fatal to this host's ratio"
+        );
+        assert!(
+            r["tokenization"]["method"]
+                .as_str()
+                .is_some_and(|m| !m.is_empty()),
+            "I-13: tokenization.method has no default"
+        );
+        assert!(
+            r["drain_ms"].as_f64().is_some(),
+            "§4.4.7: drain_ms is recorded — the field with zero producers on 62d23d8d1"
+        );
+        for b in r["bands"].as_array().expect("bands") {
+            assert_ne!(
+                b["tokens_total"], 0,
+                "Arm C: a zero-token response is a failure, not a fast request"
+            );
+        }
+    }
+
+    /// Arm A's denominator and the four declared bands of §4.5.
+    #[test]
+    fn a_produced_receipt_carries_every_declared_band_including_the_arm_a_denominator() {
+        let r = rendered();
+        let seen: Vec<u64> = r["bands"]
+            .as_array()
+            .expect("bands")
+            .iter()
+            .filter_map(|b| b["concurrency"].as_u64())
+            .collect();
+        assert_eq!(seen, vec![1, 4, 8, 16], "§4.5: all four bands");
+        let base = r["bands"][0]["aggregate_tok_per_sec"]
+            .as_f64()
+            .expect("agg(1)");
+        assert!(base > 0.0, "Arm A is undefined without a non-zero agg(1)");
+    }
+
+    /// `scripts/lib/bench_receipt.py`'s rules, which Arm C delegates to.
+    #[test]
+    fn a_produced_receipt_satisfies_the_receipt_validators_rules() {
+        let r = rendered();
+        let prov = &r["provenance"];
+        for key in [
+            "binary_path",
+            "binary_sha256",
+            "resolution",
+            "compute_class",
+        ] {
+            assert!(prov.get(key).is_some(), "provenance.{key} is required");
+        }
+        let sha = prov["binary_sha256"].as_str().expect("digest");
+        assert_eq!(sha.len(), 64);
+        assert!(sha
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
+        let samples = r["samples_ms"].as_array().expect("samples_ms");
+        assert!(
+            !samples.is_empty(),
+            "I-4: summary-only receipts are rejected"
+        );
+        assert_eq!(r["n"].as_u64(), Some(samples.len() as u64));
+        let distinct: std::collections::BTreeSet<String> = samples
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        assert!(
+            distinct.len() > 1,
+            "F12: a constant sample set is the fabricated-measurement shape"
+        );
+    }
+
+    /// The server-only block is NAMED, not silently omitted and not invented.
+    #[test]
+    fn the_receipt_names_what_a_client_cannot_produce() {
+        let r = rendered();
+        assert!(r.get("kv").is_none(), "no invented Arm D block");
+        let notes = r["unproduced_fields"]
+            .as_array()
+            .expect("unproduced_fields")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(notes.contains("I-16"), "{notes}");
+        assert!(notes.contains("Arm D `kv` block"), "{notes}");
+    }
+
+    /// With the server's own figures supplied, the block appears — and only then.
+    #[test]
+    fn the_kv_block_appears_only_when_the_server_reported_one() {
+        let r = receipt_input(Some(KvBlock::from_server_report(50, 100, 0, 0)))
+            .render()
+            .expect("valid receipt");
+        assert_eq!(r["kv"]["bytes_used"], 50);
+        assert_eq!(r["kv"]["bytes_reserved"], 100);
+    }
+
+    /// THE MEASURED-NOT-DEFAULTED PROOF, at receipt level: the same producer
+    /// over two band sets that differ only in drain behaviour emits two
+    /// different `drain_ms`. A defaulted field cannot do this.
+    #[test]
+    fn the_emitted_drain_ms_tracks_the_measurement() {
+        let straggling = rendered();
+        let mut input = receipt_input(None);
+        for b in &mut input.bands {
+            let window = b.window_ms;
+            let last = b.requests.last_mut().expect("non-empty band");
+            last.settled_ms = window - 10.0;
+            last.token_times_ms = vec![window - 80.0, window - 20.0];
+        }
+        let quiet = input.render().expect("valid receipt");
+        assert_eq!(straggling["drain_ms"], serde_json::json!(250.0));
+        assert_eq!(quiet["drain_ms"], serde_json::json!(0.0));
+        assert_eq!(straggling["bands"][0]["drain_ms"], serde_json::json!(250.0));
+    }
+
+    /// §4.4.7 at receipt level is the MAX, so one dominated band cannot be
+    /// averaged away by three clean ones.
+    #[test]
+    fn the_receipt_drain_ms_is_the_worst_band_not_the_mean() {
+        let mut input = receipt_input(None);
+        for b in input.bands.iter_mut().take(3) {
+            let window = b.window_ms;
+            let last = b.requests.last_mut().expect("non-empty band");
+            last.settled_ms = window - 10.0;
+            last.token_times_ms = vec![window - 80.0, window - 20.0];
+        }
+        let r = input.render().expect("valid receipt");
+        assert_eq!(r["bands"][0]["drain_ms"], serde_json::json!(0.0));
+        assert_eq!(r["bands"][3]["drain_ms"], serde_json::json!(250.0));
+        assert_eq!(r["drain_ms"], serde_json::json!(250.0));
+    }
+
+    /// A band whose requests never streamed says so; nothing is filled in.
+    #[test]
+    fn a_non_streaming_band_omits_the_latency_fields_and_names_them() {
+        let plain = RequestOutcome {
+            issued_ms: 0.0,
+            settled_ms: 500.0,
+            outcome: Outcome::Completed,
+            generated_tokens: 128,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let other = RequestOutcome {
+            issued_ms: 600.0,
+            settled_ms: 1_250.0,
+            outcome: Outcome::Completed,
+            generated_tokens: 128,
+            ttft_ms: None,
+            token_times_ms: Vec::new(),
+        };
+        let input = ReceiptInput {
+            bands: vec![band(1, vec![plain, other])],
+            ..receipt_input(None)
+        };
+        let r = input.render().expect("valid receipt");
+        assert!(
+            r["bands"][0].get("ttft_p95_ms").is_none(),
+            "no invented p95"
+        );
+        let notes = r["unproduced_fields"].to_string();
+        assert!(notes.contains("did not stream"), "{notes}");
+    }
+
+    /// Provenance has no defaults: an empty `resolution` is refused outright.
+    /// A `--resolution` that defaults to `scripts/apr_bin.sh` invents provenance.
+    #[test]
+    fn an_empty_resolution_is_refused_rather_than_defaulted() {
+        let mut input = receipt_input(None);
+        input.provenance.resolution = String::new();
+        let err = input.render().expect_err("empty resolution");
+        assert!(err.contains("no default"), "{err}");
+    }
+
+    /// I-2 — a compute class the build cannot reach is a fabricated claim.
+    #[test]
+    fn a_compute_class_the_build_cannot_reach_is_refused() {
+        let mut input = receipt_input(None);
+        input.provenance.feature_set = vec!["inference".to_string()];
+        let err = input.render().expect_err("cuda without the feature");
+        assert!(err.contains("I-2"), "{err}");
+    }
+
+    /// I-13 — a `client_tokenizer` declaration without a digest is refused.
+    #[test]
+    fn a_client_tokenizer_without_a_digest_is_refused() {
+        let input = ReceiptInput {
+            tokenization: TokenizationBlock::ClientTokenizer {
+                tokenizer_sha256: "not-a-digest".to_string(),
+                counts_special_tokens: false,
+                counts_prompt_echo: false,
+            },
+            ..receipt_input(None)
+        };
+        let err = input.render().expect_err("bad digest");
+        assert!(err.contains("client_tokenizer"), "{err}");
+    }
+
+    /// A receipt with no bands is a vacuous pass, and is refused.
+    #[test]
+    fn a_receipt_with_no_bands_is_refused() {
+        let input = ReceiptInput {
+            bands: Vec::new(),
+            ..receipt_input(None)
+        };
+        let err = input.render().expect_err("no bands");
+        assert!(err.contains("vacuous"), "{err}");
+    }
+
+    /// The rendered receipt is valid JSON that round-trips.
+    #[test]
+    fn the_receipt_renders_to_parseable_json() {
+        let text = receipt_input(None).render_string().expect("renders");
+        let back: Value = serde_json::from_str(&text).expect("valid JSON");
+        assert_eq!(back["workload"], "W1");
+        assert_eq!(back["client_model"], "closed_loop");
+    }
+}

--- a/crates/aprender-test-lib/src/perf_gate/receipt.rs
+++ b/crates/aprender-test-lib/src/perf_gate/receipt.rs
@@ -1,0 +1,537 @@
+//! The receipt emitter — the half of the receipt rule that was missing.
+//!
+//! # The defect
+//!
+//! `scripts/perf_gate.sh` reads `drain_ms`, `tokenization.method`, `timeouts`
+//! and `requested`/`completed` off a receipt, and **nothing in the workspace
+//! wrote a receipt at all**. Measurement code can hold a perfect `drain_ms` in a
+//! struct field forever; the gate never sees a struct. The only artefact with
+//! `drain_ms` in it on `62d23d8d1` was the gate's own hand-typed selftest
+//! fixture (`"drain_ms":12`), so the gate was green on fiction and red on every
+//! measurement that could actually be taken.
+//!
+//! [`ReceiptInput::render`] closes that: it takes the **per-request terminal
+//! records** and derives the receipt from them. There is deliberately no way to
+//! hand it a `drain_ms`, a `timeouts` count, or an `agg_ratio` — every number it
+//! emits is computed from samples that travel in the same receipt, which is the
+//! rule `scripts/lib/bench_receipt.py` already applies to ratios.
+//!
+//! # What this refuses to emit
+//!
+//! - **§4.4.9's scheduler block.** `max_in_flight`, `admission_rejected`,
+//!   `preempted_recompute`, `preempted_swap`, `kv_blocks_*`, `gpu_layers_*`,
+//!   `backend_loaded[]`, `autofit_applied[]` are **server**-reported by
+//!   construction — I-16 says `max_in_flight` "is reported by the **server**,
+//!   not inferred by the harness", and I-2 says `gpu_layers_resolved` is read
+//!   from the loader. A client-side estimate would be indistinguishable from a
+//!   real answer, which is worse than a missing field. The block is omitted and
+//!   named in `unproduced_fields`, with the reason.
+//! - **Arm D's `kv` block**, for the same reason, unless a caller supplies one
+//!   via [`KvBlock::from_server_report`]. Without it the receipt is legal at
+//!   merge phase and honestly fails at release phase, which is the correct
+//!   posture: Arm D is REPORTING on its threshold, not on its fields.
+//! - **Any comparator ratio.** See [`super::drain::ComparatorStatus`]: there is
+//!   no `Measured` variant, because a ratio needs a baseline object that itself
+//!   passes every receipt rule (I-3) and a comparator lane driven by the same
+//!   client binary (I-15).
+//! - **A default `resolution`.** Every [`Provenance`] string is required and an
+//!   empty one is refused. A `--resolution` that defaults to `scripts/apr_bin.sh`
+//!   invents provenance, and invented provenance is indistinguishable from
+//!   measured provenance.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use super::drain::{BandInput, ComparatorStatus, DerivedBand};
+
+/// §4.4.9 fields a client cannot observe, and why. Emitted verbatim into the
+/// receipt's `unproduced_fields` rather than guessed at.
+pub const SERVER_ONLY_FIELDS: &str = "§4.4.9 scheduler block (max_in_flight, admission_rejected, \
+     preempted_recompute, preempted_swap, kv_blocks_total, kv_blocks_peak_used, \
+     kv_bytes_reserved, kv_bytes_used, gpu_layers_requested, gpu_layers_resolved, \
+     gpu_layers_total, backend_loaded[], autofit_applied[]) — every one is reported by the \
+     SERVER. I-16: max_in_flight is reported by the server, not inferred by the harness; I-2: \
+     gpu_layers_resolved is read from the loader and never inferred. A client-side estimate \
+     would read exactly like a measurement, so none is emitted.";
+
+/// The dispatch path a run actually took. Mirrors `bench_receipt.py`'s
+/// `COMPUTE_CLASSES`; I-2 requires this be the path **taken**, read from the
+/// running process, never the hardware present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputeClass {
+    /// SIMD on the host CPU.
+    Cpu,
+    /// NVIDIA CUDA.
+    Cuda,
+    /// Apple Metal.
+    Metal,
+    /// wgpu.
+    Wgpu,
+    /// The run could not determine its own path. Legal, and never a ratio.
+    Unknown,
+}
+
+impl ComputeClass {
+    /// The wire token, matching `bench_receipt.py`.
+    #[must_use]
+    pub fn wire_token(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Cuda => "cuda",
+            Self::Metal => "metal",
+            Self::Wgpu => "wgpu",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// §4.2.2 identity plus the §4.2.3 join key. **No `Default` impl**: every field
+/// is a fact about a specific run, and a blank one that serialises is how a
+/// receipt acquires provenance it never had.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Provenance {
+    /// The binary that ran, as an absolute path.
+    pub binary_path: String,
+    /// Host-local anti-substitution fingerprint. 64 lowercase hex characters.
+    pub binary_sha256: String,
+    /// How that path was resolved. **No default** — see the module docs.
+    pub resolution: String,
+    /// The dispatch path taken (I-2).
+    pub compute_class: ComputeClass,
+    /// Join key: which host.
+    pub host: String,
+    /// Join key: which accelerator.
+    pub accelerator: String,
+    /// Join key: which model.
+    pub model: String,
+    /// Join key: which quantization.
+    pub quantization: String,
+    /// Cargo features read **from the built binary**, never from `Cargo.toml`.
+    pub feature_set: Vec<String>,
+}
+
+impl Provenance {
+    /// §4.2 checks that a receipt cannot be written without passing.
+    ///
+    /// # Errors
+    /// When any field is empty, the digest is not 64 lowercase hex characters,
+    /// or the declared `compute_class` is a path the build cannot reach.
+    pub fn validate(&self) -> Result<(), String> {
+        for (name, value) in self.required_strings() {
+            if value.trim().is_empty() {
+                return Err(format!(
+                    "provenance.{name}: empty — this field has no default; a receipt that does \
+                     not say {name} is an anonymous number, not evidence"
+                ));
+            }
+        }
+        if !is_sha256(&self.binary_sha256) {
+            return Err(format!(
+                "provenance.binary_sha256: {:?} is not 64 lowercase hex characters",
+                self.binary_sha256
+            ));
+        }
+        self.validate_feature_set()
+    }
+
+    fn required_strings(&self) -> [(&'static str, &str); 7] {
+        [
+            ("binary_path", &self.binary_path),
+            ("binary_sha256", &self.binary_sha256),
+            ("resolution", &self.resolution),
+            ("host", &self.host),
+            ("accelerator", &self.accelerator),
+            ("model", &self.model),
+            ("quantization", &self.quantization),
+        ]
+    }
+
+    /// I-2's other half: a class the build cannot reach is a fabricated claim.
+    fn validate_feature_set(&self) -> Result<(), String> {
+        let needs_feature = matches!(self.compute_class, ComputeClass::Cuda | ComputeClass::Wgpu);
+        let token = self.compute_class.wire_token();
+        if needs_feature && !self.feature_set.iter().any(|f| f == token) {
+            return Err(format!(
+                "provenance.compute_class={token} but feature_set={:?} does not contain it — a \
+                 build without the feature cannot take that path (I-2)",
+                self.feature_set
+            ));
+        }
+        Ok(())
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "binary_path": self.binary_path,
+            "binary_sha256": self.binary_sha256,
+            "resolution": self.resolution,
+            "compute_class": self.compute_class.wire_token(),
+            "host": self.host,
+            "accelerator": self.accelerator,
+            "model": self.model,
+            "quantization": self.quantization,
+            "feature_set": self.feature_set,
+        })
+    }
+}
+
+/// §4.4.6 — how tokens were counted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenCountingMethod {
+    /// Counts taken from the server's own `usage` fields — two servers'
+    /// `usage` fields are two implementations' opinions.
+    ServerUsage,
+    /// Counts computed client-side with the model's own tokenizer. Canonical.
+    ClientTokenizer,
+}
+
+impl TokenCountingMethod {
+    /// The wire token `perf_gate.sh` reads from `tokenization.method`.
+    #[must_use]
+    pub fn wire_token(self) -> &'static str {
+        match self {
+            Self::ServerUsage => "server_usage",
+            Self::ClientTokenizer => "client_tokenizer",
+        }
+    }
+}
+
+/// §4.4.6 — the `tokenization` block, required in every receipt.
+///
+/// `method` has **no default** (I-13). The variants below make
+/// "`client_tokenizer` with no digest" unrepresentable rather than merely
+/// rejected, and `counts_special_tokens` / `counts_prompt_echo` are plain
+/// non-optional booleans the caller must state.
+///
+/// > `counts_*` under `server_usage` is an operator **declaration** about the
+/// > server's counting semantics, not a client measurement — §4.4.6 is titled
+/// > "Token counting must be **declared**". It is required rather than
+/// > defaulted precisely so it cannot be silently wrong.
+///
+/// MERGE NOTE (PERF-024 / `feat/n1-band-cli`): that branch adds
+/// `perf_gate::protocol::Tokenization`, the measurement-side type, which
+/// serialises to exactly this shape. The integration commit should keep one of
+/// the two and re-point the other; they are the same block, not two blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenizationBlock {
+    /// Server-reported counts.
+    ServerUsage {
+        /// Whether the count includes special tokens.
+        counts_special_tokens: bool,
+        /// Whether the count includes the echoed prompt.
+        counts_prompt_echo: bool,
+    },
+    /// Client-side counts with the model's own tokenizer.
+    ClientTokenizer {
+        /// Digest of the tokenizer actually used. 64 lowercase hex characters.
+        tokenizer_sha256: String,
+        /// Whether the count includes special tokens.
+        counts_special_tokens: bool,
+        /// Whether the count includes the echoed prompt.
+        counts_prompt_echo: bool,
+    },
+}
+
+impl TokenizationBlock {
+    /// The declared counting method.
+    #[must_use]
+    pub fn method(&self) -> TokenCountingMethod {
+        match self {
+            Self::ServerUsage { .. } => TokenCountingMethod::ServerUsage,
+            Self::ClientTokenizer { .. } => TokenCountingMethod::ClientTokenizer,
+        }
+    }
+
+    /// # Errors
+    /// When a `client_tokenizer` digest is not 64 lowercase hex characters.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::ServerUsage { .. } => Ok(()),
+            Self::ClientTokenizer {
+                tokenizer_sha256, ..
+            } if is_sha256(tokenizer_sha256) => Ok(()),
+            Self::ClientTokenizer {
+                tokenizer_sha256, ..
+            } => Err(format!(
+                "tokenization.tokenizer_sha256: {tokenizer_sha256:?} is not 64 lowercase hex \
+                 characters — §4.4.6 requires it when method = client_tokenizer"
+            )),
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        let mut map = Map::new();
+        map.insert("method".into(), json!(self.method().wire_token()));
+        let (special, echo) = match self {
+            Self::ServerUsage {
+                counts_special_tokens,
+                counts_prompt_echo,
+            } => (*counts_special_tokens, *counts_prompt_echo),
+            Self::ClientTokenizer {
+                tokenizer_sha256,
+                counts_special_tokens,
+                counts_prompt_echo,
+            } => {
+                map.insert("tokenizer_sha256".into(), json!(tokenizer_sha256));
+                (*counts_special_tokens, *counts_prompt_echo)
+            }
+        };
+        map.insert("counts_special_tokens".into(), json!(special));
+        map.insert("counts_prompt_echo".into(), json!(echo));
+        Value::Object(map)
+    }
+}
+
+/// Arm D's memory block. **Server-reported**: the only constructor says so in
+/// its name, so a client-side guess has nowhere to enter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvBlock {
+    bytes_used: u64,
+    bytes_reserved: u64,
+    admission_rejected: u64,
+    preempted_swap: u64,
+}
+
+impl KvBlock {
+    /// Build the block from figures the **server** reported.
+    #[must_use]
+    pub fn from_server_report(
+        bytes_used: u64,
+        bytes_reserved: u64,
+        admission_rejected: u64,
+        preempted_swap: u64,
+    ) -> Self {
+        Self {
+            bytes_used,
+            bytes_reserved,
+            admission_rejected,
+            preempted_swap,
+        }
+    }
+
+    fn to_json(self) -> Value {
+        json!({
+            "bytes_used": self.bytes_used,
+            "bytes_reserved": self.bytes_reserved,
+            "admission_rejected": self.admission_rejected,
+            "preempted_swap": self.preempted_swap,
+        })
+    }
+}
+
+/// §4.3 — which workload the band set ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Workload {
+    /// Homogeneous, `prompt_tokens = 512 ± 8`, `max_tokens = 128`, ignore-EOS.
+    W1,
+    /// Ragged prompt and generation mixture, with an injector at `window/2`.
+    W2,
+}
+
+impl Workload {
+    /// The wire token.
+    #[must_use]
+    pub fn wire_token(self) -> &'static str {
+        match self {
+            Self::W1 => "W1",
+            Self::W2 => "W2",
+        }
+    }
+}
+
+/// Everything needed to render one host × workload receipt.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReceiptInput {
+    /// §4.2.2 identity and §4.2.3 join key.
+    pub provenance: Provenance,
+    /// §4.4.6 counting declaration.
+    pub tokenization: TokenizationBlock,
+    /// §4.3 workload.
+    pub workload: Workload,
+    /// The commit under test (I-10).
+    pub commit: String,
+    /// One entry per band, each carrying its own per-request records.
+    pub bands: Vec<BandInput>,
+    /// Arm D's server-reported memory block, when the server reported one.
+    pub kv: Option<KvBlock>,
+}
+
+impl ReceiptInput {
+    /// Derive and render the receipt.
+    ///
+    /// # Errors
+    /// When provenance or the tokenization block is invalid, when there are no
+    /// bands, when any band violates §4.4.3/§4.4.7 (see [`BandInput::derive`]),
+    /// or when the retained samples are a constant — `bench_receipt.py` calls
+    /// that the fabricated-measurement shape (F12) and so does this.
+    pub fn render(&self) -> Result<Value, String> {
+        self.provenance.validate()?;
+        self.tokenization.validate()?;
+        if self.bands.is_empty() {
+            return Err(
+                "receipt has no bands — a measurement over zero bands is a vacuous pass"
+                    .to_string(),
+            );
+        }
+        let bands = self
+            .bands
+            .iter()
+            .map(BandInput::derive)
+            .collect::<Result<Vec<_>, _>>()?;
+        let samples = samples_ms(&bands);
+        validate_samples(&samples)?;
+        Ok(self.assemble(&bands, samples))
+    }
+
+    /// [`Self::render`], as pretty-printed JSON.
+    ///
+    /// # Errors
+    /// As [`Self::render`]; serialisation itself cannot fail for this shape.
+    pub fn render_string(&self) -> Result<String, String> {
+        let value = self.render()?;
+        serde_json::to_string_pretty(&value).map_err(|e| format!("serialising receipt: {e}"))
+    }
+
+    fn assemble(&self, bands: &[DerivedBand], samples: Vec<f64>) -> Value {
+        let mut map = Map::new();
+        map.insert("spec".into(), json!("APR-PERF-GATE-001 v2.2 §4.4"));
+        map.insert("commit".into(), json!(self.commit));
+        map.insert("workload".into(), json!(self.workload.wire_token()));
+        map.insert("client_model".into(), json!("closed_loop"));
+        map.insert("provenance".into(), self.provenance.to_json());
+        map.insert("tokenization".into(), self.tokenization.to_json());
+        insert_counts(&mut map, bands);
+        map.insert("drain_ms".into(), json!(receipt_drain_ms(bands)));
+        map.insert("n".into(), json!(samples.len()));
+        map.insert("samples_ms".into(), json!(samples));
+        map.insert(
+            "bands".into(),
+            Value::Array(bands.iter().map(band_json).collect()),
+        );
+        if let Some(kv) = self.kv {
+            map.insert("kv".into(), kv.to_json());
+        }
+        map.insert("unproduced_fields".into(), json!(self.unproduced(bands)));
+        Value::Object(map)
+    }
+
+    fn unproduced(&self, bands: &[DerivedBand]) -> Vec<String> {
+        let mut out = vec![SERVER_ONLY_FIELDS.to_string()];
+        if self.kv.is_none() {
+            out.push(
+                "Arm D `kv` block (bytes_used, bytes_reserved, admission_rejected, \
+                 preempted_swap) — server-reported. Absent here, so this receipt is legal at \
+                 merge phase and correctly FAILS at release phase rather than carrying invented \
+                 memory figures."
+                    .to_string(),
+            );
+        }
+        out.extend(bands.iter().flat_map(|b| b.unproduced.clone()));
+        out
+    }
+}
+
+/// §4.4.7 at receipt level: the **maximum** band drain, not a mean or a sum.
+///
+/// The `SUSPECT` rule is per-band and asks whether *one request dominated a
+/// window*. Averaging four bands hides the one that did; summing invents a
+/// drain phase no band ran. The worst band is the one a reader must see.
+fn receipt_drain_ms(bands: &[DerivedBand]) -> f64 {
+    bands.iter().map(|b| b.drain_ms).fold(0.0_f64, f64::max)
+}
+
+fn insert_counts(map: &mut Map<String, Value>, bands: &[DerivedBand]) {
+    map.insert("requested".into(), json!(sum(bands, |b| b.requested)));
+    map.insert("completed".into(), json!(sum(bands, |b| b.completed)));
+    map.insert("timeouts".into(), json!(sum(bands, |b| b.timeouts)));
+    map.insert("truncated".into(), json!(sum(bands, |b| b.truncated)));
+    map.insert("errors".into(), json!(sum(bands, |b| b.errors)));
+}
+
+fn sum(bands: &[DerivedBand], f: impl Fn(&DerivedBand) -> usize) -> usize {
+    bands.iter().map(f).sum()
+}
+
+fn samples_ms(bands: &[DerivedBand]) -> Vec<f64> {
+    bands.iter().flat_map(|b| b.latencies_ms.clone()).collect()
+}
+
+/// I-4 and F12, applied by the producer rather than discovered by the validator.
+fn validate_samples(samples: &[f64]) -> Result<(), String> {
+    if samples.is_empty() {
+        return Err(
+            "samples_ms would be empty — no band completed a single request, and a \
+                    receipt with no retained samples permanently forecloses the bootstrap (I-4)"
+                .to_string(),
+        );
+    }
+    let first = samples[0];
+    if samples.len() > 1 && samples.iter().all(|s| (s - first).abs() < f64::EPSILON) {
+        return Err(format!(
+            "samples_ms: all {} samples identical ({first}) — a real timing distribution is not \
+             constant; this is the fabricated-measurement shape (F12)",
+            samples.len()
+        ));
+    }
+    Ok(())
+}
+
+fn band_json(b: &DerivedBand) -> Value {
+    let mut map = Map::new();
+    map.insert("concurrency".into(), json!(b.concurrency));
+    map.insert(
+        "aggregate_tok_per_sec".into(),
+        json!(b.aggregate_tok_per_sec),
+    );
+    map.insert("tokens_total".into(), json!(b.tokens_total));
+    map.insert("span_ms".into(), json!(b.span_ms));
+    map.insert("window_ms".into(), json!(b.window_ms));
+    map.insert("drain_ms".into(), json!(b.drain_ms));
+    map.insert("requested".into(), json!(b.requested));
+    map.insert("completed".into(), json!(b.completed));
+    map.insert("timeouts".into(), json!(b.timeouts));
+    map.insert("truncated".into(), json!(b.truncated));
+    map.insert("errors".into(), json!(b.errors));
+    map.insert("suspect".into(), json!(b.suspect));
+    insert_optional_latency(&mut map, b);
+    insert_comparator(&mut map, &b.comparator);
+    Value::Object(map)
+}
+
+/// Streaming-only metrics. Absent means absent: no zero stands in for one.
+fn insert_optional_latency(map: &mut Map<String, Value>, b: &DerivedBand) {
+    for (key, value) in [
+        ("decode_tok_per_sec", b.decode_tok_per_sec),
+        ("ttft_p50_ms", b.ttft_p50_ms),
+        ("ttft_p95_ms", b.ttft_p95_ms),
+        ("itl_p50_ms", b.itl_p50_ms),
+        ("itl_p95_ms", b.itl_p95_ms),
+    ] {
+        if let Some(v) = value {
+            map.insert(key.into(), json!(v));
+        }
+    }
+}
+
+fn insert_comparator(map: &mut Map<String, Value>, status: &ComparatorStatus) {
+    map.insert("comparator_status".into(), json!(status.wire_token()));
+    match status {
+        ComparatorStatus::NotApplicable { decided_by, reason } => {
+            map.insert("comparator_decided_by".into(), json!(decided_by));
+            map.insert("comparator_reason".into(), json!(reason));
+        }
+        ComparatorStatus::Unmeasured { owner, reason } => {
+            map.insert("comparator_owner".into(), json!(owner));
+            map.insert("comparator_reason".into(), json!(reason));
+        }
+    }
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}


### PR DESCRIPTION
Epic #2706 (the receipt rule). The perf gate has never rendered a verdict on a real receipt. This is the half that makes one possible, and the reason it never happened is worth stating exactly.

## Arm C was green on a string literal and red on every measurement that could ever be taken

`scripts/perf_gate.sh:42` fails any receipt without `drain_ms`. Repo-wide on `62d23d8d1`, `drain_ms` existed in exactly four places: the spec, that check, a `perf-matrix.yaml` comment — and the gate's own hand-typed selftest fixture at `:247`:

```
local OK='{"requested":16,"completed":16,"timeouts":0,"drain_ms":12, …
```

```
grep -rn "drain_ms" --include="*.rs" crates   ->  rc=1, 0 lines
```

**The gate proved itself against its own fiction.** Its selftest passed on a literal typed by its author; any receipt a machine could actually produce failed. The same held for §4.4.6's required `tokenization` block. That is this epic's thesis committed inside the epic's own enforcement.

## `VERDICT PASS`, for the first time

| case | phase | rc | gate line |
|---|---|---|---|
| **produced receipt** | merge | **0** | `VERDICT PASS` — never achieved before |
| `drain_ms` deleted | merge | 1 | `FAIL ArmC drain_ms absent` |
| `tokenization` deleted | merge | 1 | `FAIL ArmC tokenization.method absent` |
| `timeouts=1` (I-5) | merge | 1 | `FAIL ArmC timeouts=1` |
| band `tokens_total=0` | merge | 1 | `FAIL ArmC zero-token response` |
| produced receipt, no kv | release | 1 | `FAIL ArmD instrumentation absent` |
| produced receipt + server kv | release | **0** | `VERDICT PASS` |
| control: expiry passed | merge | 1 | `FAIL ArmA EXPIRED 2026-09-25` |

Both directions, 8/8. In-repo mutations: emitter stops writing `drain_ms` → 4 RED; drop the `kv` unproducible classification → ratchet RED; break the field-extractor regex → RED (`only 0 field reads found`). No-op restore → 34/34 green.

## §4.4.7, and the conflation it would have been easy to ship

> `drain_ms` = last settlement of any **pre-`T`** request − `T`, clamped at 0.

The length of the *drain phase*, not a property of one request; `0` when nothing was in flight at `T`. §4.4.7's `SUSPECT` rule (`> 0.5 × window` ⟹ "one request dominated") only parses under that reading.

`truncated` counts **only** `Outcome::AbandonedAtDrain`. W1 generates `max_tokens=128` with EOS ignored, so every healthy request has `finish_reason == "length"` — under the finish-reason reading, §4.4.3's "completed, non-truncated" numerator would be **empty**. There is a test named for exactly that: `max_tokens_truncation_is_not_drain_truncation`.

`timeouts` is separate from failures and the label is **checked against the clock** rather than trusted — a `Timeout` under 120 s is refused as a mislabelled `Failed`, and a `Failed` over it is refused as a `Timeout`. I-5 makes timeouts fatal, so the label has to be earned.

**Measured, not defaulted:** the same producer over two band sets differing only in drain behaviour emits `drain_ms = 250.0` vs `0.0`. The receipt-level value is the **max** band, not the mean, so one dominated band cannot be averaged away.

## A finding that changes where the gate can be wired at all

**The `workspace-test` container has no python3.** Probed on the intel runner and confirmed independently:

```
docker run --rm localhost:5000/sovereign-ci:stable command -v python3   ->  NO_PYTHON3
ls /usr/bin | grep -c '^python'                                         ->  0
```

`perf_gate.sh` is bash wrapping five embedded python programs. A first draft had lib tests shelling out to the gate, which **would have reddened `workspace-test` on every PR**. Caught before committing and rewritten so the CI-side coupling is *textual against the gate's own source*: the field universe is extracted from `perf_gate.sh` at test time, so a newly-required field goes red until it is produced or explicitly classified.

**Whoever wires the gate's real mode must target the `ci` job** (`ci.yml:981` already runs `--selftest` there), **not `workspace-test`.**

## What is deliberately still refused

Release phase passes only with a server-reported `kv` block. That is a boundary, not a shortfall — Arm D is REPORTING on its *threshold*, not its *fields*, and inventing memory figures to make a release green is the defect this epic exists to remove. §4.4.9's scheduler block is likewise omitted and **named** in `unproduced_fields` with I-16/I-2 cited. `ComparatorStatus` has no `Measured` variant at all: an `agg_ratio` needs I-3's baseline object and I-15's same-client lane. `Provenance` has no defaults; an empty `resolution` is a hard error.

## Unproven, stated plainly

- **The producer has never seen a real server.** Every number in the tests and in the receipt that reached rc=0 is protocol-shaped synthetic data. rc=0 proves the *shape and derivation* clear the gate — **not that any host passes**. No baseline committed; `perf-matrix.yaml` untouched; all 8 cells remain `UNMEASURED`.
- The `ci` job having python3+PyYAML is **inferred** from `ci.yml:981` passing on green main, not probed.
- `aprender-test-lib` only (6338 lib tests, fmt rc=0, `clippy --all-targets -D warnings` rc=0). No full workspace build.
- A caller could still hand `ReceiptInput` fabricated outcomes. Provenance and the nightly push hosts are the defence, and neither is in this ticket.

## Integration note

PERF-024 (#2719) supplies the protocol — `WindowController::drain_ms`, `Tokenization`, the four `Outcome` counters. This PR supplies the **emitter**, which #2719's own module docs scope out ("Nothing here writes `receipt.json`"). A perfect `drain_ms` in a struct field is invisible to the gate forever. The halves compose; `perf_gate/mod.rs` carries a MERGE NOTE recording that `protocol::Tokenization` ≡ `receipt::TokenizationBlock` and `protocol::Outcome` ≡ `drain::Outcome` — keep one of each. Only `mod.rs` conflicts, on a few `pub mod` lines.

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
