### PR TITLE
fix(gate): thirteen baselines called themselves shrink-only and none compared against anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,36 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      # THE COMPARAND, FETCHED ONCE, BEFORE ANY GUARD THAT NEEDS IT.
+      #
+      # Every shrink-only baseline in scripts/ is now compared against a ref a
+      # pull request cannot rewrite, because twelve of them were compared
+      # against nothing: appending one entry -- cloned from that file's own last
+      # real entry -- returned rc=0 from all twelve, and on two of them the
+      # appended entry laundered a violation created in the same commit.
+      #
+      # This step used to sit ~180 lines down, next to the one guard that
+      # needed it. Three ratcheted guards (shell lint, hand-rolled parsers,
+      # assertion exclusion) run BEFORE that point and would have had an
+      # unresolvable comparand -- which those guards treat as a hard failure,
+      # never as "no growth", so the mistake would have been loud rather than
+      # silent. It is still a mistake. One fetch, before all of them.
+      #
+      # fetch-depth is 1 here, so the merge-base is usually unavailable and the
+      # ratchets fall back to the origin/main TIP. That is the STRICTER
+      # comparand, and it means the CI path is the tip path: a local run that
+      # passes on the merge-base can still red here, and CI is authoritative.
+      - name: Fetch origin/main as the comparand for every ratchet in this job
+        run: git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+      # A baseline that no guard compares to anything is an allowlist wearing
+      # the word "ratchet". This is the coverage backstop: every scripts/*.txt
+      # is classified shrink-only (and compared) or NOT-a-ratchet (with the
+      # reason printed), and an unclassified one is a hard failure -- so the
+      # next baseline file to arrive cannot arrive unratcheted.
+      - name: Baseline ratchet mutation table
+        run: bash scripts/check_baseline_ratchets.sh --self-test
+      - name: Every shrink-only baseline is classified and may not grow
+        run: bash scripts/check_baseline_ratchets.sh
       - name: Every self-hosted job must pin a discriminating label
         run: bash scripts/check_runner_labels.sh
       # Poka-yoke: a beat that no workflow executes reads as enforcement, is
@@ -731,11 +761,11 @@ jobs:
       # number in this repo to edit: every floor is derived at run time from a
       # ref a pull request cannot rewrite.
       #
-      # fetch-depth for this job is 1, so origin/main must be fetched. A failed
-      # fetch does NOT degrade to a self-comparison -- the guard hard-fails on an
-      # unresolvable comparand. Text-only, no build.
-      - name: Fetch origin/main for the dogfood coverage comparand
-        run: git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+      # fetch-depth for this job is 1, so origin/main must be fetched -- and it
+      # is now fetched ONCE, immediately after checkout, because the baseline
+      # ratchets that run earlier in this job need the same comparand. A failed
+      # fetch does NOT degrade to a self-comparison; every guard that uses it
+      # hard-fails on an unresolvable comparand.
       #
       # DOGFOOD_RECEIPT extends the T2 pairing rule to the receipt when a run
       # produces one. The rule is enforced on every channel a cluster-level ratio

--- a/scripts/check_assertions_exclude.sh
+++ b/scripts/check_assertions_exclude.sh
@@ -264,6 +264,27 @@ if [ "$nsites" -eq 0 ] && [ -s "$BASELINE" ]; then
   exit 1
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "the committed sum can only fall"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/assertion_exclusion_baseline.txt keyed || exit 1
+
 if [ ! -f "$BASELINE" ]; then
   printf 'FAIL: %s is missing. Create it with --update-baseline.\n' "$BASELINE"
   exit 1

--- a/scripts/check_baseline_ratchets.sh
+++ b/scripts/check_baseline_ratchets.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# check_baseline_ratchets.sh — every baseline in scripts/ is classified, and
+# every one classified as shrink-only is compared against a ref this branch
+# cannot rewrite.
+#
+# WHY THIS EXISTS
+# ---------------
+# Twelve guards in this repository described their baseline as "shrink-only",
+# "monotonically decreasing", "may only fall", "the count is enforced, not
+# asserted". A sweep that appended ONE entry to each — cloned from that file's
+# own last real entry, so no scanner could tell it from a real one — found
+# 12 of 12 green. On two of them the appended entry then laundered a fresh
+# violation created in the same commit: guard rc=0, defect in the tree.
+#
+# The individual guards now enforce their own baseline (each sources
+# scripts/lib_baseline_ratchet.sh). This file is the COVERAGE backstop, and it
+# is not a second opinion:
+#
+#   1. THE UNIVERSE. A baseline that no guard ratchets is invisible to every
+#      per-guard fix, and the way this class stays alive is a NEW baseline file
+#      arriving unclassified. So the universe is derived at run time from the
+#      working tree, unioned with the index, and an unclassified file is a HARD
+#      FAILURE — never a silent skip.
+#
+#   2. THE FILES WITH NO SHELL OWNER. contract_duplicate_stem_baseline.txt is
+#      read by Rust (`pv lint`, PV-DUP-001/002) and hardcoded_path_shipped_-
+#      baseline.txt only by `check_hardcoded_paths.sh --full`, which no
+#      workflow runs. Their shrink-only claim would be unenforced in CI if this
+#      guard only checked the guards.
+#
+#   3. `git ls-files` ALONE IS A FREE PASS. A baseline present in the working
+#      tree but not yet added is invisible to a tracked-only universe — the
+#      shape that cost this repo four separate guards. The universe is the
+#      UNION of a `find` over the working tree and the index.
+#
+# WHAT IT DOES NOT DO. It does not decide whether a finding is real; the owning
+# guard does that. It decides only whether the recorded set grew.
+#
+#   bash scripts/check_baseline_ratchets.sh              # check
+#   bash scripts/check_baseline_ratchets.sh --self-test  # case table
+#
+# Refs: paiml/aprender#2706 (APR-PERF-GATE-001), PERF-008, PERF-028.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+
+# ---------------------------------------------------------------------------
+# THE CLASSIFICATION. Every scripts/*.txt is either a shrink-only ratchet with
+# a comparison kind, or is NOT one and says why. There is no third answer, and
+# an unlisted file takes none of these branches — it fails.
+#
+#   set   — the entry LIST may only shrink. Subset, not count: counting passes
+#           a swap, which is an append wearing the old total.
+#   count — the file holds one integer, which may only fall.
+#   keyed — lines are <path><TAB><count>; no key may rise, no key may appear.
+#   none  — not a ratchet by its own stated contract; the reason is the value.
+classify() { # classify <basename> -> "<kind>[<TAB>reason]", rc 1 if unclassified
+    case "$1" in
+        assertion_exclusion_baseline.txt)        printf 'keyed\n' ;;
+        claim_literal_baseline.txt)              printf 'set\n' ;;
+        contract_duplicate_stem_baseline.txt)    printf 'set\n' ;;
+        contract_test_binding_baseline.txt)      printf 'keyed\n' ;;
+        fabricated_baseline_rust_sites.txt)      printf 'set\n' ;;
+        hand_rolled_parsers_baseline.txt)        printf 'set\n' ;;
+        hardcoded_path_shipped_baseline.txt)     printf 'count\n' ;;
+        lockfile_registry_siblings_baseline.txt) printf 'set\n' ;;
+        perf_claim_citation_baseline.txt)        printf 'set\n' ;;
+        shell_lint_baseline.txt)                 printf 'count\n' ;;
+        test_fixture_path_baseline.txt)          printf 'count\n' ;;
+        tracked_ignored_baseline.txt)            printf 'count\n' ;;
+        unwired_guards_baseline.txt)             printf 'set\n' ;;
+        # NOT a ratchet, and deliberately so. This file MODELS INTENT: its own
+        # header says the declared set must match the OBSERVED set EXACTLY, an
+        # entry whose duplicate no longer exists FAILS as stale, and adding a
+        # line is a reviewed claim that two packages must ship one bin name.
+        # Freezing it against main would forbid renaming a crate. Growth here
+        # is a decision, not a leak — the distinction this guard exists to keep.
+        duplicate_bin_names_allowlist.txt)
+            printf 'none\tintent model, exact-match against the observed set (stale entries FAIL)\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+# THE UNIVERSE, and where its edge is.
+#
+# `find` over the working tree UNION the index. Tracked-only is a free pass —
+# an untracked file is invisible to `git ls-files`, and untracked is exactly
+# how a new baseline arrives. That shape has cost this repository four separate
+# guards, so it is not repeated here.
+#
+# The edge: baselines live at scripts/*.txt, depth 1. Deeper scripts/**/*.txt
+# are case fixtures for guard self-tests (scripts/lib/facade_cases/*, etc.) and
+# enumerating them as exemptions would be the same defect one level up. So the
+# depth-1 set is taken whole, and a deeper file is pulled in ONLY if its name
+# claims to be one of these — `baseline`, `allowlist` or `ledger` anywhere in
+# it. Such a file arrives with its directory in the key, so classify() refuses
+# it and the guard says so out loud rather than skipping it silently.
+universe() {
+    {
+        find "$REPO_ROOT/scripts" -maxdepth 1 -type f -name '*.txt' -printf '%f\n' 2>/dev/null
+        find "$REPO_ROOT/scripts" -mindepth 2 -type f -name '*.txt' 2>/dev/null \
+            | sed "s|^${REPO_ROOT}/scripts/||"
+        git -C "$REPO_ROOT" ls-files 'scripts/*.txt' 2>/dev/null | sed 's|^scripts/||'
+    } | LC_ALL=C sort -u | grep -vE '^$' | while IFS= read -r rel; do
+        case "$rel" in
+            */*) printf '%s\n' "$rel" | grep -iE 'baseline|allowlist|ledger' ;;
+            *)   printf '%s\n' "$rel" ;;
+        esac
+    done
+}
+
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ] || [ "${1:-}" = "--selftest" ]; then
+    TD=$(mktemp -d) || exit 1
+    trap 'rm -rf "${TD:?}"' EXIT
+    bad=0
+    rows=0
+
+    say_row() { # say_row <label> <want-rc> <got-rc>
+        rows=$((rows + 1))
+        if [ "$2" != "$3" ]; then
+            printf 'FAIL  %-46s want rc=%s got rc=%s\n' "$1" "$2" "$3"
+            bad=1
+        fi
+    }
+
+    # -- set: subset semantics, including the SWAP that a count would pass.
+    printf '%b' 'a\nb\nc\n'        > "$TD/set_base"
+    printf '%b' '# note\na\nb\nc\n' > "$TD/set_same"
+    printf '%b' 'a\nb\nc\nd\n'     > "$TD/set_grow"
+    printf '%b' 'a\nb\nd\n'        > "$TD/set_swap"
+    printf '%b' 'a\nb\n'           > "$TD/set_shrink"
+    printf '%b' ''                 > "$TD/set_empty"
+    printf '%b' 'a\n'              > "$TD/set_one"
+    _br_cmp_set "$TD/set_base" "$TD/set_same";    say_row 'set   unchanged (comment added)' 0 $?
+    _br_cmp_set "$TD/set_base" "$TD/set_grow";    say_row 'set   one entry appended'        1 $?
+    _br_cmp_set "$TD/set_base" "$TD/set_swap";    say_row 'set   swap, count unchanged'     1 $?
+    _br_cmp_set "$TD/set_base" "$TD/set_shrink";  say_row 'set   one entry deleted'         0 $?
+    _br_cmp_set "$TD/set_empty" "$TD/set_one";    say_row 'set   empty base, one entry'     1 $?
+    _br_cmp_set "$TD/set_base" "$TD/set_empty";   say_row 'set   emptied entirely'          0 $?
+
+    # -- count: one integer, may only fall.
+    printf '876\n'            > "$TD/cnt_base"
+    printf '# why\n876\n'     > "$TD/cnt_same"
+    printf '877\n'            > "$TD/cnt_grow"
+    printf '875\n'            > "$TD/cnt_shrink"
+    printf 'not-a-number\n'   > "$TD/cnt_junk"
+    _br_cmp_count "$TD/cnt_base" "$TD/cnt_same";   say_row 'count unchanged (comment added)' 0 $?
+    _br_cmp_count "$TD/cnt_base" "$TD/cnt_grow";   say_row 'count raised by one'             1 $?
+    _br_cmp_count "$TD/cnt_base" "$TD/cnt_shrink"; say_row 'count lowered by one'            0 $?
+    _br_cmp_count "$TD/cnt_base" "$TD/cnt_junk";   say_row 'count unreadable in tree'        2 $?
+    _br_cmp_count "$TD/cnt_junk" "$TD/cnt_base";   say_row 'count unreadable at comparand'   2 $?
+
+    # -- keyed: per-key non-increase, no new keys. A DROPPED key is a shrink,
+    #    and a raised key is refused even while another key falls further --
+    #    the keyed form of the swap.
+    printf 'a\t3\nb\t2\n'          > "$TD/kv_base"
+    printf '# hdr\na\t3\nb\t2\n'   > "$TD/kv_same"
+    printf 'a\t4\nb\t2\n'          > "$TD/kv_raise"
+    printf 'a\t3\nb\t2\nc\t1\n'    > "$TD/kv_newkey"
+    printf 'a\t2\nb\t2\n'          > "$TD/kv_lower"
+    printf 'a\t3\n'                > "$TD/kv_drop"
+    printf 'a\t4\nb\t0\n'          > "$TD/kv_swap"
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_same";   say_row 'keyed unchanged (header added)' 0 $?
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_raise";  say_row 'keyed one key raised'          1 $?
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_newkey"; say_row 'keyed new key appears'         1 $?
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_lower";  say_row 'keyed one key lowered'         0 $?
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_drop";   say_row 'keyed one key dropped'         0 $?
+    _br_cmp_keyed "$TD/kv_base" "$TD/kv_swap";   say_row 'keyed raise + deeper fall'     1 $?
+
+    # -- THE COMPARAND RESOLVER, against a scratch repository. The branch that
+    #    must NEVER be taken is "fall back to comparing this branch against
+    #    itself", and it cannot be exercised from inside a checkout that
+    #    already satisfies it. A missing comparand has to be provably LOUD.
+    SR="$TD/scratch"
+    P='scripts/probe_baseline.txt'
+    if mkdir -p "$SR/scripts" \
+       && git -C "$SR" init -q >/dev/null 2>&1 \
+       && git -C "$SR" config user.email selftest@example.invalid \
+       && git -C "$SR" config user.name selftest \
+       && printf 'x\n' > "$SR/scripts/unrelated.txt" \
+       && git -C "$SR" add -A \
+       && git -C "$SR" -c commit.gpgsign=false commit -qm 'no baseline yet' >/dev/null 2>&1; then
+        SR_NOBASE=$(git -C "$SR" rev-parse HEAD)
+        printf '# header\na\nb\n' > "$SR/$P"
+        if git -C "$SR" add -A \
+           && git -C "$SR" -c commit.gpgsign=false commit -qm 'add baseline' >/dev/null 2>&1; then
+            SR_BASE=$(git -C "$SR" rev-parse HEAD)
+
+            res_row() { # res_row <label> <want-mode> <ref>
+                local got
+                got=$(baseline_ratchet_resolve "$SR" "$3" "$P")
+                got=${got%%$'\t'*}
+                rows=$((rows + 1))
+                if [ "$got" != "$2" ]; then
+                    printf 'FAIL  %-46s want %-12s got %s\n' "$1" "$2" "$got"
+                    bad=1
+                fi
+            }
+            res_row 'resolve ref does not exist'  UNRESOLVABLE 'refs/heads/no-such-branch-xyzzy'
+            res_row 'resolve ref predates baseline' ABSENT     "$SR_NOBASE"
+            res_row 'resolve ref carries baseline' MERGEBASE   "$SR_BASE"
+
+            # TIP is not decoration: CI checks out shallow, so the CI path IS
+            # the tip path. Force it with a ref that shares NO history.
+            if git -C "$SR" checkout -q --orphan unrelated >/dev/null 2>&1 \
+               && git -C "$SR" rm -q -rf . >/dev/null 2>&1 \
+               && mkdir -p "$SR/scripts" \
+               && printf 'z\n' > "$SR/scripts/other.txt" \
+               && git -C "$SR" add -A \
+               && git -C "$SR" -c commit.gpgsign=false commit -qm 'orphan' >/dev/null 2>&1; then
+                res_row 'resolve no common ancestor -> TIP' TIP "$SR_BASE"
+                git -C "$SR" checkout -q "$SR_BASE" >/dev/null 2>&1
+            else
+                printf 'FAIL  resolve TIP fallback UNTESTED — the orphan branch could not\n'
+                printf '      be built, and the CI path is the tip path. Not a skip.\n'
+                bad=1
+            fi
+
+            # END TO END, through the public entry point, on a real repository:
+            # append -> RED, delete -> GREEN, unchanged -> GREEN.
+            e2e_row() { # e2e_row <label> <want-rc> <content>
+                local got
+                printf '%b' "$3" > "$SR/$P"
+                ( BASELINE_RATCHET_BASE_REF="$SR_BASE" \
+                  baseline_ratchet_check "$SR" "$P" set ) >/dev/null 2>&1
+                got=$?
+                rows=$((rows + 1))
+                if [ "$got" != "$2" ]; then
+                    printf 'FAIL  %-46s want rc=%s got rc=%s\n' "$1" "$2" "$got"
+                    bad=1
+                fi
+            }
+            e2e_row 'end-to-end unchanged'        0 '# header\na\nb\n'
+            e2e_row 'end-to-end one entry appended' 1 '# header\na\nb\nc\n'
+            e2e_row 'end-to-end swap at equal count' 1 '# header\na\nc\n'
+            e2e_row 'end-to-end one entry deleted' 0 '# header\na\n'
+
+            # A REAL RED IS NOT A CRASH, and both exit 1. A comparator returns
+            # 1 BY DESIGN on the growth path, so a caller running `set -e`
+            # (check_no_claim_literals.sh does) can die AT the call instead of
+            # reporting through it: identical status, zero verdict rows, and a
+            # guard that looks armed while proving nothing. Assert the ROW.
+            printf '%b' '# header\na\nb\nc\n' > "$SR/$P"
+            e_out=$(BASELINE_RATCHET_BASE_REF="$SR_BASE" bash -euo pipefail -c \
+                '. "$1"/scripts/lib_baseline_ratchet.sh || exit 9
+                 baseline_ratchet_check "$2" "$3" set' \
+                _ "$REPO_ROOT" "$SR" "$P" 2>&1)
+            e_rc=$?
+            say_row 'errexit caller still REPORTS the growth' 1 "$e_rc"
+            rows=$((rows + 1))
+            case "$e_out" in
+                *GREW*) : ;;
+                *)  printf 'FAIL  errexit caller produced rc=%s with NO verdict row. That is a\n' "$e_rc"
+                    printf '      crash wearing a RED exit code, not enforcement.\n'
+                    bad=1 ;;
+            esac
+            printf '' > "$SR/$P"
+
+            # A DELETED baseline is not "no growth". Both directions must be loud.
+            rm -f "$SR/$P"
+            ( BASELINE_RATCHET_BASE_REF="$SR_BASE" \
+              baseline_ratchet_check "$SR" "$P" set ) >/dev/null 2>&1
+            say_row 'end-to-end baseline deleted from tree' 1 $?
+            ( BASELINE_RATCHET_BASE_REF='refs/heads/no-such-branch-xyzzy' \
+              baseline_ratchet_check "$REPO_ROOT" 'scripts/shell_lint_baseline.txt' count ) >/dev/null 2>&1
+            say_row 'end-to-end unresolvable comparand' 1 $?
+        else
+            printf 'FAIL  scratch repo: could not commit, so UNRESOLVABLE/ABSENT/TIP are\n'
+            printf '      UNTESTED. A selftest that silently skips its hardest case is the\n'
+            printf '      defect this guard is about.\n'
+            bad=1
+        fi
+    else
+        printf 'FAIL  scratch repo: could not be built, so the branch that must never be\n'
+        printf '      taken is UNTESTED. That is not a skip.\n'
+        bad=1
+    fi
+
+    # -- the classification is TOTAL over the universe it will actually meet.
+    unclassified=0
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        classify "$f" >/dev/null || unclassified=$((unclassified + 1))
+    done <<< "$(universe)"
+    rows=$((rows + 1))
+    if [ "$unclassified" -ne 0 ]; then
+        printf 'FAIL  %s baseline file(s) in this tree are unclassified\n' "$unclassified"
+        bad=1
+    fi
+    rows=$((rows + 1))
+    if classify 'a_brand_new_baseline.txt' >/dev/null 2>&1; then
+        printf 'FAIL  an unknown baseline was CLASSIFIED. The table must be total over\n'
+        printf '      what it lists and REFUSE everything else, or a new baseline\n'
+        printf '      arrives unratcheted and this guard says nothing.\n'
+        bad=1
+    fi
+
+    if [ "$bad" -ne 0 ]; then
+        printf '\nSELF-TEST FAILED\n'
+        exit 1
+    fi
+    printf 'PASS  case table only: %s rows (set, count, keyed, comparand resolver,\n' "$rows"
+    printf '      end-to-end, classification totality). NO baseline in this tree was\n'
+    printf '      compared — run with no arguments for that.\n'
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+printf '=== every baseline in scripts/ is classified and ratcheted (check_baseline_ratchets.sh) ===\n'
+
+rc=0
+n_total=0
+n_ratchet=0
+n_none=0
+
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    n_total=$((n_total + 1))
+    if ! entry=$(classify "$f"); then
+        printf 'FAIL  %s is not classified.\n' "scripts/$f"
+        printf '      Every baseline is either shrink-only (set / count / keyed) or is\n'
+        printf '      NOT a ratchet and says why. An unclassified file is neither, and\n'
+        printf '      "no rule" is how a baseline arrives that nothing ever compares.\n'
+        printf '      Add it to classify() in %s.\n' "$(basename "$0")"
+        rc=1
+        continue
+    fi
+    kind=${entry%%$'\t'*}
+    if [ "$kind" = none ]; then
+        n_none=$((n_none + 1))
+        printf 'ok    exempt   %-44s %s\n' "scripts/$f" "${entry#*$'\t'}"
+        continue
+    fi
+    n_ratchet=$((n_ratchet + 1))
+    baseline_ratchet_check "$REPO_ROOT" "scripts/$f" "$kind" || rc=1
+done <<< "$(universe)"
+
+# Vacuity: a glob that matched nothing would compare nothing and look like a
+# pass. That is the exact failure mode this guard is about.
+if [ "$n_total" -lt 10 ]; then
+    printf '\nFAIL (vacuity): only %s baseline file(s) found under scripts/, expected 10+.\n' "$n_total"
+    printf 'The universe is broken, not the tree. Fix the scan rather than this number.\n'
+    exit 1
+fi
+
+printf '\n%s baseline file(s): %s ratcheted, %s exempt with a stated reason\n' \
+    "$n_total" "$n_ratchet" "$n_none"
+if [ "$rc" -ne 0 ]; then
+    printf 'FAIL  see rows above (#2706 PERF-028).\n'
+else
+    printf 'PASS  no shrink-only baseline grew against a ref this branch cannot rewrite.\n'
+fi
+exit "$rc"

--- a/scripts/check_contract_test_binding.sh
+++ b/scripts/check_contract_test_binding.sh
@@ -372,6 +372,27 @@ main() {
 
     [ -f "$BASELINE" ] || die "missing baseline file: $BASELINE, create it with --update-baseline"
 
+    # THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+    #
+    # Everything above compares the scan against the baseline AS IT STANDS IN THE
+    # WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+    # STALE (an entry with no finding) are the only two properties a working tree
+    # can answer, and a commit that appends one line AND lands the matching
+    # violation satisfies both at once: not new, because it is baselined; not
+    # stale, because the finding is real.
+    #
+    # Measured, not argued: appending one entry cloned from this file's own last
+    # real entry returned rc=0 from this guard, under its own words:
+    #     "the committed sum can only fall"
+    # Twelve guards in scripts/ failed the same probe.
+    #
+    # So growth is now compared against merge-base(HEAD, origin/main), falling
+    # back to the origin/main TIP because CI checks out shallow — a ref this
+    # branch cannot rewrite, and never the branch against itself.
+    # shellcheck source=scripts/lib_baseline_ratchet.sh
+    . "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+    baseline_ratchet_check "${REPO_ROOT}" scripts/contract_test_binding_baseline.txt keyed || exit 1
+
     printf 'Resolved %s test references; %s dangling across %s contract(s).\n' \
         "$refs" "$total" "$(wc -l < "$observed" | tr -d ' ')"
 

--- a/scripts/check_guards_are_wired.sh
+++ b/scripts/check_guards_are_wired.sh
@@ -25,9 +25,12 @@
 # This is the meta-guard: without it, the next one to go dark is found the same
 # way these were.
 #
-# A shrink-only baseline holds any deliberate exemption, so a guard that
-# genuinely should not run in CI can be recorded rather than argued about — but
-# the list may only get shorter.
+# A shrink-only baseline holds the exemptions that were already argued for.
+# SHRINK-ONLY IS NOW LITERAL: the list is compared against origin/main, so an
+# entry may only LEAVE it. Recording a NEW exemption is refused, not merely
+# discouraged — for one commit this header said "can be recorded rather than
+# argued about" while nothing compared the file to anything, and appending a
+# line here returned rc=0. The remedy for an unwired guard is to wire it.
 #
 #   bash scripts/check_guards_are_wired.sh              # check
 #   bash scripts/check_guards_are_wired.sh --self-test  # case table
@@ -165,6 +168,27 @@ if [ "${1:-}" = "--update" ]; then
     exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "the list may only get shorter"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/unwired_guards_baseline.txt set || exit 1
+
 if [ ! -f "$BASELINE" ]; then
     printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE"
     exit 1
@@ -173,8 +197,9 @@ baseline_count=$(grep -cvE '^\s*(#|$)' "$BASELINE" || true)
 
 if [ "$count" -gt "$baseline_count" ]; then
     printf '\nFAIL: unwired guards grew %s -> %s.\n' "$baseline_count" "$count"
-    printf 'A guard was added or unwired. Name it in a workflow, or record the\n'
-    printf 'exemption in %s with a reason.\n\n' "$(basename "$BASELINE")"
+    printf 'A guard was added or unwired. Name it in a workflow. The baseline is\n'
+    printf 'SHRINK-ONLY against origin/main, so %s is not an\n' "$(basename "$BASELINE")"
+    printf 'exemption list you can append to — an entry may only leave it.\n\n'
     comm -13 <(grep -vE '^\s*(#|$)' "$BASELINE" | LC_ALL=C sort) \
             <(printf '%s\n' "$FOUND" | grep .) | sed 's|^|  NEW: |'
     exit 1

--- a/scripts/check_hardcoded_paths.sh
+++ b/scripts/check_hardcoded_paths.sh
@@ -198,6 +198,27 @@ if [ "${1:-}" = "--full" ]; then
     [ -f "$SHIPPED_BASELINE" ] || { printf 'FAIL: %s missing.\n' "$SHIPPED_BASELINE"; exit 1; }
     baseline="$(tr -d '[:space:]' < "$SHIPPED_BASELINE")"
 
+    # THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+    #
+    # Everything above compares the scan against the baseline AS IT STANDS IN THE
+    # WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+    # STALE (an entry with no finding) are the only two properties a working tree
+    # can answer, and a commit that appends one line AND lands the matching
+    # violation satisfies both at once: not new, because it is baselined; not
+    # stale, because the finding is real.
+    #
+    # Measured, not argued: appending one entry cloned from this file's own last
+    # real entry returned rc=0 from this guard, under its own words:
+    #     "shipped-tier ratchet via pmat"
+    # Twelve guards in scripts/ failed the same probe.
+    #
+    # So growth is now compared against merge-base(HEAD, origin/main), falling
+    # back to the origin/main TIP because CI checks out shallow — a ref this
+    # branch cannot rewrite, and never the branch against itself.
+    # shellcheck source=scripts/lib_baseline_ratchet.sh
+    . "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+    baseline_ratchet_check "${REPO_ROOT}" scripts/hardcoded_path_shipped_baseline.txt count || exit 1
+
     printf 'pmat scanned %s file(s); %s shipped finding(s), baseline %s\n' "$files" "$shipped" "$baseline"
     if [ "$shipped" -gt "$baseline" ]; then
         printf '\nFAIL: shipped machine-specific paths grew %s -> %s.\n' "$baseline" "$shipped"

--- a/scripts/check_lockfile_no_registry_siblings.sh
+++ b/scripts/check_lockfile_no_registry_siblings.sh
@@ -154,6 +154,27 @@ if [ "${1:-}" = "--update" ]; then
   exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "The list may only SHRINK."
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/lockfile_registry_siblings_baseline.txt set || exit 1
+
 if [ ! -f "$BASELINE_FILE" ]; then
   printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE_FILE"
   exit 1

--- a/scripts/check_no_claim_literals.sh
+++ b/scripts/check_no_claim_literals.sh
@@ -343,6 +343,28 @@ if [ -f "$BASELINE" ]; then
     fi
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "known (baselined, must shrink)"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+RATCHET_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${RATCHET_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "$RATCHET_ROOT" scripts/claim_literal_baseline.txt set || rc=1
+
 printf '\n'
 if [ "$rc" -eq 0 ]; then
     printf 'PASS  no NEW claim literal on a user-facing surface.\n'

--- a/scripts/check_no_hand_rolled_parsers.sh
+++ b/scripts/check_no_hand_rolled_parsers.sh
@@ -225,6 +225,27 @@ if [ "${1:-}" = "--update" ]; then
     exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "--update # re-baseline (shrink only)"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/hand_rolled_parsers_baseline.txt set || exit 1
+
 if [ ! -f "$BASELINE" ]; then
     printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE"
     exit 1

--- a/scripts/check_no_tracked_ignored_files.sh
+++ b/scripts/check_no_tracked_ignored_files.sh
@@ -98,6 +98,27 @@ if [ "${1:-}" = "--update" ]; then
   exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "the count may only fall"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/tracked_ignored_baseline.txt count || exit 1
+
 if [ ! -f "$BASELINE" ]; then
   printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE"
   exit 1

--- a/scripts/check_perf_claims_cite_receipts.sh
+++ b/scripts/check_perf_claims_cite_receipts.sh
@@ -279,8 +279,10 @@ if [ "${1:-}" = "--update" ]; then
         printf '# written. Recorded, not blessed.\n#\n'
         printf '# THE RATCHET: this file may only SHRINK. Remove a line by deleting\n'
         printf '# the claim, or by citing the evidence/ receipt that produced it\n'
-        printf '# within three lines of it. Adding a line requires editing this\n'
-        printf '# header and arguing for it.\n#\n'
+        printf '# within three lines of it. A line may only LEAVE this file: it is\n'
+        printf '# compared against origin/main by check_perf_claims_cite_receipts.sh\n'
+        printf '# and by check_baseline_ratchets.sh, so an append is REFUSED, not\n'
+        printf '# merely discouraged.\n#\n'
         printf '# A DANGLING citation is never baselined — see the guard header.\n'
         printf '%s\n' "$records" | grep -v '^$' \
             | awk -F: '$3=="uncited"{print $1":"$2}' | LC_ALL=C sort -u
@@ -326,6 +328,28 @@ if [ "$stale" -gt 0 ]; then
     printf 'REPORT %s stale baseline location/s no longer carry a claim — prune\n' "$stale"
     printf '       with --update, or the ratchet re-admits a claim there later.\n'
 fi
+
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "THE RATCHET: this file may only SHRINK."
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+RATCHET_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${RATCHET_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "$RATCHET_ROOT" scripts/perf_claim_citation_baseline.txt set || rc=1
 
 printf '\n'
 if [ "$rc" -eq 0 ]; then

--- a/scripts/check_shell_lint_ratchet.sh
+++ b/scripts/check_shell_lint_ratchet.sh
@@ -80,6 +80,27 @@ if [ "${1:-}" = "--update" ]; then
     exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "the count is baselined and may only SHRINK"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/shell_lint_baseline.txt count || exit 1
+
 if [ ! -f "$BASELINE" ]; then
     printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE"
     exit 1

--- a/scripts/check_test_fixture_paths.sh
+++ b/scripts/check_test_fixture_paths.sh
@@ -96,6 +96,27 @@ if [ "${1:-}" = "--update" ]; then
   exit 0
 fi
 
+# THE RATCHET IS A PROPERTY OF THE DIFF, NOT OF THE TREE.
+#
+# Everything above compares the scan against the baseline AS IT STANDS IN THE
+# WORKING TREE, and that is not a ratchet. NEW (a finding with no entry) and
+# STALE (an entry with no finding) are the only two properties a working tree
+# can answer, and a commit that appends one line AND lands the matching
+# violation satisfies both at once: not new, because it is baselined; not
+# stale, because the finding is real.
+#
+# Measured, not argued: appending one entry cloned from this file's own last
+# real entry returned rc=0 from this guard, under its own words:
+#     "--update # re-baseline (shrink only)"
+# Twelve guards in scripts/ failed the same probe.
+#
+# So growth is now compared against merge-base(HEAD, origin/main), falling
+# back to the origin/main TIP because CI checks out shallow — a ref this
+# branch cannot rewrite, and never the branch against itself.
+# shellcheck source=scripts/lib_baseline_ratchet.sh
+. "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+baseline_ratchet_check "${REPO_ROOT}" scripts/test_fixture_path_baseline.txt count || exit 1
+
 if [ ! -f "$BASELINE" ]; then
   printf 'FAIL: %s missing. Run --update once to establish it.\n' "$BASELINE"
   exit 1

--- a/scripts/claim_literal_baseline.txt
+++ b/scripts/claim_literal_baseline.txt
@@ -4,10 +4,16 @@
 # reads — a doc comment on shipped code, or printed output. None of them was
 # produced by a measurement. They are recorded, not blessed.
 #
-# THE RATCHET: this file may only SHRINK. Adding a line requires editing this
-# header and arguing for it, which is the point — a baseline that may grow
-# quietly is a permission slip. Remove a line by deleting the claim or by
-# deriving it from a receipt under evidence/.
+# THE RATCHET: this file may only SHRINK, and that is now the MECHANISM rather
+# than this sentence. For one commit the sentence read "adding a line requires
+# editing this header and arguing for it" while nothing compared the file to
+# anything: appending `book/src/tools/apr-cli.md:1786` and writing the matching
+# claim on that line printed "known (baselined, must shrink): 138 / new: 0 /
+# PASS" — grown from 137, laundering the claim it had just admitted.
+#
+# It is now compared against origin/main by check_no_claim_literals.sh and by
+# check_baseline_ratchets.sh. A line may only LEAVE this file: delete the claim,
+# or derive it from a receipt under evidence/.
 #
 # Already removed: the two printed banners in serve/server.rs, one of which
 # advertised "800+ tok/s (2.8x Ollama)" on a code path that HANGS on four

--- a/scripts/contract_duplicate_stem_baseline.txt
+++ b/scripts/contract_duplicate_stem_baseline.txt
@@ -4,8 +4,11 @@
 # copies have DIFFERENT content. Such a stem cannot be resolved to one contract,
 # so it is refused by the stem index rather than tie-broken by directory order.
 #
-# This list may only SHRINK. Adding a line is not a fix — deduplicate the stem
-# (pick the correct contract, delete or rename the other) and remove the line.
+# This list may only SHRINK, and it is compared against origin/main by
+# check_baseline_ratchets.sh — `pv` reads this file but cannot ratchet it, so a
+# shell guard carries the comparison. Adding a line is not a fix — deduplicate
+# the stem (pick the correct contract, delete or rename the other) and remove
+# the line.
 # A stem that diverges but is absent here fails `pv lint` (PV-DUP-001).
 # A line whose stem no longer diverges also fails `pv lint` (PV-DUP-002).
 #

--- a/scripts/lib_baseline_ratchet.sh
+++ b/scripts/lib_baseline_ratchet.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# lib_baseline_ratchet.sh — turn a "shrink-only" baseline into an actual ratchet.
+#
+# THE DEFECT THIS EXISTS FOR
+# --------------------------
+# check_no_fabricated_baselines.sh printed
+#
+#     ok  rust  37 ledgered site(s) = 37 ledger entr(ies), 0 new, 0 stale
+#               (shrink-only, PERF-008-RUST; the count is enforced, not asserted)
+#
+# while appending one line to its ledger and landing a fabrication at exactly
+# that coordinate returned rc=0. The words "SHRINK-ONLY" appeared four times in
+# that file; a comparison against anything appeared zero times.
+#
+# The transferable diagnosis, and the reason this is a library rather than one
+# more fix: NEW and STALE are the two properties checkable from the WORKING
+# TREE, and neither one is a ratchet.
+#
+#   * NEW   — a finding with no baseline entry.  A ledgered finding is not new.
+#   * STALE — a baseline entry with no finding.   A real finding is not stale.
+#
+# A baseline line and its matching violation, added in the SAME commit, satisfy
+# both at once. That commit is the laundering shape, and every guard in this
+# repository that called itself shrink-only accepted it: a sweep appending one
+# entry cloned from each file's own last real entry found 12 of 12 green.
+#
+# A ratchet is a property of the DIFF against a ref the author cannot rewrite.
+# Nothing derivable from the working tree alone can be one, because the working
+# tree contains both the rule and the exception to it.
+#
+# WHY A SUBSET AND NOT A COUNT
+# ----------------------------
+# Counting passes a SWAP: drop one coordinate, add another, total unchanged.
+# That is an append wearing the old total. The current entry set must be a
+# SUBSET of the comparand's — removal is the point of a ratchet and stays
+# green, and any entry not already on the comparand fails whether it arrived by
+# append or by substitution.
+#
+# For the baselines that hold a single integer rather than a list, the integer
+# itself is the whole state, and "current <= comparand" is the same property
+# with a one-element universe. For `path<TAB>count` ledgers the property is
+# per-key: no key may rise and no key may appear.
+#
+# THE COMPARAND IS A REF A PULL REQUEST CANNOT REWRITE
+# ----------------------------------------------------
+# This mirrors check_dogfood_coverage.sh, which exists because a floor and its
+# universe both lived in one editable file: "There is no baseline NUMBER in
+# this repository for a PR to edit."
+#
+#   * merge-base(HEAD, origin/main) is PREFERRED — it isolates this branch's
+#     own edits, so a branch merely behind main stays green. It needs shared
+#     history.
+#   * the origin/main TIP is the FALLBACK, and it is not decoration: CI checks
+#     this repository out at fetch-depth 1, so a grafted shallow head has no
+#     common ancestor and the CI path IS the tip path. The tip is strictly
+#     stronger (it also forbids re-adding an entry main has already deleted).
+#     The cost is a false red on a branch behind a main that already shrank the
+#     baseline; the remedy is `git rebase origin/main`, and the FAIL says so.
+#   * if NEITHER resolves, this is a HARD FAILURE. It never degrades to
+#     comparing the branch against itself, which would disarm every ratchet
+#     silently — the exact failure this library is about.
+#   * if the ref resolves but carries no baseline, that is ABSENT and also a
+#     hard failure. A missing measurement is never "no growth".
+#
+# Set BASELINE_RATCHET_BASE_REF to override the comparand. Every row then says
+# the ref is NOT protected, because a gate that keeps printing its guarantee
+# after the guarantee was overridden is lying in the way this whole file is
+# about.
+#
+# CONSEQUENCE, STATED PLAINLY: an entry may only LEAVE a ratcheted baseline.
+# Adding one is not "hard", it is refused, and there is no in-branch way around
+# it. If a baseline genuinely must grow, that is a decision to argue in a PR
+# that changes the guard's contract — not a line to slip into a data file.
+#
+# OPTION-NEUTRAL. This file is SOURCED, and `set` in a sourced file mutates the
+# CALLER's shell (see check_sourced_libs_option_neutral.sh, and the nightly it
+# killed six lines in). There is no `set` at file scope here; every entry point
+# reports by RETURN STATUS. Source it as:
+#
+#     . "${REPO_ROOT}/scripts/lib_baseline_ratchet.sh" || exit 1
+#
+# Refs: paiml/aprender#2706 (APR-PERF-GATE-001), PERF-008, PERF-028.
+
+BASELINE_RATCHET_BASE_REF="${BASELINE_RATCHET_BASE_REF:-origin/main}"
+
+# ---------------------------------------------------------------------------
+# Readers. Deliberately no pipe whose READER can exit early: `grep … | head -1`
+# returns 141 under pipefail when the writer takes SIGPIPE, which is
+# input-size dependent and therefore green locally and red in CI at random.
+# `sort` and `comm` consume their whole input, so those pipes are safe.
+
+_br_data() { # _br_data <file>  -> the data lines, in file order
+    grep -vE '^[[:space:]]*(#|$)' "$1" 2>/dev/null || true
+}
+
+_br_entries() { # _br_entries <file>  -> data lines, sorted, deduplicated
+    _br_data "$1" | LC_ALL=C sort -u
+}
+
+_br_number() { # _br_number <file> -> the single integer it holds, rc 1 if it holds none
+    local all first
+    all=$(_br_data "$1")
+    first=${all%%$'\n'*}
+    first=${first//[[:space:]]/}
+    case "$first" in
+        '' | *[!0-9]*) return 1 ;;
+    esac
+    printf '%s\n' "$first"
+}
+
+# ---------------------------------------------------------------------------
+# Comparators. Each sets BR_DELTA to the human-readable growth it refused and
+# BR_REMOVED to the number of entries that legitimately left.
+
+_br_cmp_set() { # _br_cmp_set <base-file> <cur-file>
+    BR_DELTA=$(LC_ALL=C comm -13 <(_br_entries "$1") <(_br_entries "$2") | sed 's/^/        + /')
+    BR_REMOVED=$(LC_ALL=C comm -23 <(_br_entries "$1") <(_br_entries "$2") | grep -c . || true)
+    [ -z "$BR_DELTA" ]
+}
+
+_br_cmp_count() { # _br_cmp_count <base-file> <cur-file>
+    local b c
+    BR_DELTA=""
+    BR_REMOVED=0
+    b=$(_br_number "$1") || { BR_DELTA="        comparand holds no integer"; return 2; }
+    c=$(_br_number "$2") || { BR_DELTA="        working tree holds no integer"; return 2; }
+    if [ "$c" -gt "$b" ]; then
+        BR_DELTA=$(printf '        + the recorded count rose %s -> %s' "$b" "$c")
+        return 1
+    fi
+    if [ "$c" -lt "$b" ]; then
+        BR_REMOVED=$((b - c))
+    fi
+    return 0
+}
+
+# Comment stripping happens in grep, NOT in awk. An awk program carrying
+# `/^[ \t]*#/` reads to a shell linter as a `[ ` test with parentheses inside
+# it: bashrs reports SC1028/SC2104 errors against a line that is awk source,
+# and check_shell_lint_ratchet.sh counts error LINES, so a false positive still
+# moves a shrink-only baseline. Feeding awk pre-filtered data keeps both the
+# awk simpler and the lint honest.
+_br_cmp_keyed() { # _br_cmp_keyed <base-file> <cur-file>   (lines are <key><TAB><integer>)
+    BR_DELTA=$(LC_ALL=C awk -F'\t' '
+        NR == FNR { b[$1] = $2; seen[$1] = 1; next }
+        {
+            if (!($1 in seen))       { printf "        + NEW KEY  %s (%s)\n", $1, $2 }
+            else if ($2+0 > b[$1]+0) { printf "        + RAISED   %s  %s -> %s\n", $1, b[$1], $2 }
+        }
+    ' <(_br_data "$1") <(_br_data "$2"))
+    BR_REMOVED=$(LC_ALL=C awk -F'\t' '
+        NR == FNR { c[$1] = $2; next }
+        { if (!($1 in c) || c[$1]+0 < $2+0) { n++ } }
+        END { print n+0 }
+    ' <(_br_data "$2") <(_br_data "$1"))
+    [ -z "$BR_DELTA" ]
+}
+
+# ---------------------------------------------------------------------------
+# Comparand resolution. Returns "<MODE>\t<commit-ish>" and never fails: the
+# CALLER decides, so that "could not resolve" is a loud verdict row rather than
+# a swallowed error.
+
+baseline_ratchet_resolve() { # baseline_ratchet_resolve <root> <ref> <path>
+    local root="$1" ref="$2" path="$3" mb
+    if ! git -C "$root" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null 2>&1; then
+        printf 'UNRESOLVABLE\t%s\n' "$ref"
+        return 0
+    fi
+    mb=$(git -C "$root" merge-base HEAD "$ref" 2>/dev/null) || mb=""
+    if [ -n "$mb" ] && git -C "$root" cat-file -e "${mb}:${path}" 2>/dev/null; then
+        printf 'MERGEBASE\t%s\n' "$mb"
+        return 0
+    fi
+    if git -C "$root" cat-file -e "${ref}:${path}" 2>/dev/null; then
+        printf 'TIP\t%s\n' "$ref"
+        return 0
+    fi
+    printf 'ABSENT\t%s\n' "$ref"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# The entry point every guard calls.
+#
+#     baseline_ratchet_check <root> <baseline-path-relative-to-root> <set|count|keyed>
+#
+# rc 0 = the baseline did not grow against a ref this branch cannot rewrite.
+# rc 1 = it grew, or growth is UNMEASURABLE. Both are failures, and they are
+#        distinguished in the text but never in the status.
+
+baseline_ratchet_check() {
+    local root="$1" path="$2" kind="$3"
+    local resolution mode ref tmp base_copy how note cmp_rc
+
+    if [ ! -f "$root/$path" ]; then
+        printf 'FAIL  ratchet  %s is missing from the working tree. Growth is\n' "$path"
+        printf '               UNMEASURED without it, and an unmeasured ratchet is not a\n'
+        printf '               ratchet. Restore it, or retire the check in the same commit.\n'
+        return 1
+    fi
+
+    resolution=$(baseline_ratchet_resolve "$root" "$BASELINE_RATCHET_BASE_REF" "$path")
+    mode=${resolution%%$'\t'*}
+    ref=${resolution##*$'\t'}
+
+    case "$mode" in
+        UNRESOLVABLE)
+            printf 'FAIL  ratchet  cannot resolve the comparand ref <%s>, so shrink-only\n' "$ref"
+            printf '               for %s is UNMEASURED. It is NOT degraded to\n' "$path"
+            printf '               comparing this branch against itself — that disarms the\n'
+            printf '               ratchet silently. In CI, before this guard runs:\n'
+            printf '               git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main\n'
+            return 1 ;;
+        ABSENT)
+            printf 'FAIL  ratchet  %s carries no %s, so there is nothing\n' "$ref" "$path"
+            printf '               to shrink from. A missing comparand is not "no growth".\n'
+            printf '               Either this branch predates the baseline (git rebase\n'
+            printf '               origin/main), or the baseline was deleted to escape its\n'
+            printf '               own gate. Retire the check in the same commit if it is\n'
+            printf '               genuinely being retired.\n'
+            return 1 ;;
+    esac
+
+    tmp=$(mktemp -d) || {
+        printf 'FAIL  ratchet  could not create a scratch directory, so %s is\n' "$path"
+        printf '               UNMEASURED. That is a failure, not a skip.\n'
+        return 1
+    }
+    base_copy="$tmp/base"
+    if ! git -C "$root" show "${ref}:${path}" > "$base_copy" 2>/dev/null; then
+        rm -rf "${tmp:?}"
+        printf 'FAIL  ratchet  could not read %s:%s\n' "$ref" "$path"
+        return 1
+    fi
+
+    BR_DELTA=""
+    BR_REMOVED=0
+    # `if` rather than `cmd; rc=$?`: a comparator returns 1 BY DESIGN on the
+    # growth path, and a caller running `set -e` (check_no_claim_literals.sh
+    # does) would die there before printing a single verdict row -- rc=1 with
+    # no evidence, which reads exactly like a broken run. An errexit-safe
+    # capture is the difference between a RED and a crash.
+    case "$kind" in
+        set)   if _br_cmp_set   "$base_copy" "$root/$path"; then cmp_rc=0; else cmp_rc=$?; fi ;;
+        count) if _br_cmp_count "$base_copy" "$root/$path"; then cmp_rc=0; else cmp_rc=$?; fi ;;
+        keyed) if _br_cmp_keyed "$base_copy" "$root/$path"; then cmp_rc=0; else cmp_rc=$?; fi ;;
+        *)
+            rm -rf "${tmp:?}"
+            printf 'FAIL  ratchet  unknown comparison kind <%s> for %s.\n' "$kind" "$path"
+            return 1 ;;
+    esac
+    rm -rf "${tmp:?}"
+
+    case "$mode" in
+        MERGEBASE) how="merge-base with $BASELINE_RATCHET_BASE_REF" ;;
+        TIP)       how="tip of $BASELINE_RATCHET_BASE_REF (no merge-base available; stricter)" ;;
+        *)         how="$mode" ;;
+    esac
+    note="protected; a pull request cannot rewrite it"
+    if [ "$BASELINE_RATCHET_BASE_REF" != "origin/main" ]; then
+        note="OVERRIDDEN via BASELINE_RATCHET_BASE_REF — NOT a protected ref"
+    fi
+
+    if [ "$cmp_rc" -eq 0 ]; then
+        printf 'ok    ratchet  %s did not grow (%s removed) vs %s\n' \
+            "$path" "$BR_REMOVED" \
+            "$(git -C "$root" rev-parse --short "$ref" 2>/dev/null || printf '%s' "$ref")"
+        printf '               comparand: %s (%s)\n' "$how" "$note"
+        return 0
+    fi
+
+    if [ "$cmp_rc" -eq 2 ]; then
+        printf 'FAIL  ratchet  %s could not be compared:\n' "$path"
+    else
+        printf 'FAIL  ratchet  %s GREW. It is SHRINK-ONLY:\n' "$path"
+    fi
+    printf '%s\n' "$BR_DELTA"
+    printf '               comparand: %s (%s)\n' "$how" "$note"
+    printf '               An entry may only LEAVE this file. Fix the finding instead of\n'
+    printf '               recording it. If the branch is merely behind a main that has\n'
+    printf '               already shrunk this baseline: git rebase origin/main.\n'
+    return 1
+}

--- a/scripts/perf_claim_citation_baseline.txt
+++ b/scripts/perf_claim_citation_baseline.txt
@@ -4,8 +4,10 @@
 #
 # THE RATCHET: this file may only SHRINK. Remove a line by deleting
 # the claim, or by citing the evidence/ receipt that produced it
-# within three lines of it. Adding a line requires editing this
-# header and arguing for it.
+# within three lines of it. A line may only LEAVE this file: it is
+# compared against origin/main by check_perf_claims_cite_receipts.sh
+# and by check_baseline_ratchets.sh, so an append is REFUSED, not
+# merely discouraged.
 #
 # A DANGLING citation is never baselined — see the guard header.
 book/src/best-practices/performance.md:250


### PR DESCRIPTION
Epic #2706 (the receipt rule). Thirteen baseline files claimed to be ratchets and none of them were.

## The diagnosis, and why a count is not enough

`check_no_fabricated_baselines.sh` printed *"(shrink-only; the count is enforced, not asserted)"* and enforced nothing: append one ledger line, land a fabrication at that coordinate, **rc=0 PASS**.

`new` and `stale` are the two properties checkable from the **working tree**, and neither is a ratchet — a ledger line and its violation added in the same commit satisfy both at once. **A ratchet is a property of the diff against a ref the author cannot rewrite.** These files never looked at one.

A count is also not enough: counting passes a **swap**, which is an append wearing the old total. Enforcement here is a subset for lists, per-key for `path<TAB>count`, integer for counts.

## Per-file, with laundering demonstrated where it could be

| file | its own prose | growth refused | laundering BEFORE rc=0 → AFTER rc=1 |
|---|---|---|---|
| `assertion_exclusion` | "monotonically decreasing" | keyed | **yes** |
| `claim_literal` | "may only SHRINK" | set | **yes** |
| `contract_test_binding` | "the committed sum can only fall" | keyed | **yes** |
| `perf_claim_citation` | "may only SHRINK" | set | **yes** |
| `shell_lint` | "may only SHRINK" | count | **yes** |
| `test_fixture_path` | "RATCHET… (shrink only)" | count | **yes** |
| `tracked_ignored` | "the count may only fall" | count | **yes** |
| `unwired_guards` | "the list may only get shorter" | set | **yes** |
| `contract_duplicate_stem` | "may only SHRINK" | set (meta-guard) | not attempted |
| `hand_rolled_parsers` | "shrink only" | set | needs a new workspace binary crate |
| `hardcoded_path_shipped` | "shipped-tier ratchet" | count | not attempted |
| `lockfile_registry_siblings` | "may only SHRINK" | set | needs a hand-edited `Cargo.lock` |
| `fabricated_baseline_rust_sites` | yes | meta-guard only | already demonstrated |
| `duplicate_bin_names_allowlist` | **no** — intent model | **deliberately not** | n/a |

The last row matters: its header requires EXACT match with the observed set and fails on stale entries, so freezing it against main would forbid renaming a crate. Classified `none`, with the reason printed rather than silently skipped.

Sharpest single receipt — `claim_literal`, same mutation, two guard versions:

```
BEFORE  known (baselined, must shrink): 138   new: 0     PASS   rc=0     # grew from 137
AFTER   known (baselined, must shrink): 138   new: 0
        FAIL  ratchet  scripts/claim_literal_baseline.txt GREW. It is SHRINK-ONLY:
                + book/src/tools/apr-cli.md:1786                        rc=1
```

Every mutation row asserts the **verdict row**, not merely the exit status, so a crash cannot be mistaken for a RED. Rows per guard: unchanged → 0; append → 1; **append + its matching violation → 1**; swap → 1; legitimate shrink → 0. The third row is the one that distinguishes this work — the others were often already red for other reasons, and claiming the ratchet on their evidence would repeat the over-attribution being fixed.

## What was built

`scripts/lib_baseline_ratchet.sh` — option-neutral sourced library (a sourced `set -euo pipefail` mutates the caller's shell and once killed a nightly six lines in). merge-base preferred, `origin/main` tip fallback, and UNRESOLVABLE / ABSENT / missing-in-tree all **hard-fail**: a missing measurement must be RED, never read as clean.

One subtlety worth recording: a comparator returns 1 by design, and `check_no_claim_literals.sh` runs `set -euo pipefail`, so the naive `cmd; rc=$?` **died at the call** — rc=1 with zero verdict rows. The self-test has a row that reverts to that form and goes RED.

`scripts/check_baseline_ratchets.sh` — coverage backstop with a run-time universe (`find` ∪ index; tracked-only would be a free pass, which has recurred four times here). Every `scripts/*.txt` is classified or it hard-fails. 31-row case table.

`ci.yml` — the `origin/main` fetch moved to immediately after checkout, because **three ratcheted guards ran before it**.

## Incidental finding: a red guard CI does not run in the mode that matters

`scripts/check_hardcoded_paths.sh --full` is **rc=1 on `origin/main`**:

```
FAIL: shipped machine-specific paths grew 278 -> 299.
```

CI *does* invoke this guard (`ci.yml:1204`, plus `--self-test` at `:1206`) — but **not with `--full`**, which is the mode that catches shipped machine-specific paths. So 21 new ones landed. Pre-existing, not caused here, **not fixed here** — it wants its own ticket rather than a drive-by baseline bump.

Related, and the reason that ticket matters: **`shell_lint_baseline.txt` is 876 against an observed 149** — 727 of slack. It is now diff-ratcheted, but as a *behaviour* gate it is inert; 727 new bashrs errors could land before it complains. Same shape in `hand_rolled_parsers` (1 vs 0) and `lockfile_siblings` (7 vs 1). A ratchet with that much slack enforces its diff and not its subject.

## Unproven, stated plainly

- **On `main` itself the ratchet is trivially green** — merge-base equals HEAD, so it compares the tip against itself. Inherent to the design and identical in the reference implementation; the enforcement is real on branches, which is where growth is authored.
- TIP scope was re-mutated (8 rows, correct) but via an orphan ref with the env override, so it also prints `NOT a protected ref`. **A genuinely shallow CI checkout was not run.**
- R3 (swap) is **vacuous for count-kind** baselines — a single integer has no swap. Proven for set and keyed kinds only.
- `check_no_fabricated_baselines.sh` itself was left untouched: #2719 rewrites 478 lines of it. Its baseline file is ratcheted by the meta-guard, so the claim is true in CI on this branch; the misleading in-file prose is #2719's to fix.
- No cargo or workspace tests run — this is shell plus one workflow file. `bashrs lint` 0 errors on both new files; `check_shell_lint_ratchet.sh` rc=0 with total error lines **149, unchanged from base**.

## Process note worth carrying

The prose fixes were **silently wiped mid-run** by a `git checkout -- .` inside a mutation probe, and every guard still passed afterwards — the edits looked effective and were gone. Caught by grepping for the new strings rather than trusting the green. A shadowed or reverted artifact is worse than a missing one, because success is indistinguishable.

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
