### PR TITLE
ci: silicon-nightly — per-silicon coverage, with the gaps as data

### DIFF
--- a/.github/silicon-coverage.txt
+++ b/.github/silicon-coverage.txt
@@ -1,0 +1,36 @@
+# SILICON COVERAGE POLICY — one axis per line (paiml/infra#361).
+#
+#   <axis-id>  <status>  <runs-on labels, comma-separated>  # note
+#
+# STATUS is one of:
+#   required        this axis MUST have a runner that can serve its selector.
+#                   If none exists, silicon-nightly FAILS — a lane that silently
+#                   stops covering an architecture is indistinguishable from one
+#                   that never covered it.
+#   pending:<issue> the axis is declared but not yet runnable. It does NOT fail
+#                   the lane — AND IT CANNOT ROT: the preflight fails if a runner
+#                   able to serve the selector APPEARS, because at that point the
+#                   only thing standing between us and the coverage is this line.
+#
+# WHY A POLICY FILE AND NOT A MATRIX. aprender's correctness is silicon-dependent
+# — SIMD paths, CUDA kernels, arch intrinsics, float behaviour — and the axes we
+# do NOT cover are the interesting number. A `matrix:` lists what runs; this
+# lists what SHOULD run and makes the gap a value rather than an absence.
+#
+# The gap is real and was widened deliberately: paiml/aprender#2740 makes
+# cuda-nightly gx10-only because its x86_64 GPU leg ran on lambda-labs, which
+# must never be a CI host (paiml/infra#359). sm_89 was the STABLE reference and
+# sm_121 the higher-risk target with a history of JIT bugs; we now gate only the
+# risky one. `x86_64-cuda-sm89` below is that hole, named.
+
+x86_64-cpu          required        self-hosted,clean-room,intel
+aarch64-cuda-sm121  required        self-hosted,gpu,gx10,cuda,blackwell
+
+# ── declared, not yet runnable ──────────────────────────────────────────────
+# Each of these has `runner-register` make targets in paiml/infra and no
+# registration. Standing one up needs the paiml/infra#352 treatment: an opt-in
+# label, never the default pool, and a guard that nothing can select it
+# implicitly.
+x86_64-cuda-sm89    pending:361     self-hosted,gpu,yoga,cuda,ada
+aarch64-cuda-sm87   pending:361     self-hosted,gpu,jetson,cuda,orin
+aarch64-macos       pending:361     self-hosted,mini,macos,arm64

--- a/.github/workflows/silicon-nightly.yml
+++ b/.github/workflows/silicon-nightly.yml
@@ -1,0 +1,128 @@
+# SILICON NIGHTLY — the same arch-sensitive suite on every silicon we sanction,
+# reported PER SILICON rather than collapsed to one verdict (paiml/infra#361).
+#
+# WHY. aprender is the ML stack and its correctness is silicon-dependent: SIMD
+# paths, CUDA kernels, arch intrinsics, float behaviour. Two axes are exercised
+# nightly today — x86_64-CPU and aarch64+Blackwell — and the gap just widened on
+# purpose: #2740 makes cuda-nightly gx10-only because its x86_64 GPU leg ran on
+# lambda-labs, which must never be a CI host (paiml/infra#359). sm_89 was the
+# STABLE reference and sm_121 the higher-risk target with a history of JIT bugs.
+# We now gate only the risky one.
+#
+# THE UNCOVERED AXES ARE THE POINT, so they are DATA, not an absence. They live
+# in .github/silicon-coverage.txt with a status, and scripts/check_silicon_coverage.sh
+# fails this lane when a `required` axis has no runner that can serve it — and,
+# just as importantly, when a `pending:` axis DOES. A deferral that outlives its
+# own blocker is how a debt ledger becomes a blanket exemption.
+#
+# SCHEDULE. 03:30 UTC, chosen to miss the fleet's other lanes: clean-room sweep
+# 23:00, protection-drift 00:00, nightly-audit 02:00, quality-history 05:00.
+# GitHub cron is UTC-only; this is 05:30 Madrid on CEST, 04:30 on CET.
+name: Silicon Nightly
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+    inputs:
+      axis:
+        description: 'Run a single axis, or all'
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - x86_64-cpu
+          - aarch64-cuda-sm121
+
+permissions:
+  contents: read
+
+jobs:
+  # THE POLICY GATE, FIRST AND BLOCKING. If an architecture stopped being tested,
+  # that is the finding — a green suite on the two remaining axes is exactly what
+  # a silent loss of coverage looks like.
+  coverage:
+    runs-on: [self-hosted, clean-room, intel]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # Probe the instrument before believing it. The label matcher must classify
+      # six committed cases — including a runner whose labels are a strict SUBSET
+      # of the selector, which must NOT match — or this exits 2 rather than green.
+      - name: The coverage guard's own matcher must be able to fail
+        run: bash scripts/check_silicon_coverage.sh --self-test
+
+      - name: Every required silicon axis must have a runner that can serve it
+        run: bash scripts/check_silicon_coverage.sh
+
+  x86_64-cpu:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.axis == 'all' || inputs.axis == 'x86_64-cpu' }}
+    runs-on: [self-hosted, clean-room, intel]
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Put the runner's Rust toolchain on PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      # THE ARCH-SENSITIVE SUBSET, not the whole suite. Five legs of a full
+      # aprender run nightly is not free on a 16-runner fleet that already carries
+      # a ~6h clean-room sweep, and a lane that is too expensive gets disabled.
+      - name: SIMD and numeric paths (x86_64, widest vectors)
+        run: |
+          set -euo pipefail
+          nice -n 19 cargo test -p aprender-compute --release --lib
+          nice -n 19 cargo test -p aprender-primitives --release --lib
+
+  aarch64-cuda-sm121:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.axis == 'all' || inputs.axis == 'aarch64-cuda-sm121' }}
+    # LITERAL LABELS, not a matrix expression. paiml/infra#352 requires any
+    # selector that can reach gx10 to name `gpu`, and a guard can only check
+    # labels it can see — labels hidden behind `${{ }}` are invisible to it.
+    runs-on: [self-hosted, gpu, gx10, cuda, blackwell]
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Put the runner's Rust toolchain on PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: NEON and numeric paths (aarch64)
+        run: |
+          set -euo pipefail
+          nice -n 19 cargo test -p aprender-compute --release --lib
+          nice -n 19 cargo test -p aprender-primitives --release --lib
+
+  # PER-SILICON REPORTING. The table is the deliverable: "silicon-nightly failed"
+  # is not actionable, "aarch64-cuda-sm121 failed and x86_64-cpu passed" is.
+  summary:
+    needs: [coverage, x86_64-cpu, aarch64-cuda-sm121]
+    if: always()
+    runs-on: [self-hosted, clean-room, intel]
+    steps:
+      - name: Report per silicon
+        run: |
+          {
+            echo "### Silicon nightly"
+            echo
+            echo "| axis | result |"
+            echo "|---|---|"
+            echo "| coverage policy | ${{ needs.coverage.result }} |"
+            echo "| x86_64-cpu | ${{ needs.x86_64-cpu.result }} |"
+            echo "| aarch64-cuda-sm121 | ${{ needs['aarch64-cuda-sm121'].result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # A deselected axis reports `skipped`; that is a scoped manual run, not
+          # a failure. Only failure/cancelled gate. `if: always()` WITHOUT this
+          # inspection is a job that is green whatever happened upstream — the
+          # exact shape this repo's beat guard exists to stamp out.
+          rc=0
+          for pair in \
+            "coverage:${{ needs.coverage.result }}" \
+            "x86_64-cpu:${{ needs.x86_64-cpu.result }}" \
+            "aarch64-cuda-sm121:${{ needs['aarch64-cuda-sm121'].result }}"; do
+            name="${pair%%:*}"; res="${pair#*:}"
+            if [ "$res" != "success" ] && [ "$res" != "skipped" ]; then
+              echo "::error::silicon axis $name: $res"
+              rc=1
+            fi
+          done
+          exit $rc

--- a/scripts/check_silicon_coverage.sh
+++ b/scripts/check_silicon_coverage.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Every silicon axis we claim to cover must have a runner that can serve it —
+# and every axis we have DEFERRED must still be deferred for a reason.
+#
+# WHY THIS EXISTS (paiml/infra#361).
+#
+# aprender's correctness is silicon-dependent: SIMD paths, CUDA kernels, arch
+# intrinsics, float behaviour. Today two axes are exercised nightly — x86_64-CPU
+# and aarch64+Blackwell — and the gap just widened on purpose: paiml/aprender#2740
+# makes cuda-nightly gx10-only because its x86_64 GPU leg ran on lambda-labs,
+# which must never be a CI host (paiml/infra#359). sm_89 was the STABLE reference
+# and sm_121 the higher-risk target with a history of JIT bugs. We now gate only
+# the risky one.
+#
+# That is a defensible trade, but an UNRECORDED one decays into "we test on
+# whatever is plugged in". So the axes live in .github/silicon-coverage.txt and
+# this asks GitHub which of them a runner could actually serve.
+#
+# TWO DIRECTIONS, and the second is the one that keeps the ledger honest:
+#
+#   required   -> FAIL if no runner can serve the selector. A lane that silently
+#                 stops covering an architecture looks exactly like one that
+#                 never covered it.
+#   pending:N  -> FAIL if a runner CAN now serve it. At that moment the only
+#                 thing between us and the coverage is a line in a policy file,
+#                 and a "pending" that survives its own blocker is how a debt
+#                 ledger becomes a blanket exemption.
+#
+# SELECTOR SEMANTICS, because getting this backwards is the fleet's recorded
+# mistake (paiml/infra#352): a `runs-on` list matches a runner when EVERY named
+# label is present on that runner. Extra runner labels never exclude. So "can
+# this axis run?" is "does some online runner's label set CONTAIN all of ours?".
+#
+# INSTRUMENT PROBES, both mandatory:
+#   1. --self-test runs committed fixtures through the matcher and demands each
+#      verdict. A matcher that cannot tell a subset from a superset exits 2.
+#   2. A POSITIVE CONTROL on the live API: the runner listing must be non-empty.
+#      Zero runners looks identical whether the fleet is down or the token lost
+#      its scope, and blind is a NO-GO.
+#
+# AUTH: the runner's ambient org-scoped gh auth. GPU runners are REPO-scoped and
+# invisible in the org listing, so BOTH lists are read and merged — that
+# invisibility is exactly why yoga-gpu's absence went unnoticed for months.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY="${SILICON_POLICY:-$REPO_ROOT/.github/silicon-coverage.txt}"
+ORG="${ORG:-paiml}"
+REPO="${GITHUB_REPOSITORY:-paiml/aprender}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# labels_contain <runner-label-csv> <required-label-csv>
+# 0 when every required label is present in the runner's set. Case-insensitive:
+# GitHub's built-in labels are `Linux`/`X64`/`ARM64` and a selector may spell
+# them either way.
+# All locals are `_lc_`-prefixed. The first version used `_have`/`_want`, which
+# are also the loop variables in selftest() — POSIX sh has no function scope, so
+# the call CLOBBERED the caller's expectation and every case compared a verdict
+# against a label string. The self-test caught it on the first run, which is the
+# only reason to have one.
+labels_contain() {
+    _lc_have=",$(printf '%s' "$1" | tr 'A-Z' 'a-z'),"
+    _lc_want="$(printf '%s' "$2" | tr 'A-Z' 'a-z')"
+    _lc_ifs="$IFS"; IFS=','
+    for _lc_l in $_lc_want; do
+        [ -n "$_lc_l" ] || continue
+        case "$_lc_have" in
+            *",$_lc_l,"*) ;;
+            *) IFS="$_lc_ifs"; return 1 ;;
+        esac
+    done
+    IFS="$_lc_ifs"
+    return 0
+}
+
+selftest() {
+    _broken=0
+    # runner labels                    | selector                | want (0=serves)
+    for _case in \
+        "self-hosted,linux,x64,clean-room,intel|self-hosted,clean-room,intel|0" \
+        "self-hosted,linux,arm64,gpu,gx10,cuda,blackwell,gb10|self-hosted,gpu,gx10,cuda,blackwell|0" \
+        "self-hosted,linux,x64,clean-room,intel|self-hosted,gpu,gx10|1" \
+        "self-hosted,linux,arm64,gpu,gx10,cuda|self-hosted,gpu,gx10,cuda,blackwell|1" \
+        "self-hosted,Linux,ARM64,gpu,gx10,cuda,blackwell|self-hosted,gpu,gx10,cuda,blackwell|0" \
+        "self-hosted,linux,x64,cuda,gpu,lambda-4090|self-hosted,gpu,yoga,cuda,ada|1" \
+        ; do
+        _have="${_case%%|*}"; _rest="${_case#*|}"
+        _want_sel="${_rest%%|*}"; _want="${_rest#*|}"
+        if labels_contain "$_have" "$_want_sel"; then _got=0; else _got=1; fi
+        if [ "$_got" != "$_want" ]; then
+            printf '  [%s] vs [%s]: expected %s (0=serves), got %s\n' \
+                "$_have" "$_want_sel" "$_want" "$_got"
+            _broken=$((_broken + 1))
+        fi
+    done
+    if [ "$_broken" -gt 0 ]; then
+        printf 'INSTRUMENT BROKEN — the label matcher cannot classify its own cases.\n'
+        printf 'Refusing to report on the fleet with a matcher that failed its own tests.\n'
+        return 2
+    fi
+    printf 'self-test: 6 label cases, matcher classifies all of them as specified\n'
+    return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    printf -- '-- instrument self-test --\n'
+    selftest; exit $?
+fi
+
+printf '== silicon coverage ==\n'
+printf 'policy: %s\n\n' "$POLICY"
+[ -f "$POLICY" ] || { printf 'NO-GO: %s does not exist.\n' "$POLICY"; exit 2; }
+
+printf -- '-- instrument self-test --\n'
+selftest || exit 2
+
+# ── the runners: org-scoped AND repo-scoped ─────────────────────────────────
+RUNNERS="$(mktemp)"; trap 'rm -f "$RUNNERS"' EXIT
+: > "$RUNNERS"
+for src in "orgs/$ORG/actions/runners" "repos/$REPO/actions/runners"; do
+    gh api --paginate "$src?per_page=100" \
+        --jq '.runners[] | select(.status=="online") | (.name) + "\t" + ([.labels[].name] | join(","))' \
+        2>/dev/null >> "$RUNNERS" || true
+done
+sort -u -o "$RUNNERS" "$RUNNERS"
+n_runners="$(grep -cve '^[[:space:]]*$' "$RUNNERS" || true)"
+
+printf -- '\n-- runners --\n'
+printf 'online runners visible (org + this repo): %s\n' "${n_runners:-0}"
+# Probe 2: the positive control.
+if [ "${n_runners:-0}" -eq 0 ]; then
+    printf 'NO-GO: zero online runners. That looks identical whether the fleet is\n'
+    printf 'down or this token lost its scope, and GPU runners are REPO-scoped and\n'
+    printf 'invisible in the org listing. Blind is a NO-GO, not a pass.\n'
+    exit 2
+fi
+
+# ── the axes ────────────────────────────────────────────────────────────────
+printf -- '\n-- axes --\n'
+axes=0; required=0; covered=0; missing=0; deferred=0; promotable=0
+fail=0
+while IFS= read -r line; do
+    line="${line%%#*}"
+    case "$line" in ''|[[:space:]]*[[:space:]]) ;; esac
+    set -- $line
+    [ $# -ge 3 ] || continue
+    axis="$1"; status="$2"; selector="$3"
+    axes=$((axes + 1))
+
+    server=""
+    while IFS="$(printf '\t')" read -r rname rlabels; do
+        [ -n "$rname" ] || continue
+        if labels_contain "$rlabels" "$selector"; then server="$rname"; break; fi
+    done < "$RUNNERS"
+
+    case "$status" in
+        required)
+            required=$((required + 1))
+            if [ -n "$server" ]; then
+                covered=$((covered + 1))
+                printf '  ok        %-20s served by %s\n' "$axis" "$server"
+            else
+                missing=$((missing + 1)); fail=1
+                printf '  MISSING   %-20s REQUIRED, but no online runner carries [%s]\n' "$axis" "$selector"
+            fi
+            ;;
+        pending:*)
+            deferred=$((deferred + 1))
+            if [ -n "$server" ]; then
+                promotable=$((promotable + 1)); fail=1
+                printf '  PROMOTE   %-20s marked %s, but %s can serve it NOW\n' "$axis" "$status" "$server"
+            else
+                printf '  deferred  %-20s %s — no runner yet\n' "$axis" "$status"
+            fi
+            ;;
+        *)
+            printf '  BAD       %-20s unknown status "%s"\n' "$axis" "$status"
+            fail=1
+            ;;
+    esac
+done < "$POLICY"
+
+printf -- '\n-- denominators --\n'
+printf 'axes declared: %s  (required %s: covered %s, MISSING %s; deferred %s: PROMOTABLE %s)\n' \
+    "$axes" "$required" "$covered" "$missing" "$deferred" "$promotable"
+
+# THE DENOMINATOR. A policy that parsed nothing must not read as clean.
+if [ "$axes" -eq 0 ]; then
+    printf '\nNO-GO: 0 axes parsed from %s. Nothing was measured.\n' "$POLICY"; exit 2
+fi
+
+{
+    printf '\n### Silicon coverage\n\n'
+    printf -- '- axes: **%s** (required %s, deferred %s)\n' "$axes" "$required" "$deferred"
+    printf -- '- required covered: **%s of %s**\n' "$covered" "$required"
+    # No parentheses in this string, and an `if` rather than `[ ] &&`: bashrs
+    # lexes a `(` inside a printf argument on the same line as a `[ ]` test as an
+    # unescaped test paren (SC1028), and a `[ ] &&` tail returns non-zero when the
+    # test is false.
+    if [ "$promotable" -gt 0 ]; then
+        printf -- '- **%s deferred axis/axes now have a runner and must be promoted**\n' "$promotable"
+    fi
+    printf -- '- runners inspected: %s\n' "$n_runners"
+} >> "$SUMMARY"
+
+if [ "$fail" -ne 0 ]; then
+    printf '\nFAIL: silicon coverage does not match the policy.\n'
+    printf 'A MISSING required axis means an architecture stopped being tested and\n'
+    printf 'nothing said so. A PROMOTABLE deferred axis means the blocker is gone and\n'
+    printf 'the only thing left is the line in .github/silicon-coverage.txt.\n'
+    exit 1
+fi
+printf '\nOK: every required axis has a runner, and every deferred axis is still blocked.\n'


### PR DESCRIPTION
Refs paiml/infra#361.

aprender's correctness is **silicon-dependent** — SIMD paths, CUDA kernels, arch intrinsics, float behaviour — and essentially none of that breadth is exercised nightly. The gap just widened on purpose: #2740 makes `cuda-nightly` gx10-only because its x86_64 GPU leg ran on lambda-labs, which must never be a CI host (paiml/infra#359). `sm_89` was the *stable reference*; `sm_121` the higher-risk target with a history of JIT bugs. **We now gate only the risky one.**

## The uncovered axes are the point, so they are data

`.github/silicon-coverage.txt` names five axes and a status each. A `matrix:` lists what runs; this lists what **should**.

| axis | status | box | today |
|---|---|---|---|
| `x86_64-cpu` | required | intel | covered |
| `aarch64-cuda-sm121` | required | gx10 | covered |
| `x86_64-cuda-sm89` | `pending:361` | yoga | not registered |
| `aarch64-cuda-sm87` | `pending:361` | jetson | not registered |
| `aarch64-macos` | `pending:361` | mini | not registered |

`scripts/check_silicon_coverage.sh` enforces it in **both** directions, and the second is what keeps the ledger honest:

- **`required`** → FAIL if no online runner can serve the selector. An architecture that stops being tested looks exactly like one that was never tested.
- **`pending:N`** → FAIL if a runner **can** now serve it. At that moment the only thing between us and the coverage is a line in a policy file, and a deferral that outlives its own blocker is how a debt ledger becomes a blanket exemption.

## Selector semantics, because the fleet has the scar

`runs-on` matches when **every** named label is on the runner; extra runner labels never exclude. So the question is *does some online runner's label set contain ours*. Both the org list **and** this repo's list are read — GPU runners are repo-scoped and invisible in the org listing, which is exactly why yoga-gpu's absence went unnoticed for months.

## Two instrument probes

`--self-test` runs six label cases, including a runner whose labels are a strict **subset** of the selector (must not match) and a case-mismatched `Linux`/`ARM64` pair (must match). The live run refuses to report on an empty runner listing — zero runners looks identical whether the fleet is down or the token lost its scope, and blind is a NO-GO.

The self-test earned its place immediately. The first `labels_contain` used `_have`/`_want`, which are also `selftest()`'s loop variables; POSIX sh has no function scope, so the call clobbered the caller and every case compared a verdict against a label string. All six went red on the first run.

## Scope and cost

The lane runs the **arch-sensitive subset**, not the whole suite — five full legs nightly is not free on a 16-runner fleet already carrying a ~6h clean-room sweep, and a lane too expensive to keep gets disabled. 03:30 UTC misses the other four fleet lanes (sweep 23:00, protection-drift 00:00, nightly-audit 02:00, quality-history 05:00).

The summary job inspects `needs.*.result` rather than relying on `if: always()`, and reports **per axis**: "silicon-nightly failed" is not actionable, "aarch64-cuda-sm121 failed and x86_64-cpu passed" is.

## One thing this immediately found

On its first live run the guard reported `aarch64-cuda-sm121` **MISSING**, and it was right. From the box:

```
/home/noah/actions-runner-gx10/.runner
  "gitHubUrl": "https://github.com/paiml/aprender"      <- REPO-scoped, not org
labels: self-hosted,Linux,ARM64,cuda,blackwell,gb10     <- no `gpu`, no `gx10`
```

So gx10 does not carry the `gpu` opt-in label the paiml/infra#352 design depends on, and `#2740`'s literal selector would never have resolved. That is being fixed in paiml/infra by re-registering the runner at org scope with its declared labels; this lane is what would have caught it every night.

`bashrs lint`: 0 errors. `check_runner_labels` and `check_beats_gated` both pass.