### PR TITLE
fix(security): wasmtime 43 -> 47.0.4 -- the real fix for RUSTSEC-2026-0269, and it needed ZERO source changes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -19,59 +19,18 @@ ignore = [
     # rand 0.8.5 — unmaintained, transitive (no drop-in for 0.8 API)
     "RUSTSEC-2026-0097",
 
-    # wasmtime 43 + cranelift — test-only dep (aprender-test-lib), not production.
-    # v43 still has advisories for cranelift internals. Upgrade to >=43.0.2 when available.
-    "RUSTSEC-2026-0085",
-    "RUSTSEC-2026-0086",
-    "RUSTSEC-2026-0088",
-    "RUSTSEC-2026-0089",
-    "RUSTSEC-2026-0091",
-    "RUSTSEC-2026-0092",
-    "RUSTSEC-2026-0094",
-    "RUSTSEC-2026-0096",
-    # wasmtime 43 — table allocation panic (severity 5.9 medium). Same
-    # test-only dep + same upgrade path (>=43.0.2 / >=44.0.1) as the
-    # cranelift cluster above. Availability bug, not RCE. Published
-    # 2026-04-30; surfaced first on 2026-05-01 CI runs.
-    "RUSTSEC-2026-0114",
-    # wasmtime 43.0.2 — "Stores can mix up type indices between engines",
-    # severity 3.8 LOW. Published 2026-07-31 and broke the security gate the
-    # same day, blocking the v0.62.0 release.
-    #
-    # NOT taken on faith from the cluster above — the "test-only, not
-    # production" claim was re-verified for this one:
-    #   cargo tree -p aprender                        -> 0 wasmtime paths
-    #   cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
-    # wasmtime is optional and gated behind aprender-test-lib's `runtime`
-    # feature, which NOTHING in the workspace enables (its only consumer,
-    # aprender-qa-runner, takes `features = ["llm-types"]`). It appears here
-    # solely because Cargo.lock records optional dependencies, so cargo-audit
-    # sees it while no shipped artifact ever links it.
-    #
-    # The fix is a real upgrade, not this line: 43 -> >=46.0.2,<47 or >=47.0.3,
-    # a four-major jump on a test-only dep. Tracked separately; revisit before
-    # anything starts enabling `runtime`.
-    "RUSTSEC-2026-0222",
-    # wasmtime 43.0.2 - "Filesystem sandbox escape when paths or symlinks
-    # contain trailing slashes", CVSS 8.8 HIGH. Published 2026-08-20; first
-    # broke the security gate on 2026-08-31, taking `ci / gate` -- a REQUIRED
-    # check -- red on every open pull request at once (#2799 through #2803).
-    #
-    # Highest severity in this cluster so far, so the reachability claim was
-    # re-verified rather than inherited from the entries above:
-    #   cargo tree -p aprender                        -> 0 wasmtime paths
-    #   cargo tree -p aprender --no-default-features  -> 0 wasmtime paths
-    #   cargo tree -p apr-cli                         -> 0 wasmtime paths
-    # wasmtime is optional and gated behind aprender-test-lib's `runtime`
-    # feature, which nothing in the workspace enables. No shipped artifact
-    # links it, and nothing here runs untrusted wasm with a preopened
-    # directory, which is the only way the escape is reachable at all.
-    #
-    # There is NO fixed 43.x: the advisory's ranges are >=24.0.13,<25,
-    # >=36.0.14,<37, >=46.0.3,<47 and >=47.0.4. So the real fix is the same
-    # three-major-version bump the -0222 note above already defers, and it
-    # must land before anything starts enabling `runtime`.
-    "RUSTSEC-2026-0269",
+    # wasmtime: the whole 43.x cluster is GONE. The workspace dep moved 43 ->
+    # 47.0.4, a patched line for every advisory that was exempted here (ten of
+    # them, plus the 8.8 filesystem-sandbox escape that took every open PR red
+    # on 2026-08-31). The `runtime` feature compiles and its 73 tests pass
+    # against 47.0.4 with ZERO source changes -- the deferral note that used to
+    # live here called it 'a four-major jump' and assumed API breakage; there
+    # was none. Deliberately naming no advisory id in this prose: CI builds its
+    # --ignore list by grepping every RUSTSEC token out of this file, comments
+    # included, so a mention here would silently re-exempt what we just fixed.
+    # Eleven entries go, not ten: #2805's same-day containment line for the
+    # 8.8 sandbox escape is one of them, obsolete for exactly the same reason
+    # as the 43.x cluster it was appended to.
 
     # rustls-webpki 0.101.7 — transitive via aws-smithy-http-client (rustls 0.21).
     # Direct 0.103.x path already bumped to >=0.103.12. The 0.101.7 pin lives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,15 +3322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if 1.0.4",
 ]
@@ -4401,27 +4392,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -4429,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4440,9 +4431,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -4454,13 +4445,16 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.2",
  "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -4468,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -4481,24 +4475,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -4508,11 +4502,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -4520,15 +4515,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -4537,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.2"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc"
@@ -6751,6 +6746,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -7346,20 +7346,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -8088,12 +8074,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -9066,8 +9049,17 @@ version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
  "crc32fast",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -10078,9 +10070,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -10090,9 +10082,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10413,15 +10405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10639,6 +10622,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "rustc-hash 2.1.2",
+ "serde",
  "smallvec",
 ]
 
@@ -11850,16 +11834,6 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -13821,33 +13795,19 @@ checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
 
 [[package]]
 name = "wasm-compose"
-version = "0.245.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
+checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "im-rc",
  "indexmap 2.14.0",
  "log",
  "petgraph",
- "serde",
- "serde_derive",
- "serde_yaml",
  "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
  "wat",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -13857,7 +13817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -13888,44 +13848,33 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.13.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
 ]
 
 [[package]]
-name = "wasmparser"
+name = "wasmprinter"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
-dependencies = [
- "bitflags 2.13.0",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.245.1",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -13942,7 +13891,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.38.1",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -13956,8 +13905,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -13969,16 +13918,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -13986,10 +13935,10 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
- "object 0.38.1",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -13998,8 +13947,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -14007,9 +13956,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed398988226d7aa0505ac6bb576e09532ad722d702ec4e66365d78ed695c95f"
+checksum = "ede02ba77442cab88a2ddd5d16373e8bc450b55e05de8be039b024987a53d5a7"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -14027,9 +13976,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5ec9fff073ff13b81732d56a9515d761c245750bcda09093827f84130ebc25"
+checksum = "c5bba4eff4804620bae04d7793308d97a0c5a8a97ea19e635452518f84560f84"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -14042,27 +13991,27 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935d9ab293ba27d1ec9aa7bc1b3a43993dbe961af2a8f23f90a11e1331b4c13f"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
@@ -14073,12 +14022,12 @@ dependencies = [
  "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object 0.38.1",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -14087,9 +14036,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
@@ -14102,21 +14051,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
- "object 0.38.1",
+ "object 0.39.1",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
@@ -14126,22 +14075,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if 1.0.4",
  "cranelift-codegen",
  "log",
- "object 0.38.1",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14149,27 +14098,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.0",
- "log",
- "object 0.38.1",
- "target-lexicon",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.2"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
+checksum = "bfdbdd9d6fab1ecb67a7dc189e32c9e341444945fb709437bf8aab25d9a88459"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -14188,7 +14120,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.252.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -14830,25 +14762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "winch-codegen"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.0",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
-
-[[package]]
 name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15460,12 +15373,12 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -15473,8 +15386,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.245.1",
+ "unicode-ident",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,20 @@ mime_guess = "2"
 
 # Browser / WASM runtime (heavy optional deps for test framework)
 chromiumoxide = { version = "0.8", default-features = false, features = ["tokio-runtime"] }
-wasmtime = "43"
+# 47.0.4 is a PATCHED line for RUSTSEC-2026-0269 (CVSS 8.8 filesystem sandbox
+# escape) and for the ten wasmtime/cranelift advisories that used to be exempted
+# in .cargo/audit.toml. The old deferral note there called 43 -> 47 "a four-major
+# jump" and assumed API breakage; there is none -- runtime.rs needed ZERO source
+# changes and its 73 tests pass unmodified.
+#
+# MSRV: wasmtime >=46 requires Rust 1.94.0, and rust-toolchain.toml pins 1.93.0.
+# That is fine for CI and for every shipped artifact, because `wasmtime` is
+# optional behind aprender-test-lib's `runtime` feature and NOTHING in the
+# workspace, .github/workflows/, scripts/, or the Makefile enables it -- cargo
+# never builds it, so the MSRV check never fires. It does mean
+# `--features runtime` needs Rust 1.94+ until the toolchain pin moves. Tracked
+# in #2806; cargo fails with an explicit MSRV message, not silently.
+wasmtime = "47.0.4"
 bollard = "0.17"
 
 # Old crate name aliases (workspace = true refs in migrated sub-crates)

--- a/contracts/wasmtime-upgrade-v1.yaml
+++ b/contracts/wasmtime-upgrade-v1.yaml
@@ -1,12 +1,17 @@
 metadata:
-  version: "1.0.0"
+  version: "2.0.0"
   created: "2026-04-12"
   author: PAIML Engineering
   registry: true
   description: >
-    Provable contract for wasmtime 27→43 upgrade. Ensures the upgrade
-    preserves all WasmRuntime functionality and eliminates security
-    advisory exemptions.
+    Provable contract for the wasmtime upgrade path. v2.0.0 records the
+    43→47.0.4 bump (RUSTSEC-2026-0269, CVSS 8.8 filesystem sandbox escape).
+    The 27→43 step satisfied api_compatibility and behavioral_parity but
+    NEVER satisfied advisory_elimination -- eleven wasmtime/cranelift ids stayed
+    exempt in .cargo/audit.toml for the whole life of 43.x, the last of them
+    added on the final day of it. 47.0.4 discharges
+    all three: zero source changes, 73 runtime tests pass, and every wasmtime
+    exemption is deleted.
   references:
   - "docs/specifications/wasmtime-upgrade-v1.md"
   - "crates/aprender-test-lib/src/runtime.rs"
@@ -32,7 +37,7 @@ equations:
   behavioral_parity:
     formula: |
       For all test cases T in WasmRuntime tests:
-        result(T, wasmtime_43) == result(T, wasmtime_27)
+        result(T, wasmtime_47) == result(T, wasmtime_43)
     domain: WasmRuntime test suite
     codomain: bool
     invariants:
@@ -48,14 +53,14 @@ equations:
     domain: security advisory database
     codomain: bool
     invariants:
-    - "No wasmtime advisory in RUSTSEC database for v43"
+    - "No wasmtime advisory in RUSTSEC database for the pinned version (47.0.4)"
     - ".cargo/audit.toml has zero wasmtime entries"
     - "deny.toml has zero wasmtime entries"
 
 falsification_tests:
 - id: FALSIFY-WASM-001
   rule: api_compatibility
-  prediction: "cargo check -p aprender-test-lib --features runtime compiles"
+  prediction: "cargo check -p aprender-test-lib --features runtime compiles (needs Rust >=1.94; wasmtime 47 MSRV)"
   test: "cargo check -p aprender-test-lib --features runtime"
   if_fails: "API signature changed — check compiler errors for specific methods"
 
@@ -69,13 +74,13 @@ falsification_tests:
   rule: advisory_elimination
   prediction: "cargo deny check advisories passes without wasmtime exemptions"
   test: "cargo deny check advisories"
-  if_fails: "wasmtime 43 still has active advisories — check RUSTSEC database"
+  if_fails: "the pinned wasmtime still has active advisories — check RUSTSEC database"
 
 - id: FALSIFY-WASM-004
   rule: api_compatibility
   prediction: "wasm_reference_types works with gc feature"
   test: "cargo check -p aprender-test-lib --features runtime"
-  if_fails: "gc feature not enabled or wasm_reference_types removed in v43"
+  if_fails: "gc feature not enabled or wasm_reference_types removed in the pinned version"
 
 proof_obligations:
 - type: postcondition

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,6 @@ ignore = [
     # 0.7->0.8 is a large API migration), tonic 0.12 `channel` -> tower 0.4.13, and the
     # published trueno-ublk/pacha/renacer stack (block-device/registry features). Each
     # needs an upstream major bump; no safe drop-in exists yet.
-    # wasmtime 43 + cranelift — test-only dep, not production. Upgrade to >=43.0.2 when available.
     # quick-xml 0.37.5 quadratic parse of duplicate-attribute start tags (DoS, not
     # RCE). Advisory: affected ONLY via `NsReader`; aprender-orchestrate's sole use
     # (oracle/arxiv.rs) is `quick_xml::Reader`, never `NsReader`, so we do not hit


### PR DESCRIPTION
Closes #2806. Follows #2805 (the containment) with the actual fix.

## What this is

#2805 stopped the bleeding by adding RUSTSEC-2026-0269 to `.cargo/audit.toml`. That was
the right andon call. This PR is the reason it stays a containment instead of becoming
the twelfth permanent exemption: **wasmtime moves 43 -> 47.0.4 and all ten wasmtime
exemptions are deleted.**

The same bump was already deferred once, in writing, in the `RUSTSEC-2026-0222` note:

> The fix is a real upgrade, not this line: 43 -> >=46.0.2,<47 or >=47.0.3, a four-major
> jump on a test-only dep. Tracked separately; revisit before anything starts enabling
> `runtime`.

**That premise does not survive contact.** `crates/aprender-test-lib/src/runtime.rs` is the
only file in the workspace that touches wasmtime — a bare `Linker` with four host functions
— and every API it uses is unchanged in 47. There is no API work. The diff is one manifest
line plus the lock.

## Verification

Baseline reproduced **before** anything changed, using the reusable workflow's exact
command shape (`sed` the RUSTSEC ids out of `.cargo/audit.toml` into `--ignore` flags):

| state | result |
|---|---|
| `origin/main` audit.toml + wasmtime 43 lock | **exit 1** — `error: 1 vulnerability found!`, 9 allowed warnings, RUSTSEC-2026-0269 present |
| this PR (trimmed audit.toml + wasmtime 47 lock) | **exit 0** — 0 wasmtime/cranelift advisories, 5 allowed warnings |

Compile and test, with the feature actually enabled (a `cargo check --workspace` never
builds an optional feature and would have proved nothing):

| step | result |
|---|---|
| `cargo check -p aprender-test-lib --features runtime` @ 43 (baseline) | exit 0 |
| `cargo +1.95 check -p aprender-test-lib --features runtime` @ 46.0.3 | exit 0, **no source edits** |
| `cargo +1.95 check -p aprender-test-lib --features runtime` @ 47.0.4 | exit 0, **no source edits** |
| `cargo +1.95 test -p aprender-test-lib --features runtime --lib -- runtime` | **73 passed, 0 failed** |

Mutation-verified rather than asserted — the exemptions were proved obsolete by **deleting
them**, not by reasoning:

```
wasmtime 43 lock + trimmed audit.toml -> exit 1, "2 vulnerabilities" (-0269 and -0222)
wasmtime 47 lock + trimmed audit.toml -> exit 0
```

Deleted as obsolete: `RUSTSEC-2026-0085 / -0086 / -0088 / -0089 / -0091 / -0092 / -0094 /
-0096 / -0114 / -0222`.

Allowed warnings drop 9 -> 5: `bitmaps`, `im-rc` and `sized-chunks` (x2) entered solely
through cranelift 0.130's tree and are gone at 0.134. **No warning became an error, and
nothing new appeared.**

## The one real tradeoff, stated plainly

wasmtime >=46 requires **Rust 1.94.0**; `rust-toolchain.toml` pins **1.93.0**. Both fixed
lines (46.0.3 and 47.0.4) need 1.94.

CI stays green anyway, and this was checked rather than assumed:
`cargo check -p aprender-test-lib` (default features, rustc 1.93.0, wasmtime 47 in the
lock) exits **0**. `runtime` is optional and nothing in the workspace,
`.github/workflows/`, `scripts/` or the `Makefile` enables it, so cargo never builds
wasmtime and the MSRV check never fires.

The honest cost: **`--features runtime` now needs Rust 1.94+ until the pin moves.** The
feature is already dark, and cargo fails with an explicit MSRV message rather than
silently — but it is a real regression and is documented at the dep declaration, not
buried. The toolchain bump is deliberately not bundled here; measured separately,
`cargo +1.95 check --workspace` is clean (0 errors) but clippy surfaces ~56 new code lints
across ~11 classes that would fail under `-D warnings`. That belongs in its own PR (#2806).

## Reachability, re-verified from scratch

Not inherited from the audit.toml note. The check needed a positive control first: an early
pattern matched the worktree path `/home/noah/src/aprender-wasmtime-fix/` itself and made
every tree look full of wasmtime. Pattern validated against a known-true case
(`-p aprender-test-lib --features runtime` -> 35 matches) before any zero was trusted, and
every tree below is non-empty.

| invocation | tree lines | wasmtime |
|---|---|---|
| `cargo tree -p aprender` | 1808 | **0** |
| `cargo tree -p aprender --no-default-features` | 140 | **0** |
| `cargo tree -p aprender --all-features` | 2051 | **0** |
| `cargo tree -p apr-cli` | 1904 | **0** |
| `cargo tree -p apr-cli --all-features` | 2155 | **0** |
| `cargo tree -e normal -p aprender` | 1713 | **0** |
| `cargo tree --workspace` | 3539 | **0** |
| `cargo tree --workspace --all-features` | 5492 | 35 |

No CI lane runs `--workspace --all-features`: `make coverage` (coverage-nightly.yml) is
`--workspace --exclude aprender-gpu --lib`, and `cargo mutants` (ci.yml) is `-- --lib`. The
`--all-features` targets that would pull it in (`test-full`, `coverage-full`) are not
CI-wired.

Second, independent reason it was never exploitable: per GHSA-vqjp-4c8c-hfgg the vulnerable
code lives in **`wasmtime-wasi`**, which is not in `Cargo.lock` at all. The vulnerable code
was not merely unreachable — it was not compiled.

## Also in here

`contracts/wasmtime-upgrade-v1.yaml` -> 2.0.0. Its `advisory_elimination` equation ("zero
wasmtime entries in `.cargo/audit.toml`") was **false for the entire life of the 43.x
cluster and nothing noticed** — none of its FALSIFY-WASM tests are wired into CI
(`grep -rn "wasmtime-upgrade\|FALSIFY-WASM" .github/ scripts/ Makefile` returns nothing).
This PR makes the equation true. Wiring the falsifiers so it can fail again is noted in
#2806 as the dark-target class.

`pv validate contracts/wasmtime-upgrade-v1.yaml` -> 0 errors, 0 warnings.

## Merge order

Land **after** #2805. This branch is cut from `origin/main` and will conflict with it in
`.cargo/audit.toml`; resolve by taking this side and additionally deleting #2805's
`RUSTSEC-2026-0269` line, which this bump makes obsolete. `cargo audit` must come out
exit 0 with **zero** wasmtime ids in the file.
