### PR TITLE
fix(security): RUSTSEC-2026-0269 took the required `ci / gate` red on EVERY open PR at once

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -52,6 +52,26 @@ ignore = [
     # a four-major jump on a test-only dep. Tracked separately; revisit before
     # anything starts enabling `runtime`.
     "RUSTSEC-2026-0222",
+    # wasmtime 43.0.2 - "Filesystem sandbox escape when paths or symlinks
+    # contain trailing slashes", CVSS 8.8 HIGH. Published 2026-08-20; first
+    # broke the security gate on 2026-08-31, taking `ci / gate` -- a REQUIRED
+    # check -- red on every open pull request at once (#2799 through #2803).
+    #
+    # Highest severity in this cluster so far, so the reachability claim was
+    # re-verified rather than inherited from the entries above:
+    #   cargo tree -p aprender                        -> 0 wasmtime paths
+    #   cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
+    #   cargo tree -p apr-cli                         -> 0 wasmtime paths
+    # wasmtime is optional and gated behind aprender-test-lib's `runtime`
+    # feature, which nothing in the workspace enables. No shipped artifact
+    # links it, and nothing here runs untrusted wasm with a preopened
+    # directory, which is the only way the escape is reachable at all.
+    #
+    # There is NO fixed 43.x: the advisory's ranges are >=24.0.13,<25,
+    # >=36.0.14,<37, >=46.0.3,<47 and >=47.0.4. So the real fix is the same
+    # three-major-version bump the -0222 note above already defers, and it
+    # must land before anything starts enabling `runtime`.
+    "RUSTSEC-2026-0269",
 
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already bumped to >=0.103.12. The 0.101.7 pin lives


### PR DESCRIPTION
## Not a defect in any PR — an advisory-DB catch-up that fails a required check

cargo-audit picked up **RUSTSEC-2026-0269** — wasmtime 43.0.2, *"Filesystem sandbox escape when paths or symlinks contain trailing slashes"*, **CVSS 8.8 HIGH**, published 2026-08-20 — on **2026-08-31**, and failed `ci / security`.

`ci / security` is not itself a required context, but the required `ci / gate` hard-requires it:

```
##[error]security did not succeed (result: failure)
Gate FAILED — a mandatory job did not succeed.
Note: cancelled and skipped both count as not-passed.
```

So **every open pull request went red simultaneously** — #2799, #2800, #2801, #2802, #2803 — with nothing wrong in any of them. `main`'s last run was green at `745fa8588` on 2026-08-30, *eleven days after* the advisory was published, so this is the advisory database catching up rather than any change in this repository. This is the "all-PRs-red + nothing changed in-repo" signature.

## Reachability — re-verified, not inherited

This is the **twelfth** wasmtime/cranelift advisory handled by the policy already written into `.cargo/audit.toml`. It is the highest severity of them, so the "test-only, not production" claim was re-derived rather than taken from the entries above:

```
cargo tree -p aprender                        -> 0 wasmtime paths
cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
cargo tree -p apr-cli                         -> 0 wasmtime paths
```

`wasmtime` is optional and gated behind `aprender-test-lib`'s `runtime` feature, which nothing in the workspace enables. It reaches cargo-audit only because `Cargo.lock` records optional dependencies. No shipped artifact links it, and nothing here runs untrusted wasm with a preopened directory — the only configuration in which the escape is reachable at all.

## Why this is a deferral and not the fix

There is **no fixed 43.x**. The advisory's ranges are `>=24.0.13,<25` | `>=36.0.14,<37` | `>=46.0.3,<47` | `>=47.0.4`. The real fix is the same three-major-version bump that the `RUSTSEC-2026-0222` note directly above this entry already defers, and it must land before anything starts enabling `runtime`. That is a dependency decision worth its own ticket, not something to rush through to unblock a queue.

## Verification

Mutation-verified, the same way the guards in this repo are:

| | `cargo audit` |
|---|---|
| entry removed | **rc=1** (`error: 1 vulnerability found!`) |
| entry present | **rc=0** |

One file, one entry, no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)