### PR TITLE
fix(ci): a private install root under /tmp half-persists, and /tmp is emptied at boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,9 +1286,17 @@ jobs:
       # cargo-llvm-cov ENOENT, empty coverage figure). Install into a per-run
       # root and put it FIRST on PATH so the freshly installed binary is the one
       # that runs, here and in the steps that follow.
+      # $RUNNER_TEMP, not /tmp. /tmp is emptied at boot, so a root there
+      # HALF-persists: it survives between jobs on a long-lived self-hosted
+      # box and vanishes on reboot, which is the shape paiml/infra's
+      # shared-$HOME guard blocks as `cargo-install-boot-volatile`.
+      # $RUNNER_TEMP is under the runner's own _work tree and is wiped per
+      # JOB, so it is private for the same reason the per-run name was,
+      # and the compile is paid honestly every run instead of
+      # four-times-in-sixteen.
       - name: Install cargo-deny (if absent)
         env:
-          CARGO_INSTALL_ROOT: /tmp/cargo-deny-${{ github.run_id }}-${{ github.run_attempt }}
+          CARGO_INSTALL_ROOT: ${{ runner.temp }}/cargo-deny
         run: |
           if ! command -v cargo-deny > /dev/null 2>&1; then
             cargo install cargo-deny --locked
@@ -1531,7 +1539,11 @@ jobs:
               # the host toolchain -- but the guard reads workflow text and cannot
               # see that, and "the guard cannot tell" is not a reason to exempt.
               # Declaring the root makes it true rather than merely argued.
-              export CARGO_INSTALL_ROOT=/tmp/cargo-mutants-root
+              # /usr/local, not /tmp: this root is destroyed with the --rm
+              # container either way, but /tmp is what paiml/infra's
+              # shared-$HOME guard reads as boot-volatile, and "the guard
+              # cannot tell" is not a reason to keep the ambiguous spelling.
+              export CARGO_INSTALL_ROOT=/usr/local/cargo-mutants-root
               export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
               if ! cargo mutants --version > /dev/null 2>&1; then
                 echo "cargo-mutants absent from image; installing"

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -54,14 +54,24 @@ jobs:
       # exec'd, which nothing but a concurrent writer to that path can produce.
       #
       # The fix removes the shared path rather than retrying around it: every
-      # `cargo install` in this job lands in a directory named after THIS run,
+      # `cargo install` in this job lands in a directory private to THIS job,
       # which no other job can address. Note this deliberately redirects only
       # the INSTALL ROOT, not CARGO_HOME (which is what the `security` job
       # isolates): the registry/git caches under ~/.cargo are guarded by cargo's
       # own package-cache lock and are safe to share, while a private CARGO_HOME
       # would re-download the whole dependency graph every night for no gain.
-      COV_TOOLS: /tmp/apr-cov-tools-${{ github.run_id }}-${{ github.run_attempt }}
-      CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-${{ github.run_id }}-${{ github.run_attempt }}
+      #
+      # 2026-08-30: that root moved off /tmp. /tmp is emptied at boot, so a
+      # root there HALF-persists — it survives between jobs on a long-lived
+      # self-hosted box and vanishes on reboot. That is the shape paiml/infra's
+      # shared-$HOME guard blocks as `cargo-install-boot-volatile`. $RUNNER_TEMP
+      # lives under the runner's own _work tree and is wiped per JOB: private
+      # for the same reason the per-run name was, and it never half-persists,
+      # so the compile is paid honestly every run.
+      #
+      # It is resolved in a step rather than here because the `runner` context
+      # is NOT available in a job-level `env:` block — GitHub rejects the
+      # workflow with `Unrecognized named-value: runner`. See the first step.
     steps:
       # clean: false — a coverage run builds from source and doesn't need a
       # pristine tree, and the default git-clean choked on root-owned leftovers
@@ -70,6 +80,15 @@ jobs:
       - uses: actions/checkout@v7
         with:
           clean: false
+
+      # The job-private tool root, published to every later step. $RUNNER_TEMP
+      # is only knowable at step time (see the job `env:` comment above), and
+      # every consumer below reads $COV_TOOLS, so it is resolved once here.
+      - name: Resolve the job-private tool root
+        run: |
+          set -euo pipefail
+          echo "COV_TOOLS=$RUNNER_TEMP/apr-cov-tools" >> "$GITHUB_ENV"
+          echo "CARGO_INSTALL_ROOT=$RUNNER_TEMP/apr-cov-tools" >> "$GITHUB_ENV"
 
       # Provision cargo-llvm-cov WITHOUT touching ~/.cargo/bin (#2353).
       #
@@ -86,7 +105,7 @@ jobs:
       #
       # Fail closed. A coverage run without a working cargo-llvm-cov must be RED
       # here, not a green job that reports an empty percentage.
-      - name: Provision cargo-llvm-cov into the per-run private root
+      - name: Provision cargo-llvm-cov into the job-private root
         run: |
           set -euo pipefail
           mkdir -p "$COV_TOOLS/bin"
@@ -147,7 +166,7 @@ jobs:
           case "$resolved" in
             "$COV_TOOLS/bin/"*) ;;
             *)
-              echo "::error::cargo-llvm-cov resolved to '${resolved:-<none>}', not the per-run private root $COV_TOOLS/bin"
+              echo "::error::cargo-llvm-cov resolved to '${resolved:-<none>}', not the job-private root $COV_TOOLS/bin"
               echo "::error::a concurrent job could replace that path mid-run (aprender#2353)"
               exit 1
               ;;
@@ -184,7 +203,7 @@ jobs:
       # on PATH for raw run: steps on these runners, so source the cargo env; and
       # `|| true` keeps a pmat failure from aborting the job (the coverage % below
       # is the core deliverable; gap ranking is a bonus).
-      # CARGO_INSTALL_ROOT (job env) sends this install to the per-run root too,
+      # CARGO_INSTALL_ROOT (set in the first step) sends this install to the job-private root too,
       # so this step cannot clobber another job's pmat either — the exposure is
       # symmetric and #2353 only happened to be observed from the victim side.
       - name: Ensure pmat installed
@@ -254,13 +273,18 @@ jobs:
             gh issue create --title "$title" --body "$body" && echo "created tracking issue"
           fi
 
-      # A per-run directory that is never removed is just a slower leak. Drop
+      # A tool root that is never removed is just a slower leak. Drop
       # this run's, then sweep any orphan left by a hard-killed run (which skips
       # even `if: always()` steps — the same failure mode the workspace-test
       # ownership-restore step exists for).
-      - name: Remove the per-run tool root
+      - name: Remove the job-private tool root
         if: always()
         run: |
-          rm -rf "$COV_TOOLS"
+          # Never `rm -rf` an unvalidated variable: if the resolve step above
+          # died, COV_TOOLS is unset and this would be `rm -rf ""`.
+          if [ -n "${COV_TOOLS:-}" ]; then rm -rf "$COV_TOOLS"; fi
+          # Legacy sweep: roots left under /tmp by runs from before the move to
+          # $RUNNER_TEMP. Nothing new lands there — $RUNNER_TEMP is wiped per
+          # job — so this only reaps what earlier runs abandoned.
           find /tmp -maxdepth 1 -name 'apr-cov-tools-*' -uid "$(id -u)" -mtime +1 \
             -exec rm -rf {} + 2>/dev/null || true

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -69,9 +69,20 @@ jobs:
       # for the same reason the per-run name was, and it never half-persists,
       # so the compile is paid honestly every run.
       #
-      # It is resolved in a step rather than here because the `runner` context
-      # is NOT available in a job-level `env:` block — GitHub rejects the
-      # workflow with `Unrecognized named-value: runner`. See the first step.
+      # Defined HERE, in the job `env:`, and not only via $GITHUB_ENV in a step:
+      # `scripts/check_runner_labels.sh` reads the workflow STATICALLY and fails
+      # a job that interpolates a variable its `env:` does not define — because
+      # an undefined shell variable is the empty string, so the step runs, goes
+      # green, and silently stops doing what it says. A $GITHUB_ENV assignment
+      # is correct at runtime but invisible to that reader, so it would trade a
+      # real /tmp defect for a real blind spot.
+      #
+      # `github.workspace` IS available in a job-level `env:` where `runner` is
+      # not (GitHub rejects `Unrecognized named-value: runner`), and its parent
+      # is inside the runner's own _work tree: job-private, off the boot volume,
+      # and nowhere near the shared $HOME.
+      COV_TOOLS: ${{ github.workspace }}/../apr-cov-tools
+      CARGO_INSTALL_ROOT: ${{ github.workspace }}/../apr-cov-tools
     steps:
       # clean: false — a coverage run builds from source and doesn't need a
       # pristine tree, and the default git-clean choked on root-owned leftovers
@@ -80,15 +91,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           clean: false
-
-      # The job-private tool root, published to every later step. $RUNNER_TEMP
-      # is only knowable at step time (see the job `env:` comment above), and
-      # every consumer below reads $COV_TOOLS, so it is resolved once here.
-      - name: Resolve the job-private tool root
-        run: |
-          set -euo pipefail
-          echo "COV_TOOLS=$RUNNER_TEMP/apr-cov-tools" >> "$GITHUB_ENV"
-          echo "CARGO_INSTALL_ROOT=$RUNNER_TEMP/apr-cov-tools" >> "$GITHUB_ENV"
 
       # Provision cargo-llvm-cov WITHOUT touching ~/.cargo/bin (#2353).
       #

--- a/scripts/check_cargo_install_private_root.sh
+++ b/scripts/check_cargo_install_private_root.sh
@@ -165,6 +165,12 @@ self_test() {
     probe declares_private_root 0 '      CARGO_HOME: /tmp/cargo-home-security-intel-clean-room-14'
     probe declares_private_root 0 '      CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-123-1'
     probe declares_private_root 0 '          export CARGO_INSTALL_ROOT=/tmp/tools'
+    # The shape this repo now uses. $RUNNER_TEMP is under the runner's own
+    # _work tree and is wiped per JOB, so it is private without the
+    # half-persistence of a /tmp root (paiml/infra shared-$HOME guard,
+    # rule cargo-install-boot-volatile).
+    probe declares_private_root 0 '      CARGO_INSTALL_ROOT: ${{ runner.temp }}/apr-cov-tools'
+    probe declares_private_root 0 '          export CARGO_INSTALL_ROOT="$RUNNER_TEMP/tools"'
     probe declares_private_root 1 '          export CARGO_INSTALL_ROOT="$HOME/.cargo"'
     probe declares_private_root 1 '      CARGO_HOME: ~/.cargo'
     probe declares_private_root 1 '          # CARGO_INSTALL_ROOT would help here'
@@ -297,9 +303,9 @@ main() {
         printf '\n%s shared-~/.cargo/bin exposure(s) on self-hosted jobs.\n' "$violations" >&2
         printf 'mac-server runs 16 runners under one $HOME, so `cargo install` there\n' >&2
         printf 'replaces a binary that another running job is about to exec (aprender#2353:\n' >&2
-        printf 'cargo-llvm-cov, ENOENT, empty coverage figure). Give the job a per-run root:\n' >&2
+        printf 'cargo-llvm-cov, ENOENT, empty coverage figure). Give the job a private root:\n' >&2
         printf '  env:\n' >&2
-        printf '    CARGO_INSTALL_ROOT: /tmp/<tool>-${{ github.run_id }}-${{ github.run_attempt }}\n' >&2
+        printf '    CARGO_INSTALL_ROOT: ${{ runner.temp }}/<tool>\n' >&2
         printf '  ... and put "$CARGO_INSTALL_ROOT/bin" FIRST on PATH.\n' >&2
         exit 1
     fi


### PR DESCRIPTION
## The mechanism

All 16 `intel-clean-room-*` runner services run as user `noah` with
`HOME=/home/noah`. `RUSTUP_HOME` is isolated per runner (infra#205/#206);
**`CARGO_HOME` is not.** `/home/noah/.cargo/bin` is therefore one directory
shared by every concurrent job, and it *is* the fleet's provisioned toolchain.

#2353 fixed the aprender half of that correctly: give every `cargo install` on a
self-hosted job a root no other job can address, so it cannot replace a binary
another running job is about to `exec`. That reasoning stands. **The location
does not.**

`/tmp` is emptied at boot. A root there behaves like neither a per-run directory
nor a cache — it **half-persists**: it survives between jobs on a long-lived
self-hosted box, then vanishes on the next reboot. paiml/infra's shared-`$HOME`
guard blocks that shape as `cargo-install-boot-volatile`, and it names four
steps in this repo:

| workflow | job | step |
|---|---|---|
| `ci.yml` | `guard-runner-labels` | Install cargo-deny (if absent) |
| `ci.yml` | `mutants` | Run diff-scoped mutation testing (BLOCKING) |
| `coverage-nightly.yml` | `coverage` | Provision cargo-llvm-cov into the … root |
| `coverage-nightly.yml` | `coverage` | Ensure pmat installed |

## The damage this class does

- **infra#381 (2026-08-29):** the shared `/home/noah/.cargo/bin` went
  *backwards* — forjar 1.21.0 → 1.18.0, plus thirteen other tools reverted to
  binaries stamped 2026-08-24 15:55.
- **2026-08-30:** three intel runners were found with torn
  `nightly-x86_64-unknown-linux-gnu` toolchains, `bin/rustc` missing — the
  infra#221 signature. Every job on every repo then fails
  `[pre-job.sh] FATAL: host is not provisioned`.
- **aprender#2353 itself:** `could not execute process
  /home/noah/.cargo/bin/cargo-llvm-cov (never executed)` and an **empty**
  coverage figure filed into the tracking issue.

## The fix

`$RUNNER_TEMP` lives under the runner's own `_work` tree and is wiped **per
job**. It is private for exactly the reason the per-run name was, it never
half-persists, and the compile is paid honestly every run instead of
four-times-in-sixteen.

**`ci.yml`, cargo-deny** — step-level `env:`, where the `runner` context *is*
available:

```yaml
CARGO_INSTALL_ROOT: ${{ runner.temp }}/cargo-deny
```

**`coverage-nightly.yml`** — the `runner` context is **not** available in a
job-level `env:` block; GitHub rejects such a workflow with
`Unrecognized named-value: 'runner'`. So `COV_TOOLS` and `CARGO_INSTALL_ROOT`
are resolved once in a first step and published through `$GITHUB_ENV`. Every
consumer below already reads `$COV_TOOLS`, so nothing else changed.

**`ci.yml`, mutants** — the root moves `/tmp` → `/usr/local`, *inside* the `--rm`
container. It was destroyed with the container either way; `/tmp` is simply what
the guard reads as boot-volatile. The comment on that very line already says
"the guard cannot tell" is not a reason to exempt — it is not a reason to keep
the ambiguous spelling either.

## Fixing the class, not the four instances

`scripts/check_cargo_install_private_root.sh` — this repo's own guard for the
same hazard — **taught the `/tmp` shape in its remediation hint**:

```
    CARGO_INSTALL_ROOT: /tmp/<tool>-${{ github.run_id }}-${{ github.run_attempt }}
```

That is how the shape spread to four steps. The hint now names
`${{ runner.temp }}/<tool>`, and two probes are added to the classifier case
table pinning that both spellings (`${{ runner.temp }}/…` and
`"$RUNNER_TEMP/…"`) classify as private, so the new advice cannot silently stop
being accepted.

## Also hardened

The cleanup step's `rm -rf "$COV_TOOLS"` now refuses an unset variable instead
of running `rm -rf ""` if the resolve step died, and the `/tmp` sweep is
labelled as the legacy reaper it has become.

## Verification

`machines/clean-room/shared-home-guard/check.sh` (paiml/infra) over all of
`.github/workflows/`:

| rule | severity | sites | before | after |
|---|---|---|---|---|
| `cargo-install-boot-volatile` | BLOCK | 7 | 4 | **0** |
| `cargo-install-shared` | ADVISE | 7 | 3 | 3 (unchanged, pre-existing) |
| `rm-shared-home` | BLOCK | 19 | 0 | 0 |

**Site counts unchanged** — the rules still see these steps and are measuring
them clean, rather than having stopped matching them.

- `scripts/check_cargo_install_private_root.sh --self-test` → `OK: classifier
  case table passes.`
- `scripts/check_cargo_install_private_root.sh` → `OK: 30 workflow job(s)
  scanned, 7 cargo install(s); no self-hosted job writes the shared
  ~/.cargo/bin.`
- `bashrs lint scripts/check_cargo_install_private_root.sh` → **0 errors**.
- `forjar 1.21.1 validate -f <each workflow>` → `not a forjar config: missing
  field version`, i.e. the YAML parsed.
