### PR TITLE
fix(ci): sweep the remaining 103 EPIPE-inverting `producer | grep -q` sites — 32 of them fail SILENTLY OPEN

### DIFF
--- a/.github/workflows/book-contracts.yml
+++ b/.github/workflows/book-contracts.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           FAIL=0
           for f in book/src/chapters/ch*.md; do
-            if ! head -1 "$f" | grep -q "PCU:"; then
+            if ! grep -q "PCU:" <<< "$(head -1 "$f")" ; then
               echo "::error::No PCU frontmatter: $f"
               FAIL=1
             fi
@@ -145,7 +145,7 @@ jobs:
           FAIL=0
           for md in $(find book/src -name "*.md" -not -name "SUMMARY.md"); do
             hdr=$(head -1 "$md")
-            if echo "$hdr" | grep -q 'PCU:'; then
+            if grep -q 'PCU:' <<< "$hdr" ; then
               CONTRACT=$(echo "$hdr" | grep -oE 'contract:[[:space:]]*[^ |]+' | sed 's/^contract:[[:space:]]*//')
               if [ -z "$CONTRACT" ]; then
                 echo "::error::$md has PCU header but no contract: field"

--- a/.github/workflows/cuda-nightly.yml
+++ b/.github/workflows/cuda-nightly.yml
@@ -213,7 +213,7 @@ jobs:
             echo "::error::APR_GGUF not found on gx10: $APR_GGUF"
             exit 1
           fi
-          "$HOME/.local/bin/ollama" list | grep -q "$OLLAMA_MODEL" || {
+          grep -q "$OLLAMA_MODEL" <<< "$("$HOME/.local/bin/ollama" list)" || {
             echo "::error::ollama model not pulled: $OLLAMA_MODEL"
             exit 1
           }

--- a/crates/aprender-compute/scripts/check-simd-target-feature.sh
+++ b/crates/aprender-compute/scripts/check-simd-target-feature.sh
@@ -107,7 +107,7 @@ check_file() {
                 fi
 
                 # Check if function body contains SIMD intrinsics
-                if echo "$fn_body" | grep -qE "$pattern"; then
+                if grep -qE "$pattern" <<< "$fn_body" ; then
                     # Function uses SIMD intrinsics
                     if [[ "$has_target_feature" == false ]]; then
                         # Missing #[target_feature] attribute!

--- a/crates/aprender-orchestrate/scripts/build-wasm.sh
+++ b/crates/aprender-orchestrate/scripts/build-wasm.sh
@@ -28,7 +28,7 @@ echo "================================="
 echo
 
 # Check if wasm32 target is installed
-if ! rustup target list | grep -q "wasm32-unknown-unknown (installed)"; then
+if ! grep -q "wasm32-unknown-unknown (installed)" <<< "$(rustup target list)" ; then
     echo -e "${YELLOW}⚠️  wasm32-unknown-unknown target not installed${NC}"
     echo "Installing..."
     rustup target add wasm32-unknown-unknown

--- a/crates/aprender-present/scripts/install-hooks.sh
+++ b/crates/aprender-present/scripts/install-hooks.sh
@@ -70,7 +70,7 @@ for f in $PTOP_IMPL; do
 done
 
 # Run interface tests for ptop changes
-if echo "$STAGED" | grep -q 'crates/presentar-terminal/src/ptop/'; then
+if grep -q 'crates/presentar-terminal/src/ptop/' <<< "$STAGED" ; then
     echo "Running interface tests for ptop changes..."
     if ! cargo test -p presentar-terminal --features ptop --test cpu_exploded_async --quiet 2>/dev/null; then
         echo ""

--- a/crates/aprender-serve/scripts/perf-gate.sh
+++ b/crates/aprender-serve/scripts/perf-gate.sh
@@ -48,7 +48,7 @@ trap "kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null" EXIT
 
 # Wait for server
 for i in $(seq 1 30); do
-    if curl -s "http://127.0.0.1:$PORT/health" 2>/dev/null | grep -qi "ok\|healthy\|alive"; then
+    if grep -qi "ok\|healthy\|alive" <<< "$(curl -s "http://127.0.0.1:$PORT/health" 2>/dev/null)" ; then
         break
     fi
     if ! kill -0 "$SERVER_PID" 2>/dev/null; then

--- a/crates/aprender-serve/scripts/sync-models_test.sh
+++ b/crates/aprender-serve/scripts/sync-models_test.sh
@@ -13,7 +13,7 @@ test_script_exists() {
 
 # Test: Script has bash shebang
 test_has_shebang() {
-    head -1 "$SCRIPT_UNDER_TEST" | grep -q '^#!/bin/bash'
+    grep -q '^#!/bin/bash' <<< "$(head -1 "$SCRIPT_UNDER_TEST")"
 }
 
 # Test: Script uses strict mode
@@ -88,10 +88,10 @@ test_idempotent_symlink() {
 
 # Test: No bashrs lint errors
 test_no_lint_errors() {
-    ! bashrs lint "$SCRIPT_UNDER_TEST" 2>&1 | grep -q '^✗'
+    ! grep -q '^✗' <<< "$(bashrs lint "$SCRIPT_UNDER_TEST" 2>&1)"
 }
 
 # Test: No bashrs lint warnings (only warnings, not info)
 test_no_lint_warnings() {
-    ! bashrs lint "$SCRIPT_UNDER_TEST" 2>&1 | grep -qF '[warning]'
+    ! grep -qF '[warning]' <<< "$(bashrs lint "$SCRIPT_UNDER_TEST" 2>&1)"
 }

--- a/crates/aprender-serve/scripts/validate-book-code.sh
+++ b/crates/aprender-serve/scripts/validate-book-code.sh
@@ -55,7 +55,7 @@ for md_file in $MARKDOWN_FILES; do
         LINE_NUM=$((LINE_NUM + 1))
 
         # Start of rust code block
-        if echo "$line" | grep -q '^```rust'; then
+        if grep -q '^```rust' <<< "$line" ; then
             IN_CODE_BLOCK=true
             CODE_BLOCK=""
             TOTAL_CODE_BLOCKS=$((TOTAL_CODE_BLOCKS + 1))
@@ -64,7 +64,7 @@ for md_file in $MARKDOWN_FILES; do
         fi
 
         # End of code block
-        if echo "$line" | grep -q '^```$' && [ "$IN_CODE_BLOCK" = true ]; then
+        if grep -q '^```$' <<< "$line" && [ "$IN_CODE_BLOCK" = true ]; then
             IN_CODE_BLOCK=false
 
             # Skip empty code blocks

--- a/crates/aprender-shell/scripts/chaos-baseline.sh
+++ b/crates/aprender-shell/scripts/chaos-baseline.sh
@@ -86,7 +86,7 @@ test_gentle_chaos() {
     output=$(renacer --chaos gentle -c -- "$BINARY" suggest "git " --model "$MODEL" 2>&1)
 
     # Check for anomalies
-    if echo "$output" | grep -q "ANOMALY"; then
+    if grep -q "ANOMALY" <<< "$output" ; then
         log_error "Gentle chaos: Anomalies detected!"
         echo "$output"
         return 1
@@ -104,7 +104,7 @@ test_memory_pressure() {
     output=$(renacer --chaos-memory-limit 64M -c -- "$BINARY" suggest "cargo " --model "$MODEL" 2>&1)
 
     # Check process completed without OOM
-    if echo "$output" | grep -q "killed\|OOM\|Cannot allocate"; then
+    if grep -q "killed\|OOM\|Cannot allocate" <<< "$output" ; then
         log_error "Memory pressure: Process killed due to memory limit!"
         echo "$output"
         return 1

--- a/crates/aprender-zram/scripts/docker-test-harness.sh
+++ b/crates/aprender-zram/scripts/docker-test-harness.sh
@@ -89,7 +89,7 @@ trap cleanup EXIT INT TERM
 # Helper Functions
 # ============================================================================
 ensure_ublk_module() {
-    if ! lsmod | grep -q ublk_drv; then
+    if ! grep -q ublk_drv <<< "$(lsmod)" ; then
         log "Loading ublk_drv module..."
         modprobe ublk_drv || { log_fail "Cannot load ublk_drv"; return 1; }
         UBLK_LOADED=1
@@ -242,7 +242,7 @@ run_component_tests() {
     # F004: Device ID -1 auto-assigns
     log_info "F004: Auto-assign device ID"
     if "$TRUENO_UBLK" create --size 1G --foreground &
-       sleep 2 && ls /dev/ublkb* 2>/dev/null | grep -q ublkb; then
+       grep -q ublkb <<< "$(sleep 2 && ls /dev/ublkb* 2>/dev/null)" ; then
         log_pass "F004: Auto-assign worked"
         ((passed++))
     else
@@ -451,7 +451,7 @@ run_filesystem_tests() {
     log_info "F092: mkswap/swapon"
     if mkswap /dev/ublkb0 2>&1 | tee -a "$RESULTS_DIR/filesystem.log" && \
        swapon /dev/ublkb0 2>&1; then
-        if swapon --show | grep -q ublkb0; then
+        if grep -q ublkb0 <<< "$(swapon --show)" ; then
             log_pass "F092: Swap active on ublk device"
             ((passed++))
 

--- a/crates/aprender-zram/scripts/falsification-runner.sh
+++ b/crates/aprender-zram/scripts/falsification-runner.sh
@@ -115,7 +115,7 @@ test_F004() {
     log "F004: Device ID -1 auto-assigns"
     if "$TRUENO_UBLK" create --size 1G --foreground 2>/dev/null &
        sleep 2
-       ls /dev/ublkb* 2>/dev/null | grep -q ublkb; then
+       grep -q ublkb <<< "$(ls /dev/ublkb* 2>/dev/null)" ; then
         pass "F004"
         pkill -f "trueno-ublk.*foreground" 2>/dev/null || true
     else
@@ -126,7 +126,7 @@ test_F004() {
 test_F005() {
     log "F005: Device ID collision rejected"
     if pid1=$(start_device 1G 5); then
-        if "$TRUENO_UBLK" create --size 1G --dev-id 5 --foreground 2>&1 | grep -qi "exists\|error"; then
+        if grep -qi "exists\|error" <<< "$("$TRUENO_UBLK" create --size 1G --dev-id 5 --foreground 2>&1)" ; then
             pass "F005"
         else
             fail "F005" "Collision not rejected"
@@ -177,7 +177,7 @@ test_F007() {
 test_F008() {
     log "F008: Module unload with active device"
     if pid=$(start_device 1G 8); then
-        if rmmod ublk_drv 2>&1 | grep -qi "in use"; then
+        if grep -qi "in use" <<< "$(rmmod ublk_drv 2>&1)" ; then
             pass "F008"
         else
             # Module unloaded - reload it

--- a/crates/aprender-zram/scripts/scientific-swap-benchmark.sh
+++ b/crates/aprender-zram/scripts/scientific-swap-benchmark.sh
@@ -64,7 +64,7 @@ esac
 GPU_BACKEND="none"
 if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
     GPU_BACKEND="cuda"
-elif $IS_MACOS && system_profiler SPDisplaysDataType 2>/dev/null | grep -q "Metal"; then
+elif $IS_MACOS && grep -q "Metal" <<< "$(system_profiler SPDisplaysDataType 2>/dev/null)"; then
     GPU_BACKEND="wgpu"  # Metal via WGPU on macOS
 fi
 
@@ -321,8 +321,8 @@ verify_simd_capabilities() {
         [[ "$flags" == *"avx512f"* ]] && avx512f=true
         [[ "$flags" == *"avx512bw"* ]] && avx512bw=true
     elif $IS_MACOS; then
-        avx512f=$(sysctl -n hw.optional.avx512f 2>/dev/null | grep -q 1 && echo true || echo false)
-        avx2=$(sysctl -n hw.optional.avx2_0 2>/dev/null | grep -q 1 && echo true || echo false)
+        avx512f=$(grep -q 1 <<< "$(sysctl -n hw.optional.avx512f 2>/dev/null)" && echo true || echo false)
+        avx2=$(grep -q 1 <<< "$(sysctl -n hw.optional.avx2_0 2>/dev/null)" && echo true || echo false)
     fi
 
     # Log to renacer trace

--- a/scripts/book-ci-local.sh
+++ b/scripts/book-ci-local.sh
@@ -76,7 +76,7 @@ $ALL_CONTRACTS && pass || fail "missing contract"
 gate "27 chapter pages have PCU frontmatter"
 ALL_PCU=true
 for f in book/src/chapters/ch*.md; do
-  head -1 "$f" | grep -q "PCU:" || { ALL_PCU=false; break; }
+  grep -q "PCU:" <<< "$(head -1 "$f")" || { ALL_PCU=false; break; }
 done
 $ALL_PCU && pass || fail "missing PCU"
 

--- a/scripts/book-gate.sh
+++ b/scripts/book-gate.sh
@@ -50,7 +50,7 @@ fi
 
 # Gate 4: Page has PCU frontmatter
 if [ -f "$PAGE_PATH" ]; then
-    if head -1 "$PAGE_PATH" | grep -q "PCU:"; then
+    if grep -q "PCU:" <<< "$(head -1 "$PAGE_PATH")" ; then
         echo "  G4  PASS: PCU frontmatter"
     else
         echo "  G4  FAIL: no PCU frontmatter"
@@ -119,7 +119,7 @@ if [ -f "$PAGE_PATH" ]; then
         MISSING_SECTIONS=0
         while IFS= read -r section; do
             [ -z "$section" ] && continue
-            if ! echo "$PAGE_H2S" | grep -qiF "$section"; then
+            if ! grep -qiF "$section" <<< "$PAGE_H2S" ; then
                 MISSING_SECTIONS=$((MISSING_SECTIONS+1))
             fi
         done <<< "$CONTRACT_SECTIONS"
@@ -180,10 +180,10 @@ fi
 
 # Gate 12: arXiv IDs are well-formed (L3 partial fix)
 ARXIV_LINE=$(grep "arxiv:" "$CONTRACT" 2>/dev/null | head -1)
-if echo "$ARXIV_LINE" | grep -qP '\d{4}\.\d{4,5}'; then
+if grep -qP '\d{4}\.\d{4,5}' <<< "$ARXIV_LINE" ; then
     # Check format: YYMM.NNNNN
     BAD_IDS=$(echo "$ARXIV_LINE" | grep -oP '"[^"]*"' | tr -d '"' | while read -r id; do
-        echo "$id" | grep -qP '^\d{4}\.\d{4,5}$|^math/\d{7}$' || echo "$id"
+        grep -qP '^\d{4}\.\d{4,5}$|^math/\d{7}$' <<< "$id" || echo "$id"
     done)
     if [ -n "$BAD_IDS" ]; then
         echo "  G12 WARN: malformed arXiv ID(s): $BAD_IDS"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -184,7 +184,7 @@ if [ "${1:-}" = "--check" ]; then
 fi
 
 NEW="${1:-}"
-if ! printf '%s' "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<< "$NEW" ; then
     printf 'Usage: %s <x.y.z> | --check | --self-test\n' "$0" >&2
     exit 2
 fi

--- a/scripts/cascade-publish.sh
+++ b/scripts/cascade-publish.sh
@@ -138,10 +138,11 @@ version_live() {
   elif [ "$n" -eq 3 ]; then p="3/${crate:0:1}/${crate}"
   else p="${crate:0:2}/${crate:2:2}/${crate}"
   fi
-  curl -s --retry 3 --retry-delay 2 \
+  local idx
+  idx=$(curl -s --retry 3 --retry-delay 2 \
     -H "User-Agent: aprender-cascade-publish (release automation)" \
-    "https://index.crates.io/${p}" 2>/dev/null \
-    | grep -qF "\"vers\":\"${want}\""
+    "https://index.crates.io/${p}" 2>/dev/null) || idx=''
+  grep -qF "\"vers\":\"${want}\"" <<< "$idx"
 }
 
 # PUBLISH ORDER AS A PRECONDITION, NOT AS A COMMENT.
@@ -271,11 +272,11 @@ publish_crate() {
   fi
   local out
   out=$(cargo publish "${sel[@]}" --allow-dirty --locked 2>&1 | tail -6)
-  if echo "$out" | grep -q "Published $crate"; then
+  if grep -q "Published $crate" <<< "$out" ; then
     echo "✓ PUBLISHED"
     sleep 10  # let crates.io index settle before dependents try to fetch
     return 0
-  elif echo "$out" | grep -qE "already.*upload|already exists"; then
+  elif grep -qE "already.*upload|already exists" <<< "$out" ; then
     echo "(already on registry)"
     return 0
   # Surface the two FATAL classes that are NOT dep-ordering deferrals — a bare
@@ -287,10 +288,10 @@ publish_crate() {
   #      [patch.crates-io] in .cargo/config.toml points at ../<repo> paths that
   #      don't exist in a worktree. Fix: remove .cargo/config.toml before publish
   #      (the consolidated monorepo resolves siblings via in-tree path deps).
-  elif echo "$out" | grep -qiE "403|authentication failed"; then
+  elif grep -qiE "403|authentication failed" <<< "$out" ; then
     echo "FATAL-AUTH (403 — unset stale \$CARGO_REGISTRY_TOKEN; use ~/.cargo/credentials.toml)"
     return 1
-  elif echo "$out" | grep -qiE "failed to load source|no such file or directory"; then
+  elif grep -qiE "failed to load source|no such file or directory" <<< "$out" ; then
     echo "FATAL-CONFIG (dev [patch.crates-io] in .cargo/config.toml — remove it before publish)"
     return 1
   else

--- a/scripts/check_book_examples_executable.sh
+++ b/scripts/check_book_examples_executable.sh
@@ -75,7 +75,7 @@ rewrite_destructive() {
     # decrypt, rm, upload, stamp).
     local first
     first=$(printf '%s\n' "$code" | sed -n '1p')
-    if printf '%s\n' "$first" | grep -qE '^apr\s+[a-z]'; then
+    if grep -qE '^apr\s+[a-z]' <<< "$first" ; then
         local cmd
         cmd=$(printf '%s\n' "$first" | awk '{print $2}')
         echo "apr $cmd --help"
@@ -113,7 +113,7 @@ while IFS= read -r record; do
 
     case "$cost" in
         trivial)
-            if [ -z "$APR_BIN" ] && printf '%s' "$code" | grep -qE '^apr\b'; then
+            if [ -z "$APR_BIN" ] && grep -qE '^apr\b' <<< "$code" ; then
                 skip=$((skip + 1))
                 echo "[SKIP] $path :: trivial (apr binary not available)"
                 continue
@@ -168,7 +168,7 @@ while IFS= read -r record; do
             if [ -n "$model" ] \
                 && ! [ -e "$model" ] \
                 && [ -e "$MODELS_DIR/$model" ] \
-                && ! printf '%s' "$run_code" | grep -qF "$MODELS_DIR/$model"; then
+                && ! grep -qF "$MODELS_DIR/$model" <<< "$run_code" ; then
                 run_code=$(printf '%s' "$run_code" | sed "s#\\b$model\\b#$MODELS_DIR/$model#g")
             fi
             if timeout 60 bash -c "$run_code" >/dev/null 2>&1; then

--- a/scripts/check_cargo_install_private_root.sh
+++ b/scripts/check_cargo_install_private_root.sh
@@ -75,12 +75,12 @@ is_exempt() {
 RE_INSTALL='(^|[;&|]|&&|\|\||run:)[[:space:]]*(sudo[[:space:]]+)?cargo[[:space:]]+install([[:space:]]|$)'
 
 is_install() {
-    printf '%s\n' "$1" | grep -qE "$RE_INSTALL"
+    grep -qE "$RE_INSTALL" <<< "$1"
 }
 
 # An explicit `--root <dir>` / `--root=<dir>` on the install itself.
 has_explicit_root() {
-    printf '%s\n' "$1" | grep -qE -- '--root([[:space:]]|=)'
+    grep -qE -- '--root([[:space:]]|=)' <<< "$1"
 }
 
 # A CARGO_INSTALL_ROOT / CARGO_HOME declaration (YAML `KEY: value`, `export
@@ -89,8 +89,8 @@ has_explicit_root() {
 # already does) and `CARGO_INSTALL_ROOT: /tmp/apr-cov-tools-...` both qualify;
 # `CARGO_INSTALL_ROOT="$HOME/.cargo"` does not.
 declares_private_root() {
-    printf '%s\n' "$1" | grep -qE '(CARGO_INSTALL_ROOT|CARGO_HOME)[[:space:]]*[:=]' || return 1
-    if printf '%s\n' "$1" | grep -qE '(\$HOME|\$\{HOME\}|~)/\.cargo'; then
+    grep -qE '(CARGO_INSTALL_ROOT|CARGO_HOME)[[:space:]]*[:=]' <<< "$1" || return 1
+    if grep -qE '(\$HOME|\$\{HOME\}|~)/\.cargo' <<< "$1" ; then
         return 1
     fi
     return 0
@@ -100,11 +100,11 @@ declares_private_root() {
 # continuations further down (ci.yml's mutants job is exactly that shape). The
 # caller clears the chain on the first line that does not end in a backslash.
 opens_docker_chain() {
-    printf '%s\n' "$1" | grep -qE '(^|[[:space:]])docker[[:space:]]+run([[:space:]]|$)'
+    grep -qE '(^|[[:space:]])docker[[:space:]]+run([[:space:]]|$)' <<< "$1"
 }
 
 continues_line() {
-    printf '%s\n' "$1" | grep -qE '\\[[:space:]]*$'
+    grep -qE '\\[[:space:]]*$' <<< "$1"
 }
 
 # First component of an `export PATH=...` assignment, or empty if the line is
@@ -231,7 +231,7 @@ check_job() {
     # Pass 1: job-wide facts (runs-on, private-root declarations anywhere in the
     # job - job env, step env, or an inline export).
     while IFS= read -r line; do
-        if printf '%s\n' "$line" | grep -q 'runs-on:' && printf '%s\n' "$line" | grep -q 'self-hosted'; then
+        if grep -q 'runs-on:' <<< "$line" && grep -q 'self-hosted' <<< "$line"; then
             selfhosted=1
         fi
         trimmed="$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"

--- a/scripts/check_cascade_covers_all_crates.sh
+++ b/scripts/check_cascade_covers_all_crates.sh
@@ -86,8 +86,9 @@ facade_edges() {
         local up
         up=$(sed -n 's/^upstream *=.*package *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1)
         [ -n "$up" ] || continue
-        sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1 \
-            | grep -q . || continue
+        local ver
+        ver=$(sed -n 's/^upstream *=.*version *= *"\([^"]*\)".*/\1/p' "${dir}Cargo.toml" | head -1)
+        grep -q . <<< "$ver" || continue
         printf '%s\t%s\n' "$(basename "$dir")" "$up"
     done
 }

--- a/scripts/check_contract_test_binding.sh
+++ b/scripts/check_contract_test_binding.sh
@@ -235,7 +235,7 @@ self_test() {
 
     # MUST flag: one per binding field.
     for want in MUTANT_absent_alpha MUTANT_absent_bravo MUTANT_absent_charlie; do
-        if printf '%s\n' "$msg" | grep -qF "$want"; then
+        if grep -qF "$want" <<< "$msg" ; then
             printf '  ok    must-flag   %s\n' "$want"
         else
             printf '  FAIL  must-flag   %s (not reported)\n' "$want"
@@ -245,7 +245,7 @@ self_test() {
 
     # MUST NOT flag: the shell harness and the fn that really exists.
     for unwanted in module_mentioned real_test_exists; do
-        if printf '%s\n' "$msg" | grep -qF "$unwanted"; then
+        if grep -qF "$unwanted" <<< "$msg" ; then
             printf '  FAIL  must-not-flag %s (false positive)\n' "$unwanted"
             rc=1
         else
@@ -255,7 +255,7 @@ self_test() {
 
     # The field name must appear in the finding, so an operator knows the line.
     for field in '].test)' '].test_harness)' '].name)'; do
-        if printf '%s\n' "$msg" | grep -qF "$field"; then
+        if grep -qF "$field" <<< "$msg" ; then
             printf '  ok    names field  %s\n' "$field"
         else
             printf '  FAIL  names field  %s (missing from message)\n' "$field"

--- a/scripts/check_dogfood_llm_probe_armed.sh
+++ b/scripts/check_dogfood_llm_probe_armed.sh
@@ -59,7 +59,7 @@ check_tree() {
     if [ -z "$build_line" ]; then
         printf 'FAIL: no `cargo build -p aprender-test-cli` invocation found in %s\n' "$sweep"
         fails=$((fails + 1))
-    elif ! printf '%s' "$build_line" | grep -qE -- '--features[= ]+[^ ]*llm'; then
+    elif ! grep -qE -- '--features[= ]+[^ ]*llm' <<< "$build_line" ; then
         printf 'FAIL: the probe binary is built WITHOUT --features llm.\n'
         printf '      clap still advertises `llm`, so the probe will parse and then\n'
         printf '      return "LLM features not enabled" -- reported as a server failure.\n'

--- a/scripts/check_dogfood_shim.sh
+++ b/scripts/check_dogfood_shim.sh
@@ -177,7 +177,7 @@ check_shim_file() {
         printf 'FAIL  3c shim EXITED 0 with the aprender checkout absent — it fell back to\n'
         printf '         something. A shim that degrades instead of failing is the shadow.\n'
         rc=1
-    elif ! printf '%s' "$out" | grep -qi 'REVISIT TRIGGER'; then
+    elif ! grep -qi 'REVISIT TRIGGER' <<< "$out" ; then
         printf 'FAIL  3c shim failed (rc=%s) but did not name the REVISIT TRIGGER. It must\n' "$srrc"
         printf '         say WHAT the reader is looking at, or the next person patches around it.\n'
         rc=1
@@ -208,7 +208,7 @@ self_test() {
     cp "$td/good.sh" "$td/gate.sh"
     printf 'mark pv-contracts PASS "ported"\n' >> "$td/gate.sh"
     out=$(check_shim_file "$td/gate.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+    if grep -q 'FAIL  3b' <<< "$out" ; then
         printf 'ok    row 2 a shim that invokes a gate is REJECTED\n'
     else
         printf 'FAIL  row 2 a shim invoking `mark pv-contracts` was accepted\n'; fails=1
@@ -218,7 +218,7 @@ self_test() {
     cp "$td/good.sh" "$td/long.sh"
     for _ in $(seq 1 "$((SHIM_MAX_LINES + 5))"); do printf '# padding\n' >> "$td/long.sh"; done
     out=$(check_shim_file "$td/long.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3a'; then
+    if grep -q 'FAIL  3a' <<< "$out" ; then
         printf 'ok    row 3 a shim over the line cap is REJECTED\n'
     else
         printf 'FAIL  row 3 an over-cap shim was accepted\n'; fails=1
@@ -227,7 +227,7 @@ self_test() {
     # Mutation C: the shim degrades instead of failing closed.
     printf '#!/usr/bin/env bash\nexit 0\n' > "$td/soft.sh"
     out=$(check_shim_file "$td/soft.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3c'; then
+    if grep -q 'FAIL  3c' <<< "$out" ; then
         printf 'ok    row 4 a shim that exits 0 without a checkout is REJECTED\n'
     else
         printf 'FAIL  row 4 a silently-succeeding shim was accepted\n'; fails=1
@@ -236,7 +236,7 @@ self_test() {
     # Mutation D: it fails, but says nothing useful.
     printf '#!/usr/bin/env bash\nexit 2\n' > "$td/mute.sh"
     out=$(check_shim_file "$td/mute.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3c'; then
+    if grep -q 'FAIL  3c' <<< "$out" ; then
         printf 'ok    row 5 a shim that fails MUTELY is REJECTED\n'
     else
         printf 'FAIL  row 5 a mute failing shim was accepted\n'; fails=1
@@ -247,7 +247,7 @@ self_test() {
     cp "$td/good.sh" "$td/midline.sh"
     printf 'true; mark pv-contracts PASS "ported"\n' >> "$td/midline.sh"
     out=$(check_shim_file "$td/midline.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+    if grep -q 'FAIL  3b' <<< "$out" ; then
         printf 'ok    row 6 a MID-LINE `; mark pv-contracts` is REJECTED\n'
     else
         printf 'FAIL  row 6 a mid-line gate invocation was accepted\n'; fails=1
@@ -259,7 +259,7 @@ self_test() {
     cp "$td/good.sh" "$td/dynamic.sh"
     printf 'mark "$dg_name" FAIL "declared but absent"\n' >> "$td/dynamic.sh"
     out=$(check_shim_file "$td/dynamic.sh" 2>&1)
-    if printf '%s' "$out" | grep -q 'FAIL  3b'; then
+    if grep -q 'FAIL  3b' <<< "$out" ; then
         printf 'ok    row 7 a DYNAMIC `mark "$name"` invocation is REJECTED\n'
     else
         printf 'FAIL  row 7 a dynamic gate invocation was accepted\n'; fails=1
@@ -363,9 +363,9 @@ while IFS= read -r f; do
     # installs nothing — it was flagged as a second sweep on the strength of
     # that sentence. Found when PARITY-003 and PARITY-011 met in the cumulative
     # stack head: each branch was green alone.
-    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -q 'cargo install aprender' || continue
+    grep -q 'cargo install aprender' <<< "$(grep -vE '^[[:space:]]*#' "$f" 2>/dev/null)" || continue
     # ...and writes a per-host receipt. Both halves, or it is not a sweep.
-    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -qE 'evidence/dogfood|install_rc' || continue
+    grep -qE 'evidence/dogfood|install_rc' <<< "$(grep -vE '^[[:space:]]*#' "$f" 2>/dev/null)" || continue
     sweep_hits="$sweep_hits $f"
 done < <(
     { git ls-files 'scripts/*.sh' 'crates/*/scripts/*.sh' 2>/dev/null

--- a/scripts/check_format_sovereignty.sh
+++ b/scripts/check_format_sovereignty.sh
@@ -63,7 +63,7 @@ forbidden_in() {
   local hit=""
   local f
   for f in ${FORBIDDEN}; do
-    if printf '%s\n' "${clo}" | grep -qx "${f}"; then
+    if grep -qx "${f}" <<< "${clo}" ; then
       hit="${hit} ${f}"
     fi
   done

--- a/scripts/check_guards_are_wired.sh
+++ b/scripts/check_guards_are_wired.sh
@@ -91,10 +91,11 @@ unwired_in() {
         # rather than by reading it. Erring strict is correct here: a `#` inside
         # a quoted YAML string would make a wired guard look unwired, which is a
         # loud false alarm rather than a silent miss.
-        if ! grep -rh --include='*.yml' --include='*.yaml' -- "$base" \
+        local mentions
+        mentions=$(grep -rh --include='*.yml' --include='*.yaml' -- "$base" \
                 "$root"/.github/workflows/ 2>/dev/null \
-             | sed 's/#.*$//' \
-             | grep -qE "(^|[[:space:];&|(])((ba)?sh[[:space:]]+|\\./)?[^[:space:]]*${base}([[:space:]]|$|['\"])" ; then
+             | sed 's/#.*$//') || mentions=''
+        if ! grep -qE "(^|[[:space:];&|(])((ba)?sh[[:space:]]+|\\./)?[^[:space:]]*${base}([[:space:]]|$|['\"])" <<< "$mentions" ; then
             printf '%s\n' "$base"
         fi
     done | LC_ALL=C sort

--- a/scripts/check_msrv.sh
+++ b/scripts/check_msrv.sh
@@ -18,7 +18,7 @@ MSRV="$(grep -m1 '^rust-version' Cargo.toml | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)
 [ -n "$MSRV" ] || { echo "check_msrv: could not read rust-version from Cargo.toml" >&2; exit 2; }
 echo "Declared MSRV (Cargo.toml rust-version): $MSRV"
 
-if ! rustup toolchain list 2>/dev/null | grep -q "^${MSRV}"; then
+if ! grep -q "^${MSRV}" <<< "$(rustup toolchain list 2>/dev/null)" ; then
   echo "Installing rust ${MSRV} toolchain ..."
   rustup toolchain install "${MSRV}" --profile minimal --no-self-update
 fi

--- a/scripts/check_multiplatform_dogfood.sh
+++ b/scripts/check_multiplatform_dogfood.sh
@@ -221,7 +221,7 @@ for h in $HOSTS; do
                     while read -r lane ratio verdict; do
                         printf '      %-7s parity %-6s %sx vs llama.cpp  %s\n' "$h" "$lane" "$ratio" "$verdict"
                     done
-                    if python3 "$REPO_BENCH_VALIDATOR" --parity-ratio "$f" 2>/dev/null | grep -q ' FAIL$'; then
+                    if grep -q ' FAIL$' <<< "$(python3 "$REPO_BENCH_VALIDATOR" --parity-ratio "$f" 2>/dev/null)" ; then
                         printf 'FAIL  %-7s a parity lane is below its declared floor\n' "$h"
                         rc=1
                     else

--- a/scripts/check_no_claim_literals.sh
+++ b/scripts/check_no_claim_literals.sh
@@ -224,9 +224,9 @@ if [ "${1:-}" = "--selftest" ]; then
     t=0; f=0
     check() { # check <expect match|nomatch> <line>
         local want="$1" line="$2" got=nomatch
-        if printf '%s\n' "$line" | grep -qE "$CLAIM_RE" \
-           && printf '%s\n' "$line" | grep -qE "$RATIO_RE|$TPUT_RE|$DIAGNOSIS_RE" \
-           && ! printf '%s\n' "$line" | grep -qE "$TARGET_RE"; then got=match; fi
+        if grep -qE "$CLAIM_RE" <<< "$line" \
+           && grep -qE "$RATIO_RE|$TPUT_RE|$DIAGNOSIS_RE" <<< "$line" \
+           && ! grep -qE "$TARGET_RE" <<< "$line" ; then got=match; fi
         t=$((t+1))
         if [ "$got" = "$want" ]; then printf '  ok    %-8s %s\n' "$want" "$(printf '%s' "$line" | cut -c1-64)"
         else printf '  FAIL  want %-8s got %-8s %s\n' "$want" "$got" "$(printf '%s' "$line" | cut -c1-52)"; f=$((f+1)); fi

--- a/scripts/check_pass_grep_anchored.sh
+++ b/scripts/check_pass_grep_anchored.sh
@@ -120,13 +120,13 @@ while IFS= read -r hit; do
     while IFS= read -r pat; do
         [ -z "$pat" ] && continue
         # Only patterns that actually assert a zero count are in scope.
-        printf '%s\n' "$pat" | grep -qE "$KEYWORDS" || continue
+        grep -qE "$KEYWORDS" <<< "$pat" || continue
 
         CHECKED=$((CHECKED + 1))
 
         # THE PROBE. If a "zero errors" detector matches an all-failing line,
         # it can never turn red on that failure mode.
-        if printf '%s\n' "$PROBE" | grep -qE -- "$pat" 2>/dev/null; then
+        if grep -qE -- "$pat" 2>/dev/null <<< "$PROBE" ; then
             VIOLATIONS=$((VIOLATIONS + 1))
             printf 'FAIL-OPEN %s:%s\n' "$file" "$lineno"
             printf '          pattern: %s\n' "$pat"

--- a/scripts/check_perf_claims_cite_receipts.sh
+++ b/scripts/check_perf_claims_cite_receipts.sh
@@ -173,9 +173,9 @@ scan_file() {
         if [ "$hi" -gt "$total" ]; then hi="$total"; fi
         block=$(sed -n "${lo},${hi}p" "$f")
         cites=$(resolve_citations "$root" "$block")
-        if printf '%s\n' "$cites" | grep -q ' exists$'; then
+        if grep -q ' exists$' <<< "$cites" ; then
             continue                                   # cited, and it resolves
-        elif printf '%s\n' "$cites" | grep -q ' missing$'; then
+        elif grep -q ' missing$' <<< "$cites" ; then
             printf '%s:%s:dangling:%s\n' "$rel" "$n" "$text"
         else
             printf '%s:%s:uncited:%s\n' "$rel" "$n" "$text"
@@ -380,7 +380,7 @@ stale=0
 while IFS= read -r loc; do
     [ -n "$loc" ] || continue
     case "$loc" in '#'*) continue ;; esac
-    printf '%s\n' "$records" | grep -q "^${loc}:" || stale=$((stale + 1))
+    grep -q "^${loc}:" <<< "$records" || stale=$((stale + 1))
 done < "$BASELINE"
 if [ "$stale" -gt 0 ]; then
     printf 'REPORT %s stale baseline location/s no longer carry a claim — prune\n' "$stale"

--- a/scripts/check_publish_safety.sh
+++ b/scripts/check_publish_safety.sh
@@ -42,7 +42,7 @@ echo -n "  Cargo config leak check... "
 checked=$((checked + 1))
 config_leak=0
 for pkg in aprender apr-cli; do
-    if cargo package -p "$pkg" --list 2>/dev/null | grep -q '\.cargo/config'; then
+    if grep -q '\.cargo/config' <<< "$(cargo package -p "$pkg" --list 2>/dev/null)" ; then
         if [ "$config_leak" -eq 0 ]; then
             echo "FAIL"
         fi

--- a/scripts/check_publishable_deps_publishable.sh
+++ b/scripts/check_publishable_deps_publishable.sh
@@ -106,7 +106,7 @@ if [ "${1:-}" = "--self-test" ]; then
     mk w1/libx libx yes ""
     mk w1/appy appy no libx
     got=$(scan "$W" | tail -n +2)
-    if printf '%s' "$got" | grep -q "^appy	libx$"; then
+    if grep -q "^appy	libx$" <<< "$got" ; then
         printf 'ok    row 1 publishable -> unpublishable is reported\n'
     else
         printf 'FAIL  row 1 not reported; got [%s]\n' "$got"; fails=1
@@ -160,7 +160,7 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
 
     # Row 5: with both workspaces merged, the same edge IS reported.
-    if scan "$W" "$WX" | tail -n +2 | grep -q "^face	libx$"; then
+    if grep -q "^face	libx$" <<< "$(scan "$W" "$WX" | tail -n +2)" ; then
         printf 'ok    row 5 scanning BOTH workspaces reports face -> libx\n'
     else
         printf 'FAIL  row 5 merged scan missed the cross-workspace edge; got [%s]\n' \

--- a/scripts/check_pv_version_parse.sh
+++ b/scripts/check_pv_version_parse.sh
@@ -85,10 +85,10 @@ bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
 # code as prose; both have shipped here. Strip full-line comments first.
 pv_bin_code() { grep -v '^[[:space:]]*#' "$PV_BIN_SH"; }
 
-if ! pv_bin_code | grep -qF -- "$EXTRACTOR"; then
+if ! grep -qF -- "$EXTRACTOR" <<< "$(pv_bin_code)" ; then
     bad "EXTRACTOR_MISMATCH: this table tests '$EXTRACTOR' but $PV_BIN_SH does not run it"
 fi
-if pv_bin_code | grep -qF -- "awk '$PRE_2559_EXTRACTOR'"; then
+if grep -qF -- "awk '$PRE_2559_EXTRACTOR'" <<< "$(pv_bin_code)" ; then
     bad "$PV_BIN_SH still runs the pre-#2559 last-field extractor"
 fi
 

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -285,10 +285,10 @@ check_install_line() {
     # have forced the docs to avoid the clearest available wording. Only an
     # affirmative mention counts, so a `no <backend>` / `without <backend>` /
     # `not <backend>` is skipped. Both directions are in the case table below.
-    if printf '%s' "$install_line" | grep -qiE "(no|not|without|never)[[:space:]]+$backend"; then
+    if grep -qiE "(no|not|without|never)[[:space:]]+$backend" <<< "$install_line" ; then
       continue
     fi
-    if printf '%s' "$install_line" | grep -qiE "(^|[^a-z])$backend([^a-z]|$)"; then
+    if grep -qiE "(^|[^a-z])$backend([^a-z]|$)" <<< "$install_line" ; then
       printf 'FAIL FALSIFY-README-005 install_line: advertises %s, but default = [%s]\n' \
              "$backend" "$default_feats"
       printf '       %s\n' "$install_line"

--- a/scripts/check_runner_labels.sh
+++ b/scripts/check_runner_labels.sh
@@ -21,8 +21,8 @@ fail=0
 
 while IFS=: read -r file line sel; do
   # Only inline self-hosted selectors.
-  printf '%s' "$sel" | grep -q 'self-hosted' || continue
-  if ! printf '%s' "$sel" | grep -qE "$DISCRIM"; then
+  grep -q 'self-hosted' <<< "$sel" || continue
+  if ! grep -qE "$DISCRIM" <<< "$sel" ; then
     echo "::error file=${file},line=${line}::self-hosted job lacks a discriminating runner label (need clean-room or a GPU/macOS label): ${sel# }"
     fail=1
   fi

--- a/scripts/check_story_json_streams.sh
+++ b/scripts/check_story_json_streams.sh
@@ -49,7 +49,7 @@ want "RC_ERR is stderr only" "ERRLINE" "$RC_ERR"
 # A Rust panic is written to STDERR. If RC_ALL dropped it, the story would stop
 # detecting panics - a strictly worse failure than the one being fixed here.
 run_cmd 10 bash -c "echo normal; echo \"thread 'main' panicked at src/x.rs:1:1\" >&2"
-if printf '%s\n' "$RC_ALL" | grep -qE 'thread.*panicked'; then
+if grep -qE 'thread.*panicked' <<< "$RC_ALL" ; then
   ok "RC_ALL still sees a panic written to stderr"
 else
   bad "RC_ALL still sees a panic written to stderr" "match" "$RC_ALL"

--- a/scripts/check_story_pmat_hunt.sh
+++ b/scripts/check_story_pmat_hunt.sh
@@ -164,7 +164,7 @@ if grep -q 'pmat-hunt check' "$FAILLOG"; then
 else
   bad "a hunt with zero rows calls emit_fail" "a pmat-hunt failure" "$(cat "$FAILLOG")"
 fi
-if printf '%s\n' "$out" | grep -q -- '-- pmat bug-hunt manifest'; then
+if grep -q -- '-- pmat bug-hunt manifest' <<< "$out" ; then
   ok "the empty hunt did print a header (this is the inert shape being caught)"
 else
   bad "the empty hunt did print a header" "a header" "$out"

--- a/scripts/check_wasm32_core_builds.sh
+++ b/scripts/check_wasm32_core_builds.sh
@@ -59,7 +59,7 @@ ensure_target() {
         echo "      Install rustup, or run the cargo command in this file by hand." >&2
         return 1
     fi
-    if rustup target list --installed 2> /dev/null | grep -qx "${TARGET}"; then
+    if grep -qx "${TARGET}" <<< "$(rustup target list --installed 2> /dev/null)" ; then
         return 0
     fi
     echo "note: ${TARGET} not installed; adding it."

--- a/scripts/check_workflow_path_filters.sh
+++ b/scripts/check_workflow_path_filters.sh
@@ -103,7 +103,7 @@ check_workflow() {
     [ -z "$line" ] && continue
     case "$line" in "${name}|"*) ;; *) continue ;; esac
     req="${line#*|}"
-    if ! printf '%s\n' "$push" | grep -Fxq "$req" || ! printf '%s\n' "$pr" | grep -Fxq "$req"; then
+    if ! grep -Fxq "$req" <<< "$push" || ! grep -Fxq "$req" <<< "$pr"; then
       printf '\nFAIL %s: runs code from `%s` but does not watch it in BOTH filters.\n' "$name" "$req"
       printf '     A regression in that source breaks this gate without triggering it.\n'
       fail=1

--- a/scripts/dogfood-use.sh
+++ b/scripts/dogfood-use.sh
@@ -91,7 +91,7 @@ APR_MODEL="$MODELS_DIR/qwen2.5-coder-1.5b-instruct-q4k.apr"
 if [ -f "$APR_MODEL" ]; then
     OUT=$(timeout 300 "$BIN" run "$APR_MODEL" --prompt "What is the capital of France?" \
             --max-tokens 24 2>/dev/null); EC=$?
-    if [ "$EC" -eq 0 ] && printf '%s' "$OUT" | grep -qi "paris"; then
+    if [ "$EC" -eq 0 ] && grep -qi "paris" <<< "$OUT" ; then
         ok "run APR -> answered 'Paris'"
     else
         bad "run APR: exit=$EC, no 'Paris' in output: $(printf '%s' "$OUT" | tail -2 | tr '\n' ' ')"
@@ -100,7 +100,7 @@ if [ -f "$APR_MODEL" ]; then
     # qa is the product's own falsifiable gate suite — the strongest single
     # assertion available that the binary works end to end on a real model.
     OUT=$(timeout 600 "$BIN" qa "$APR_MODEL" 2>&1); EC=$?
-    if printf '%s' "$OUT" | grep -q "ALL GATES PASSED"; then
+    if grep -q "ALL GATES PASSED" <<< "$OUT" ; then
         ok "qa APR -> ALL GATES PASSED"
     else
         bad "qa APR: exit=$EC, no 'ALL GATES PASSED' — $(printf '%s' "$OUT" | grep -E '✗|FAIL' | head -2 | tr '\n' ' ')"

--- a/scripts/dogfood.sh
+++ b/scripts/dogfood.sh
@@ -96,7 +96,7 @@ fi
 # So the fallback is every declared feature MINUS known-broken quarantines, and
 # the exclusion is REPORTED. A silent exclusion is how a gate quietly stops
 # covering what it claims to.
-if awk '/^\[features\]/{f=1;next} /^\[/{f=0} f' Cargo.toml | grep -qE '^cli *='; then
+if grep -qE '^cli *=' <<< "$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f' Cargo.toml)" ; then
   FEATS="--features cli"; FEAT_NOTE="--features cli"
 else
   ALL_FEATS=$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f' Cargo.toml \
@@ -949,10 +949,10 @@ done
 if [ -n "$MKPATH" ]; then
   MK_RECIPE=$(awk '/^contracts:/{f=1;next} /^[^\t]/{f=0} f' "$MKPATH")
   MK_SMELL=""
-  printf '%s' "$MK_RECIPE" | grep -qE 'for .*; *do' \
-    && ! printf '%s' "$MK_RECIPE" | grep -qE '\|\| *exit' \
+  grep -qE 'for .*; *do' <<< "$MK_RECIPE" \
+    && ! grep -qE '\|\| *exit' <<< "$MK_RECIPE" \
     && MK_SMELL="a for-loop with no \`|| exit\` (exits with its LAST iteration)"
-  printf '%s' "$MK_RECIPE" | grep -qE '\|\| *true' \
+  grep -qE '\|\| *true' <<< "$MK_RECIPE" \
     && MK_SMELL="$MK_SMELL${MK_SMELL:+; }\`|| true\` swallows a real failure"
   if [ -n "$MK_SMELL" ]; then
     mark contracts-exit-integrity FAIL "the \`contracts:\` recipe launders its exit code: $MK_SMELL. Its GREEN cannot be believed — fix the recipe before trusting it."
@@ -1151,7 +1151,7 @@ else
     esac
     satisfied=""
     for w in $want; do
-      printf '%s' "$TP_NAMES" | grep -qw "$w" && satisfied=yes
+      grep -qw "$w" <<< "$TP_NAMES" && satisfied=yes
     done
     [ -n "$satisfied" ] || TP_INTRUDERS="$TP_INTRUDERS $probe(→${want// //})"
   done

--- a/scripts/dogfood_surfaces.sh
+++ b/scripts/dogfood_surfaces.sh
@@ -668,7 +668,7 @@ for line in sys.stdin:
         | LC_ALL=C sort -u)
     while IFS= read -r b; do
         [ -n "$b" ] || continue
-        if ! printf '%s\n' "$built_names" | grep -qx "$b"; then
+        if ! grep -qx "$b" <<< "$built_names" ; then
             printf 'UNPROBED\t%s (declared by cargo, not built -- required-features)\n' "$b"
         fi
     done <<< "$declared"

--- a/scripts/pcu-batch.sh
+++ b/scripts/pcu-batch.sh
@@ -142,7 +142,7 @@ falsification:
 YAML
 
     # Prepend PCU frontmatter to .md (if not already present)
-    if ! head -1 "$md" | grep -q "PCU:"; then
+    if ! grep -q "PCU:" <<< "$(head -1 "$md")" ; then
         TMPF=$(mktemp)
         echo "<!-- PCU: ${ID} | contract: ${CONTRACT} -->" > "$TMPF"
         echo "<!-- Example: cargo run -p aprender-core --example ${EXAMPLE:-none} -->" >> "$TMPF"

--- a/scripts/publish/albor-370m-publish-readiness.sh
+++ b/scripts/publish/albor-370m-publish-readiness.sh
@@ -136,8 +136,8 @@ fi
 # Gate 6: smoke generation (model produces output, not garbage)
 echo "Gate 6: smoke generation (apr run)"
 SMOKE=$("$APR_BIN" run "$CKPT" "def fibonacci(n):" --max-tokens 32 --temperature 0.0 2>&1 | head -50)
-if echo "$SMOKE" | grep -qE "^(Output|generation|tokens):" 2>/dev/null; then
-    if echo "$SMOKE" | grep -qE "[a-zA-Z]{5,}" 2>/dev/null; then
+if grep -qE "^(Output|generation|tokens):" 2>/dev/null <<< "$SMOKE" ; then
+    if grep -qE "[a-zA-Z]{5,}" 2>/dev/null <<< "$SMOKE" ; then
         ok "smoke generation produced text output"
     else
         warn "smoke generation produced output but no English/code-like text - may be degenerate"

--- a/scripts/qwen-story.sh
+++ b/scripts/qwen-story.sh
@@ -188,7 +188,7 @@ beat2_trust() {
   emit_evidence "apr qa $M_15B_APR"
   # RC_ALL: the banner is a human-facing line and apr is free to put it on
   # either stream; this check is about presence, not about parsing.
-  if echo "$RC_ALL" | grep -q "ALL GATES PASSED"; then
+  if grep -q "ALL GATES PASSED" <<< "$RC_ALL" ; then
     emit_pass "B2 apr qa"
   else
     emit_fail "B2 apr qa" "no 'ALL GATES PASSED' line"
@@ -278,7 +278,7 @@ beat4_adapt() {
     emit_pass "B4 apr export (clean exit=5, no panic)"
   # RC_ALL, NOT RC_OUT: a Rust panic message is written to STDERR. Grepping
   # stdout alone would silently stop detecting panics.
-  elif [ "$RC_EC" -eq 101 ] || echo "$RC_ALL" | grep -qE 'thread.*panicked'; then
+  elif [ "$RC_EC" -eq 101 ] || grep -qE 'thread.*panicked' <<< "$RC_ALL" ; then
     emit_fail "B4 apr export" "PANIC (exit=$RC_EC)  -  #1865 regression"
   else
     emit_fail "B4 apr export" "unexpected exit=$RC_EC"
@@ -298,9 +298,9 @@ beat5_use() {
   fi
   run_cmd 120 apr run "$M_15B_APR" "fn sum(a: i32, b: i32) -> i32 {" --max-tokens 16
   # Heuristic gibberish detector  -  flag if chat-template tokens repeat.
-  if echo "$RC_OUT" | grep -qE '<\|im_start\|>.*<\|im_start\|>'; then
+  if grep -qE '<\|im_start\|>.*<\|im_start\|>' <<< "$RC_OUT" ; then
     emit_fail "B5 apr run" "gibberish (chat-template token repeats)"
-  elif [ "$RC_EC" -eq 0 ] && echo "$RC_OUT" | grep -qE 'Output:'; then
+  elif [ "$RC_EC" -eq 0 ] && grep -qE 'Output:' <<< "$RC_OUT" ; then
     emit_pass "B5 apr run (Rust code completion)"
   else
     emit_fail "B5 apr run" "exit=$RC_EC, no Output line"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,7 +18,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Validate version format
-if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<< "$VERSION" ; then
     echo "❌ Invalid version format: $VERSION"
     echo "   Expected: MAJOR.MINOR.PATCH (e.g., 0.1.0)"
     exit 1

--- a/scripts/runner-infra/runner-disk-guard.sh
+++ b/scripts/runner-infra/runner-disk-guard.sh
@@ -82,7 +82,7 @@ prune_target_dirs() {
 
         if [ "$mode" = "stale" ]; then
             # Only prune if nothing touched in STALE_DAYS days
-            if find "$tgt" -maxdepth 0 -mtime +"$STALE_DAYS" | grep -q .; then
+            if grep -q . <<< "$(find "$tgt" -maxdepth 0 -mtime +"$STALE_DAYS")" ; then
                 log "pruning stale target: $tgt"
                 rm -rf --one-file-system "$tgt" 2>/dev/null || sudo rm -rf --one-file-system "$tgt" 2>/dev/null || true
             fi

--- a/scripts/ship-discharges/ship-008-discharge.sh
+++ b/scripts/ship-discharges/ship-008-discharge.sh
@@ -99,7 +99,7 @@ echo "Step 2: apr run + capture rendered prompt"
 CAPTURE_MODE=""
 START_EPOCH=$(date -u +%s)
 RUN_EXIT=0
-if "$APR_BINARY" run --help 2>&1 | grep -q -- '--print-prompt'; then
+if grep -q -- '--print-prompt' <<< "$("$APR_BINARY" run --help 2>&1)" ; then
     "$APR_BINARY" run "$MODEL" --system "$SYSTEM_MSG" --prompt "$USER_MSG" --print-prompt >"$RENDERED_FILE" 2>&1 || RUN_EXIT=$?
     CAPTURE_MODE="--print-prompt"
 else

--- a/scripts/verify-chat-models.sh
+++ b/scripts/verify-chat-models.sh
@@ -146,8 +146,8 @@ verify_model() {
 
     # Check for success indicators
     if [[ ${exit_code} -eq 0 ]] && \
-       echo "${output}" | grep -qiE "(loaded|format|model)" && \
-       echo "${output}" | grep -qiE "(goodbye|quit|exit|4)"; then
+       grep -qiE "(loaded|format|model)" <<< "${output}" && \
+       grep -qiE "(goodbye|quit|exit|4)" <<< "${output}" ; then
         log_success "${model_key}: chat completed successfully"
         echo "pass"
         return 0


### PR DESCRIPTION
Follow-up to #2799 (which fixes the two sites that took `guard-runner-labels` red on #2776). Same defect, 48 more files, 103 more sites.

`grep -q` exits at its FIRST match and closes the pipe. If the producer still has a `write()` to perform it takes EPIPE, and under `set -o pipefail` the pipeline reports the **producer's** 141/1 rather than grep's 0 — so **a match is read as a non-match**.

## The universe

Re-derived from `origin/main` with `git show`, not the checkout (the checkout is 50+ commits behind on an old branch and does not even contain `check_verifier_pinning.sh`). **129 raw hits across 58 files** in `*.sh`, `.github/workflows/*.yml`, `Makefile`. Of those:

| | |
|---:|---|
| 23 | **not live code** — 20 comments documenting this exact hazard, 3 fixture strings inside guard case tables |
| 1 | **not a pipe** — `[ -f x ] \|\| grep -q p FILE` is a `\|\|`, not a `\|` |
| **105** | **live pipelines** — the real universe |

## Polarity — the inverted half is the dangerous one

EPIPE only ever turns a **match** into a read-as-non-match. So the damage is decided by what a match *means* at each site:

| count | class | what a match means | what EPIPE does |
|---:|---|---|---|
| 57 | **NORMAL** | "expected thing is present" | fabricates an absence → **false RED**. Noisy, self-announcing. This is what hit #2776. |
| **32** | **INVERTED** | "violation found" | drops the detection → **silent false GREEN**. A safety check that passes. |
| 16 | BRANCH | capability probe / retry / diagnosis | degrades; no verdict flips |

**The 32 inverted sites**, by file:

`check-simd-target-feature.sh:110` · `install-hooks.sh:73` · `sync-models_test.sh:91,96` · `validate-book-code.sh:58,67` · `chaos-baseline.sh:89,107` · `book-contracts.yml:148` · `book-gate.sh:183` · `check_book_examples_executable.sh:78` · `check_cargo_install_private_root.sh:78,93,103,107,234` · `check_cascade_covers_all_crates.sh:90` · `check_contract_test_binding.sh:248` · `check_dogfood_shim.sh:366,368` · `check_format_sovereignty.sh:66` · `check_multiplatform_dogfood.sh:224` · `check_pass_grep_anchored.sh:123,129` · `check_publish_safety.sh:45` · `check_pv_version_parse.sh:91` · `check_readme_claims.sh:291` · `check_runner_labels.sh:24` · `dogfood.sh:952,955` · `qwen-story.sh:301` · `runner-disk-guard.sh:85`

Five are the same sub-class — `producer | grep -q X || continue`, where a lost match silently **removes an item from the guard's own universe**: `check_cascade_covers_all_crates.sh:90`, `check_dogfood_shim.sh:366` and `:368`, `check_pass_grep_anchored.sh:123`, `check_runner_labels.sh:24`.

## Measurement — the size story was wrong in both directions

The governing variable is **not** payload size. It is whether the producer still has a `write()` pending when grep exits. Two ways that happens:

**(a) burst producer, more than ~96 KB left to write after an early match**

| bytes | 32768 | 65536 | 98304 | 131072 | 262144 | 1048576 |
|---|---|---|---|---|---|---|
| match **EARLY** | 0/200 | 0/200 | 3/200 | **200/200** | **200/200** | **200/200** |
| match **LATE** | 0/200 | 0/200 | 0/200 | 0/200 | 0/200 | 0/200 |

**Match position is the variable nobody had held constant.** A large payload with the needle at the end never reproduces.

**(b) incremental producer still alive when grep exits — 100% loss at ANY size**

```
{ echo NEEDLE; sleep 0.02; echo tail; } | grep -q NEEDLE   ->  lost 100/100   (30 bytes)
{ echo NEEDLE;             echo tail; } | grep -q NEEDLE   ->  lost   0/100
```

So `apr run … | grep -q`, `curl … | grep -q`, `cargo … | grep -q` are the shapes to fear — not the big ones.

**Is any guard permanently fail-open?** No — and I checked rather than assumed. Largest producer in the tree is 40346 bytes (`grep -v` over `dogfood.sh`); every producer writes in one burst; every real needle sits late. Measured **0/300** on all five files that actually match at `check_dogfood_shim.sh:366`, and **0/40** on `cargo package --list | grep -q` (28143 bytes) at `check_publish_safety.sh:45`. These are stochastic fail-opens (~1/20000 at load 13.6), not permanent ones — but a false GREEN is unobservable, so it accrues in silence while a false RED announces itself.

## Before / after

Command-producer class (the 34 sites converted to capture-then-here-string):

```
BEFORE  cmd | grep -q            lost: 200/200
AFTER   grep -q <<< "$(cmd)"     lost:   0/200
```

## Verification

**14 guard self-tests / case tables**, all rc=0, 0 unexpected FAIL rows. (`check_pv_version_parse.sh --self-test` prints 3 FAIL rows by design — byte-identical to `origin/main`; they are the table proving the pre-#2559 extractor turns RED.)

**7 mutations, each RED then GREEN on revert:**

| # | guard | mutation | mutated | revert |
|---|---|---|---|---|
| M1 | `check_runner_labels.sh` | add a self-hosted job with no discriminating label | **rc=1** | rc=0 |
| M2 | `check_cargo_install_private_root.sh` | add a self-hosted `cargo install` with no private root | **rc=1** (`SHARED-INSTALL … job mut-install`) | rc=0 |
| M3 | `check_workflow_path_filters.sh` | drop `crates/aprender-core/src/**` from both filters | **rc=1** | rc=0 |
| M4 | `check_dogfood_shim.sh` | add a SECOND install-sweep runner | **rc=1** (`FAIL 1b`) | rc=0 |
| M5 | `check_guards_are_wired.sh` | unwire `check_runner_labels.sh` from every workflow | **rc=1** (`grew 4 -> 5, NEW: check_runner_labels.sh`) | rc=0 |
| M6 | `check_pass_grep_anchored.sh` | its own built-in proof: plant the PMAT-CI-PASSGREP-001 pattern | **RED** | — |
| M7 | `check_publish_safety.sh` | repoint the needle at a path that IS in the package list | **rc=1** | rc=0 |

M5 took three attempts, and the two failures are worth recording: `DISABLED_check_runner_labels.sh` still contains the substring `check_runner_labels.sh`, and the guard is named in `coverage-nightly.yml` as well as `ci.yml`. Both invalid mutations looked like a guard that could not fire. Only removing the invocation lines from **both** workflows produced the real RED.

Also green: `check_shell_lint_ratchet.sh` (bashrs over all 48 touched scripts), `check_apr_bin_pinned.sh` (164 files), `check_beats_gated.sh`, `check_baseline_ratchets.sh`, `check_no_hand_rolled_parsers.sh`, `check_sourced_libs_option_neutral.sh`, `check_hermetic_stdin_tests.sh`, `check_exclude_anchored.sh`, `check_story_json_streams.sh`, `check_no_timing_in_required.sh`, `check_workflow_env_defined.sh`, `check_duplicate_bin_names.sh`. `bash -n` clean on all 48. Tree-wide re-scan: **0 live sites remain** outside `check_verifier_pinning.sh` (deliberately left to #2799 to avoid a conflict).

Confirmed the sweep did not shrink any guard's universe: `check_pass_grep_anchored.sh` reports the same `2 checked` before and after.

## The fix

- producer is a **variable** → `grep -q PAT <<< "$var"` (no subprocess at all)
- producer is a **command** → capture, then here-string

Never by disabling `pipefail` — that trades a rare false verdict for a permanent blind spot.

Four sites needed hand treatment rather than the mechanical rewrite: `check_cargo_install_private_root.sh:234` and `check_workflow_path_filters.sh:106` (two greps on one line), `cascade-publish.sh:144` / `check_guards_are_wired.sh:97` / `check_cascade_covers_all_crates.sh:90` (multi-line pipelines, captured into a local first), `scientific-swap-benchmark.sh:324-325` (inside a command substitution).

Three of the 48 files are workflows (`book-contracts.yml`, `cuda-nightly.yml`) — one-line edits inside `run:` blocks, the same construct as everywhere else, no job/trigger/matrix change. `scripts/perf-matrix.yaml` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)