### PR TITLE
fix(perf): the receipt producer recorded accel_absent for every accelerator, on every host

### DIFF
--- a/scripts/parity_host_receipt.sh
+++ b/scripts/parity_host_receipt.sh
@@ -128,8 +128,17 @@ run_lane() { # run_lane <class> <apr-flags> <llama-ngl> -> writes $WORK/<class>.
 # A published apr has no GPU path at all, so its only honest lane is cpu, and
 # that is the finding rather than a gap in coverage.
 run_lane cpu "--no-gpu" 0
-if "$APR" serve run --help 2>&1 | grep -q -- '--gpu' && \
-   strings -a "$APR" 2>/dev/null | grep -qE 'cudarc|libcuda\.so|libcublas|Metal'; then
+# Both probes read a herestring, never a pipe. `grep -q` exits on its FIRST
+# match, the producer takes SIGPIPE, and `set -o pipefail` hands the pipeline
+# the producer's 141 -- so the condition was FALSE on a binary that does
+# contain the markers. Measured on gx10 and reproduced on lambda: 141 on
+# 10/10 repeats with pipefail, 0 without, while the pattern matches 5 times.
+# Every receipt therefore recorded `accel_absent` for a CUDA-capable apr,
+# which is a fabricated provenance field emitted by the provenance producer.
+APR_HELP="$( "$APR" serve run --help 2>&1 )"
+APR_STRINGS="$( strings -a "$APR" 2>/dev/null )"
+if grep -q -- '--gpu' <<< "$APR_HELP" && \
+   grep -qE 'cudarc|libcuda\.so|libcublas|Metal' <<< "$APR_STRINGS"; then
     run_lane accel "--gpu" 999
 else
     # Say WHY, in the receipt, in a form the gate can read. A gate that demands


### PR DESCRIPTION
Epic #2706 (the receipt rule). Found on gx10 by PERF-030, reproduced independently on lambda before fixing.

## The provenance producer fabricated a provenance field, on every host, always

`parity_host_receipt.sh:132` decides whether the accelerator lane runs at all. Both halves of its condition were pipes into `grep -q`, under `set -o pipefail`:

```bash
if "$APR" serve run --help 2>&1 | grep -q -- '--gpu' && \
   strings -a "$APR" 2>/dev/null | grep -qE 'cudarc|libcuda\.so|libcublas|Metal'; then
```

`grep -q` exits on its **first** match, the producer takes SIGPIPE, and `pipefail` hands the pipeline the producer's status. Measured against a CUDA-capable `apr` (75,829,792 bytes):

```
with    set -euo pipefail :  141 141 141 141 141 141 141 141 141 141
without pipefail          :  0 0 0
the pattern actually matches: 5 times
```

The condition was **FALSE on a binary that plainly contains the markers**. The accel lane was skipped on every host, and the `else` branch wrote `no-accelerator-linked` into the receipt.

This is the failure the epic exists to remove, committed by the provenance producer itself: a receipt field **asserting the absence of an accelerator that is present**. It is not a missing measurement, it is a fabricated one — and it was *unfalsifiable*, because the branch that would contradict it could never be taken on any host, for any binary.

## Fix and proof

Both probes now read a herestring. No pipe, no SIGPIPE.

| mutation | result |
|---|---|
| restore the pipe form | lane **SKIPPED** — the defect returns |
| fixed form, CUDA-capable apr | lane **WOULD RUN** |
| fixed form, binary with no accelerator markers | lane **SKIPPED** — discrimination holds |

The third row is the one that makes the fix meaningful: removing the pipe must not make the probe say yes to everything.

## Two notes for whoever hardens this further

**`ldd` is not the alternative.** apr `dlopen`s CUDA (`cuInit`, `cuLaunchKernel`, `cublasCreate_v2`), so `ldd` reports zero CUDA libs on a CUDA-capable build. The two static probes fail in *opposite* directions — `strings` under a pipe says no when the answer is yes; `ldd` says no because the linkage is deferred. The behavioural read this script already performs for `compute_class` is the sounder signal.

`bashrs`: 0 errors. Region is disjoint from #2719's edit to the same file (that one is the `run_lane` header at ~:87).

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
