### PR TITLE
fix(compute): the zscore test asserted a precision f32 cannot deliver — blocking the merge queue

### DIFF
--- a/crates/aprender-compute/src/vector/tests/property_tests/statistics/covariance_and_normalize.rs
+++ b/crates/aprender-compute/src/vector/tests/property_tests/statistics/covariance_and_normalize.rs
@@ -164,11 +164,16 @@ proptest! {
     fn test_zscore_produces_zero_mean(
         a in prop::collection::vec(-100.0f32..100.0, 2..100)
     ) {
-        // Ensure vector is not constant
-        let std_a: f32 = a.iter().map(|x| x * x).sum::<f32>() / a.len() as f32
-                       - (a.iter().sum::<f32>() / a.len() as f32).powi(2);
+        // Ensure vector is not constant. Two-pass, because E[x^2] - E[x]^2
+        // catastrophically cancels: on the input that broke this test in CI
+        // (a = [75.395966, 75.466225]) it returns 0.001953125 against a true
+        // variance of 0.001234085 -- 58% high. A skip criterion that wrong is
+        // unreliable in both directions.
+        let n = a.len() as f32;
+        let mean_a: f32 = a.iter().sum::<f32>() / n;
+        let var_a: f32 = a.iter().map(|x| (x - mean_a) * (x - mean_a)).sum::<f32>() / n;
 
-        if std_a < 1e-6 {
+        if var_a < 1e-6 {
             return Ok(());  // Skip constant vectors
         }
 
@@ -176,12 +181,51 @@ proptest! {
         let z = va.zscore().unwrap();
         let mean = z.mean().unwrap();
 
+        // The achievable precision here is NOT absolute. z_i = (x_i - mu) / sigma
+        // carries a rounding residue of about eps*|x_i|, so |mean(z)| is bounded
+        // by eps * max|a| / sigma -- which grows without limit as the data
+        // approaches constant. The old fixed 1e-4 asserted a precision f32
+        // cannot deliver: for the CI input, sigma = 0.0351 and max|a| = 75.47,
+        // giving a bound of 2.56e-4, so the test was ~2.6x too tight and failed
+        // at 1.086e-4 after 114 successes. The floor keeps the assertion
+        // meaningful for well-conditioned inputs.
+        let sigma = var_a.sqrt();
+        let max_abs = a.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+        let tol = (10.0 * f32::EPSILON * max_abs / sigma).max(1e-4);
+
         prop_assert!(
-            mean.abs() < 1e-4,
-            "zscore mean = {}, expected ~ 0",
-            mean
+            mean.abs() < tol,
+            "zscore mean = {}, tolerance = {} (sigma = {}, max|a| = {})",
+            mean, tol, sigma, max_abs
         );
     }
+}
+
+/// Regression, aprender CI 2026-08-28: this exact pair broke
+/// `test_zscore_produces_zero_mean` after 114 successes. Two large,
+/// nearly-equal values make sigma tiny relative to |a|, so the rounding
+/// residue in mean(zscore(a)) is ~eps*max|a|/sigma = 2.56e-4 -- larger than
+/// the fixed 1e-4 the test used to assert. Deterministic, so it cannot
+/// depend on proptest drawing the seed again.
+#[test]
+fn zscore_zero_mean_tolerates_ill_conditioned_input() {
+    let a = [75.395966_f32, 75.466225_f32];
+    let n = a.len() as f32;
+    let mean_a: f32 = a.iter().sum::<f32>() / n;
+    let var_a: f32 = a.iter().map(|x| (x - mean_a) * (x - mean_a)).sum::<f32>() / n;
+    let sigma = var_a.sqrt();
+    let max_abs = a.iter().fold(0.0f32, |m, x| m.max(x.abs()));
+    let tol = (10.0 * f32::EPSILON * max_abs / sigma).max(1e-4);
+
+    let mean = Vector::from_slice(&a).zscore().unwrap().mean().unwrap();
+
+    // The point of the regression: the residue really does exceed the old
+    // fixed bound, so this input would still fail the pre-fix assertion.
+    assert!(
+        tol > 1e-4,
+        "input must be ill-conditioned enough to need a scaled tolerance, tol = {tol}"
+    );
+    assert!(mean.abs() < tol, "zscore mean = {mean}, tolerance = {tol}");
 }
 
 proptest! {


### PR DESCRIPTION
**This is blocking the merge queue.** #2707 has been evicted twice; its second queue run failed here.

## Not a flake, and not a defect in `zscore()`

The failing step is named *"Compute tests (tolerate SIGSEGV at exit — all tests pass but harness crashes on cleanup)"*, which invites reading any failure there as the known trueno cleanup flake. It was a real test failure:

```
test_zscore_produces_zero_mean
  zscore mean = 0.00010859966, expected ~ 0
  minimal failing input: a = [75.395966, 75.466225]
  successes: 114
```

Two large, nearly-equal values. `zscore()` is fine — the **test's tolerance model** was wrong, and its skip criterion was computed by a formula that catastrophically cancels.

## Defect 1 — the skip criterion is 58% wrong

```rust
let std_a: f32 = a.iter().map(|x| x * x).sum::<f32>() / a.len() as f32
               - (a.iter().sum::<f32>() / a.len() as f32).powi(2);
if std_a < 1e-6 { return Ok(()); }
```

`std_a` is named for a standard deviation and holds a **variance**, computed as `E[x²] − E[x]²`. On the failing input:

| | |
|---|---|
| guard value (f32) | **0.001953125** |
| true variance | 0.001234085 |
| relative error | **58.3%** |

Both terms are ≈5688.6, where f32 resolves ≈0.0005, so the difference is barely above representable resolution. A skip criterion that wrong is unreliable in **both** directions — it admits ill-conditioned inputs and can skip legitimate ones. Replaced with the two-pass form.

## Defect 2 — the tolerance asserted a precision f32 cannot deliver

`z_i = (x_i − μ)/σ` carries a rounding residue of about `ε·|x_i|`, so `|mean(z)|` is bounded by

```
ε · max|a| / σ
```

which grows without limit as the data approaches constant. For this input `σ = 0.0351`, `max|a| = 75.47`:

```
1.19e-7 × 75.47 / 0.0351 = 2.56e-4        the fixed 1e-4 was ~2.6x too tight
observed failure          = 1.086e-4       inside the predicted bound
```

Tolerance now scales as `10·ε·max|a|/σ` with a **1e-4 floor**, so well-conditioned inputs keep the strict bound.

## This is not a loosening in the sense that matters

Mutation-verified in both directions:

| mutation | result |
|---|---|
| restore the fixed `1e-4` | regression test **FAILS** (rc=101) — the fix is load-bearing |
| bypass `zscore()` entirely | `mean = 75.43109` vs `tolerance = 0.0025609` — **still fails by ~29,000×** |
| unmutated | rc=0 |

The second row is the one that matters: a scaled tolerance is only acceptable if it still rejects a broken implementation, and it does, by four orders of magnitude.

## Pinned two ways so it cannot regress on a dice roll

- `proptest-regressions/.../covariance_and_normalize.txt` carries the shrunk seed, so proptest replays it before generating novel cases.
- `zscore_zero_mean_tolerates_ill_conditioned_input` asserts it **deterministically**, and additionally asserts that the input really is ill-conditioned enough to require a scaled tolerance — so the regression cannot quietly become vacuous if the conditioning ever changes.

`cargo test -p aprender-compute --lib` → **3510 passed, 0 failed**. `cargo fmt --all -- --check` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
