### PR TITLE
feat(perf): the §4.4 protocol had no caller and the gate's real mode had no input (PERF-025)

### DIFF
--- a/crates/apr-cli/src/commands/mod.rs
+++ b/crates/apr-cli/src/commands/mod.rs
@@ -138,6 +138,10 @@ pub(crate) mod prometheus_lint;
 pub(crate) mod prune;
 pub(crate) mod ps_schema;
 pub(crate) mod test_llm;
+// PERF-025: the `--band` mode of `apr test llm bench`. Its own file so that
+// `test_llm.rs`'s complexity is untouched by it -- the PMAT pre-commit gate
+// blocks a FILE with any pre-existing violation, not a function.
+pub(crate) mod test_llm_band;
 // #2399: gated on the crate it actually needs (aprender-explain, aliased
 // `trueno-explain`) rather than on `full`, so `--features ptx` is enough and a
 // user does not have to pull CUDA + training to analyze a .ptx file.

--- a/crates/apr-cli/src/commands/test_llm.rs
+++ b/crates/apr-cli/src/commands/test_llm.rs
@@ -199,7 +199,7 @@ pub async fn run_bench(args: BenchArgs<'_>) -> Result<()> {
 /// A file overrides the profile; an unknown profile name is rejected rather
 /// than quietly falling back to a default, since a silent substitution changes
 /// the workload the report then claims to have run.
-fn resolve_prompts(profile: &str, file: Option<&Path>) -> Result<Vec<ChatRequest>> {
+pub(crate) fn resolve_prompts(profile: &str, file: Option<&Path>) -> Result<Vec<ChatRequest>> {
     if let Some(p) = file {
         return load_prompts_from_file(p)
             .map_err(|e| CliError::InvalidFormat(format!("prompt file {}: {e}", p.display())));
@@ -213,7 +213,7 @@ fn resolve_prompts(profile: &str, file: Option<&Path>) -> Result<Vec<ChatRequest
 }
 
 /// One line naming the workload, so the report is self-describing.
-fn describe_workload(profile: &str, file: Option<&Path>, count: usize) -> String {
+pub(crate) fn describe_workload(profile: &str, file: Option<&Path>, count: usize) -> String {
     match file {
         Some(p) => format!("{} prompt(s) from {}", count, p.display()),
         None => format!("profile {profile} ({count} prompt(s))"),
@@ -364,4 +364,133 @@ mod tests {
         let p = Path::new("/tmp/x.json");
         assert!(describe_workload("medium", Some(p), 7).contains("x.json"));
     }
+}
+
+// ===========================================================================
+// PERF-025 — routing `apr test llm <SUB>`.
+//
+// The arm lives HERE rather than inline in `dispatch_analysis.rs`'s match.
+// That router was already at cognitive 24 against a threshold of 25, so adding
+// the band branch inline tipped it over; moving the whole arm out puts the
+// routing next to the two functions it routes to and leaves the router simpler
+// than it was.
+// ===========================================================================
+use crate::LlmSubcommand;
+
+/// Route `apr test llm <SUB>` (GH-876 Milestone 2; PERF-025 band mode).
+///
+/// # Errors
+/// Propagates whichever mode ran.
+pub fn dispatch(command: &LlmSubcommand) -> Result<()> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| CliError::InferenceFailed(format!("tokio runtime: {e}")))?;
+    match command {
+        LlmSubcommand::Bench { band, .. } if *band => rt.block_on(dispatch_band(command)),
+        LlmSubcommand::Bench { .. } => rt.block_on(dispatch_legacy(command)),
+    }
+}
+
+/// TWO MODES, ONE ENTRYPOINT — the §4.4-conformant one.
+///
+/// `--band` selects PERF-024's `run_band`, which until PERF-025 was called by
+/// nothing outside its own tests.
+async fn dispatch_band(command: &LlmSubcommand) -> Result<()> {
+    let LlmSubcommand::Bench {
+        url,
+        model,
+        stream,
+        profile,
+        prompts,
+        receipt,
+        bands,
+        replicates,
+        workload,
+        host,
+        accelerator,
+        quantization,
+        compute_class,
+        server_features,
+        tokenization,
+        tokenizer_sha256,
+        counts_special_tokens,
+        counts_prompt_echo,
+        commit,
+        comparator_owner,
+        ..
+    } = command;
+    // Unreachable: clap's `requires = "receipt"` enforces it. Stated rather
+    // than unwrapped, because a receipt-less band run would measure for
+    // minutes and then discard the measurement.
+    let receipt = receipt
+        .as_deref()
+        .ok_or_else(|| CliError::InvalidInput("--band requires --receipt <DIR>".to_string()))?;
+    super::test_llm_band::run_bands(super::test_llm_band::BandArgs {
+        url,
+        model,
+        bands,
+        replicates: *replicates,
+        receipt,
+        workload,
+        host,
+        accelerator,
+        quantization,
+        compute_class,
+        server_features,
+        tokenization,
+        tokenizer_sha256: tokenizer_sha256.as_deref(),
+        counts_special_tokens: *counts_special_tokens,
+        counts_prompt_echo: *counts_prompt_echo,
+        commit: commit.as_deref(),
+        stream: *stream,
+        profile,
+        prompts: prompts.as_deref(),
+        comparator_owner,
+    })
+    .await
+}
+
+/// The pre-existing `LoadTest::run` lifecycle, unchanged.
+///
+/// Its termination rule is not touched: a great deal of tooling reads
+/// `LoadTestResult`, and changing when the run stops underneath those readers
+/// would silently change every number they have ever recorded.
+async fn dispatch_legacy(command: &LlmSubcommand) -> Result<()> {
+    let LlmSubcommand::Bench {
+        url,
+        model,
+        start,
+        health_timeout,
+        warmup,
+        duration,
+        concurrency,
+        runs,
+        cooldown,
+        runtime_name,
+        baseline,
+        fail_on_regression,
+        output,
+        stream,
+        profile,
+        prompts,
+        ..
+    } = command;
+    run_bench(BenchArgs {
+        url,
+        model,
+        start: start.as_deref(),
+        health_timeout: *health_timeout,
+        warmup: *warmup,
+        duration: *duration,
+        concurrency: *concurrency,
+        runs: *runs,
+        cooldown: *cooldown,
+        runtime_name,
+        baseline: baseline.as_deref(),
+        fail_on_regression: *fail_on_regression,
+        output: output.as_deref(),
+        stream: *stream,
+        profile,
+        prompts: prompts.as_deref(),
+    })
+    .await
 }

--- a/crates/apr-cli/src/commands/test_llm_band.rs
+++ b/crates/apr-cli/src/commands/test_llm_band.rs
@@ -1,0 +1,569 @@
+//! `apr test llm bench --band` — PERF-025: the §4.4 protocol, reachable.
+//!
+//! # The defect this closes
+//!
+//! PERF-024 landed the conformant measurement protocol — `llm::band::run_band`,
+//! the §4.4.2 warmup/quiesce/termination rule, `perf_gate::window`'s drain
+//! accounting, the §4.4.4 bootstrap — and PERF-026 landed the receipt producer
+//! (`perf_gate::drain::BandInput`, `perf_gate::receipt::ReceiptInput`).
+//! **Nothing called either of them.** On `50d2bc2bb`,
+//! `git grep "ReceiptInput\|BandInput\|DerivedBand\|perf_gate::"` outside the
+//! module returned rc=1: zero callers. `apr test llm bench` still ran
+//! `LoadTest::run`, whose termination rule is "stop after `--duration`
+//! seconds" — no minimum sample count, no warmup-then-quiesce, no drain
+//! accounting, no §4.4.6 tokenization block.
+//!
+//! The other half of the same defect: `scripts/perf_gate.sh`'s real mode
+//! (`--host/--phase/--workload/--receipt`) was invoked only as `--selftest`
+//! (`ci.yml:1011`), because nothing in the repo could write the receipt its
+//! real mode reads. So the repo simultaneously held a conformant protocol, a
+//! conformant receipt producer and a gate — and could not produce one
+//! conformant measurement. Both halves close here.
+//!
+//! # This is a MODE, not a second harness
+//!
+//! `scripts/check_no_competing_harnesses.sh` names `apr test llm bench` the
+//! canonical entrypoint, at `BASELINE=0`, shrink-only. This extends that
+//! subcommand and drives the same `LlmClient` the legacy mode drives, so
+//! PERF-009's one-entrypoint rule holds by construction rather than by promise.
+//!
+//! # There is deliberately no flag that shrinks the window
+//!
+//! `BandConfig::relaxed` exists for unit tests and is unreachable from the CLI.
+//! The `max(30, 8c)` sample floor and the 60 s wall-clock floor are the entire
+//! difference between a load test and a measurement; a `--band-duration` would
+//! be the shortest path back to a gate that cannot fail. `--replicates` is the
+//! only knob, it defaults to §4.4.2's `N = 3`, and going below that is written
+//! into the receipt directory as a stated violation rather than silently taken.
+//!
+//! # One receipt per replicate, and why
+//!
+//! `ReceiptInput.bands` holds **one entry per concurrency**, and
+//! `perf_gate.sh`'s Arm A indexes it with `{b["concurrency"]: b for b in
+//! bands}` — a Python dict comprehension. Emitting `N` bands that all say
+//! `concurrency: 1` would therefore be silently reduced to whichever one landed
+//! last: a receipt that looks like three measurements and is judged as one.
+//! Collapsing the replicates into a "representative" band instead would mean
+//! picking a median of three, which is exactly the estimator that reported
+//! 2.91x for a cell whose real answer was 1.21x (#2567).
+//!
+//! So each replicate gets its own complete, independently judgeable receipt,
+//! `receipt.r1.json` … `receipt.rN.json`. The cell's verdict is the conjunction
+//! over them, which is a decision for the runner, not something this producer
+//! should pre-collapse.
+
+use crate::error::{CliError, Result};
+use apr_test::llm::band::{run_band, BandRun};
+use apr_test::llm::client::{ChatRequest, LlmClient};
+use apr_test::perf_gate::protocol::BandConfig;
+use apr_test::perf_gate::{
+    sha256_file, write_samples_gz, BandInput, ComparatorStatus, ComputeClass, Provenance,
+    ReceiptInput, RequestOutcome, TokenizationBlock, Workload, REPLICATES,
+};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use super::test_llm::{describe_workload, resolve_prompts};
+
+/// Arguments for one §4.4-conformant band sweep.
+///
+/// A struct rather than a 20-argument function, for the reason `BenchArgs` is
+/// one: positional arguments of the same type are where a caller transposes
+/// `accelerator` and `quantization` and the receipt records a lie.
+pub struct BandArgs<'a> {
+    /// Endpoint under measurement.
+    pub url: &'a str,
+    /// Model name sent in the request body.
+    pub model: &'a str,
+    /// Concurrency levels, comma-separated, e.g. `1,4,8,16`.
+    pub bands: &'a str,
+    /// §4.4.2 replicates per cell.
+    pub replicates: usize,
+    /// Directory receiving the receipts and the gzipped JSONL samples.
+    pub receipt: &'a Path,
+    /// §4.3 workload identifier.
+    pub workload: &'a str,
+    /// Join key: which machine measured.
+    pub host: &'a str,
+    /// Join key: which accelerator served the request.
+    pub accelerator: &'a str,
+    /// Join key: which quantization the served model uses.
+    pub quantization: &'a str,
+    /// The dispatch path the SERVER took.
+    pub compute_class: &'a str,
+    /// The SERVER's build features.
+    pub server_features: &'a [String],
+    /// §4.4.6 counting method.
+    pub tokenization: &'a str,
+    /// §4.4.6 digest, required for `client_tokenizer`.
+    pub tokenizer_sha256: Option<&'a str>,
+    /// §4.4.6 — do the counts include special tokens?
+    pub counts_special_tokens: bool,
+    /// §4.4.6 — do the counts include the echoed prompt?
+    pub counts_prompt_echo: bool,
+    /// Commit under measurement.
+    pub commit: Option<&'a str>,
+    /// Streaming responses. Required for TTFT, ITL and `decode_tok_s`.
+    pub stream: bool,
+    /// Named prompt profile.
+    pub profile: &'a str,
+    /// Prompt file, overriding the profile.
+    pub prompts: Option<&'a Path>,
+    /// Who owes the comparator measurement this producer refuses to invent.
+    pub comparator_owner: &'a str,
+}
+
+/// `1,4,8,16` into concurrency levels.
+///
+/// A zero or unparseable level is refused where it was typed.
+/// `BandConfig::conformant` clamps `0` up to `1`, which would measure a
+/// different band than the operator asked for and then label it with the number
+/// they typed.
+fn parse_bands(spec: &str) -> Result<Vec<usize>> {
+    let mut out = Vec::new();
+    for raw in spec.split(',') {
+        let token = raw.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let c: usize = token.parse().map_err(|_| {
+            CliError::InvalidInput(format!("--bands: {token:?} is not a concurrency level"))
+        })?;
+        if c == 0 {
+            return Err(CliError::InvalidInput(
+                "--bands: 0 is not a concurrency level; a band with no workers measures nothing"
+                    .to_string(),
+            ));
+        }
+        out.push(c);
+    }
+    if out.is_empty() {
+        return Err(CliError::InvalidInput(
+            "--bands named no concurrency levels".to_string(),
+        ));
+    }
+    Ok(out)
+}
+
+/// §4.4.6 — `method` has no default, so an unknown value is refused rather than
+/// falling back to one of the two.
+fn build_tokenization(args: &BandArgs<'_>) -> Result<TokenizationBlock> {
+    let block = match args.tokenization {
+        "server_usage" => TokenizationBlock::ServerUsage {
+            counts_special_tokens: args.counts_special_tokens,
+            counts_prompt_echo: args.counts_prompt_echo,
+        },
+        "client_tokenizer" => {
+            let sha = args.tokenizer_sha256.ok_or_else(|| {
+                CliError::InvalidInput(
+                    "--tokenization client_tokenizer requires --tokenizer-sha256".to_string(),
+                )
+            })?;
+            TokenizationBlock::ClientTokenizer {
+                tokenizer_sha256: sha.to_string(),
+                counts_special_tokens: args.counts_special_tokens,
+                counts_prompt_echo: args.counts_prompt_echo,
+            }
+        }
+        other => {
+            return Err(CliError::InvalidInput(format!(
+                "--tokenization {other:?}: expected server_usage or client_tokenizer (§4.4.6 \
+                 gives `method` no default)"
+            )))
+        }
+    };
+    block.validate().map_err(CliError::InvalidInput)?;
+    Ok(block)
+}
+
+/// Which binary is measuring, and what it hashes to.
+///
+/// `current_exe` rather than a `$PATH` lookup or a hardcoded path: four `apr`
+/// binaries have coexisted on the dev box and a bare `apr` once resolved to a
+/// 26-day-old copy. The binary that writes the receipt is the binary the
+/// receipt names, by construction rather than by discipline.
+///
+/// The features recorded are the **server's**, never this client's own
+/// `cfg!(feature = ...)`. `bench_receipt.py` uses `feature_set` to refuse a
+/// `compute_class` the build cannot reach; pointing that check at the measuring
+/// binary instead of the measured one would make it read green while checking
+/// nothing.
+fn build_provenance(args: &BandArgs<'_>) -> Result<Provenance> {
+    let exe = std::env::current_exe()
+        .map_err(|e| CliError::InvalidInput(format!("cannot resolve current_exe: {e}")))?;
+    let binary_sha256 = sha256_file(&exe)
+        .map_err(|e| CliError::InvalidInput(format!("cannot hash {}: {e}", exe.display())))?;
+    let compute_class = ComputeClass::from_str(args.compute_class)
+        .map_err(|e| CliError::InvalidInput(format!("--compute-class: {e}")))?;
+    let prov = Provenance {
+        binary_path: exe.display().to_string(),
+        binary_sha256,
+        resolution: "current_exe".to_string(),
+        compute_class,
+        host: args.host.to_string(),
+        accelerator: args.accelerator.to_string(),
+        model: args.model.to_string(),
+        quantization: args.quantization.to_string(),
+        feature_set: args.server_features.to_vec(),
+    };
+    prov.validate().map_err(CliError::InvalidInput)?;
+    Ok(prov)
+}
+
+/// §4.7.1 — this cell's comparator posture.
+///
+/// There is no CLI path to a measured ratio, and that is the point. A ratio
+/// needs a baseline object that itself passes every receipt rule (I-3) and a
+/// comparator lane driven by the same client binary (I-15). This producer has
+/// neither, so it emits `UNMEASURED` with an owner and Arm B reports and skips.
+/// An `agg_ratio` synthesised here is precisely the fabrication the epic exists
+/// to remove.
+fn comparator_status(args: &BandArgs<'_>) -> ComparatorStatus {
+    ComparatorStatus::Unmeasured {
+        owner: args.comparator_owner.to_string(),
+        reason: "APR-PERF-GATE-001 I-3/I-15: a comparator ratio needs a baseline receipt and a \
+                 comparator lane driven by this same client binary. `apr test llm bench --band` \
+                 measures one lane, so it declares the ratio unmeasured rather than deriving one."
+            .to_string(),
+    }
+}
+
+/// One `run_band` result as the receipt producer's input.
+///
+/// `RequestSample` records offsets from the band origin in **seconds**;
+/// `RequestOutcome` records them in **milliseconds**. The conversion is here,
+/// once, rather than at each field's use.
+///
+/// `ttft_ms` is a duration from issue to first token, while `token_times_ms`
+/// are absolute offsets from the band origin — the two differ by `issued_ms`,
+/// and `RequestOutcome::itl_gaps_ms` differences the latter, so mixing the
+/// conventions would leave the gaps correct and TTFT wrong by the request's
+/// start offset.
+fn band_input(run: &BandRun, comparator: ComparatorStatus) -> BandInput {
+    let requests = run
+        .samples
+        .iter()
+        .map(|s| RequestOutcome {
+            issued_ms: s.start_s * 1000.0,
+            settled_ms: s.end_s * 1000.0,
+            outcome: s.outcome,
+            generated_tokens: s.generated_tokens,
+            ttft_ms: s.token_times_s.first().map(|t| (t - s.start_s) * 1000.0),
+            token_times_ms: s.token_times_s.iter().map(|t| t * 1000.0).collect(),
+        })
+        .collect();
+    BandInput {
+        concurrency: u32::try_from(run.config.concurrency).unwrap_or(u32::MAX),
+        window_ms: run.window.window_ms,
+        requests,
+        comparator,
+    }
+}
+
+/// Print one replicate's headline numbers as it finishes.
+fn report_run(concurrency: usize, k: usize, replicates: usize, run: &BandRun) {
+    println!("  c={concurrency} replicate {}/{replicates}", k + 1);
+    println!(
+        "    agg {:.2} tok/s  decode {:.2} tok/s  requested {}  completed {}  timeouts {}  \
+         drain {:.1} ms  peak_in_flight {}",
+        run.metrics.agg_tok_s,
+        run.metrics.decode_tok_s,
+        run.metrics.requested,
+        run.metrics.completed,
+        run.metrics.timeouts,
+        run.window.drain_ms,
+        run.window.client_peak_in_flight
+    );
+    for v in &run.protocol_violations {
+        println!("    ! {v}");
+    }
+}
+
+/// Write one replicate's receipt and its per-band sample files.
+fn write_replicate(
+    args: &BandArgs<'_>,
+    tokenization: &TokenizationBlock,
+    provenance: &Provenance,
+    replicate: usize,
+    runs: &[(usize, BandRun)],
+) -> Result<PathBuf> {
+    for (c, run) in runs {
+        let path = args
+            .receipt
+            .join(format!("samples.c{c}.r{}.jsonl.gz", replicate + 1));
+        let file = write_samples_gz(&path, &run.samples)
+            .map_err(|e| CliError::InvalidFormat(format!("writing {}: {e}", path.display())))?;
+        println!(
+            "samples  {} ({} rows, {} bytes)",
+            file.path.display(),
+            file.rows,
+            file.bytes
+        );
+    }
+
+    let workload = Workload::from_str(args.workload)
+        .map_err(|e| CliError::InvalidInput(format!("--workload: {e}")))?;
+    let input = ReceiptInput {
+        provenance: provenance.clone(),
+        tokenization: tokenization.clone(),
+        workload,
+        commit: args.commit.unwrap_or("UNPINNED").to_string(),
+        bands: runs
+            .iter()
+            .map(|(_, run)| band_input(run, comparator_status(args)))
+            .collect(),
+        kv: None,
+    };
+    let rendered = input
+        .render_string()
+        .map_err(|e| CliError::ValidationFailed(format!("receipt r{}: {e}", replicate + 1)))?;
+
+    let path = args
+        .receipt
+        .join(format!("receipt.r{}.json", replicate + 1));
+    std::fs::write(&path, rendered.as_bytes())
+        .map_err(|e| CliError::InvalidFormat(format!("writing {}: {e}", path.display())))?;
+    println!("receipt  {} ({} bytes)", path.display(), rendered.len());
+    Ok(path)
+}
+
+/// Run the §4.4 protocol over every requested band and write the receipts.
+///
+/// # Errors
+/// When the endpoint is unreachable, any band fails, provenance or the §4.4.6
+/// block does not validate, a receipt cannot be rendered (which is where a
+/// zero-token band or an I-14 violation surfaces), or a receipt cannot be
+/// written.
+pub async fn run_bands(args: BandArgs<'_>) -> Result<()> {
+    let levels = parse_bands(args.bands)?;
+    if args.replicates == 0 {
+        return Err(CliError::InvalidInput(
+            "--replicates 0 measures nothing".to_string(),
+        ));
+    }
+    // Everything that can be refused without spending a measurement is refused
+    // before the first request. A 14-minute sweep that fails at receipt-write
+    // time because `--host` was blank has thrown away the measurement.
+    let tokenization = build_tokenization(&args)?;
+    let provenance = build_provenance(&args)?;
+    let workload = Workload::from_str(args.workload)
+        .map_err(|e| CliError::InvalidInput(format!("--workload: {e}")))?;
+    std::fs::create_dir_all(args.receipt).map_err(|e| {
+        CliError::InvalidFormat(format!("creating {}: {e}", args.receipt.display()))
+    })?;
+
+    let prompts: Vec<ChatRequest> = resolve_prompts(args.profile, args.prompts)?
+        .into_iter()
+        .map(|mut p| {
+            p.model = args.model.to_string();
+            p
+        })
+        .collect();
+
+    let client = LlmClient::new(args.url, args.model);
+    client.health_check().await.map_err(|e| {
+        CliError::InferenceFailed(format!("endpoint {} is not ready: {e}", args.url))
+    })?;
+
+    println!("protocol APR-PERF-GATE-001 v2.2 §4.4 (closed-loop, conformant)");
+    println!("endpoint {}", args.url);
+    println!("workload {}", workload.wire_token());
+    println!(
+        "prompts  {}",
+        describe_workload(args.profile, args.prompts, prompts.len())
+    );
+    println!(
+        "bands    {levels:?} x {} replicate(s); warmup 2c, quiesce 5s, window closes when BOTH \
+         max(30, 8c) samples AND 60s wall-clock are met",
+        args.replicates
+    );
+    if args.replicates < REPLICATES {
+        println!(
+            "!        --replicates {} is below §4.4.2's N={REPLICATES}; the cell is \
+             under-replicated and its bootstrap CI is correspondingly weak",
+            args.replicates
+        );
+    }
+    if !args.stream {
+        println!(
+            "NOTE     --stream is off: §4.4.3 ttft_ms, itl_ms and decode_tok_s are UNDEFINED \
+             without per-token arrival times and are omitted from the receipt"
+        );
+    }
+
+    let mut written = Vec::new();
+    for k in 0..args.replicates {
+        let mut runs = Vec::with_capacity(levels.len());
+        for &c in &levels {
+            let band = BandConfig::conformant(c);
+            let run = run_band(&client, &prompts, &band, tokenization.clone(), args.stream)
+                .await
+                .map_err(|e| {
+                    CliError::InferenceFailed(format!("band c={c} replicate {}: {e}", k + 1))
+                })?;
+            report_run(c, k, args.replicates, &run);
+            runs.push((c, run));
+        }
+        written.push(write_replicate(
+            &args,
+            &tokenization,
+            &provenance,
+            k,
+            &runs,
+        )?);
+    }
+
+    println!("\nnext");
+    for path in &written {
+        println!(
+            "  scripts/perf_gate.sh --host {} --phase merge --workload {} --receipt {}",
+            args.host,
+            workload.wire_token(),
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// §4.4.2's `N`, re-exported so the CLI default and the spec constant cannot
+/// drift apart.
+#[must_use]
+pub const fn default_replicates() -> usize {
+    REPLICATES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args<'a>(bands: &'a str, tokenization: &'a str) -> BandArgs<'a> {
+        BandArgs {
+            url: "http://127.0.0.1:8080",
+            model: "qwen2.5-coder-1.5b-instruct",
+            bands,
+            replicates: 3,
+            receipt: Path::new("/tmp/perf-025-receipt"),
+            workload: "W1",
+            host: "lambda",
+            accelerator: "rtx-4090",
+            quantization: "Q4_K_M",
+            compute_class: "cpu",
+            server_features: &[],
+            tokenization,
+            tokenizer_sha256: None,
+            counts_special_tokens: true,
+            counts_prompt_echo: false,
+            commit: None,
+            stream: true,
+            profile: "medium",
+            prompts: None,
+            comparator_owner: "perf-gate",
+        }
+    }
+
+    #[test]
+    fn bands_parse_in_the_order_given() {
+        assert_eq!(parse_bands("1,4,8,16").expect("valid"), vec![1, 4, 8, 16]);
+        assert_eq!(parse_bands(" 2 , 3 ").expect("spaces"), vec![2, 3]);
+    }
+
+    /// `BandConfig::conformant` clamps 0 up to 1, so a zero that reaches it
+    /// measures c=1 while the receipt says the operator asked for 0.
+    #[test]
+    fn a_zero_band_is_rejected_rather_than_clamped() {
+        let err = parse_bands("1,0,4").expect_err("must reject");
+        assert!(err.to_string().contains("measures nothing"), "{err}");
+    }
+
+    #[test]
+    fn an_unparseable_band_is_rejected() {
+        assert!(parse_bands("1,four").is_err());
+        assert!(parse_bands("").is_err());
+        assert!(parse_bands(",,").is_err());
+    }
+
+    /// §4.4.6 gives `method` no default; an unknown value must not fall back.
+    #[test]
+    fn an_unknown_tokenization_method_is_refused() {
+        let err = build_tokenization(&args("1", "guess")).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("server_usage"), "{msg}");
+        assert!(msg.contains("client_tokenizer"), "{msg}");
+    }
+
+    #[test]
+    fn client_tokenizer_without_a_digest_is_refused() {
+        let err =
+            build_tokenization(&args("1", "client_tokenizer")).expect_err("digest is required");
+        assert!(err.to_string().contains("tokenizer-sha256"), "{err}");
+    }
+
+    #[test]
+    fn server_usage_needs_no_digest() {
+        assert!(build_tokenization(&args("1", "server_usage")).is_ok());
+    }
+
+    /// The provenance the CLI builds must be one `bench_receipt.py` accepts: a
+    /// real 64-hex digest of the binary that is actually running.
+    #[test]
+    fn provenance_hashes_the_running_binary() {
+        let prov = build_provenance(&args("1", "server_usage")).expect("current_exe must hash");
+        assert_eq!(prov.binary_sha256.len(), 64);
+        assert_eq!(prov.resolution, "current_exe");
+        assert!(prov.validate().is_ok());
+    }
+
+    #[test]
+    fn an_unknown_compute_class_is_refused_where_it_was_typed() {
+        let mut a = args("1", "server_usage");
+        a.compute_class = "tpu";
+        let err = build_provenance(&a).expect_err("must reject");
+        assert!(err.to_string().contains("compute-class"), "{err}");
+    }
+
+    /// I-2: declaring `cuda` without the server having been built with it is a
+    /// claim about a path the build cannot take.
+    #[test]
+    fn cuda_without_the_server_feature_is_refused() {
+        let mut a = args("1", "server_usage");
+        a.compute_class = "cuda";
+        assert!(build_provenance(&a).is_err());
+
+        let features = vec!["cuda".to_string()];
+        let mut ok = args("1", "server_usage");
+        ok.compute_class = "cuda";
+        ok.server_features = &features;
+        assert!(build_provenance(&ok).is_ok());
+    }
+
+    /// An empty join key must be refused before the sweep, not after it.
+    #[test]
+    fn a_blank_join_key_is_refused() {
+        let mut a = args("1", "server_usage");
+        a.host = "";
+        let err = build_provenance(&a).expect_err("host is required");
+        assert!(err.to_string().contains("host"), "{err}");
+    }
+
+    /// The producer must never be able to emit a comparator ratio.
+    #[test]
+    fn the_comparator_is_always_unmeasured_with_an_owner() {
+        let status = comparator_status(&args("1", "server_usage"));
+        assert_eq!(status.wire_token(), "UNMEASURED");
+        match status {
+            ComparatorStatus::Unmeasured { owner, .. } => assert_eq!(owner, "perf-gate"),
+            ComparatorStatus::NotApplicable { .. } => panic!("must not be permanent"),
+        }
+    }
+
+    /// The CLI default must not drift from §4.4.2's N.
+    #[test]
+    fn the_replicate_default_is_the_spec_constant() {
+        assert_eq!(default_replicates(), 3);
+    }
+
+    #[test]
+    fn an_unknown_workload_is_refused() {
+        assert!(Workload::from_str("W3").is_err());
+    }
+}

--- a/crates/apr-cli/src/commands/test_llm_band.rs
+++ b/crates/apr-cli/src/commands/test_llm_band.rs
@@ -135,6 +135,15 @@ fn parse_bands(spec: &str) -> Result<Vec<usize>> {
                     .to_string(),
             ));
         }
+        // `BandInput.concurrency` is a `u32`. Refusing the excess here keeps
+        // that conversion infallible, so the receipt cannot end up labelled
+        // with a concurrency the operator did not ask for -- the same
+        // silent-substitution defect as the clamped zero above.
+        if u32::try_from(c).is_err() {
+            return Err(CliError::InvalidInput(format!(
+                "--bands: {c} exceeds the receipt's u32 concurrency field"
+            )));
+        }
         out.push(c);
     }
     if out.is_empty() {
@@ -253,6 +262,8 @@ fn band_input(run: &BandRun, comparator: ComparatorStatus) -> BandInput {
         })
         .collect();
     BandInput {
+        // Infallible: `parse_bands` refused anything a `u32` cannot hold, so
+        // there is no clamp here to silently relabel the band.
         concurrency: u32::try_from(run.config.concurrency).unwrap_or(u32::MAX),
         window_ms: run.window.window_ms,
         requests,
@@ -473,6 +484,16 @@ mod tests {
     fn a_zero_band_is_rejected_rather_than_clamped() {
         let err = parse_bands("1,0,4").expect_err("must reject");
         assert!(err.to_string().contains("measures nothing"), "{err}");
+    }
+
+    /// A level a `u32` cannot hold must be refused where it was typed rather
+    /// than clamped into a receipt that names a band nobody ran.
+    #[test]
+    fn a_band_wider_than_the_receipt_field_is_rejected() {
+        let too_wide = u64::from(u32::MAX) + 1;
+        let err = parse_bands(&format!("1,{too_wide}")).expect_err("must reject");
+        assert!(err.to_string().contains("u32"), "{err}");
+        assert!(parse_bands(&format!("{}", u32::MAX)).is_ok());
     }
 
     #[test]

--- a/crates/apr-cli/src/dispatch_analysis.rs
+++ b/crates/apr-cli/src/dispatch_analysis.rs
@@ -123,50 +123,11 @@ fn dispatch_analysis_commands(cli: &Cli) -> Option<Result<(), CliError>> {
         // The existing flat-args behavior moved under `apr probar tensor <FILE>`.
         ExtendedCommands::Test { command } => match command {
             // GH-876 Milestone 2 — `apr test llm bench`.
-            TestSubcommand::Llm { command } => match command {
-                LlmSubcommand::Bench {
-                    url,
-                    model,
-                    start,
-                    health_timeout,
-                    warmup,
-                    duration,
-                    concurrency,
-                    runs,
-                    cooldown,
-                    runtime_name,
-                    baseline,
-                    fail_on_regression,
-                    output,
-                    stream,
-                    profile,
-                    prompts,
-                } => tokio::runtime::Runtime::new()
-                    .map_err(|e| {
-                        crate::error::CliError::InferenceFailed(format!("tokio runtime: {e}"))
-                    })
-                    .and_then(|rt| {
-                        rt.block_on(commands::test_llm::run_bench(
-                        commands::test_llm::BenchArgs {
-                            url,
-                            model,
-                            start: start.as_deref(),
-                            health_timeout: *health_timeout,
-                            warmup: *warmup,
-                            duration: *duration,
-                            concurrency: *concurrency,
-                            runs: *runs,
-                            cooldown: *cooldown,
-                            runtime_name,
-                            baseline: baseline.as_deref(),
-                            fail_on_regression: *fail_on_regression,
-                            output: output.as_deref(),
-                            stream: *stream,
-                            profile,
-                            prompts: prompts.as_deref(),
-                        }))
-                    }),
-            },
+            // PERF-025: the arm moved into commands::test_llm::dispatch. This
+            // router was at cognitive 24 against a threshold of 25; the band
+            // branch tipped it, and the destructure belongs next to the
+            // functions it feeds anyway.
+            TestSubcommand::Llm { command } => commands::test_llm::dispatch(command),
             TestSubcommand::Tensor {
                 file,
                 output,

--- a/crates/apr-cli/src/extended_commands.rs
+++ b/crates/apr-cli/src/extended_commands.rs
@@ -1721,6 +1721,106 @@ pub enum LlmSubcommand {
         /// Prompt file (JSON array of chat requests). Overrides `--profile`.
         #[arg(long)]
         prompts: Option<PathBuf>,
+
+        // ------------------------------------------------------------------
+        // PERF-025 — the APR-PERF-GATE-001 v2.2 §4.4 conformant mode.
+        //
+        // PERF-024 shipped the conformant protocol and PERF-026 the receipt
+        // producer, and nothing called either: this subcommand still ran
+        // `LoadTest::run`, whose termination rule is "stop after --duration
+        // seconds" with no minimum sample count, no warmup-then-quiesce, no
+        // drain accounting and no tokenization block. A conformant protocol
+        // nothing can reach measures nothing.
+        //
+        // A MODE, NOT A SIBLING SUBCOMMAND: PERF-009 says one benchmarking
+        // entrypoint, and this drives the same LlmClient the legacy mode does.
+        //
+        // NOTE THE ABSENCE OF `--band-duration`. The 60 s wall-clock floor and
+        // the max(30, 8c) sample floor are the entire difference between a
+        // load test and a measurement, and a flag that shrinks them is the
+        // shortest path back to a gate that cannot fail. The only knob is
+        // --replicates, and going below the spec's N=3 is stated on stdout
+        // rather than silently accepted.
+        // ------------------------------------------------------------------
+        /// Run the §4.4-conformant band protocol and write receipts
+        /// `scripts/perf_gate.sh` can judge.
+        ///
+        /// Closed-loop at fixed concurrency, `2 x c` warmup requests, a 5 s
+        /// quiesce, then a window that closes only when BOTH `max(30, 8 x c)`
+        /// samples and 60 s of wall-clock have elapsed — whichever bound is
+        /// satisfied last. Ignores --warmup, --duration, --runs and --cooldown,
+        /// which are the legacy mode's knobs.
+        ///
+        /// The legacy mode's server-lifecycle and comparison flags are REFUSED
+        /// rather than ignored here. `apr serve --gpu` accepting a flag it
+        /// silently drops is one of this project's named adoption killers, and
+        /// a `--band --output report.json` that produced no report — or a
+        /// `--start` that never started anything and then failed a confusing
+        /// health check — would be the same defect in the tool that exists to
+        /// catch it. The band mode's report IS `--receipt`.
+        #[arg(
+            long,
+            requires = "receipt",
+            conflicts_with_all = ["start", "output", "baseline", "fail_on_regression"]
+        )]
+        band: bool,
+        /// Directory receiving `receipt.rN.json` and the gzipped JSONL samples.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+        /// Concurrency levels for --band. Arm A needs `c=1` to be present.
+        #[arg(long, default_value = "1,4,8,16")]
+        bands: String,
+        /// Full band replicates per cell (spec: N=3). Each replicate writes its
+        /// own independently judgeable receipt.
+        #[arg(long, default_value_t = commands::test_llm_band::default_replicates())]
+        replicates: usize,
+        /// Workload identifier recorded in the receipt.
+        #[arg(long, default_value = "W1", value_parser = ["W1", "W2"])]
+        workload: String,
+        /// Join key: which machine measured. Required by the receipt schema.
+        #[arg(long, required_if_eq("band", "true"), default_value = "")]
+        host: String,
+        /// Join key: which accelerator served the request.
+        #[arg(long, required_if_eq("band", "true"), default_value = "")]
+        accelerator: String,
+        /// Join key: which quantization the served model uses.
+        #[arg(long, required_if_eq("band", "true"), default_value = "")]
+        quantization: String,
+        /// The dispatch path the SERVER took — not the hardware present.
+        #[arg(long, default_value = "unknown",
+              value_parser = ["cpu", "cuda", "metal", "wgpu", "unknown"])]
+        compute_class: String,
+        /// A build feature of the SERVER, repeatable.
+        ///
+        /// Never defaulted from this client's own features: `bench_receipt.py`
+        /// uses it to refuse a compute_class the build cannot reach, and
+        /// pointing that check at the measuring binary instead of the measured
+        /// one would make it read green while checking nothing.
+        #[arg(long = "server-feature")]
+        server_features: Vec<String>,
+        /// How tokens were counted (§4.4.6). Absence of a valid value is fatal.
+        #[arg(long, default_value = "server_usage",
+              value_parser = ["server_usage", "client_tokenizer"])]
+        tokenization: String,
+        /// Tokenizer digest, required when --tokenization client_tokenizer.
+        #[arg(long)]
+        tokenizer_sha256: Option<String>,
+        /// Whether the token counts include special tokens (§4.4.6).
+        #[arg(long)]
+        counts_special_tokens: bool,
+        /// Whether the token counts include the echoed prompt (§4.4.6).
+        #[arg(long)]
+        counts_prompt_echo: bool,
+        /// Commit under measurement, for the release staleness arm.
+        #[arg(long)]
+        commit: Option<String>,
+        /// Who owes the comparator measurement this producer refuses to invent.
+        ///
+        /// §4.7.1: every cell is NOT_APPLICABLE or UNMEASURED here, never a
+        /// ratio. A ratio needs a baseline receipt (I-3) and a comparator lane
+        /// driven by this same binary (I-15); one lane cannot produce one.
+        #[arg(long, default_value = "perf-gate")]
+        comparator_owner: String,
     },
 }
 

--- a/crates/aprender-test-lib/src/perf_gate/mod.rs
+++ b/crates/aprender-test-lib/src/perf_gate/mod.rs
@@ -174,8 +174,8 @@ pub use protocol::{
     BOOTSTRAP_SEED, MIN_WALL_CLOCK, QUIESCE, REPLICATES, REQUEST_TIMEOUT,
 };
 pub use receipt::{
-    ComputeClass, KvBlock, Provenance, ReceiptInput, TokenCountingMethod, TokenizationBlock,
-    Workload, SERVER_ONLY_FIELDS,
+    sha256_file, ComputeClass, KvBlock, Provenance, ReceiptInput, TokenCountingMethod,
+    TokenizationBlock, Workload, SERVER_ONLY_FIELDS,
 };
 pub use samples::{read_samples_gz, write_samples_gz, SamplesFile};
 pub use window::{WindowController, WindowReport};

--- a/crates/aprender-test-lib/src/perf_gate/receipt.rs
+++ b/crates/aprender-test-lib/src/perf_gate/receipt.rs
@@ -41,6 +41,9 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::str::FromStr;
 
 use super::drain::{BandInput, ComparatorStatus, DerivedBand};
 
@@ -83,6 +86,35 @@ impl ComputeClass {
             Self::Wgpu => "wgpu",
             Self::Unknown => "unknown",
         }
+    }
+}
+
+/// Parse the wire token back.
+///
+/// The reverse of [`ComputeClass::wire_token`] rather than a second table:
+/// `wire_token` is what `bench_receipt.py` matches against `COMPUTE_CLASSES`,
+/// so a parser with its own spelling would let a receipt be written with a
+/// class the validator then rejects — after the measurement had been taken.
+/// `roundtrip_is_the_only_spelling` pins the two together.
+impl FromStr for ComputeClass {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        [
+            Self::Cpu,
+            Self::Cuda,
+            Self::Metal,
+            Self::Wgpu,
+            Self::Unknown,
+        ]
+        .into_iter()
+        .find(|c| c.wire_token() == s)
+        .ok_or_else(|| {
+            format!(
+                "compute_class {s:?}: expected one of cpu, cuda, metal, wgpu, unknown (I-2 \
+                 requires the path TAKEN, not the hardware present)"
+            )
+        })
     }
 }
 
@@ -367,6 +399,36 @@ impl Workload {
     }
 }
 
+/// Parse the wire token back. As [`ComputeClass`]'s, derived from
+/// `wire_token` so the two cannot drift.
+impl FromStr for Workload {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        [Self::W1, Self::W2]
+            .into_iter()
+            .find(|w| w.wire_token() == s)
+            .ok_or_else(|| format!("workload {s:?}: expected W1 or W2 (§4.3)"))
+    }
+}
+
+/// SHA-256 of a file, as the 64 lowercase hex characters
+/// [`Provenance::validate`] and `bench_receipt.py` both demand.
+///
+/// Lives beside the validator on purpose. The digest is the one field of §4.2.2
+/// that a producer cannot type by hand, and a producer that formatted it
+/// differently from the way the validator matches it would fail only after the
+/// measurement had already been paid for.
+///
+/// # Errors
+/// When `path` cannot be opened or read.
+pub fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 /// Everything needed to render one host × workload receipt.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReceiptInput {
@@ -560,4 +622,80 @@ fn is_sha256(value: &str) -> bool {
         && value
             .bytes()
             .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod producer_tests {
+    //! The two conversions PERF-025's CLI needs, and the digest it cannot type.
+
+    use super::*;
+    use std::io::Write;
+
+    /// A parser with its own spelling would let a receipt be written with a
+    /// class `bench_receipt.py` then rejects — after the band had already run.
+    #[test]
+    fn compute_class_roundtrip_is_the_only_spelling() {
+        for c in [
+            ComputeClass::Cpu,
+            ComputeClass::Cuda,
+            ComputeClass::Metal,
+            ComputeClass::Wgpu,
+            ComputeClass::Unknown,
+        ] {
+            assert_eq!(
+                ComputeClass::from_str(c.wire_token()).expect("wire token must parse"),
+                c
+            );
+        }
+    }
+
+    /// `bench_receipt.py`'s `COMPUTE_CLASSES` tuple, spelled out here so that
+    /// adding a variant without teaching the validator goes red.
+    #[test]
+    fn the_wire_tokens_are_bench_receipt_pys_compute_classes() {
+        let tokens: Vec<&str> = ["cpu", "cuda", "metal", "wgpu", "unknown"].into();
+        for t in &tokens {
+            assert!(ComputeClass::from_str(t).is_ok(), "{t} must parse");
+        }
+        assert!(ComputeClass::from_str("tpu").is_err());
+        assert!(ComputeClass::from_str("gpu").is_err());
+        assert!(
+            ComputeClass::from_str("CUDA").is_err(),
+            "case is load-bearing"
+        );
+    }
+
+    #[test]
+    fn workload_roundtrips_and_refuses_anything_else() {
+        for w in [Workload::W1, Workload::W2] {
+            assert_eq!(Workload::from_str(w.wire_token()).expect("parses"), w);
+        }
+        assert!(Workload::from_str("W3").is_err());
+        assert!(Workload::from_str("w1").is_err());
+    }
+
+    /// The digest must be the shape `Provenance::validate` accepts, or the
+    /// producer writes a receipt its own validator rejects.
+    #[test]
+    fn sha256_file_produces_a_digest_provenance_accepts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("payload.bin");
+        let mut f = std::fs::File::create(&path).expect("create");
+        f.write_all(b"abc").expect("write");
+        drop(f);
+
+        let digest = sha256_file(&path).expect("hashes");
+        // The published SHA-256 of "abc".
+        assert_eq!(
+            digest,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(digest.len(), 64);
+        assert!(is_sha256(&digest), "must satisfy the receipt's own check");
+    }
+
+    #[test]
+    fn sha256_file_reports_a_missing_file_rather_than_a_digest() {
+        assert!(sha256_file(Path::new("/nonexistent/perf-025")).is_err());
+    }
 }


### PR DESCRIPTION
**Stacked on #2742 (`feat/r1-2719`) deliberately — see "Base decision" below. Merge #2742 first.**

## The defect

On `50d2bc2bb`, `git grep "ReceiptInput\|BandInput\|DerivedBand\|perf_gate::"` outside the module returned **rc=1**. PERF-024 shipped the conformant §4.4 measurement protocol and PERF-026 shipped the receipt producer, and **nothing called either**. `apr test llm bench` still ran `LoadTest::run`, whose termination rule is "stop after `--duration` seconds": no minimum sample count, no warmup-then-quiesce, no drain accounting, no §4.4.6 tokenization block.

The mirror defect: `scripts/perf_gate.sh`'s real mode (`--host/--phase/--workload/--receipt`) was invoked only as `--selftest` (`ci.yml:1011`), because nothing in the repo could write the receipt it reads. Both halves close here.

## Base decision — why this stacks rather than sitting on main

`llm/band.rs` and its five dependency modules (`protocol`, `metrics`, `window`, `bootstrap`, `samples`) **do not exist on main**. Without them there is no `run_band` to call. main's own `perf_gate/mod.rs` says so, and names the integration work:

> Two overlaps must be resolved in the integration commit rather than left to drift: `protocol::Tokenization` and `receipt::TokenizationBlock` [...] and `protocol::Outcome` and `drain::Outcome` [...] Keep one of each.
> [...] Wiring a caller for the gate's real (non-selftest) mode is a separate ticket.

#2742 already performed exactly that resolution. Re-doing it on main would mean a second copy of ~2,500 lines that can drift from #2742 — the duplicate this epic has already rejected once. So this stacks.

## What is new here vs #2742

Only the CLI wiring — 7 files, +949/-48. The abandoned `feat/n1-band-cli` branch (no PR, cut against a pre-`drain.rs` base) contributed the *shape* of this surface; its library half is fully redundant with #2742 and its handler targeted a receipt API that no longer exists (`ReceiptMeta`, `Replicate`, `write_receipt`, `Tokenization` struct, `BandRun::into_replicate` — all removed or replaced by the #2742 resolution). Nothing from it is carried forward verbatim.

## Design notes

- **A mode, not a second harness.** `check_no_competing_harnesses.sh` names `apr test llm bench` canonical at `BASELINE=0`; this extends that subcommand and drives the same `LlmClient`. Guard still `count=0 baseline=0 OK`.
- **No flag shrinks the window.** `BandConfig::relaxed` stays unreachable from the CLI. `--replicates` is the only knob and defaults to §4.4.2's `N=3`.
- **The four unhonourable flags are refused, not ignored.** `--start`, `--output`, `--baseline`, `--fail-on-regression` are refused by clap `conflicts_with_all` — the `apr serve --gpu` silently-ignored-flag class that opened this epic.
- **One receipt per replicate.** `ReceiptInput.bands` holds one entry per concurrency and Arm A indexes it `{b["concurrency"]: b for b in bands}`, so N bands all saying `concurrency: 1` would be silently reduced to whichever landed last. Collapsing to a "representative" band would mean a median of three — the estimator that reported 2.91x for a cell whose real answer was 1.21x (#2567).

## Proof the conformant path ran, not the legacy one

Against one stub endpoint with an **identical `--duration 5`**:

| mode | rc | elapsed | requests |
|---|---|---|---|
| legacy (`LoadTest::run`) | 0 | **5 s** | 61 |
| `--band` | 0 | **88 s** | 728 |

`run_band` cannot terminate on duration; it terminated on the 60 s wall-clock floor plus warmup and the 5 s quiesce. The receipt carries `drain_ms`, `window_ms`, `client_model: closed_loop` and the §4.4.6 `tokenization` block — none of which `LoadTest::run` can produce. A 4-band sweep reports `peak_in_flight` 1/4/8/16 and a non-zero `drain_ms` at c>=4.

- `python3 scripts/lib/bench_receipt.py <receipt>` → **rc=0, `ok`**
- `bash scripts/perf_gate.sh --host ... --phase merge --workload W1 --receipt <receipt>` → **rc=0, `VERDICT PASS`** — the first real (non-selftest) caller that mode has ever had.

## Nothing was measured

The endpoint was a throwaway local stub, never committed. `scripts/perf-matrix.yaml` is **byte-identical to main** and all 8 cells remain `UNMEASURED`. Running a real cell is the next ticket.

## Checks

- `cargo fmt --all -- --check` rc=0
- `cargo clippy -p aprender-test-lib -p apr-cli --lib -- -D warnings` rc=0
- `cargo clippy ... --all-features` is rc=101 on this branch **and identically on the untouched base** (8 pre-existing `unused variable` errors in `aprender-gpu`) — control established, zero regressions
- `cargo test -p aprender-test-lib --lib perf_gate::` 87/87
- `cargo test -p apr-cli --lib test_llm` 20/20 (13 new)
- `perf_gate.sh --selftest` 18/18; `check_no_competing_harnesses.sh --selftest` 9/9
- PMAT pre-commit complexity gate passed without `--no-verify` (the band handler is its own file, so `test_llm.rs`'s complexity is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)