### PR TITLE
perf(ci): [profile.dev] debug = "line-tables-only" — 3.30x off debug/examples, backtraces keep file:line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -647,6 +647,67 @@ path = "src/lib.rs"
 # Contract: ci-infra-v1.yaml F-INFRA-004 — every patch must have tracking issue.
 
 # ----------------------------------------------------------------------------
+# Dev/test debuginfo: line tables only (aprender#2822; paiml/infra#415, #416)
+# ----------------------------------------------------------------------------
+# MEASURED, not assumed. The `workspace-test` job runs
+# `cargo build --examples --workspace --keep-going` (ci.yml), which emits 859
+# example binaries totalling 149 GB, and 94.6% of each binary is DWARF. Section
+# table for `agent_demo` (510 MB): .debug_str 219.9 MB, .debug_info 160.6 MB,
+# .debug_line 50.1 MB, .debug_ranges 36.8 MB -- against .text 11.9 MB. At
+# 186 GB/run the elastic disk budget admits only ~4 concurrent runs while 13
+# were being scheduled, so the CI reaper's emergency purges were arithmetically
+# inevitable: concurrency and disk are the same constraint.
+#
+# Root cause: this manifest had no `[profile.dev]` table at all, so the whole
+# workspace inherited cargo's default `debug = true` (full DWARF) -- and
+# `profile.test` inherits from `profile.dev`, so every test binary paid it too.
+#
+# `line-tables-only` keeps `.debug_line`, so `RUST_BACKTRACE=1` still resolves
+# `file.rs:LINE:COL` for every user frame -- verified by building a panicking
+# example under each setting and reading the backtrace, both directly and
+# through `cargo nextest run --profile ci`. It drops `.debug_info`/`.debug_str`,
+# the type and variable descriptions a *debugger* needs and CI never reads.
+#
+# MEASURED on 86 `aprender-orchestrate` examples, two isolated target dirs,
+# rustc 1.93.0 (`agent_demo` alone: 509,993,400 B -> 163,778,112 B):
+#
+#   setting                     debug/examples      whole target   backtrace
+#   default (debug = true)       17,746,294,665    21,716,092,463   file:line
+#   debug = 1  ("limited")        9,486,586,206    12,559,782,114   file:line
+#   line-tables-only (CHOSEN)     5,381,267,793     8,199,386,836   file:line
+#   line-tables-only + unpacked   3,105,547,047     6,002,663,347   file:line
+#   debug = 0                       417,720,289     2,566,061,079   NAMES ONLY
+#
+# So: 3.30x off `debug/examples`, 2.65x off the whole target dir. NOT the 29x a
+# `strip --strip-debug` of the same binaries reports -- stripping also discards
+# `.debug_line`, which is exactly the 47.3 MB per binary we are paying to keep.
+# Extrapolated to the CI run: debug/examples 149 GB -> ~45-50 GB, whole run
+# 186 GB -> ~75 GB, so the 797 GB elastic budget admits ~10 concurrent runs
+# instead of 4.3.
+#
+# Rejected alternatives:
+#   * `debug = 0`   -- 8.5x off the target dir, but backtrace frames lose
+#                      file:line entirely (measured above). Panic *messages*
+#                      keep it (that is `Location`, not DWARF), so this stays
+#                      the lever to pull if disk pressure returns.
+#   * `debug = 1`   -- alias for "limited": keeps `.debug_info` for types, so it
+#                      leaves the second-largest section in place for 1.87x.
+#   * `split-debuginfo = "unpacked"` -- a further 1.37x with backtraces intact,
+#                      but it is a second, platform-sensitive axis (it changes
+#                      what macOS runners emit) and produces ~1900 `.dwo` files
+#                      per target dir for the reaper to walk. Worth its own PR
+#                      with its own measurement on the mac runners.
+# A developer who wants full DWARF for a debugger session overrides locally:
+#   CARGO_PROFILE_DEV_DEBUG=full cargo build
+#
+# NOTE: `debug` and `debug-assertions` are INDEPENDENT settings. This sets only
+# `debug`; `debug-assertions` keeps its dev-profile default (true), so every
+# `debug_assert!` in the workspace still fires and the proptest carve-out below
+# -- the one place we deliberately disable them -- is unaffected.
+[profile.dev]
+debug = "line-tables-only"
+
+# ----------------------------------------------------------------------------
 # proptest debug-assertion workaround (Toyota Way: root-cause flaky-test fix)
 # ----------------------------------------------------------------------------
 # proptest 1.11.0 (latest published) has an OVER-STRICT, buggy `debug_assert!`


### PR DESCRIPTION
## What

The workspace root manifest has **no `[profile.dev]` table at all**, so every dev
and test target inherits cargo's default `debug = true` — full embedded DWARF.
This adds one setting:

```toml
[profile.dev]
debug = "line-tables-only"
```

`profile.test` inherits from `profile.dev`, so this covers test binaries too.

## Why

`workspace-test` runs `cargo build --examples --workspace --keep-going`
(ci.yml). That emits 859 example binaries totalling 149 GB, of which 94.6% is
DWARF. At 186 GB per run, the 797 GB elastic budget admits ~4.3 concurrent
runs; 13 were being scheduled. The reaper's emergency purge deleting
`target/debug/deps` mid-build (#2822) was arithmetically inevitable —
concurrency and disk are the same constraint.

## Measured, not asserted

Two isolated `CARGO_TARGET_DIR`s off the same worktree, 86
`aprender-orchestrate` examples, rustc 1.93.0, `CARGO_INCREMENTAL=0`. Baseline
built from unmodified `origin/main` (75b178a93), not inherited from a prior
report.

| binary | before (B) | after (B) | ratio |
|---|---:|---:|---:|
| `agent_demo` | 509,993,400 | 163,778,112 | 3.11x |
| `publish_status_demo` | 501,325,712 | 157,579,856 | 3.18x |
| `oracle_local_demo` | 498,855,608 | 155,188,664 | 3.21x |
| `playbook_demo` | 494,498,776 | 151,037,992 | 3.27x |
| `bug_hunter_demo` | 493,712,664 | 150,374,328 | 3.28x |
| **aggregate (5)** | **2,498,386,160** | **777,958,952** | **3.21x** |

Directory totals over all 86 examples:

| | before (B) | after (B) | ratio |
|---|---:|---:|---:|
| `debug/examples` | 17,746,294,665 | 5,381,267,793 | 3.30x |
| `debug/deps` | 3,653,535,950 | 2,513,710,346 | 1.45x |
| whole target dir | 21,716,092,463 | 8,199,386,836 | 2.65x |

Per-binary ratio across the 86: median 3.33x, max 3.35x, min 1.00x (five
trivial 3.9 MB examples whose debug info is entirely precompiled `std`).

**Extrapolated to the CI run:** `debug/examples` 149 GB → ~45–50 GB (the fleet's
mean binary is 173 MB against this sample's 403 MB, and small binaries save
proportionally less, hence the range), whole run 186 GB → **~75 GB**. The
797 GB budget then admits **~10 concurrent runs instead of 4.3**.

### The saving is 3.3x, not 29x — and that is correct

The 29.4x figure came from `strip --strip-debug`, which also discards
`.debug_line`. `line-tables-only` deliberately keeps it: 47.3 MB of the
163.8 MB that remains in `agent_demo` **is** the line table, and it is the whole
reason to prefer this over `debug = 0`. Section table for `agent_demo`:

| section | before | after |
|---|---:|---:|
| `.debug_str` | 220,512,764 | 51,990,644 |
| `.debug_info` | 157,997,709 | 20,088,040 |
| `.debug_line` | 49,360,075 | 47,284,851 |
| `.debug_ranges` | 36,950,368 | 10,527,968 |
| `.text` | 9,588,116 | 8,673,124 |

## Backtraces still carry file:line (measured)

A panicking example built under each setting, run with `RUST_BACKTRACE=1`:

```
default (debug = true)        line-tables-only              debug = 0
 2: zz_panic_probe::level_three   2: zz_panic_probe::level_three   2: zz_panic_probe::level_three
      at .../probe.rs:3:5              at .../probe.rs:3:5         3: zz_panic_probe::level_two
 3: zz_panic_probe::level_two    3: zz_panic_probe::level_two      4: zz_panic_probe::level_one
      at .../probe.rs:7:5              at .../probe.rs:7:5
```

`debug = 0` keeps function names and loses file:line. `line-tables-only` is
byte-for-byte identical to the default here. Also verified end-to-end through
`cargo nextest run --profile ci` on a deliberately failing test, since that is
the exact path a `workspace-test` failure takes.

One honest note: **nextest does not set `RUST_BACKTRACE=1` by default** — a
failing test in `workspace-test` prints only the panic-message `file.rs:LINE`,
which comes from `Location` and survives `debug = 0` too. The frame-level
file:line matters for `qwen-story-daily.yml` (which sets `RUST_BACKTRACE: '1'`)
and for anyone reproducing locally.

## Alternatives, all built and measured

| setting | `debug/examples` | whole target | backtrace |
|---|---:|---:|---|
| default (`debug = true`) | 17,746,294,665 | 21,716,092,463 | file:line |
| `debug = 1` ("limited") | 9,486,586,206 | 12,559,782,114 | file:line |
| **`line-tables-only` (chosen)** | **5,381,267,793** | **8,199,386,836** | **file:line** |
| `line-tables-only` + `split-debuginfo = "unpacked"` | 3,105,547,047 | 6,002,663,347 | file:line |
| `debug = 0` | 417,720,289 | 2,566,061,079 | names only |

- **`debug = 1`** keeps `.debug_info` for types — the second-largest section.
  Only 1.87x.
- **`split-debuginfo = "unpacked"`** is *not* pure relocation as I expected: it
  dedupes DWARF that 86 statically-linked binaries otherwise each copy, so it is
  a real further 1.37x with backtraces intact. Deliberately **not** in this PR:
  it is a second, platform-sensitive axis (it changes what macOS runners emit)
  and produces ~1900 `.dwo` files per target dir for the reaper to walk. It
  deserves its own PR and its own measurement on the mac runners.
- **`debug = 0`** is 8.5x off the target dir and would extrapolate to ~26 GB per
  run (~30 concurrent runs). **Dissent recorded:** if the goal is to admit 13
  concurrent runs without the reaper firing, `line-tables-only` alone gets to
  ~10 and does not fully clear it; `debug = 0` or stacking `split-debuginfo`
  would. I chose the setting that keeps the diagnostic CI cannot reconstruct
  after the fact (logs expire), because it is a one-token change to tighten
  later and the measured table above is already in hand.

## Collateral damage checked

- **`debug` and `debug-assertions` are independent settings.** Verified, not
  assumed: a probe binary built under the new profile prints
  `cfg!(debug_assertions) = true`, its `debug_assert!` fires, and `255u8 + 1`
  still panics (overflow-checks on).
- **The `[profile.dev.package.proptest]` carve-out still applies.**
  `cargo test -v` shows proptest compiled with
  `-C debug-assertions=off -C debuginfo=line-tables-only`; the new profile
  reaches it and the override is not shadowed.
- **Nothing in the workspace reads DWARF from a workspace-built artifact.**
  `aprender-profile` depends on `gimli`/`addr2line`, but its DWARF tests compile
  their own fixtures with an explicit `rustc -g` (and are `#[ignore]`d).
- **No size-based assertion is affected.** `beat_pytorch_deploy_footprint`
  measures the **release** binary (`cargo test --release`), which this does not
  touch; every other `*_size` assertion in the tree is about model files.
- `cargo test -p aprender-core --lib` — **14256 passed, 0 failed**.
- `cargo test -p aprender-profile --lib` — **1469 passed, 0 failed**.
- `cargo fmt --all -- --check` — clean.

A developer who wants full DWARF for a debugger session overrides locally:
`CARGO_PROFILE_DEV_DEBUG=full cargo build`.

Refs #2822, paiml/infra#415, paiml/infra#416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
