### PR TITLE
batch: five sub-tickets — a zero-brick report scored green, a swallowed refusal published as PASS, and a REPORT channel nobody could see

### DIFF
--- a/contracts/apr-cli-operations-v1.yaml
+++ b/contracts/apr-cli-operations-v1.yaml
@@ -253,6 +253,11 @@ falsification_tests:
   prediction: apr cbtop --iterations 0 is rejected at parse time rather than producing a report scoring every brick a perfect 100/A from zero samples
   test: tests::test_parse_cbtop_rejects_zero_iterations
   if_fails: Appending --iterations 0 turns any cbtop --ci gate unconditionally green
+- id: FALSIFY-OPS-010
+  rule: Report timestamps carry the real UTC date
+  prediction: The timestamp in a cbtop report matches the UTC date at the moment it was generated, on both headless paths
+  test: commands::cbtop::tests::test_chrono_timestamp_is_current_utc_date
+  if_fails: Persisted CI provenance is stamped with a stale hardcoded date
 - id: FALSIFY-OPS-011
   rule: Both flags that shape a measurement are validated, not just one
   prediction: apr cbtop --warmup 0 is rejected at parse time (exit 2), exactly as --iterations 0 already is, while --warmup 1, --warmup 3 and the declared default 10 all still parse
@@ -263,11 +268,6 @@ falsification_tests:
   prediction: The JSON emitted by apr cbtop --headless --json records both the warmup and the iteration count it ran, so two reports differing only in warmup do not serialise identically
   test: commands::cbtop::tests::test_json_output_records_measurement_parameters
   if_fails: A cold-start number and a steady-state number are byte-indistinguishable in a file persisted with --output, and no consumer of the receipt can recover which regime produced it
-- id: FALSIFY-OPS-010
-  rule: Report timestamps carry the real UTC date
-  prediction: The timestamp in a cbtop report matches the UTC date at the moment it was generated, on both headless paths
-  test: commands::cbtop::tests::test_chrono_timestamp_is_current_utc_date
-  if_fails: Persisted CI provenance is stamped with a stale hardcoded date
 kani_harnesses:
 - id: KANI-OPS-001
   obligation: ReadOnly commands have no side effects
@@ -322,7 +322,7 @@ qa_gate:
   - progress_reporting
   - concurrent_model_access
   - tokenizer_consistency
-  pass_criteria: All 10 falsification tests pass
+  pass_criteria: All 12 falsification tests pass
   falsification: >
     Run read-only command with filesystem watcher to detect mutations.
     Force inference error and measure GPU memory leak.

--- a/contracts/apr-cli-operations-v1.yaml
+++ b/contracts/apr-cli-operations-v1.yaml
@@ -253,6 +253,16 @@ falsification_tests:
   prediction: apr cbtop --iterations 0 is rejected at parse time rather than producing a report scoring every brick a perfect 100/A from zero samples
   test: tests::test_parse_cbtop_rejects_zero_iterations
   if_fails: Appending --iterations 0 turns any cbtop --ci gate unconditionally green
+- id: FALSIFY-OPS-011
+  rule: Both flags that shape a measurement are validated, not just one
+  prediction: apr cbtop --warmup 0 is rejected at parse time (exit 2), exactly as --iterations 0 already is, while --warmup 1, --warmup 3 and the declared default 10 all still parse
+  test: tests::test_parse_cbtop_rejects_zero_warmup
+  if_fails: A zero-warmup run reports the cold-start regime — allocation, CUDA context, kernel JIT, cache-cold weights — as though it were steady state, and the arithmetic is real so nothing downstream looks wrong
+- id: FALSIFY-OPS-012
+  rule: A persisted performance report records how it was measured
+  prediction: The JSON emitted by apr cbtop --headless --json records both the warmup and the iteration count it ran, so two reports differing only in warmup do not serialise identically
+  test: commands::cbtop::tests::test_json_output_records_measurement_parameters
+  if_fails: A cold-start number and a steady-state number are byte-indistinguishable in a file persisted with --output, and no consumer of the receipt can recover which regime produced it
 - id: FALSIFY-OPS-010
   rule: Report timestamps carry the real UTC date
   prediction: The timestamp in a cbtop report matches the UTC date at the moment it was generated, on both headless paths

--- a/crates/apr-cli/src/commands/cbtop.rs
+++ b/crates/apr-cli/src/commands/cbtop.rs
@@ -120,6 +120,36 @@ impl Default for CbtopConfig {
     }
 }
 
+/// The two parameters that decide what a cbtop report is a report OF.
+///
+/// #2731: the emitted JSON recorded NEITHER. `grep -ic "warmup|iterations"`
+/// over a persisted report returned 0, so a cold-start number written with
+/// `--warmup 0` and a steady-state number written with `--warmup 10` were
+/// byte-indistinguishable once on disk. Under APR-PERF-GATE-001 a performance
+/// number is evidence only if something can prove how it was measured, and a
+/// receipt that cannot express its own warmup is not a receipt.
+///
+/// These live on the REPORT rather than being spliced in from `CbtopConfig` at
+/// emit time so that the compiler asks the question where the measurement
+/// loops are. A future producer cannot construct a report and leave its
+/// provenance to be filled in by whoever happens to print it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeasurementParams {
+    /// Iterations run and discarded before sampling began.
+    pub warmup: usize,
+    /// Iterations the reported statistics were computed from.
+    pub iterations: usize,
+}
+
+impl Default for MeasurementParams {
+    fn default() -> Self {
+        Self {
+            warmup: 10,
+            iterations: 100,
+        }
+    }
+}
+
 /// Headless report output per spec section 7.0.1
 #[derive(Debug, Clone)]
 pub struct HeadlessReport {
@@ -132,6 +162,8 @@ pub struct HeadlessReport {
     pub falsification: FalsificationSummary,
     pub status: String,
     pub ci_result: String,
+    /// How this report was measured — see [`MeasurementParams`].
+    pub measurement: MeasurementParams,
 }
 
 /// PMAT quality scores per spec section 7.0.1
@@ -401,6 +433,20 @@ pub fn run(config: CbtopConfig) -> Result<()> {
         return Err(CliError::ValidationFailed(
             "cbtop requires at least 1 measurement iteration (--iterations 0 measures nothing: \
              every brick would report 0.0µs and score a perfect 100/A)"
+                .to_string(),
+        ));
+    }
+
+    // #2731: the same refusal for the other half of the pair. Zero warmup does
+    // not empty the report, it fills it from the cold-start regime and labels
+    // the result a measurement. `CbtopConfig` is public and constructible
+    // without going through clap, so the guard is repeated here rather than
+    // left to the `--warmup` value_parser alone.
+    if config.warmup == 0 {
+        return Err(CliError::ValidationFailed(
+            "cbtop requires at least 1 warmup iteration (--warmup 0 measures the cold-start \
+             regime — allocation, CUDA context, kernel JIT, cache-cold weights — and reports \
+             it as steady state)"
                 .to_string(),
         ));
     }

--- a/crates/apr-cli/src/commands/cbtop_app_tick_model.rs
+++ b/crates/apr-cli/src/commands/cbtop_app_tick_model.rs
@@ -312,6 +312,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -364,6 +365,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -426,6 +428,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {

--- a/crates/apr-cli/src/commands/cbtop_brick_timing.rs
+++ b/crates/apr-cli/src/commands/cbtop_brick_timing.rs
@@ -173,6 +173,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -218,6 +219,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -269,6 +271,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);

--- a/crates/apr-cli/src/commands/cbtop_chrono_timestamp_get.rs
+++ b/crates/apr-cli/src/commands/cbtop_chrono_timestamp_get.rs
@@ -196,6 +196,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -240,6 +241,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         // No thresholds set, should pass
@@ -280,6 +282,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -395,6 +398,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -444,6 +448,7 @@
             },
             status: "".to_string(),
             ci_result: "".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);

--- a/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
+++ b/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
@@ -242,6 +242,7 @@
             },
             status: "X".to_string(),
             ci_result: "X".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -288,6 +289,7 @@
             },
             status: "X".to_string(),
             ci_result: "X".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -467,6 +469,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         }
     }
 
@@ -522,6 +525,40 @@
             msg.contains("iteration"),
             "unexpected rejection message: {msg}"
         );
+    }
+
+    /// #2731: the same refusal for the other half of the pair.
+    ///
+    /// `CbtopConfig` is public and constructible without going through clap, so
+    /// the `--warmup` value_parser alone does not cover every caller of
+    /// `run()`. Zero warmup does not empty the report the way zero iterations
+    /// does — it fills it from the cold-start regime and labels the result a
+    /// measurement.
+    #[test]
+    fn test_run_rejects_zero_warmup() {
+        let config = CbtopConfig {
+            headless: true,
+            simulated: true,
+            warmup: 0,
+            ..Default::default()
+        };
+        let err = run(config).expect_err("cbtop accepted warmup 0");
+        let msg = err.to_string();
+        assert!(msg.contains("warmup"), "unexpected rejection message: {msg}");
+    }
+
+    /// Discrimination for the warmup guard: one warmup iteration is legal and
+    /// must still be served, so the guard rejects the value and not the run.
+    #[test]
+    fn test_run_accepts_one_warmup() {
+        let config = CbtopConfig {
+            headless: true,
+            simulated: true,
+            warmup: 1,
+            iterations: 1,
+            ..Default::default()
+        };
+        assert!(run(config).is_ok(), "cbtop refused a legitimate warmup of 1");
     }
 
     /// The guard must discriminate on the value, not reject every run: one

--- a/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
+++ b/crates/apr-cli/src/commands/cbtop_falsification_summary_hardware.rs
@@ -309,7 +309,13 @@
         assert!((report.throughput.p50_us - 0.0).abs() < 0.001);
         assert!((report.throughput.p99_us - 0.0).abs() < 0.001);
         assert!((report.throughput.cv_percent - 0.0).abs() < 0.001);
-        assert_eq!(report.status, "PASS"); // Empty bricks -> all pass vacuously
+        // #2730: this line used to read
+        //     assert_eq!(report.status, "PASS"); // Empty bricks -> all pass vacuously
+        // It named the defect in its own comment and then locked it in. A
+        // report that measured zero bricks is a failure to measure; the
+        // percentile behaviour this test is actually about is asserted above.
+        assert_eq!(report.status, "FAIL");
+        assert_eq!(report.ci_result, "red");
     }
 
     // ========================================================================

--- a/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
+++ b/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
@@ -83,7 +83,7 @@ fn weighted_brick_score(brick_scores: &[BrickScore]) -> u32 {
 fn generate_headless_report_simulated(
     model_name: &str,
     pipeline: &PipelineState,
-    _config: &CbtopConfig,
+    config: &CbtopConfig,
 ) -> HeadlessReport {
     // The date must be the real UTC date. A string-literal date with a
     // computed time-of-day stamped every report ever written — including
@@ -142,6 +142,13 @@ fn generate_headless_report_simulated(
         // GH-425 B18: Status from brick pass/fail only — no hardcoded target.
         status: if all_pass { "PASS" } else { "FAIL" }.to_string(),
         ci_result: if all_pass { "green" } else { "red" }.to_string(),
+        // #2731: recorded from the config that drove the warmup and
+        // measurement loops in `run_headless_simulated`, so the persisted
+        // receipt states the regime it came from.
+        measurement: MeasurementParams {
+            warmup: config.warmup,
+            iterations: config.iterations,
+        },
     }
 }
 

--- a/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
+++ b/crates/apr-cli/src/commands/cbtop_get_cpu_memory.rs
@@ -79,6 +79,38 @@ fn weighted_brick_score(brick_scores: &[BrickScore]) -> u32 {
     { (sum / brick_scores.len() as f64) as u32 }
 }
 
+/// The report's own verdict, as `(status, ci_result)`.
+///
+/// #2730: **an empty brick slice is a FAIL, never a pass.**
+/// `bricks.iter().all(..)` is vacuously true over the empty set, and both
+/// report builders used it bare. So a run in which the profiler collected no
+/// per-brick data was scored `"status": "PASS"` / `"ci_result": "green"` inside
+/// the same document that said `"brick_scores": []`, `"grade": "F"` and
+/// `"falsification": {"passed": 0, "failed": 1}` — the `.max(1)` that produced
+/// that `failed: 1` asserts one brick exists so it can be counted failed, while
+/// the `.all()` four lines below asserted every brick passed. Identical input,
+/// opposite conclusions.
+///
+/// It is not a display bug: `check_ci_thresholds` delegates to `ci_result`, so
+/// `apr cbtop --ci` exited 0 on a grade-F report that measured nothing.
+///
+/// Zero bricks measured is a failure to MEASURE, not a measurement that passed,
+/// so it earns the same verdict as a brick over budget. A non-empty slice is
+/// judged exactly as before, so a healthy run is still green.
+fn report_verdict(bricks: &[BrickScore]) -> (&'static str, &'static str) {
+    if bricks.is_empty() {
+        return ("FAIL", "red");
+    }
+    // 1e-9 epsilon: the budget is derived from the same profiler data, so a
+    // healthy gap is ~1.0; without the epsilon, floating-point rounding turns
+    // it into 1.0000000000001 and fails a passing brick.
+    if bricks.iter().all(|b| b.gap_factor <= 1.0 + 1e-9) {
+        ("PASS", "green")
+    } else {
+        ("FAIL", "red")
+    }
+}
+
 /// Generate headless report from pipeline state (simulated data)
 fn generate_headless_report_simulated(
     model_name: &str,
@@ -100,7 +132,9 @@ fn generate_headless_report_simulated(
     let cv_percent = cv_percent_from_samples(&all_samples);
     let (p50, p99) = pipeline.bricks.first().map_or((0.0, 0.0), percentiles_from_brick);
 
-    let all_pass = brick_scores.iter().all(|b| b.gap_factor <= 1.0 + 1e-9);
+    // #2730: shared with the real-profiling builder so neither can drift back
+    // into scoring an empty measurement green.
+    let (status, ci_result) = report_verdict(&brick_scores);
     let pmat_brick_score = weighted_brick_score(&brick_scores);
 
     // GH-425 B14-B18: Derive falsification from brick pass/fail, not hardcoded.
@@ -140,8 +174,9 @@ fn generate_headless_report_simulated(
             blocked: 0,
         },
         // GH-425 B18: Status from brick pass/fail only — no hardcoded target.
-        status: if all_pass { "PASS" } else { "FAIL" }.to_string(),
-        ci_result: if all_pass { "green" } else { "red" }.to_string(),
+        // #2730: and FAIL when no brick was measured at all.
+        status: status.to_string(),
+        ci_result: ci_result.to_string(),
     }
 }
 

--- a/crates/apr-cli/src/commands/cbtop_headless_report.rs
+++ b/crates/apr-cli/src/commands/cbtop_headless_report.rs
@@ -115,6 +115,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -166,6 +167,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -210,6 +212,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -265,6 +268,7 @@
             // threshold set, the failing brick score must not be consulted.
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -324,6 +328,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let config = CbtopConfig {
@@ -373,6 +378,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -413,6 +419,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);

--- a/crates/apr-cli/src/commands/cbtop_headless_report.rs
+++ b/crates/apr-cli/src/commands/cbtop_headless_report.rs
@@ -426,3 +426,122 @@
                 || json.contains("\"p99_us\": 9.876")
         );
     }
+
+    // ========================================================================
+    // #2730: the report's own verdict must not be vacuous over zero bricks
+    //
+    // RED-turning mutation for this block: delete the `bricks.is_empty()`
+    // clause in `report_verdict`, restoring the bare
+    // `bricks.iter().all(|b| b.gap_factor <= 1.0 + 1e-9)`. The two
+    // `zero_brick` / `empty` tests must go RED; the three discrimination
+    // tests below must stay GREEN, which is what makes the floor a floor
+    // rather than a blanket refusal.
+    // ========================================================================
+
+    fn brick_with_gap(name: &str, gap_factor: f64) -> BrickScore {
+        BrickScore {
+            name: name.to_string(),
+            score: 100,
+            grade: "A".to_string(),
+            budget_us: 10.0,
+            actual_us: 10.0 * gap_factor,
+            gap_factor,
+        }
+    }
+
+    #[test]
+    fn test_empty_bricks_is_fail_not_vacuous_pass() {
+        // `.all()` over an empty slice is TRUE. That vacuity scored a report
+        // carrying `brick_scores: []`, `grade: "F"` and `failed: 1` as
+        // PASS/green, and `apr cbtop --ci` exited 0 on it.
+        assert_eq!(report_verdict(&[]), ("FAIL", "red"));
+    }
+
+    #[test]
+    fn test_report_verdict_one_passing_brick_is_still_green() {
+        // Discrimination: the empty-set floor must not red every input.
+        assert_eq!(
+            report_verdict(&[brick_with_gap("Attention", 0.9)]),
+            ("PASS", "green")
+        );
+    }
+
+    #[test]
+    fn test_report_verdict_over_budget_brick_is_red() {
+        assert_eq!(
+            report_verdict(&[brick_with_gap("ok", 0.5), brick_with_gap("slow", 1.5)]),
+            ("FAIL", "red")
+        );
+    }
+
+    #[test]
+    fn test_report_verdict_gap_exactly_one_is_green() {
+        // The 1e-9 epsilon must survive the refactor: a brick landing exactly
+        // on budget is a pass, not a rounding-error failure.
+        assert_eq!(
+            report_verdict(&[brick_with_gap("on-budget", 1.0)]),
+            ("PASS", "green")
+        );
+    }
+
+    #[test]
+    fn test_zero_brick_report_fails_ci_without_explicit_thresholds() {
+        // The end-to-end assertion from #2730: a zero-brick report must fail
+        // `--ci` with NO `--brick-score` / `--throughput` argument supplied.
+        // `build_and_output_report` returns Err exactly when
+        // `config.ci && !check_ci_thresholds(..)`, so a false here is the
+        // non-zero exit.
+        let mut pipeline = PipelineState::new();
+        pipeline.bricks.clear();
+        let config = CbtopConfig {
+            ci: true,
+            headless: true,
+            json: true,
+            ..Default::default()
+        };
+        let report = generate_headless_report_simulated("zero-brick", &pipeline, &config);
+
+        assert!(report.brick_scores.is_empty());
+        assert_eq!(report.status, "FAIL");
+        assert_eq!(report.ci_result, "red");
+        assert!(
+            !check_ci_thresholds(&report, &config),
+            "a report that measured zero bricks must not pass --ci"
+        );
+    }
+
+    #[test]
+    fn test_healthy_report_still_passes_ci_without_explicit_thresholds() {
+        // Discrimination for the same end-to-end path: bricks inside budget
+        // stay green and still exit 0, so the fix did not turn `--ci` into a
+        // gate that always fails.
+        let pipeline = PipelineState::new(); // actual_us 0.0 => gap 0.0
+        let config = CbtopConfig {
+            ci: true,
+            headless: true,
+            json: true,
+            ..Default::default()
+        };
+        let report = generate_headless_report_simulated("healthy", &pipeline, &config);
+
+        assert!(!report.brick_scores.is_empty());
+        assert_eq!(report.status, "PASS");
+        assert_eq!(report.ci_result, "green");
+        assert!(check_ci_thresholds(&report, &config));
+    }
+
+    #[test]
+    fn test_zero_brick_report_json_verdict_matches_the_ci_gate() {
+        // --json and --ci must agree. The JSON document is what downstream
+        // receipt consumers read; it used to say PASS/green next to an empty
+        // brick_scores array and a grade of F.
+        let mut pipeline = PipelineState::new();
+        pipeline.bricks.clear();
+        let config = CbtopConfig::default();
+        let report = generate_headless_report_simulated("zero-brick", &pipeline, &config);
+        let json = format_report_as_json(&report);
+
+        assert!(json.contains("\"status\": \"FAIL\""), "{json}");
+        assert!(json.contains("\"ci_result\": \"red\""), "{json}");
+        assert!(json.contains("\"grade\": \"F\""), "{json}");
+    }

--- a/crates/apr-cli/src/commands/cbtop_json_output.rs
+++ b/crates/apr-cli/src/commands/cbtop_json_output.rs
@@ -1,5 +1,123 @@
 
     // ========================================================================
+    // #2731: the receipt must record how it was measured
+    // ========================================================================
+
+    /// A persisted cbtop report must state its own warmup and iteration count.
+    ///
+    /// Before #2731 `grep -ic "warmup|iterations"` over an emitted report
+    /// returned 0: a cold-start number written with `--warmup 0` and a
+    /// steady-state number written with `--warmup 10` were byte-identical
+    /// apart from the throughput figure itself, so nothing downstream could
+    /// tell which regime a `--output` file came from.
+    ///
+    /// The values asserted here are deliberately NOT the defaults — a test
+    /// against `10 / 100` would pass against a hardcoded emitter.
+    #[test]
+    fn test_json_output_records_measurement_parameters() {
+        let report = HeadlessReport {
+            model: "receipt".to_string(),
+            timestamp: "2026-01-12T00:00:00Z".to_string(),
+            hardware: HardwareInfo {
+                gpu: "GPU".to_string(),
+                cpu: "CPU".to_string(),
+                memory_gb: 32,
+            },
+            throughput: ThroughputMetrics {
+                tokens_per_sec: 500.0,
+                ttft_ms: 1.0,
+                cv_percent: 2.0,
+                p50_us: 1.0,
+                p99_us: 2.0,
+            },
+            brick_scores: vec![],
+            pmat_scores: PmatScores {
+                rust_project_score: 0.0,
+                tdg_score: 0.0,
+                cuda_tdg_score: 0.0,
+                brick_score: 100,
+                grade: "A".to_string(),
+            },
+            falsification: FalsificationSummary {
+                total_points: 1,
+                passed: 1,
+                failed: 0,
+                blocked: 0,
+            },
+            status: "PASS".to_string(),
+            ci_result: "green".to_string(),
+            measurement: MeasurementParams {
+                warmup: 7,
+                iterations: 23,
+            },
+        };
+
+        let json = format_report_as_json(&report);
+        assert!(
+            json.contains("\"warmup\": 7"),
+            "emitted receipt does not record the warmup it ran: {json}"
+        );
+        assert!(
+            json.contains("\"iterations\": 23"),
+            "emitted receipt does not record the iteration count it ran: {json}"
+        );
+    }
+
+    /// Two reports that differ ONLY in warmup must not serialise identically.
+    ///
+    /// This is the property the receipt rule actually needs, stated without
+    /// naming a key: whatever the schema, the emitted bytes have to carry
+    /// enough to distinguish a cold-start run from a steady-state one.
+    #[test]
+    fn test_json_output_distinguishes_cold_start_from_steady_state() {
+        let base = HeadlessReport {
+            model: "regime".to_string(),
+            timestamp: "2026-01-12T00:00:00Z".to_string(),
+            hardware: HardwareInfo {
+                gpu: "GPU".to_string(),
+                cpu: "CPU".to_string(),
+                memory_gb: 32,
+            },
+            throughput: ThroughputMetrics {
+                tokens_per_sec: 500.0,
+                ttft_ms: 1.0,
+                cv_percent: 2.0,
+                p50_us: 1.0,
+                p99_us: 2.0,
+            },
+            brick_scores: vec![],
+            pmat_scores: PmatScores {
+                rust_project_score: 0.0,
+                tdg_score: 0.0,
+                cuda_tdg_score: 0.0,
+                brick_score: 100,
+                grade: "A".to_string(),
+            },
+            falsification: FalsificationSummary {
+                total_points: 1,
+                passed: 1,
+                failed: 0,
+                blocked: 0,
+            },
+            status: "PASS".to_string(),
+            ci_result: "green".to_string(),
+            measurement: MeasurementParams {
+                warmup: 0,
+                iterations: 100,
+            },
+        };
+        let mut warm = base.clone();
+        warm.measurement.warmup = 10;
+
+        assert_ne!(
+            format_report_as_json(&base),
+            format_report_as_json(&warm),
+            "a zero-warmup report and a ten-warmup report serialise identically — \
+             the persisted receipt cannot express its own regime"
+        );
+    }
+
+    // ========================================================================
     // format_report_as_json: multiple brick scores
     // ========================================================================
 
@@ -61,6 +179,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -129,6 +248,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         // Should not panic
@@ -168,6 +288,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         // Should not panic even with empty bricks
@@ -350,6 +471,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let cloned = report.clone();
@@ -423,6 +545,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);

--- a/crates/apr-cli/src/commands/cbtop_json_output_02.rs
+++ b/crates/apr-cli/src/commands/cbtop_json_output_02.rs
@@ -39,6 +39,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -80,6 +81,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         let json = format_report_as_json(&report);
@@ -141,6 +143,7 @@
             },
             status: "PASS".to_string(),
             ci_result: "green".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         // Should not panic, exercises the pass branch
@@ -187,6 +190,7 @@
             },
             status: "FAIL".to_string(),
             ci_result: "red".to_string(),
+            measurement: MeasurementParams::default(),
         };
 
         // Should not panic, exercises the fail branch
@@ -385,6 +389,7 @@
             },
             status: "X".to_string(),
             ci_result: "X".to_string(),
+            measurement: MeasurementParams::default(),
         };
         let debug_str = format!("{report:?}");
         assert!(debug_str.contains("HeadlessReport"));

--- a/crates/apr-cli/src/commands/cbtop_measure_batch.rs
+++ b/crates/apr-cli/src/commands/cbtop_measure_batch.rs
@@ -345,13 +345,11 @@ fn build_and_output_report(
     let score_sum: f64 = brick_reports.iter().map(|b| b.score as f64).sum();
     let pmat_brick_score = (score_sum / n_bricks as f64) as u32;
 
-    // 1e-9 epsilon: budget derived from same profiler data, so gap ≈ 1.0;
-    // without epsilon, floating-point rounding makes gap 1.0000000000001 → false fail.
-    let all_pass = brick_reports.iter().all(|b| b.gap_factor <= 1.0 + 1e-9);
     // Status reflects brick gaps only — throughput targets are
-    // hardware-dependent and must not be hardcoded.
-    let status = if all_pass { "PASS" } else { "FAIL" };
-    let ci_result = if all_pass { "green" } else { "red" };
+    // hardware-dependent and must not be hardcoded. #2730: an empty
+    // `brick_reports` is a FAIL — see `report_verdict`, which owns the epsilon
+    // and the empty-set floor for both report builders.
+    let (status, ci_result) = report_verdict(&brick_reports);
 
     let brick_passed = brick_reports.iter().filter(|b| b.gap_factor <= 1.0 + 1e-9).count() as u32;
     let brick_failed = (n_bricks as u32).saturating_sub(brick_passed);

--- a/crates/apr-cli/src/commands/cbtop_measure_batch.rs
+++ b/crates/apr-cli/src/commands/cbtop_measure_batch.rs
@@ -390,6 +390,11 @@ fn build_and_output_report(
         },
         status: status.to_string(),
         ci_result: ci_result.to_string(),
+        // #2731: same config that drove the warmup/measurement loops above.
+        measurement: MeasurementParams {
+            warmup: config.warmup,
+            iterations: config.iterations,
+        },
     };
 
     let ci_passed = check_ci_thresholds(&report, config);

--- a/crates/apr-cli/src/commands/cbtop_report_tui.rs
+++ b/crates/apr-cli/src/commands/cbtop_report_tui.rs
@@ -114,7 +114,11 @@ fn format_report_as_json(report: &HeadlessReport) -> String {
     "blocked": {}
   }},
   "status": "{}",
-  "ci_result": "{}"
+  "ci_result": "{}",
+  "measurement": {{
+    "warmup": {},
+    "iterations": {}
+  }}
 }}"#,
         report.model,
         report.timestamp,
@@ -138,6 +142,10 @@ fn format_report_as_json(report: &HeadlessReport) -> String {
         report.falsification.blocked,
         report.status,
         report.ci_result,
+        // #2731: without these two keys a cold-start number and a steady-state
+        // number are byte-indistinguishable in a file persisted with --output.
+        report.measurement.warmup,
+        report.measurement.iterations,
     )
 }
 
@@ -148,6 +156,10 @@ fn print_report_text(report: &HeadlessReport) {
     println!("═══════════════════════════════════════════════════════════════");
     println!("  Model:     {}", report.model);
     println!("  Timestamp: {}", report.timestamp);
+    println!(
+        "  Measured:  {} warmup + {} measurement iterations",
+        report.measurement.warmup, report.measurement.iterations
+    );
     println!();
     println!(
         "  Throughput: {:.1} tok/s",

--- a/crates/apr-cli/src/commands/cbtop_report_tui.rs
+++ b/crates/apr-cli/src/commands/cbtop_report_tui.rs
@@ -7,6 +7,11 @@
 /// `--brick-score` number. Previously only the explicit numeric thresholds
 /// could set `passed = false`, so `apr cbtop --ci` printed a red report and
 /// exited 0 — a gate that could not fail.
+///
+/// That delegation is only as sound as the verdict it reads, and #2730 found
+/// the verdict itself computed vacuously: zero bricks measured came out
+/// `green`, so this gate still could not fail on it. The floor lives in
+/// `report_verdict`, which both report builders now call.
 fn check_ci_thresholds(report: &HeadlessReport, config: &CbtopConfig) -> bool {
     let mut passed = true;
 

--- a/crates/apr-cli/src/commands/gguf.rs
+++ b/crates/apr-cli/src/commands/gguf.rs
@@ -177,11 +177,15 @@ fn run_headless_apr(
 
     // Output JSON if requested
     if config.json {
+        // #2731: this path emits its own receipt shape and recorded
+        // `iterations` but not `warmup` — the half that says whether the
+        // number is a steady-state or a cold-start measurement.
         let json = format!(
-            r#"{{"model":"{}","format":"apr","throughput":{:.1},"total_time_ms":{:.1},"iterations":{}}}"#,
+            r#"{{"model":"{}","format":"apr","throughput":{:.1},"total_time_ms":{:.1},"warmup":{},"iterations":{}}}"#,
             model_name,
             throughput,
             total_time.as_secs_f64() * 1000.0,
+            config.warmup,
             config.iterations
         );
 

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -504,8 +504,8 @@ pub enum ExtendedCommands {
         /// Minimum brick score threshold 0-100 (for --ci)
         #[arg(long, value_name = "SCORE")]
         brick_score: Option<u32>,
-        /// Number of warmup iterations before measurement
-        #[arg(long, default_value = "10")]
+        /// Number of warmup iterations before measurement (must be >= 1)
+        #[arg(long, default_value = "10", value_parser = parse_cbtop_warmup)]
         warmup: usize,
         /// Number of measurement iterations (must be >= 1)
         #[arg(long, default_value = "100", value_parser = parse_cbtop_iterations)]
@@ -513,14 +513,14 @@ pub enum ExtendedCommands {
         /// PAR-100: Enable speculative decoding benchmark
         #[arg(long)]
         speculative: bool,
-        /// PAR-100: Number of tokens to draft speculatively (default: 4)
-        #[arg(long, default_value = "4")]
+        /// PAR-100: Number of tokens to draft speculatively (default: 4, must be >= 1)
+        #[arg(long, default_value = "4", value_parser = parse_cbtop_speculation_k)]
         speculation_k: usize,
         /// PAR-099: Path to draft model for speculative decoding
         #[arg(long, value_name = "DRAFT_MODEL")]
         draft_model: Option<PathBuf>,
-        /// PAR-102: Number of concurrent requests
-        #[arg(long, default_value = "1")]
+        /// PAR-102: Number of concurrent requests (must be >= 1)
+        #[arg(long, default_value = "1", value_parser = parse_cbtop_concurrent)]
         concurrent: usize,
         /// Use simulated data (for CI testing only)
         #[arg(long)]
@@ -1724,6 +1724,22 @@ pub enum LlmSubcommand {
     },
 }
 
+/// Reject `0` for an `apr cbtop` knob that shapes the measurement.
+///
+/// Shared by `--iterations`, `--warmup`, `--concurrent` and `--speculation-k`.
+/// All four decide what the emitted report is a report OF, and a zero in any
+/// of them yields a populated report describing something other than the run
+/// the caller asked for.
+fn parse_cbtop_positive(s: &str, unit: &str, why: &str) -> std::result::Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a valid {unit}"))?;
+    if n == 0 {
+        return Err(format!("must be at least 1 — {why}"));
+    }
+    Ok(n)
+}
+
 /// Parse `apr cbtop --iterations`, rejecting 0.
 ///
 /// With zero measurement iterations every brick keeps zero samples, so its
@@ -1731,15 +1747,64 @@ pub enum LlmSubcommand {
 /// 100/A — a green report attesting to measurements that never ran. Reject the
 /// value where the user typed it rather than emitting the fabricated report.
 fn parse_cbtop_iterations(s: &str) -> std::result::Result<usize, String> {
-    let n: usize = s
-        .parse()
-        .map_err(|_| format!("`{s}` is not a valid iteration count"))?;
-    if n == 0 {
-        return Err(
-            "must be at least 1 — a zero-iteration run measures nothing and would report every \
-             brick as a perfect 100/A from zero samples"
-                .to_string(),
-        );
-    }
-    Ok(n)
+    parse_cbtop_positive(
+        s,
+        "iteration count",
+        "a zero-iteration run measures nothing and would report every brick as a perfect \
+         100/A from zero samples",
+    )
+}
+
+/// Parse `apr cbtop --warmup`, rejecting 0.
+///
+/// #2731. `--warmup` and `--iterations` are the two flags that decide how the
+/// number was measured, and only one of them had a validator: `--iterations 0`
+/// exited 2 while `--warmup 0` exited 0 and reported its result as a
+/// measurement.
+///
+/// Zero warmup does not empty the report the way zero iterations does — it
+/// FILLS it, from the cold-start regime: first-touch allocation, CUDA context
+/// creation, kernel JIT / graph capture, cache-cold weights. The arithmetic is
+/// real and the regime is wrong, which is materially harder to notice than a
+/// missing number. This project has cold-vs-warm deltas on record measured in
+/// orders of magnitude, so a zero-warmup run and a ten-warmup run are not two
+/// samples of one quantity.
+///
+/// Rejecting it here is the same remedy the sibling flag already had:
+/// refuse the value where the user typed it rather than emit a report whose
+/// regime nobody can recover afterwards.
+fn parse_cbtop_warmup(s: &str) -> std::result::Result<usize, String> {
+    parse_cbtop_positive(
+        s,
+        "warmup iteration count",
+        "a zero-warmup run measures the cold-start regime (allocation, CUDA context, kernel \
+         JIT, cache-cold weights), not steady state, and reports it as though it were",
+    )
+}
+
+/// Parse `apr cbtop --concurrent`, rejecting 0.
+///
+/// PAR-102 builds the batch as `(0..config.concurrent)`, so zero issues no
+/// requests at all and the aggregate-throughput report is computed over an
+/// empty batch.
+fn parse_cbtop_concurrent(s: &str) -> std::result::Result<usize, String> {
+    parse_cbtop_positive(
+        s,
+        "concurrency",
+        "a zero-concurrency run issues no requests, so the aggregate throughput it reports is \
+         computed over an empty batch",
+    )
+}
+
+/// Parse `apr cbtop --speculation-k`, rejecting 0.
+///
+/// PAR-100 drafts `k` tokens per step; with `k = 0` nothing is drafted and the
+/// run is no longer the speculative-decoding benchmark it is labelled as.
+fn parse_cbtop_speculation_k(s: &str) -> std::result::Result<usize, String> {
+    parse_cbtop_positive(
+        s,
+        "draft length",
+        "drafting zero tokens is not speculative decoding, so the run would be labelled \
+         speculative while measuring the ordinary path",
+    )
 }

--- a/crates/apr-cli/src/parsing.rs
+++ b/crates/apr-cli/src/parsing.rs
@@ -342,6 +342,104 @@
         }
     }
 
+    /// #2731: `--warmup 0` must be rejected where it is typed, exactly as
+    /// `--iterations 0` already is.
+    ///
+    /// The two flags shape the same measurement and only one had a validator.
+    /// Zero warmup does not empty the report the way zero iterations does — it
+    /// fills it from the cold-start regime (allocation, CUDA context, kernel
+    /// JIT, cache-cold weights) and labels the result a measurement, which is
+    /// harder to spot than a missing number.
+    #[test]
+    fn test_parse_cbtop_rejects_zero_warmup() {
+        let args = vec![
+            "apr",
+            "cbtop",
+            "--headless",
+            "--simulated",
+            "--ci",
+            "--warmup",
+            "0",
+        ];
+        assert!(
+            parse_cli(args).is_err(),
+            "cbtop accepted --warmup 0 at parse time"
+        );
+
+        // Discrimination: the guard must reject ONLY 0. One warmup iteration is
+        // the smallest honest steady-state attempt and must still parse.
+        let ok = vec!["apr", "cbtop", "--headless", "--warmup", "1"];
+        let cli = parse_cli(ok).expect("--warmup 1 should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop { warmup, .. }) => {
+                assert_eq!(warmup, 1);
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+
+        // A legitimate multi-iteration warmup, and the declared default, must
+        // both survive the validator.
+        let three = vec!["apr", "cbtop", "--headless", "--warmup", "3"];
+        let cli = parse_cli(three).expect("--warmup 3 should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop { warmup, .. }) => {
+                assert_eq!(warmup, 3);
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+
+        let defaulted = vec!["apr", "cbtop", "--headless"];
+        let cli = parse_cli(defaulted).expect("default warmup should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop { warmup, .. }) => {
+                assert_eq!(warmup, 10, "default --warmup must survive its own parser");
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+    }
+
+    /// #2731 survey: the two remaining cbtop knobs that shape what the report
+    /// is a report OF were declared without validators beside one that had it.
+    ///
+    /// `--concurrent 0` builds the batch as `(0..0)` and reports aggregate
+    /// throughput over an empty batch; `--speculation-k 0` drafts nothing and
+    /// labels the ordinary decode path a speculative-decoding benchmark.
+    #[test]
+    fn test_parse_cbtop_rejects_zero_concurrency_and_draft_length() {
+        assert!(
+            parse_cli(vec!["apr", "cbtop", "--headless", "--concurrent", "0"]).is_err(),
+            "cbtop accepted --concurrent 0 at parse time"
+        );
+        assert!(
+            parse_cli(vec!["apr", "cbtop", "--headless", "--speculation-k", "0"]).is_err(),
+            "cbtop accepted --speculation-k 0 at parse time"
+        );
+
+        // Discrimination: 1 is legal for both (single request, single draft
+        // token), as is the declared default.
+        let cli = parse_cli(vec![
+            "apr",
+            "cbtop",
+            "--headless",
+            "--concurrent",
+            "1",
+            "--speculation-k",
+            "1",
+        ])
+        .expect("--concurrent 1 --speculation-k 1 should parse");
+        match *cli.command {
+            Commands::Extended(ExtendedCommands::Cbtop {
+                concurrent,
+                speculation_k,
+                ..
+            }) => {
+                assert_eq!(concurrent, 1);
+                assert_eq!(speculation_k, 1);
+            }
+            _ => panic!("Expected Cbtop command"),
+        }
+    }
+
     /// #2397 finding 4: `--json` and `--output` document "requires --headless",
     /// so the parser must enforce it. Without the constraint the flag was
     /// silently dropped and cbtop entered the interactive TUI instead.

--- a/crates/aprender-core/tests/falsification_spec_v10_tests.rs
+++ b/crates/aprender-core/tests/falsification_spec_v10_tests.rs
@@ -357,6 +357,25 @@ fn target_dir_candidates() -> Vec<PathBuf> {
 }
 
 fn find_generated_file(filename: &str) -> Option<PathBuf> {
+    // FIRST: this compilation unit's own OUT_DIR, resolved at COMPILE time by
+    // exactly the mechanism `src/format/family_registry.rs:464` uses to
+    // `include!` the generated file into the crate under test.
+    //
+    // #2732: the directory scan below is not merely slow, it reads the WRONG
+    // FILE. `<target>/debug/build/` is SHARED across every worktree and branch
+    // on this machine -- 398 `aprender-core-<hash>/out/model_families_generated.rs`
+    // copies were present when this was written -- and `search_dir_for_file`
+    // returns whichever the directory walk reaches first. Proven by mutation:
+    // deleting the VOCAB_SIZE proof from `build_codegen.rs` and rebuilding left
+    // F-PROVE-007 GREEN, because it read a months-old OUT_DIR that still had
+    // the proof. A gate pointed at an arbitrary stale artifact cannot fail for
+    // the reason it exists. `env!("OUT_DIR")` is baked into this binary at the
+    // same moment the crate is compiled, so it cannot drift.
+    let out_dir = PathBuf::from(env!("OUT_DIR")).join(filename);
+    if out_dir.exists() {
+        return Some(out_dir);
+    }
+
     for target_dir in target_dir_candidates() {
         for profile in &["debug", "release"] {
             let search_root = target_dir.join(profile).join("build");

--- a/crates/aprender-core/tests/includes/falsification_spec_v10_contract_model.rs
+++ b/crates/aprender-core/tests/includes/falsification_spec_v10_contract_model.rs
@@ -239,22 +239,102 @@ fn f_prove_006_oracle_validate_catches_hf_mismatch() {
     );
 }
 
+/// The nine algebraic proofs `build_codegen.rs::generate_algebraic_proofs`
+/// emits for EVERY size variant, with no guard around them.
+///
+/// This list is the specification, not a census: it is what FALSIFY-ALG-003
+/// (head_dim bounds), -004 (FFN expansion), -005 (non-degeneracy) and -008
+/// (GQA ordering) require of every variant. The four remaining proof kinds --
+/// Vaswani divisibility, Ainslie GQA divisibility, and the two RoPE proofs --
+/// are emitted conditionally, so they are deliberately absent here: asserting
+/// them unconditionally would fail on the variants the generator legitimately
+/// skips (Qwen3.5-27B has head_dim=256 with hidden=5120/heads=24, Whisper is
+/// not RoPE, MQA variants have num_kv_heads=1).
+///
+/// `{P}` is a variant prefix such as `QWEN2_0_5B`.
+const UNCONDITIONAL_PROOFS: &[&str] = &[
+    "const _: () = assert!({P}_HIDDEN_DIM > 0,",
+    "const _: () = assert!({P}_NUM_LAYERS > 0,",
+    "const _: () = assert!({P}_NUM_HEADS > 0,",
+    "const _: () = assert!({P}_VOCAB_SIZE > 0,",
+    "const _: () = assert!({P}_NUM_KV_HEADS > 0,",
+    "const _: () = assert!({P}_NUM_KV_HEADS <= {P}_NUM_HEADS,",
+    "const _: () = assert!({P}_HEAD_DIM >= {P}_HIDDEN_DIM / {P}_NUM_HEADS,",
+    "const _: () = assert!({P}_HEAD_DIM <= 2 * ({P}_HIDDEN_DIM / {P}_NUM_HEADS),",
+    "const _: () = assert!({P}_INTERMEDIATE_DIM > {P}_HIDDEN_DIM,",
+];
+
+/// Variant prefixes present in the generated file, in file order.
+///
+/// Every size variant declares exactly one `pub const {P}_HIDDEN_DIM: usize`,
+/// so this enumerates the population the proofs must cover WITHOUT hardcoding
+/// how large that population is.
+fn generated_variant_prefixes(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("pub const ")?;
+            let name = rest.split(':').next()?.trim();
+            let prefix = name.strip_suffix("_HIDDEN_DIM")?;
+            Some(prefix.to_string())
+        })
+        .collect()
+}
+
+/// The `KNOWN_FAMILIES` list as written in the generated FILE (not the one
+/// compiled into this binary). Used to prove the two agree -- see the note on
+/// the shared target directory in `f_prove_007`.
+fn generated_known_families(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .skip_while(|l| !l.starts_with("pub const KNOWN_FAMILIES"))
+        .skip(1)
+        .take_while(|l| !l.starts_with("];"))
+        .filter_map(|l| l.trim().trim_end_matches(',').strip_prefix('"')?.strip_suffix('"').map(str::to_string))
+        .collect()
+}
+
 #[test]
-fn f_prove_007_proof_count_is_exactly_297() {
-    // F-PROVE-007: every known model family carries its build-time proofs.
+fn f_prove_007_every_variant_carries_its_unconditional_proofs() {
+    // F-PROVE-007: every model size variant in the generated artifact carries
+    // all nine of the proofs the generator emits unconditionally.
     //
-    // #2522, two independent rots in one gate:
+    // HISTORY OF THE CONSTANT (#2522, #2631, #2732). This gate has been wrong
+    // in three different ways, and the third is the reason it is now derived.
+    //
     //  1. `find_generated_file` searched `<project_root>/target` only. Every
     //     build here redirects CARGO_TARGET_DIR, so it returned None ALWAYS and
-    //     this gate could only ever panic with "Run `cargo build` first" -- it
-    //     has never once read the file. Its four siblings F-PROVE-003/004/005
-    //     wrote the same lookup as `if let Some(..)`, so they passed VACUOUSLY
-    //     for the same reason. The finder now derives the target dir from
-    //     `current_exe()`, which cannot be redirected out from under it.
-    //  2. `== 297` was frozen. The generator emits 578 today. A literal count of
-    //     a generated artifact is a number that rots by construction, so the
-    //     gate is now stated against the thing it actually means: every family
-    //     in KNOWN_FAMILIES must be proved, and a family carries several proofs.
+    //     the gate could only ever panic with "Run `cargo build` first" -- it
+    //     had never once read the file. Its siblings F-PROVE-003/004/005 wrote
+    //     the same lookup as `if let Some(..)` and so passed VACUOUSLY. Fixed
+    //     in #2522: the finder derives the target dir from `current_exe()`.
+    //
+    //  2. `assert_eq!(count, 297)` was frozen. 297 was NEVER wrong -- it was a
+    //     correct census of a moving population. The archived spec that
+    //     published it (docs/specifications/archive/
+    //     compiler-enforced-model-types-model-oracle.md §4.1) states its own
+    //     basis: "297 total across 8 families, 24 size variants", and its
+    //     per-class table sums to exactly 297 at that size
+    //     (24+19+19+24+24+24+24+19+120). The registry has since grown to 16
+    //     families / 47 variants and the same generator emits 578. The
+    //     per-variant density is unchanged: 297/24 = 12.4, 578/47 = 12.3.
+    //     Nothing stopped being proved; more models arrived. So neither 297
+    //     nor 578 is authoritative -- BOTH are snapshots, and any literal is
+    //     wrong again the next time a family YAML lands.
+    //
+    //  3. #2631 replaced the literal with `count >= KNOWN_FAMILIES.len() * 3`.
+    //     That is 578 >= 48 -- a 12x margin. The generator could drop EIGHT of
+    //     its nine unconditional proofs and this gate would still report ok.
+    //     Measured: deleting the VOCAB_SIZE non-degeneracy proof from
+    //     build_codegen.rs removes 47 proofs (578 -> 531) and `>= 48` stays
+    //     GREEN. A ratchet with 12x of slack is a literal's failure mode in a
+    //     different costume.
+    //
+    // The assertion below is derived from the artifact rather than from any
+    // number: it enumerates the variants the file itself declares, and requires
+    // each one to carry each of the nine proofs the generator emits with no
+    // guard. It cannot rot when a family is added or removed, and it fails on
+    // the loss of a single proof for a single variant.
     let gen_path = find_generated_file("model_families_generated.rs").unwrap_or_else(|| {
         panic!(
             "F-PROVE-007: model_families_generated.rs not found under any of {:?}. \
@@ -264,18 +344,70 @@ fn f_prove_007_proof_count_is_exactly_297() {
     });
 
     let content = std::fs::read_to_string(&gen_path).expect("generated file readable");
+
+    // The target directory is SHARED across worktrees on this machine, so
+    // `find_generated_file` can hand back an OUT_DIR written by a different
+    // branch's build. Everything below is read from `content`, so a stale file
+    // would still be self-consistent and the gate would pass while proving
+    // nothing about this tree. Cross-check the one thing that spans both
+    // sources: the family list compiled into this binary must be the family
+    // list in the file being read.
+    let file_families = generated_known_families(&content);
+    assert_eq!(
+        file_families,
+        KNOWN_FAMILIES.iter().map(|f| (*f).to_string()).collect::<Vec<_>>(),
+        "F-PROVE-007: {} declares families {:?} but this binary was compiled \
+         against {:?} -- the generated file found is from a different build. \
+         Re-run `cargo build -p aprender-core`.",
+        gen_path.display(),
+        file_families,
+        KNOWN_FAMILIES,
+    );
+
+    let prefixes = generated_variant_prefixes(&content);
+    assert!(
+        !prefixes.is_empty(),
+        "F-PROVE-007: {} declares no `{{P}}_HIDDEN_DIM` size variants at all",
+        gen_path.display()
+    );
+
+    let mut missing: Vec<String> = Vec::new();
+    for prefix in &prefixes {
+        for template in UNCONDITIONAL_PROOFS {
+            let expected = template.replace("{P}", prefix);
+            if !content.contains(&expected) {
+                missing.push(expected);
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "F-PROVE-007: {} of {} unconditional proofs are missing from {} \
+         ({} variants x {} proofs expected). First 5 missing:\n  {}",
+        missing.len(),
+        prefixes.len() * UNCONDITIONAL_PROOFS.len(),
+        gen_path.display(),
+        prefixes.len(),
+        UNCONDITIONAL_PROOFS.len(),
+        missing.iter().take(5).cloned().collect::<Vec<_>>().join("\n  "),
+    );
+
+    // Aggregate floor, stated as the same derivation rather than a literal:
+    // the file must hold at least the unconditional proofs counted above, plus
+    // whatever the conditional rules add. Measured on this tree:
+    // 9*47 = 423 unconditional + 47 Vaswani + 46 Ainslie + 31 RoPE-even
+    // + 31 RoPE-maxpos = 578, which is the whole file.
     let count = content
         .lines()
         .filter(|line| line.contains("const _: () = assert!"))
         .count();
-
-    let families = KNOWN_FAMILIES.len();
-    assert!(families > 0, "F-PROVE-007: KNOWN_FAMILIES is empty");
     assert!(
-        count >= families * 3,
-        "F-PROVE-007: {count} build-time proofs for {families} model families -- \
-         fewer than 3 per family means the generator stopped proving something \
+        count >= prefixes.len() * UNCONDITIONAL_PROOFS.len(),
+        "F-PROVE-007: {count} build-time proofs for {} size variants -- fewer \
+         than the {} unconditional proofs the generator must emit \
          (generated file: {})",
+        prefixes.len(),
+        prefixes.len() * UNCONDITIONAL_PROOFS.len(),
         gen_path.display()
     );
 }

--- a/docs/audits/surface_audit.csv
+++ b/docs/audits/surface_audit.csv
@@ -7,7 +7,7 @@ apr,apr beat-run,2,x86_64-linux,NONE,yes,10,apr-core-commands,crates/apr-cli/src
 apr,apr bench,6,x86_64-linux,llama.cpp,yes,1,apr-lint-diag,crates/apr-cli/src/extended_commands.rs:88,high
 apr,apr canary check,4,x86_64-linux,NONE,no,10,apr-core-commands,crates/apr-cli/src/commands/canary.rs:44,medium
 apr,apr canary create,4,x86_64-linux,NONE,no,10,apr-core-commands,crates/apr-cli/src/commands/canary.rs:30,medium
-apr,apr cbtop,3,x86_64-linux,NONE,yes,1,apr-lint-diag,crates/apr-cli/src/extended_commands.rs:478,high
+apr,apr cbtop,4,x86_64-linux,NONE,yes,1,apr-lint-diag,crates/apr-cli/src/extended_commands.rs:478,high
 apr,apr cgp baseline,6,x86_64-linux,NONE,no,7,qa-cgp,crates/aprender-cgp/src/cli.rs:117,low
 apr,apr cgp bench,6,x86_64-linux,NONE,no,7,qa-cgp,crates/aprender-cgp/src/cli.rs:46,low
 apr,apr cgp compete,6,x86_64-linux,NONE,no,7,qa-cgp,crates/aprender-cgp/src/cli.rs:128,low

--- a/scripts/check_no_competing_harnesses.sh
+++ b/scripts/check_no_competing_harnesses.sh
@@ -59,6 +59,22 @@ is_allowed() {
     */perf000_serialization_probe.sh) return 0 ;;  # PERF-000 falsifier: measures
                                                    # wall-clock scaling, derives no
                                                    # tok/s and no comparator ratio
+    */parity_host_receipt.sh) return 0 ;;  # DRIVES the canonical instrument, it is
+                                           # not a second definition of it: every
+                                           # number in its receipt comes out of
+                                           # `apr test llm bench`, and the ratios
+                                           # are derived by lib/parity_block.py
+                                           # from those reports. Same basis as
+                                           # perf000_serialization_probe.sh above.
+                                           # It starts servers because a parity
+                                           # run needs two of them; it computes no
+                                           # rate of its own. Allowlisted by
+                                           # operator decision, not by silence --
+                                           # the alternative on the table was
+                                           # rewording the comment that tripped
+                                           # the old predicate, which would have
+                                           # left the blind spot armed for the
+                                           # next prose change.
     *) return 1 ;;
   esac
 }
@@ -89,10 +105,36 @@ trap 'rm -f "$COUNT_FILE"' EXIT
 # files instead of guessing. `llama-cli` and `llama-bench` are included because
 # §4.4.8 forbids driving the comparator with llama-bench at all, so a script
 # reaching for it is a competing harness by definition.
+# COMMENTS ARE PROSE, NOT BEHAVIOUR — and this guard could not tell them apart.
+#
+# Both predicates grepped the whole file. scripts/parity_host_receipt.sh gained
+# a paragraph of explanation containing the words `tokens_per_sec` (it was
+# describing which fields ANOTHER file reads), and that one line of prose flipped
+# `computes_rate` from false to true and reported the script as a competing
+# harness. It computes no rate; it delegates every number to `apr test llm bench`.
+# A guard that reds on a comment is a guard people learn to route around, and
+# this repo has already lost a CI job to a shell comment once (#2733-class).
+#
+# FULL-LINE COMMENTS ONLY, deliberately. Stripping trailing `# ...` as well
+# would mangle `${var#pattern}` and any `#` inside a quoted string, and an
+# over-strip removes text — which can only turn a real harness INVISIBLE. A
+# false negative here defeats the guard's whole purpose (keeping four specific
+# files deleted), while a false positive merely annoys. So the conservative
+# direction is the correct one, and the residual gap — a trailing comment on a
+# code line — is recorded as a case-table row below rather than papered over.
+#
+# NO PIPE into `grep -q`. `code_only "$f" | grep -q X` returns 141 even when
+# grep MATCHES: grep exits at the first hit, sed takes SIGPIPE, and the
+# `set -o pipefail` at the top of this file hands the pipeline sed's death
+# signal. It is input-size dependent, so it would pass here and red in CI.
+code_only() { sed 's/^[[:space:]]*#.*$//' "$1" 2>/dev/null; }
+
 starts_server() {
-  grep -qE "serve run|llama-server|llama-cli|llama-bench|ollama (serve|run)|vllm serve|apr[[:space:]]+run|curl[^|]*(/v1/|/api/generate)" "$1" 2>/dev/null
+  grep -qE "serve run|llama-server|llama-cli|llama-bench|ollama (serve|run)|vllm serve|apr[[:space:]]+run|curl[^|]*(/v1/|/api/generate)" <<< "$(code_only "$1")"
 }
-computes_rate() { grep -qE "date \+%s|tok/s|tokens?_per_sec|SECONDS" "$1" 2>/dev/null; }
+computes_rate() {
+  grep -qE "date \+%s|tok/s|tokens?_per_sec|SECONDS" <<< "$(code_only "$1")"
+}
 
 # UNIVERSE: tracked UNION working tree. A `git ls-files`-only universe gives an
 # untracked harness a free pass, which is how three earlier guards were blind.
@@ -159,11 +201,39 @@ selftest() {
   _row "vllm counts as a server"           detect 'vllm serve m & \n echo tokens_per_sec'
   _row "plain script is ignored"           ignore 'echo hello; ls -1'
 
+  # ── PROSE MUST NOT TRIP THE WIRE (the p4/#2737 regression) ──────────────
+  # These are the rows that would have caught the live false positive. The
+  # guard's SCOPE widened when code_only() was added, and the old proof does
+  # not transfer to the new scope, so the mutation is re-run HERE: revert
+  # code_only to a plain `grep ... "$1"` and the three `comment` rows below
+  # turn BROKE while every row above stays green.
+  _row "a comment naming tokens_per_sec"   ignore 'apr serve run m.gguf
+# parity_block.py reads `tokens_per_sec` out of the report'
+  _row "a comment naming tok/s"            ignore 'llama-server -m m.gguf
+   # the harness reports tok/s; we only start the server'
+  _row "an indented comment block"         ignore 'apr serve run m.gguf
+    #   date +%s is what the OLD harness did
+    #   SECONDS was how it timed itself'
+  # BOTH HALVES, or the fix is indistinguishable from deleting the predicate:
+  # prose must not trip it, and real code must still trip it in the same file.
+  _row "code still counts beside a comment" detect 'apr serve run m.gguf
+# this comment mentions nothing
+t=$(date +%s)'
+  # THE RECORDED LIMIT. A trailing comment on a code line is NOT stripped --
+  # see code_only(). Declared as a known false positive rather than left for
+  # someone to rediscover; tighten code_only and flip this row if it ever bites.
+  _row "trailing comment: KNOWN false pos" detect 'apr serve run m.gguf  # tok/s'
+
   # the allowlist must actually exempt, and must not exempt everything
   if is_allowed "$ROOT/scripts/perf_gate.sh"; then
     printf '  ok    %-40s expect=exempt\n' "perf_gate.sh is allowlisted"; pass=$((pass + 1))
   else
     printf '  BROKE %-40s\n' "perf_gate.sh should be allowlisted"; fail=$((fail + 1))
+  fi
+  if is_allowed "$ROOT/scripts/parity_host_receipt.sh"; then
+    printf '  ok    %-40s expect=exempt\n' "parity_host_receipt.sh allowlisted"; pass=$((pass + 1))
+  else
+    printf '  BROKE %-40s\n' "parity_host_receipt.sh should be allowlisted"; fail=$((fail + 1))
   fi
   if is_allowed "$tmp/scripts/probe.sh"; then
     printf '  BROKE %-40s\n' "allowlist must not exempt everything"; fail=$((fail + 1))

--- a/scripts/check_parity_receipt.sh
+++ b/scripts/check_parity_receipt.sh
@@ -57,6 +57,119 @@ if [ "$valid_n" -lt 5 ] || [ "$invalid_n" -lt 13 ]; then
     rc=1
 fi
 
+# ── THE MODULE PATH MUST PRINT WHAT THE CLI PATH PRINTS (#2736 residual) ──
+#
+# `validate_parity` is PURE: it resets the REPORT buffer, accumulates, and
+# returns errors. Each CALLER flushes with the label it owns -- _validate_one,
+# _mode_bench and _mode_parity all pass the receipt path.
+#
+# parity_block.py, the ONLY producer of a parity block in this tree and the
+# THIRD caller of that pure validator, imported the module and never flushed.
+# Every REPORT it computed -- the comparator-shortfall line #2736 exists to
+# raise, and #2736's own requested/completed deferral notice -- was dropped on
+# the floor. "A deferral nobody can see is indistinguishable from no deferral",
+# reproduced one level up by the commit that wrote the sentence.
+#
+# EVERY case above drives the CLI, which flushes. They therefore prove nothing
+# about the path that actually writes receipts, which is why this residual
+# survived a 29-case table. These drive the MODULE path instead.
+printf -- '\n--- the module path (what parity_block.py runs) ---------------------\n'
+
+python3 - <<'PYMOD' || rc=1
+import contextlib, io, json, os, subprocess, sys, tempfile
+sys.path.insert(0, "scripts/lib")
+import bench_receipt
+
+bad = 0
+
+def load(name):
+    b = json.load(open("scripts/lib/parity_receipt_cases/%s.json" % name))
+    b = b.get("parity", b)
+    return {k: v for k, v in b.items() if k != "_expect"}
+
+def with_join_key(block):
+    """Fill the join key so the ONLY difference between the two cases is the
+    completion shortfall. Without this both emit a join-key REPORT and the
+    silent control cannot be silent -- the pair would not be minimal."""
+    def walk(o):
+        if isinstance(o, dict):
+            if isinstance(o.get("provenance"), dict):
+                o["provenance"].update(host="h1", accelerator="cpu",
+                                       model="m.gguf", quantization="Q4_K")
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+    walk(block)
+    return block
+
+def module_path(name):
+    """Exactly the two calls parity_block.py makes, in order -- and the STDERR
+    they produce. Asserting the buffer instead would pass against a
+    `flush_reports` that writes nothing, which is the defect itself."""
+    block = with_join_key(load(name))
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        errors = bench_receipt.validate_parity(block)
+        bench_receipt.flush_reports(name)
+    return errors, buf.getvalue()
+
+# A MINIMAL PAIR. Both are VALID receipts; they differ only in whether the
+# comparator lost requests. One must speak, the other must stay silent -- a
+# channel that reports on everything is as useless as one that reports nothing.
+errs, err_text = module_path("27_the_comparator_loses_requests_is_reported")
+hits = err_text.count("comparator completed 7 of 10 requested")
+if errs:
+    print("FAIL  27 must stay VALID; got %d error(s)" % len(errs)); bad += 1
+elif hits != 2:
+    print("FAIL  27: the comparator-shortfall REPORT did not reach STDERR on")
+    print("      the module path (bands 8 and 16 expected, got %d)." % hits)
+    bad += 1
+else:
+    print("ok    27 comparator shortfall  on STDERR via the module path (2 bands)")
+
+errs, err_text = module_path("26_every_request_completes")
+if errs:
+    print("FAIL  26 must stay VALID; got %d error(s)" % len(errs)); bad += 1
+elif err_text.strip():
+    print("FAIL  26: an honest run must be SILENT; stderr carried:")
+    print("      %s" % err_text.strip().splitlines()[0][:90]); bad += 1
+else:
+    print("ok    26 every request completes  SILENT, as an honest run must be")
+
+# THE PRODUCER ITSELF. The two checks above prove the plumbing carries a
+# REPORT; this proves parity_block.py actually PULLS it. Remove
+# `flush_reports(args.out)` from that file and this is the row that reds --
+# the pair above stays green, because it calls the module directly.
+work = tempfile.mkdtemp()
+runs = {"runs": [{"decode_tok_per_sec": 100.0, "prefill_tok_per_sec": 200.0,
+                  "ttft_p50_ms": 10.0, "tokens_per_sec": 100.0}] * 3}
+for side in ("apr", "llama"):
+    for suffix in ["cpu"] + ["cpu-c%d" % c for c in (1, 4, 8, 16)]:
+        json.dump(runs, open(os.path.join(work, "%s-%s.json" % (side, suffix)), "w"))
+open(os.path.join(work, "lanes.txt"), "w").write("cpu cpu cpu\n")
+sha = "a" * 64
+proc = subprocess.run(
+    [sys.executable, "scripts/lib/parity_block.py", "--work", work,
+     "--apr", "/bin/true", "--apr-sha", sha, "--llama", "/bin/true",
+     "--llama-sha", sha, "--llama-build", "deadbeef", "--model", "/bin/true",
+     "--install-source", "local-build", "--out", os.path.join(work, "o.json")],
+    capture_output=True, text=True)
+if proc.returncode != 0:
+    print("FAIL  producer exited %d building a healthy block" % proc.returncode)
+    bad += 1
+elif "REPORT " not in proc.stderr:
+    print("FAIL  parity_block.py emitted NO REPORT. It computes them and drops")
+    print("      them: the defect #2736's own channel had. Expected the")
+    print("      requested/completed deferral notice on stderr.")
+    bad += 1
+else:
+    print("ok    parity_block.py FLUSHES its REPORTs to stderr (producer wired)")
+
+sys.exit(1 if bad else 0)
+PYMOD
+
 printf '\n'
 if [ "$rc" -eq 0 ]; then
     printf 'PASS  %s cases (%s valid / %s invalid): the validator separates a\n' "$n" "$valid_n" "$invalid_n"

--- a/scripts/lib/bench_receipt.py
+++ b/scripts/lib/bench_receipt.py
@@ -72,6 +72,26 @@ def _reset_reports():
     del _ABSENT[:]
 
 
+def flush_reports(label):
+    """PUBLIC. Emit the REPORTs accumulated by the last validate/validate_parity.
+
+    `validate` and `validate_parity` are PURE: they reset the buffer, accumulate,
+    and return errors. Every caller flushes with the label it owns -- the CLI
+    modes pass the receipt path (_validate_one, _mode_bench, _mode_parity), and
+    an in-process caller passes whatever names the artifact it is about to write.
+
+    This exists because parity_block.py -- the only producer of a parity block
+    in this tree, and the THIRD caller of the pure validator -- imported the
+    module and never flushed. Its four REPORTs, the comparator-shortfall one
+    among them, were computed and dropped on the floor. That is the exact shape
+    #2736 exists to remove ("a deferral nobody can see is indistinguishable
+    from no deferral"), reproduced one level up in the same commit that wrote
+    the sentence. A private `_flush_reports` is why the third caller did not
+    make the call; this makes the contract greppable.
+    """
+    _flush_reports(label)
+
+
 def _flush_reports(path):
     """Write every REPORT to stderr and clear. Never touches the return code:
     a REPORT that could fail a run would be a rule, not a report."""

--- a/scripts/lib/bench_receipt.py
+++ b/scripts/lib/bench_receipt.py
@@ -40,12 +40,48 @@ JOIN_KEY_REQUIRED = ("host", "accelerator", "model", "quantization")
 # `timeout` was missing, and it is the one that matters: a hung request produces
 # NO sample, so it cannot be discarded -- it simply never appears, and the mean
 # over the survivors reads as a slow result rather than a broken one. Naming it
-# forces a receipt to say so. (CRUX: SGLang asserts completed == requested.)
+# forces a receipt to say so. CRUX: SGLang asserts completed == requested
+# before it reads a throughput at all -- for two months that sentence sat
+# here as a COMMENT beside a constant while a receipt recording 10 requested
+# against 7 completed rendered PASS. It is now a rule: see _check_completion.
 DISCARD_REASONS = ("early_eos", "negative_delta", "nonzero_exit", "timeout")
 
 
 def _err(errors, msg):
     errors.append(msg)
+
+
+# THE REPORT CHANNEL (#2736). This file already had one deferral -- the join
+# key at _check_join_key, "reported, not failed, until every producer emits it"
+# -- and it reported by writing `_join_key_incomplete` into the dict, a field
+# that `grep -rn _join_key_incomplete scripts/ crates/ .github/` shows is
+# written once and read NOWHERE. A deferral nobody can see is indistinguishable
+# from no deferral, which is the shape this repo keeps rediscovering. REPORTs
+# now go to stderr, where a human and a CI log both see them, and where no
+# consumer that greps this tool's STDOUT for a verdict can be affected by them.
+REPORTS = []
+_ABSENT = []
+
+
+def _report(msg):
+    REPORTS.append(msg)
+
+
+def _reset_reports():
+    del REPORTS[:]
+    del _ABSENT[:]
+
+
+def _flush_reports(path):
+    """Write every REPORT to stderr and clear. Never touches the return code:
+    a REPORT that could fail a run would be a rule, not a report."""
+    seen = set()
+    for msg in REPORTS:
+        if msg in seen:      # _check_join_key fires once per side and cannot
+            continue         # name which; N identical lines are noise, not news
+        seen.add(msg)
+        sys.stderr.write("REPORT %s: %s\n" % (path, msg))
+    _reset_reports()
 
 
 def _check_join_key(prov, errors):
@@ -54,6 +90,7 @@ def _check_join_key(prov, errors):
     missing = [k for k in JOIN_KEY_REQUIRED if not prov.get(k)]
     if missing:
         prov.setdefault("_join_key_incomplete", missing)
+        _report("join key incomplete: %s absent" % ", ".join(missing))
 
 
 def _check_provenance(prov, errors):
@@ -139,6 +176,7 @@ def validate(receipt):
     """Return a list of human-readable errors; empty means valid."""
     # `_expect` is the case-table annotation, not receipt content.
     receipt = {k: v for k, v in receipt.items() if k != "_expect"}
+    _reset_reports()
     errors = []
 
     prov = receipt.get("provenance")
@@ -172,6 +210,7 @@ def _validate_one(path):
     except (OSError, ValueError) as exc:
         return 2, ["%s: cannot read: %s" % (path, exc)]
     errors = validate(receipt)
+    _flush_reports(path)
     if errors:
         return 1, ["FAIL %s: %s" % (path, e) for e in errors]
     return 0, ["ok   %s" % path]
@@ -203,6 +242,7 @@ def _mode_bench(path):
     errors = validate(bench)
     for e in errors:
         print("FAIL %s: %s" % (path, e))
+    _flush_reports(path)
     return 1 if errors else 0
 
 
@@ -284,6 +324,122 @@ def _side_provenance(side, label, errors):
     if prov is not None:
         _err(errors, "%s.provenance: must be an object" % label)
     return None
+
+
+# ===========================================================================
+# COMPLETION COUNTS (#2736). "recorded 18,292 times, never COMPARED", again.
+#
+# A parity run in which 3 of 10 requests died wrote `requested: 10,
+# completed: 7` into bands 8 and 16 of the artifact, and every one of those
+# bands rendered PASS. The number reached the receipt; nothing on the
+# lane-verdict path read it. The CRUX note beside DISCARD_REASONS has said
+# `SGLang asserts completed == requested` since #2696 -- as a COMMENT, next to
+# a constant, asserting nothing.
+#
+# WHY A SHORTFALL INVALIDATES RATHER THAN LOWERS. tok/s counts tokens from
+# SUCCESSFUL requests over the same wall clock, so a run that loses requests
+# does not report a slower number for the workload it declares -- it reports a
+# well-formed number for a SMALLER one. APR-PERF-GATE-001 v2.2 SS4.4.3 defines
+# the numerator over "completed, non-truncated" requests, so a survivors-only
+# throughput is a different quantity wearing the same name, and a ratio between
+# it and a full one is not a comparison. That is a validity failure, not a low
+# score: it is wrong even in a receipt that honestly renders FAIL.
+#
+# THE ASYMMETRY IS DELIBERATE, and it is what stops this rule from
+# CONTRADICTING perf_gate.sh's Arm C, which reads the same property:
+#
+#   subject shortfall     -> FAIL. `apr test llm bench` refuses a run with
+#                            failed requests (PERF-037), so a legitimate
+#                            subject receipt has none, and perf_gate.sh's Arm C
+#                            already fails on it (`completed(c) != requested(r)`).
+#   comparator shortfall  -> named REPORT. llama.cpp lost 3/80, 3/223, 6/302
+#                            and 10/522 requests on the 2026-08-25 corpus.
+#                            There is no committed threshold for a comparator's
+#                            loss rate, and inventing one here would red every
+#                            real receipt in the corpus -- which is how a gate
+#                            gets weakened rather than obeyed. perf_gate.sh
+#                            reaches the same verdict in the same words
+#                            ("Reported, not failed"), so the two agree.
+#   counts ABSENT         -> named REPORT. On main ZERO producers emit these
+#                            fields: parity_block.py is the only writer of a
+#                            parity block in this tree, and it gains them in
+#                            #2719. Failing on absence would red every receipt
+#                            that exists today, including all 23 fixtures. This
+#                            is the same deferral _check_join_key makes, taken
+#                            deliberately and made VISIBLE rather than silent.
+#   counts MALFORMED      -> FAIL on either side. A non-integer, a negative, or
+#                            a `completed` without a `requested` cannot be
+#                            reported-not-failed, because nothing downstream
+#                            can read it either.
+# ===========================================================================
+
+
+def _completion_pair(side, label, errors):
+    """(requested, completed) as validated ints, None if absent, False if bad."""
+    req, comp = side.get("requested"), side.get("completed")
+    if req is None and comp is None:
+        return None
+    for key, value, other in (("requested", req, "completed"),
+                              ("completed", comp, "requested")):
+        if value is None:
+            _err(errors, "%s.%s: missing while %s is present -- a completion "
+                         "count is meaningless without the count it is against"
+                         % (label, key, other))
+            return False
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            _err(errors, "%s.%s: must be an integer >= 0, got %r"
+                         % (label, key, value))
+            return False
+    return req, comp
+
+
+def _completion_mismatch(label, req, comp, errors, subject):
+    """What a count that does not match its request means, by side."""
+    if comp > req:
+        _err(errors, "%s: completed %d exceeds requested %d -- a counter "
+                     "reporting more completions than requests is malformed on "
+                     "either side of the ratio" % (label, comp, req))
+        return
+    if not subject:
+        _report("%s: comparator completed %d of %d requested -- its tok/s "
+                "counts only the survivors over the same wall clock, so every "
+                "lost request lowers the denominator of the ratio and FLATTERS "
+                "the subject (no committed threshold; reported, not failed)"
+                % (label, comp, req))
+        return
+    _err(errors, "%s: completed %d of %d requested -- %d request(s) never "
+                 "finished, so the throughput beside this count is over the "
+                 "SURVIVORS and is a different quantity from the one the "
+                 "receipt names. A survivors-only rate cannot be compared to a "
+                 "full one (SS4.4.3; #2736)" % (label, comp, req, req - comp))
+
+
+def _check_completion(side, label, errors, subject):
+    """completed == requested, or the throughput beside it is not the quantity
+    this receipt names. See the block comment above for the asymmetry."""
+    if not isinstance(side, dict):
+        return
+    pair = _completion_pair(side, label, errors)
+    if pair is None:
+        _ABSENT.append(label)
+        return
+    if pair is False or pair[0] == pair[1]:
+        return
+    _completion_mismatch(label, pair[0], pair[1], errors, subject)
+
+
+def _flush_absent():
+    """One REPORT per block, not one per side: a legacy receipt has ten sides
+    and ten identical lines is noise nobody reads."""
+    if not _ABSENT:
+        return
+    _report("requested/completed absent at %d position(s) (%s%s) -- these "
+            "receipts cannot say whether their throughput covers the workload "
+            "they declare. parity_block.py gains the fields in #2719; until "
+            "every producer emits them this is reported, not failed (#2736)"
+            % (len(_ABSENT), ", ".join(_ABSENT[:4]),
+               ", ..." if len(_ABSENT) > 4 else ""))
+    del _ABSENT[:]
 
 
 def _check_parity_side(side, label, errors, require_install_source):
@@ -383,6 +539,8 @@ def _check_parity_lane(lane, index, errors):
                                    errors, require_install_source=True)
     comp_prov = _check_parity_side(lane.get("comparator"), label + ".comparator",
                                    errors, require_install_source=False)
+    _check_completion(lane.get("subject"), label + ".subject", errors, True)
+    _check_completion(lane.get("comparator"), label + ".comparator", errors, False)
     _check_comparator_pin(lane.get("comparator") or {}, label, errors)
     cross = _check_class_pair(lane, (subj_prov or {}).get("compute_class"),
                               (comp_prov or {}).get("compute_class"), label, errors)
@@ -459,6 +617,11 @@ def _check_one_band(band, index, floor, ceiling, errors):
         _err(errors, "%s.concurrency: must be a positive integer" % label)
         return None
 
+    # Before the metric loop, which returns early on a missing metric: a band
+    # that lost requests must be named even when a metric is absent too.
+    _check_completion(band.get("subject"), label + ".subject", errors, True)
+    _check_completion(band.get("comparator"), label + ".comparator", errors, False)
+
     failed = []
     for metric in BAND_METRICS:
         ratio = _band_metric(band, metric, floor, ceiling, label, failed, errors)
@@ -503,6 +666,7 @@ def _walk_bands(bands, floor, ceiling, errors):
 
 def validate_parity(block):
     """Validate a parity block. Returns a list of errors; empty means valid."""
+    _reset_reports()
     errors = []
     if not isinstance(block, dict):
         return ["parity: must be an object"]
@@ -518,6 +682,7 @@ def validate_parity(block):
         return errors
     for i, lane in enumerate(lanes):
         _check_parity_lane(lane, i, errors)
+    _flush_absent()
     return errors
 
 
@@ -549,6 +714,7 @@ def _mode_parity(path):
     errors = validate_parity({k: v for k, v in block.items() if k != "_expect"})
     for e in errors:
         print("FAIL %s: %s" % (path, e))
+    _flush_reports(path)
     return 1 if errors else 0
 
 

--- a/scripts/lib/parity_block.py
+++ b/scripts/lib/parity_block.py
@@ -46,6 +46,46 @@ def _side(binary, sha, klass, path, install_source=None, feature_set=None):
     return side
 
 
+class Refusal(Exception):
+    """A ratio that cannot honestly be derived. Carries the sentence the gate
+    would have used, naming WHICH SIDE was not a measurement."""
+
+
+def _ratio(subject, comparator, label, metric, guard_subject=False):
+    """median(subject) / median(comparator), or a NAMED refusal (#2735).
+
+    A non-positive COMPARATOR median used to raise ZeroDivisionError straight
+    out of here. That exits non-zero, so it was never a false green -- but a
+    traceback names no band and no side, and reads as a tooling defect rather
+    than as a measurement that must not be published. It is reachable, not
+    theoretical: `-b 1` aborts llama.cpp at load (GGML_ASSERT, rc=134), so the
+    comparator is exactly the side that produces nothing on gx10 today.
+
+    NOT try/except -> return None. A dropped band vanishes from lane["bands"]
+    and surfaces downstream as _check_bands' declared-vs-seen mismatch, which
+    reports the wrong cause. A missing measurement must be RED, by name.
+
+    guard_subject stays False where bench_receipt._median_of already inspects
+    BOTH sides: there the producer only has to stop crashing before its own
+    gate gets to speak, and the refusal is left verbatim to the gate. It is
+    True for prefill, which no validator reads at all -- without it a zero
+    subject prefill is published as `ratio_prefill: 0.0`, a ratio derived from
+    a non-measurement, with rc=0.
+    """
+    sides = [("comparator", comparator)]
+    if guard_subject:
+        sides.append(("subject", subject))
+    for side, samples in sides:
+        median = statistics.median(samples)
+        if median <= 0:
+            raise Refusal(
+                "%s.%s.%s: median of %d sample(s) is %s -- a throughput of "
+                "zero or less is not a measurement, and a ratio derived from "
+                "it would be fabricated"
+                % (label, side, metric, len(samples), median))
+    return statistics.median(subject) / statistics.median(comparator)
+
+
 BANDS_DEFAULT = (1, 4, 8, 16)
 
 
@@ -62,8 +102,8 @@ def _band_from(name, c, work):
                            "decode_tok_per_sec": _samples(l, "decode_tok_per_sec")}}
     ok = True
     for metric in ("aggregate_tok_per_sec", "decode_tok_per_sec"):
-        ratio = (statistics.median(band["subject"][metric])
-                 / statistics.median(band["comparator"][metric]))
+        ratio = _ratio(band["subject"][metric], band["comparator"][metric],
+                       "band[%d]" % c, metric)
         band["ratio_" + metric] = round(ratio, 4)
         if ratio < FLOOR or ratio > CEILING:
             ok = False
@@ -88,13 +128,16 @@ def _lane_from(name, apr_class, comp_class, args, work):
     comparator["name"] = "llama.cpp"
     comparator["build_commit"] = args.llama_build
 
-    ratio = (statistics.median(subject["decode_tok_per_sec"])
-             / statistics.median(comparator["decode_tok_per_sec"]))
+    label = "lane[%s]" % apr_class
+    ratio = _ratio(subject["decode_tok_per_sec"],
+                   comparator["decode_tok_per_sec"], label,
+                   "decode_tok_per_sec")
+    prefill = _ratio(subject["prefill_tok_per_sec"],
+                     comparator["prefill_tok_per_sec"], label,
+                     "prefill_tok_per_sec", guard_subject=True)
     lane = {"lane": apr_class, "subject": subject, "comparator": comparator,
             "ratio_decode": round(ratio, 4),
-            "ratio_prefill": round(
-                statistics.median(subject["prefill_tok_per_sec"])
-                / statistics.median(comparator["prefill_tok_per_sec"]), 4)}
+            "ratio_prefill": round(prefill, 4)}
     bands = [b for b in (_band_from(name, c, work) for c in BANDS_DEFAULT) if b]
     if bands:
         lane["declared_bands"] = list(BANDS_DEFAULT)
@@ -151,7 +194,13 @@ def main():
         ap.add_argument(flag, required=True)
     args = ap.parse_args()
 
-    block = build(args)
+    try:
+        block = build(args)
+    except Refusal as refusal:
+        sys.stderr.write("FAIL  refusing to emit a block whose ratio would be "
+                         "derived from a non-measurement:\n")
+        sys.stderr.write("        %s\n" % refusal)
+        return 1
     if block is None:
         return 1
 

--- a/scripts/lib/parity_block.py
+++ b/scripts/lib/parity_block.py
@@ -206,6 +206,10 @@ def main():
 
     # SELF-VALIDATION. The same function the release gate calls.
     errors = bench_receipt.validate_parity(block)
+    # ...and the REPORTs it accumulated. Pure validator, caller flushes -- see
+    # bench_receipt.flush_reports. Before the error check on purpose: a refused
+    # block is when its diagnostics are worth most (#2736).
+    bench_receipt.flush_reports(args.out)
     if errors:
         sys.stderr.write("FAIL  refusing to emit a block this repo's own gate "
                          "would reject:\n")

--- a/scripts/lib/parity_receipt_cases/25_a_band_loses_requests_and_still_says_PASS.json
+++ b/scripts/lib/parity_receipt_cases/25_a_band_loses_requests_and_still_says_PASS.json
@@ -1,0 +1,224 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 448,
+            "requested": 10,
+            "completed": 7
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 448,
+            "requested": 10,
+            "completed": 7
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "invalid",
+    "why": "bands 8 and 16 completed 7 of 10 requested and render PASS; a survivors-only throughput is a different quantity (#2736)"
+  }
+}

--- a/scripts/lib/parity_receipt_cases/26_every_request_completes.json
+++ b/scripts/lib/parity_receipt_cases/26_every_request_completes.json
@@ -1,0 +1,224 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "valid",
+    "why": "completed == requested on every side of every band; the rule in 25 must not red an honest run"
+  }
+}

--- a/scripts/lib/parity_receipt_cases/27_the_comparator_loses_requests_is_reported.json
+++ b/scripts/lib/parity_receipt_cases/27_the_comparator_loses_requests_is_reported.json
@@ -1,0 +1,224 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 7
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 7
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "valid",
+    "why": "comparator completed 7/10 on bands 8 and 16 -- REPORTED, never failed; no committed threshold exists and perf_gate.sh Arm C agrees"
+  }
+}

--- a/scripts/lib/parity_receipt_cases/28_the_lane_subject_loses_requests.json
+++ b/scripts/lib/parity_receipt_cases/28_the_lane_subject_loses_requests.json
@@ -1,0 +1,224 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 7,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "invalid",
+    "why": "lane subject completed 7 of 10 requested -- the lane side is the position perf_receipt.py lifts into perf_gate.sh's top-level requested/completed, and both checks FAIL on it"
+  }
+}

--- a/scripts/lib/parity_receipt_cases/29_completed_without_requested.json
+++ b/scripts/lib/parity_receipt_cases/29_completed_without_requested.json
@@ -1,0 +1,223 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 640,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "invalid",
+    "why": "band 8 carries completed and no requested -- a completion count is meaningless without the count it is against, and cannot be deferred"
+  }
+}

--- a/scripts/lib/parity_receipt_cases/30_completed_exceeds_requested.json
+++ b/scripts/lib/parity_receipt_cases/30_completed_exceeds_requested.json
@@ -1,0 +1,224 @@
+{
+  "instrument": "apr test llm bench",
+  "protocol_ref": "scripts/llama_pin.toml#protocol.http",
+  "model": "qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+  "floor": 0.8,
+  "stretch": 1.5,
+  "lanes": [
+    {
+      "lane": "cuda",
+      "subject": {
+        "provenance": {
+          "binary_path": "/x/apr",
+          "binary_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "resolution": "scripts/apr_bin.sh",
+          "compute_class": "cuda",
+          "feature_set": [
+            "cli",
+            "inference",
+            "cuda"
+          ],
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          150.0
+        ],
+        "prefill_tok_per_sec": [
+          900.0
+        ],
+        "ttft_p50_ms": [
+          80.0
+        ],
+        "samples_ms": [
+          1000.0,
+          1007.0,
+          1014.0,
+          1021.0,
+          1028.0,
+          1035.0,
+          1042.0,
+          1049.0,
+          1056.0,
+          1063.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "install_source": "crates.io"
+      },
+      "comparator": {
+        "provenance": {
+          "binary_path": "/x/llama-server",
+          "binary_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "resolution": "scripts/llama_bin.sh",
+          "compute_class": "cuda",
+          "_join_key_incomplete": [
+            "host",
+            "accelerator",
+            "model",
+            "quantization"
+          ]
+        },
+        "decode_tok_per_sec": [
+          171.0
+        ],
+        "prefill_tok_per_sec": [
+          1000.0
+        ],
+        "ttft_p50_ms": [
+          81.0
+        ],
+        "samples_ms": [
+          1001.0,
+          1008.0,
+          1015.0,
+          1022.0,
+          1029.0,
+          1036.0,
+          1043.0,
+          1050.0,
+          1057.0,
+          1064.0
+        ],
+        "requested": 10,
+        "completed": 10,
+        "name": "llama.cpp",
+        "build_commit": "39173bcac"
+      },
+      "ratio_decode": 0.8772,
+      "ratio_prefill": 0.9,
+      "declared_bands": [
+        1,
+        4,
+        8,
+        16
+      ],
+      "bands": [
+        {
+          "concurrency": 1,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              150.0
+            ],
+            "decode_tok_per_sec": [
+              150.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              168.0
+            ],
+            "decode_tok_per_sec": [
+              171.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8929,
+          "ratio_decode_tok_per_sec": 0.8772,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 4,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              430.0
+            ],
+            "decode_tok_per_sec": [
+              115.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              484.0
+            ],
+            "decode_tok_per_sec": [
+              123.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.8884,
+          "ratio_decode_tok_per_sec": 0.935,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 8,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              600.0
+            ],
+            "decode_tok_per_sec": [
+              100.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              650.0
+            ],
+            "decode_tok_per_sec": [
+              83.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "ratio_aggregate_tok_per_sec": 0.9231,
+          "ratio_decode_tok_per_sec": 1.2048,
+          "verdict": "PASS"
+        },
+        {
+          "concurrency": 16,
+          "subject": {
+            "aggregate_tok_per_sec": [
+              980.0
+            ],
+            "decode_tok_per_sec": [
+              85.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 10
+          },
+          "comparator": {
+            "aggregate_tok_per_sec": [
+              1120.0
+            ],
+            "decode_tok_per_sec": [
+              71.0
+            ],
+            "tokens_total": 640,
+            "requested": 10,
+            "completed": 11
+          },
+          "ratio_aggregate_tok_per_sec": 0.875,
+          "ratio_decode_tok_per_sec": 1.1972,
+          "verdict": "PASS"
+        }
+      ],
+      "ceiling": 1.5,
+      "floor": 0.8,
+      "stretch": 1.5,
+      "verdict": "PASS"
+    }
+  ],
+  "_expect": {
+    "result": "invalid",
+    "why": "comparator band 16 completed 11 of 10 requested -- malformed on either side; the report-not-fail asymmetry covers loss, never nonsense"
+  }
+}

--- a/scripts/parity_host_receipt.sh
+++ b/scripts/parity_host_receipt.sh
@@ -19,6 +19,10 @@
 #      llama.cpp `-ngl 0`, never against a CUDA comparator. Cross-class is how
 #      a 0.099x artifact defect reads as a kernel defect.
 #
+#   4. It will not treat a failure of the measuring instrument as a
+#      measurement. Every `apr test llm bench` invocation is checked for its
+#      exit status AND for the report it was told to write; see measure_band.
+#
 # Usage:
 #   scripts/parity_host_receipt.sh --apr <path> --model <gguf> [--out <file>]
 #                                  [--install-source crates.io|local-build]
@@ -57,6 +61,69 @@ kill_servers() { for p in $SERVER_PIDS; do kill "$p" 2>/dev/null || true; done; 
 
 sha256_of() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$1" | cut -d' ' -f1; }
 
+# Every diagnosis names the machine it came from, because these runs are
+# collected from four hosts into one ledger and "the harness failed" is not
+# actionable without knowing whose harness.
+HOST_TAG=$(uname -n 2>/dev/null) || HOST_TAG=""
+[ -n "$HOST_TAG" ] || HOST_TAG="unknown-host"
+
+# NO PIPE. `"$APR" --version | head -1` returns 141 rather than apr's status
+# whenever head exits before apr has finished writing: head closes the pipe,
+# apr takes SIGPIPE, and `set -o pipefail` hands the pipeline apr's death
+# signal. That is input-size dependent, which is how it stays green locally and
+# reds in CI. The first line is taken with parameter expansion instead.
+APR_VERSION=$("$APR" --version 2>&1) || APR_VERSION="<--version exited non-zero>"
+APR_VERSION=${APR_VERSION%%$'\n'*}
+
+# The harness's OWN words, indented, whole. A failure diagnosis that truncates
+# is a diagnosis you have to reproduce to read.
+harness_said() { # harness_said <logfile>
+    if [ -s "$1" ]; then
+        printf '      the harness said:\n' >&2
+        sed 's/^/        /' "$1" >&2
+    else
+        printf '      the harness printed nothing at all.\n' >&2
+    fi
+}
+
+# ── THE APPARATUS IS PROVED BEFORE ANY SERVER STARTS ───────────────────────
+#
+# gx10 runs apr 0.64.0 (78d485eb), where `apr test llm bench` DOES NOT EXIST:
+# clap answers `error: unrecognized subcommand 'llm'` and exits 2. Learning
+# that after two 300-second health waits and two model loads is learning it in
+# the most expensive place available, eight times over, once per band per side.
+#
+# BEHAVIOUR, NOT EXISTENCE — llama_bin.sh's second property, for the same
+# reason: an exit status of 0 accepts `/bin/true`, which answers 0 to every
+# question ever asked of it. Probed, not assumed: pointed at /bin/true, the
+# status-only check passed preflight and then sat in wait_healthy for the full
+# 300 seconds before saying something unrelated about a server. So the probe
+# must also SPEAK, and say the one word that identifies the banded harness.
+harness_preflight() {
+    local log="$WORK/harness-preflight.log" rc=0 why=""
+    "$APR" test llm bench --help > "$log" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        why="exit $rc"
+    elif [ ! -s "$log" ]; then
+        why="exit 0 but printed nothing — this binary answers, it does not respond"
+    elif ! grep -q -- '--concurrency' "$log"; then
+        # The flag that IS the banded protocol. It was `http_concurrency = 1`
+        # until bands existed, and a harness without it can only re-measure the
+        # worst band and call it the answer.
+        why="exit 0 but its help does not mention --concurrency"
+    else
+        return 0
+    fi
+    printf 'FAIL  host=%s — the measurement harness is not usable on this apr.\n' "$HOST_TAG" >&2
+    printf '      binary  %s\n' "$APR" >&2
+    printf '      version %s\n' "$APR_VERSION" >&2
+    printf '      probe   test llm bench --help  ->  %s\n' "$why" >&2
+    harness_said "$log"
+    printf '      This is the only instrument in the chain. Nothing on this host can\n' >&2
+    printf '      be measured, so no lane is started and no receipt is written.\n' >&2
+    return 1
+}
+
 wait_healthy() { # wait_healthy <port> <seconds>
     local port="$1" limit="$2" i=0
     while [ "$i" -lt "$limit" ]; do
@@ -87,9 +154,103 @@ BANDS=$(sed -n 's/^[[:space:]]*http_concurrency_bands[[:space:]]*=[[:space:]]*\[
         "$(dirname "$0")/llama_pin.toml" | tr -d ' ' | tr ',' ' ')
 [ -n "$BANDS" ] || { printf 'FAIL  llama_pin.toml declares no http_concurrency_bands\n' >&2; exit 1; }
 
+# ── ONE BAND, ONE SIDE: A FAILURE IS A RESULT, NEVER A SHRUG ───────────────
+#
+# Both calls to `apr test llm bench` used to end `>/dev/null 2>&1 || true`,
+# discarding stdout, stderr AND the exit status of the only instrument in this
+# chain. One idiom erased three distinct faults:
+#
+#   · THE HARNESS IS NOT THERE — the gx10 case above. A silent no-op, eight
+#     times, surfacing minutes later on another machine as an absent receipt
+#     that says nothing about a subcommand.
+#
+#   · THE HARNESS REFUSED THE MEASUREMENT — and this one is a false GREEN, not
+#     merely a late red. test_llm.rs writes `--output` BEFORE it validates, then
+#     exits non-zero on a run with failed requests, on a run that generated zero
+#     tokens, and on a regression past threshold. So a swallowed refusal leaves
+#     a well-formed report on disk, and parity_block.py reads `tokens_per_sec`
+#     and `decode_tok_per_sec` out of it while never looking at `failed`. A lane
+#     whose requests failed publishes as a clean PASS — precisely the
+#     survivors' throughput that test_llm.rs exists to refuse.
+#
+#   · THE HARNESS NEVER RAN — no file, no band, and the failure lands at the
+#     gate as "bands [...] are declared in the protocol and absent from the
+#     receipt": a true statement that names the wrong thing.
+#
+# The two kinds are told apart by a MECHANICAL signal rather than by guessing
+# at exit codes, which drift: whether the harness produced its report file.
+#
+#   rc != 0, NO report      APPARATUS. It never measured — missing subcommand,
+#                           rejected flag, no connection, panic. Every band
+#                           would fail identically, so the lane aborts here
+#                           rather than spending six more minutes proving it
+#                           four more times.
+#
+#   rc != 0, report present VERDICT. It measured and refused. That is a fact
+#                           about the runtime, and its shape ACROSS bands is
+#                           the diagnosis — gx10 refuses two of four — so the
+#                           sweep finishes and the lane fails at the end with
+#                           the whole table. The report is deliberately LEFT
+#                           WHERE IT IS: deleting it would turn the producer's
+#                           honest refusal into a silently dropped band, which
+#                           is this same defect wearing a different hat.
+#
+#   rc == 0, NO report      APPARATUS, and meant to be impossible. Asserted
+#                           rather than assumed, because "cannot happen" is
+#                           where this repo keeps finding things.
+#
+# There is no fourth case in which a missing band is tolerable. The protocol
+# declares four bands and bench_receipt.py already rules that "an unmeasured
+# band is not a passing band". A band that produces nothing is a failure to
+# measure, never a measurement of nothing.
+#
+# Returns 0 measured · 1 refused (report on disk) · 2 apparatus fault.
+measure_band() { # measure_band <side> <class> <port> <concurrency> <runtime-name>
+    local side="$1" klass="$2" port="$3" c="$4" name="$5"
+    local out="$WORK/$side-$klass-c$c.json"
+    local log="$WORK/$side-$klass-c$c.harness.log"
+    local rc=0
+
+    # So that "the file is there" can only mean "THIS invocation wrote it".
+    rm -f "$out"
+    # Status captured directly, never through a pipe: `$?` after a pipeline is
+    # the LAST command's status, which has shipped twice in this repo.
+    "$APR" test llm bench --url "http://127.0.0.1:$port" \
+        --model "$(basename "$MODEL" .gguf)" \
+        --profile "$PROFILE" --warmup "$WARMUP" --duration "$DURATION" \
+        --runs "$RUNS" --cooldown "$COOLDOWN" --concurrency "$c" --stream \
+        --runtime-name "$name" --output "$out" > "$log" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ] && [ -f "$out" ]; then
+        return 0
+    fi
+
+    printf 'FAIL  host=%s lane=%s side=%s band=c%s — harness exited %s\n' \
+        "$HOST_TAG" "$klass" "$side" "$c" "$rc" >&2
+    printf '      binary   %s (%s)\n' "$APR" "$APR_VERSION" >&2
+    printf '      endpoint http://127.0.0.1:%s   runtime-name %s\n' "$port" "$name" >&2
+    harness_said "$log"
+
+    if [ -f "$out" ]; then
+        printf '      It measured and then REFUSED the result. %s is left in place so\n' "$out" >&2
+        printf '      the producer can render its own refusal rather than see a dropped\n' >&2
+        printf '      band; the sweep continues so the shape across bands is visible,\n' >&2
+        printf '      and the lane FAILS at the end.\n' >&2
+        return 1
+    fi
+    if [ "$rc" -eq 0 ]; then
+        printf '      It exited 0 and wrote NO report. A harness that reports success\n' >&2
+        printf '      without producing its measurement is broken, not successful.\n' >&2
+    fi
+    printf '      Nothing was measured. Every remaining band would fail the same way,\n' >&2
+    printf '      so this lane stops here.\n' >&2
+    return 2
+}
+
 run_lane() { # run_lane <class> <apr-flags> <llama-ngl> -> writes $WORK/<class>.json
     local klass="$1" apr_flags="$2" ngl="$3"
     local aport=8090 lport=8091
+    local refused="" brc=0
 
     # shellcheck disable=SC2086
     "$APR" serve run "$MODEL" $apr_flags --port "$aport" --context-length 4096 \
@@ -98,10 +259,13 @@ run_lane() { # run_lane <class> <apr-flags> <llama-ngl> -> writes $WORK/<class>.
     wait_healthy "$aport" 300 || { printf 'FAIL  apr did not become healthy for lane %s\n' "$klass" >&2; return 1; }
     local taken; taken=$(apr_class_from_log "$WORK/apr-$klass.log")
     for c in $BANDS; do
-        "$APR" test llm bench --url "http://127.0.0.1:$aport" --model "$(basename "$MODEL" .gguf)" \
-            --profile "$PROFILE" --warmup "$WARMUP" --duration "$DURATION" --runs "$RUNS" \
-            --cooldown "$COOLDOWN" --concurrency "$c" --stream --runtime-name "apr-$klass-c$c" \
-            --output "$WORK/apr-$klass-c$c.json" >/dev/null 2>&1 || true
+        brc=0
+        measure_band apr "$klass" "$aport" "$c" "apr-$klass-c$c" || brc=$?
+        case "$brc" in
+            0) ;;
+            1) refused="$refused apr/c$c" ;;
+            *) return 1 ;;
+        esac
     done
     kill_servers; SERVER_PIDS=""; sleep 5
 
@@ -114,15 +278,34 @@ run_lane() { # run_lane <class> <apr-flags> <llama-ngl> -> writes $WORK/<class>.
         if grep -qi "CUDA" "$WORK/llama-$klass.log"; then ctaken=cuda; else ctaken=metal; fi
     fi
     for c in $BANDS; do
-        "$APR" test llm bench --url "http://127.0.0.1:$lport" --model "$(basename "$MODEL" .gguf)" \
-            --profile "$PROFILE" --warmup "$WARMUP" --duration "$DURATION" --runs "$RUNS" \
-            --cooldown "$COOLDOWN" --concurrency "$c" --stream --runtime-name "llamacpp-$klass-c$c" \
-            --output "$WORK/llama-$klass-c$c.json" >/dev/null 2>&1 || true
+        brc=0
+        measure_band llama "$klass" "$lport" "$c" "llamacpp-$klass-c$c" || brc=$?
+        case "$brc" in
+            0) ;;
+            1) refused="$refused llama/c$c" ;;
+            *) return 1 ;;
+        esac
     done
     kill_servers; SERVER_PIDS=""; sleep 5
 
+    # BOTH sides are swept before a refusal is acted on, deliberately. Which
+    # bands refuse, and on which side, is the diagnosis: a zero-token band on
+    # apr alone is an apr defect, the same band refusing on both sides is the
+    # model or the protocol. Stopping at the first refusal reports one of the
+    # two zero-token bands gx10 actually has and hides the comparator entirely.
+    if [ -n "$refused" ]; then
+        printf 'FAIL  host=%s lane=%s — the harness refused these bands:%s\n' \
+            "$HOST_TAG" "$klass" "$refused" >&2
+        printf '      A refused band is not a measured band, and its report on disk is\n' >&2
+        printf '      not a sample. Each refusal is printed above in the harness own\n' >&2
+        printf '      words; this lane is not written to lanes.txt.\n' >&2
+        return 1
+    fi
+
     printf '%s %s %s\n' "$klass" "$taken" "$ctaken" >> "$WORK/lanes.txt"
 }
+
+harness_preflight || exit 1
 
 # WHICH LANES THIS HOST CAN ACTUALLY REACH — asked of the binary, not assumed.
 # A published apr has no GPU path at all, so its only honest lane is cpu, and


### PR DESCRIPTION
Epic #2706 (the receipt rule). Five sub-tickets in one queue slot. Supersedes **#2730 #2731 #2732 #2735 #2736** (ticket numbers; those had no PRs of their own).

| branch | the defect |
|---|---|
| **#2730** | `.all()` over an empty collection is vacuously true, so a **zero-brick report scored `PASS`/`green`** — and `--ci` didn't save it, because it gates on the vacuous value itself. A pre-existing test held it in place: `assert_eq!(report.status, "PASS"); // Empty bricks -> all pass vacuously` — it **named the vacuity in its own comment and then asserted it**. |
| **#2731 + #2732** | `--warmup 0` accepted while `--iterations 0` was rejected, and the receipt recorded **neither** — so a cold-start and a steady-state number were byte-indistinguishable artifacts. F-PROVE-007 now derives its expectation instead of pinning a literal. |
| **PERF-037** | The chain's **only two harness invocations** were `>/dev/null 2>&1 \|\| true`. Not a late diagnosis — a **fabricated PASS**: `test_llm.rs:118` writes `--output` before `:139` validates, so a swallowed refusal left a well-formed report the producer read as a sample. Measured: `rc=0`, lane `PASS`, **on a run where 3 of 10 requests died**. |
| **#2735** | Three unguarded denominators, not the two reported. And a false green next door: a zero **subject** prefill shipped at **rc=0 with `ratio_prefill: 0.0`** — `bench_receipt.py` contains zero occurrences of `prefill`, so that ratio is derived, published, and **read by no validator at all**. |
| **#2736** | `completed < requested` rendered `PASS`. The reason it was invisible: every band ratio in the lossy block is **byte-identical to the clean block's** — losing 3 of 10 requests moves no number the gate was reading. |

## The residual the batch itself found

**#2736's new REPORT channel was dark on every path that exists.** `_flush_reports` is called only by the CLI modes; `parity_block.py:208` calls `validate_parity` **as a module**, which resets and never flushes. CLI path: 3 REPORT lines on stderr. Module path — what the producer actually runs: **4 REPORTs accumulated, stderr empty.** All three consumers redirect `>/dev/null 2>&1` anyway.

That is #2736's own comment — *"a deferral nobody can see is indistinguishable from no deferral"* — reproduced one level up.

**Fixed at the call site, not inside the validator**, and the argument is the label: `_flush_reports` prefixes every line with a path, and a block in memory has none. Flushing inside would invent a label or emit an unlabelled one — and because the flush clears the buffer, it would silently empty it before `_mode_parity`'s own flush, changing the CLI's committed `REPORT <path>: <msg>` format for every existing consumer. The file's design is *pure validator, caller flushes*; `parity_block.py` was the one caller that didn't.

The new rows **assert stderr, not the buffer** — asserting the buffer would pass against a `flush_reports` that writes nothing, which is the defect itself.

## A guard broken by a comment, and a fifth SIGPIPE

`check_no_competing_harnesses.sh` went red because PERF-037's **explanatory prose** contains `tokens_per_sec` and `computes_rate` grepped the whole file, comments included. The script computes no rate — it delegates to `apr test llm bench`.

Both halves fixed: `parity_host_receipt.sh` allowlisted on the basis that it **drives** the canonical instrument rather than defining a second one (the same basis `perf000_serialization_probe.sh` already uses), **and** `code_only()` strips comments before matching, with a case-table row so prose cannot re-break it.

**Full-line comments only, deliberately**: stripping trailing `# …` would mangle `${var#pattern}` and `#` inside quoted strings, and an over-strip can only make a real harness *invisible*. A false negative defeats the guard's purpose; a false positive merely annoys. The residual is recorded as a case-table row, not left to be rediscovered.

And while writing that fix: `code_only "$f" | grep -q X` returns **141 even when grep matches** — grep exits first, `sed` takes SIGPIPE, `pipefail` hands over sed's signal. **The fifth instance of that class today.** Herestrings throughout.

Re-mutated in the widened scope, 15 rows. The one that matters: **restore a real harness → still DETECTED** (`count=1 baseline=0`, rc=1) — proof the strip did not blind the guard.

## Verification

| gate | before | after |
|---|---|---|
| 93 `check_*.sh` from `ci.yml`, derived at run time | 91×0, **2×1** | **93×0** |
| `check_no_competing_harnesses.sh --selftest` | 8 rows | **15 rows, 0 broken** |
| `check_parity_receipt.sh` | 0 | 0 (+3 module-path rows) |
| `cargo test -p apr-cli --lib` | 7133 | 7133 |
| `cargo test -p aprender-serve --lib` | 15705 | 15705 |

`cargo clippy --workspace --all-targets` and `--benches` are rc=101 **on the batch and on `origin/main` alike**, with identical failing-unit sets in both directions. Note that command is *stronger than CI* — `ci.yml` has no clippy step at all (line 6 is a comment claiming one; lint is delegated upstream), which is why it is red on untouched main.

`surface_audit.csv`: all **77** citations to `extended_commands.rs` re-audited first — every cited line byte-identical, **none inside any changed hunk**. Exactly one row edited, by exact whole-line replacement rather than rewriting through the `csv` module, which would have reformatted quoting across all 830 rows.

## Two things worth knowing

**A comment failed a complexity gate.** The PMAT pre-commit hook blocked the first commit: an added **comment block** raised `main()`'s cognitive complexity 24 → 27 past the threshold, with cyclomatic unchanged at 8. `--no-verify` was **not** used — the comment was condensed and measured back to exactly 24 with the gate's own command on both sides.

**No batch-only defect was found**, and that is stated as a negative result rather than a guarantee — the two previous batches each found one.

## Unproven

The producer/consumer composition is proved against a **synthetic `$WORK`** and a shell harness reproducing the script's tail, never against live `apr serve` / `llama-server`; `harness_preflight` has never executed. #2736's rule is proven by fixtures only and stays dormant in production until #2719 lands a producer that emits the fields.

Refs #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)
