### PR TITLE
fix(ci): workspace-test cleared its worst passing run by 12 seconds, and 180 is above the merge queue's ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,50 @@ jobs:
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
     runs-on: [self-hosted, X64, Linux, clean-room]
-    # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
-    # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
-    # timeout always fired first -- producing a bare "The operation was canceled"
-    # that names no step. Job 95162862834 died exactly on the 85-minute mark this
-    # way. The step timeout must be the one that can fire, because it points at
-    # the step; the job timeout is the backstop behind it.
-    timeout-minutes: 100
+    # 110, not 85 and not 180. The step below sets `timeout-minutes: 75`, but
+    # "Set up runner" (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85
+    # and the JOB timeout always fired first -- producing a bare "The operation was
+    # canceled" that names no step. Job 95162862834 died exactly on the 85-minute
+    # mark this way. A step timeout points at its step; the job timeout is the
+    # backstop behind it, so the step timeout should fire first wherever it can.
+    #
+    # 2026-08-31: 100 -> 110. Two measurements bracket this number. Both were taken
+    # over the last 300 ci.yml runs (2026-08-21..08-31), 263 of which have a
+    # workspace-test job, via
+    #   gh api "repos/paiml/aprender/actions/runs/<run_id>/jobs?per_page=100"
+    # reading each job's and each step's started_at/completed_at.
+    #
+    #   FLOOR -- what the job actually costs. Whole-job wall time over the 167
+    #   SUCCESSFUL workspace-test jobs: p50 49.8 / p90 79.9 / p95 86.0 / max 99.8
+    #   min. The old 100 therefore cleared the worst PASSING run by 0.2 min --
+    #   twelve seconds -- so ordinary fleet contention killed jobs outright.
+    #   Annotation "The job has exceeded the maximum execution time of 1h40m0s"
+    #   (gh api repos/paiml/aprender/check-runs/<job_id>/annotations) appears on
+    #   FOUR pull_request jobs on 2026-08-31 -- 99429841306, 99429947811,
+    #   99430178683, 99435047969 -- and earlier on 97080910427 (08-22),
+    #   98821621525 and 98885816137 (08-28). It was already firing for nine days.
+    #   110 is 1.10x the measured max.
+    #
+    #   CEILING -- what the merge queue will wait for. Ruleset 17836320
+    #   ("Merge Queue (main)", `gh api repos/paiml/aprender/rulesets/17836320`)
+    #   sets check_response_timeout_minutes: 120: an entry is dropped if its
+    #   required checks have not reported within 120 min of the merge group
+    #   forming, and that clock includes runner wait. Over the 64 merge_group runs
+    #   in the window, group-created -> workspace-test-started was p50 0.05 /
+    #   p90 3.92 / p95 7.05 min. 110 leaves 10 min for that wait, above p95.
+    #   Anything above ~113 is unreachable in the only path that merges, so the
+    #   80 minutes 180 would have added are 60 minutes of nothing plus a 3-hour
+    #   runner hold on a contended box.
+    #
+    #   NOT the cause: no merge-queue build was killed by this timeout. The two
+    #   long merge_group workspace-test jobs of 2026-08-31 ran 84.9 min
+    #   (99433658084) and 79.4 min (99441760471) and never reached 100. The first
+    #   was killed by THIS workflow's own `concurrency: cancel-in-progress` --
+    #   re-enqueuing PR #2776 formed a second merge_group run on the SAME
+    #   gh-readonly-queue ref, hence the same concurrency group ("Canceling since
+    #   a higher priority waiting request for ci-refs/heads/gh-readonly-queue/
+    #   main/pr-2776-745fa8588... exists"). The second was cancelled by hand.
+    timeout-minutes: 110
     env:
       IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
@@ -305,6 +342,37 @@ jobs:
             "$IMAGE" \
             bash -c 'cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q "test result: ok\." /tmp/compute-test.log && ! grep -q "test result: FAILED" /tmp/compute-test.log'
       - name: Integration tests
+        # 2026-08-31: this step had NO step timeout, so when it ran long the JOB
+        # timeout fired instead -- producing the bare "The operation was canceled"
+        # that names no step, which is precisely the failure the job-level comment
+        # above says the step timeout exists to prevent. All FOUR of that day's
+        # 100-minute kills were here; the lib step had already SUCCEEDED in
+        # 53.2 / 54.1 / 54.7 / 53.5 min in those same four jobs.
+        #
+        # 55 is measured on THIS step, not inferred from job totals. Subtracting
+        # the endpoints of a totals range from the endpoints of a lib-step range
+        # does not give the range of the per-run differences, and it was wrong
+        # here: that arithmetic said "21-39 min", the 170 successful Integration
+        # steps in 2026-08-21..08-31 actually ran
+        #   min 8.8  p50 20.3  p90 38.3  p95 42.6  p99 48.0  max 51.2 min
+        # -- a tail 12 minutes past the top of the inferred band.
+        #
+        # 55 is the SMALLEST value that would have killed none of those 170 runs
+        # (50 kills 2 of them) and it is 1.07x the observed max. Every larger
+        # value protects nothing more while shrinking the window in which THIS
+        # timeout -- the one that names the step -- fires ahead of the job
+        # timeout: with the 110-min job timeout and p95 fixed overhead of 6.3 min
+        # (pre-lib 1.4 + Compute tests 2.7 + post-integration 2.2), this step
+        # timeout precedes the job timeout whenever the lib step is <= 48.7 min,
+        # which is 91.5% of the 212 observed lib steps. At 75 it would be 52.4%.
+        #
+        # Residual, stated rather than papered over: 75 (lib) + 55 (this) + 6.3
+        # = 136 min > the 110 the merge queue's 120-min ceiling allows, so when
+        # BOTH steps run long the job timeout still fires first and still names
+        # no step. No timeout value fixes that -- only a faster job, less
+        # contention, or raising check_response_timeout_minutes on ruleset
+        # 17836320 (a repo-settings change, deliberately not made here).
+        timeout-minutes: 55
         # #2465: the four FALSIFY-AUTH targets were appended here because they
         # were DARK — `falsify_auth_002` appeared nowhere in .github/, scripts/
         # or Makefile, and neither did the contract loader


### PR DESCRIPTION
> **Correction to the first version of this PR.** It claimed five `workspace-test`
> jobs died at the 100-minute wall on 2026-08-31 **"including the merge queue's own
> build."** The second half is **false**, the first half is off by one, and the
> Integration step's 75 rested on invalid range arithmetic. All three are
> re-derived below from the jobs and annotations APIs. Nothing here is inherited
> from the previous description.

## What actually ended the two merge-queue builds

**Neither was killed by `timeout-minutes: 100`.** They ran **84.9 min** and
**79.4 min** and never reached 100.

| merge_group run | job | wall | what the annotation says |
|---|---|---|---|
| 33374766418 (`pr-2776`) | 99433658084 | 84.9 min | `Canceling since a higher priority waiting request for ci-refs/heads/gh-readonly-queue/main/pr-2776-745fa8588... exists` |
| 33377367243 (`pr-2773`) | 99441760471 | 79.4 min | `The run was canceled by @noahgift.` |
| 33381514714 (`pr-2776`, 2nd) | 99455900043 | 21.1 min | `The run was canceled by @noahgift.` |
| 33371582516 (`pr-2773`, 1st) | 99423697896 | 24.3 min | real test **failure** in `Compute tests` |

The first one is **this workflow cancelling itself.** `ci.yml:27` is

```yaml
group: ci-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: true
```

A `merge_group` event has no `pull_request.number`, so the key falls back to
`github.ref` — and the `gh-readonly-queue` ref is **identical across re-enqueues
of the same PR at the same base sha**. Re-adding #2776 at `10:14:19` formed run
33381514714 on `gh-readonly-queue/main/pr-2776-745fa8588…`, the same ref the
in-flight run held, and `cancel-in-progress` killed it 33 s later.

**Dequeuing was not the mechanism either**, though I did dequeue both by hand.
#2773 left the queue at `09:25:25`; its `merge_group` run held a runner for **76
more minutes** until the manual cancel at `10:41:55`. #2776 left at `10:17:00`
and held one for **25 more**. Removing a PR from the merge queue does **not**
cancel the `merge_group` run it already started — ≈101 runner-minutes of zombie
build on an already-saturated box. Separate defect; not fixed here.

```bash
gh api repos/paiml/aprender/actions/runs/<run_id>/jobs?per_page=100
gh api repos/paiml/aprender/check-runs/<job_id>/annotations
gh api repos/paiml/aprender/issues/2773/timeline
```

**Timeout kills that day: four, not five** — all `pull_request` builds, all in
`Integration tests`, all carrying `The job has exceeded the maximum execution
time of 1h40m0s`: 99429841306, 99429947811, 99430178683, 99435047969. The fifth
job I counted (99435498365, 96.6 min) says `The run was canceled by @noahgift`.

## Still true, and worse than I claimed

The gate *was* marginally sized — far more so than "23 minutes", which came from
a six-run one-day sample. Over the **167 successful** `workspace-test` jobs in
the last 300 `ci.yml` runs (2026-08-21…08-31):

| whole-job wall | p50 | p90 | p95 | **max** |
|---|---|---|---|---|
| minutes | 49.8 | 79.9 | 86.0 | **99.8** |

`timeout-minutes: 100` cleared the worst **passing** run by **0.2 min — twelve
seconds.** The same `1h40m0s` annotation also appears on 97080910427 (08-22),
98821621525 and 98885816137 (08-28): it had been firing for **nine days**, not one.

## The two numbers, both regrounded

### 1. Job timeout `100 → 110`, not 180

Ruleset **17836320** ("Merge Queue (main)") sets
**`check_response_timeout_minutes: 120`** — a queued entry is dropped if its
required checks have not reported within 120 min of the merge group forming, and
**that clock includes runner wait.** Over the window's 64 `merge_group` runs,
group-created → `workspace-test`-started was p50 `0.05` / p90 `3.92` / **p95
`7.05`** min.

```bash
gh api repos/paiml/aprender/rulesets/17836320
```

So `110` leaves 10 min for that wait (above p95) and is **1.10× the measured max
passing job (99.8)**. `180` sat **60 minutes above anything the queue will ever
wait for** — unreachable in the only path that merges, and a 3-hour runner hold
everywhere else. Raising the ruleset instead is a repo-settings change and is
deliberately out of scope for a workflow-file-only PR.

### 2. Integration step timeout `75 → 55`, and re-derived

The 75 rested on a "healthy band ~21–39 min" obtained by subtracting a lib-step
range from a totals range. **The difference of two ranges is not the range of the
differences** — the per-run pairing is what matters, and the shortcut was wrong
here. Measured directly, the **170 successful** `Integration tests` steps in the
window:

| min | p50 | p90 | p95 | p99 | **max** |
|---|---|---|---|---|---|
| 8.8 | 20.3 | 38.3 | 42.6 | 48.0 | **51.2** |

— a tail **12 minutes past the top of the inferred band**.

`55` is chosen, not assumed:

| candidate | successful integ steps it would have killed | step timeout fires before the job timeout in… |
|---|---|---|
| 50 | **2 / 170** | 97.2% of lib steps |
| **55** | **0 / 170** (1.07× max) | **91.5%** |
| 60 | 0 / 170 | 83.0% |
| 75 | 0 / 170 | 52.4% |

It is the **smallest value that kills none of the observed passing runs**, and
every larger value protects nothing more while shrinking the window in which the
*step* timeout — the one that names the step — fires ahead of the job timeout.
That window: with `110` and 6.3 min of p95 fixed overhead (pre-lib 1.4 + Compute
tests 2.7 + post-integration 2.2), the step timeout fires first whenever the lib
step is ≤ 48.7 min, which is 91.5% of the 212 observed lib steps.

## Residual, stated rather than papered over

`75` (lib) + `55` (integration) + `6.3` overhead = **136 min**, above the `110`
the queue's 120-minute ceiling permits. **When both steps run long the job
timeout still fires first and still names no step.** No timeout value fixes that
— only a faster job, less contention, or raising
`check_response_timeout_minutes` on ruleset 17836320.

## Scope

Unchanged from before, and still true: this does not address *why* the fleet
slowed. 16 org runners share one 32-core box and `paiml/rmedia` CI was running
concurrently. That is a capacity decision. This PR makes the gate correctly
sized against what it measurably costs and against the ceiling the merge queue
actually imposes.

Every number above is a measurement or arithmetic on one, with the command that
produced it.

Refs APR-PERF-GATE-001 (#2706)
