### PR TITLE
ci(2822): make the next mid-build ENOENT name the step and the host actor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,21 @@ jobs:
       # passes on the merge-base can still red here, and CI is authoritative.
       - name: Fetch origin/main as the comparand for every ratchet in this job
         run: git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+      # aprender#2822. Case table FIRST, per the convention above: the probe
+      # below is only worth its 0.15s if the classifier it feeds can still turn
+      # RED. Seven rows over a throwaway tree - no cargo, no network, no host.
+      # Mutation-verified: deleting the sentinel rule, deleting the inode rule,
+      # or restoring the read-after-plant ordering bug each takes it RED.
+      #
+      # This step IS a gate and may fail the job. The probe and report steps are
+      # not and never can - a recorder that can red a required check is a
+      # liability, and #2822 is already red.
+      - name: "target-watch case table (aprender#2822)"
+        run: bash scripts/ci_target_watch.sh --self-test
+      - name: "target-watch: post-checkout"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "post-checkout"
       # A baseline that no guard compares to anything is an allowlist wearing
       # the word "ratchet". This is the coverage backstop: every scripts/*.txt
       # is classified shrink-only (and compared) or NOT-a-ratchet (with the
@@ -574,6 +589,10 @@ jobs:
         run: bash scripts/check_pv_version_parse.sh
       - name: "pv --version parse guard must still turn RED (case table)"
         run: bash scripts/check_pv_version_parse.sh --self-test
+      - name: "target-watch: before-cargo-install-bashrs"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-cargo-install-bashrs"
       # CLAUDE.md mandates bashrs over shellcheck; CI honoured that for SEVEN of
       # 72 scripts (`bashrs lint scripts/check_book_*.sh` in book.yml).
       # apr_bin.sh -- sourced by every gate in this repo -- was not one of them,
@@ -831,6 +850,10 @@ jobs:
         run: bash scripts/check_publish_safety.sh
       - name: Every include!() file is tracked by git (CB-510)
         run: bash scripts/check_include_files.sh
+      - name: "target-watch: before-pv-build"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-pv-build"
       # #2512: these two were invoked by NO workflow -- one Makefile-only
       # (`make tier3`, which CI does not run), one reachable from nothing at all.
       # Both pass today and are cheap, so there was never a reason for them to be
@@ -854,6 +877,10 @@ jobs:
         run: bash scripts/check_pv_bin_resolution.sh
       - name: Every contract cites a test that exists (strict-test-binding)
         run: bash scripts/check_contract_test_binding.sh
+      - name: "target-watch: before-contracts-tests"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-contracts-tests"
       # Poka-yoke (#2551): `cargo test -p aprender-contracts --test
       # validate_contracts` is the only thing that parses and validates the
       # contract corpus from Rust rather than through `pv lint`. It failed 3 of
@@ -874,8 +901,16 @@ jobs:
           cargo test -p aprender-contracts --test validate_contracts
           cargo test -p aprender-contracts --test kani_harness_generation
           cargo test -p aprender-contracts --test probar_test_generation
+      - name: "target-watch: before-wasm32-build"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-wasm32-build"
       - name: aprender-core builds for wasm32
         run: bash scripts/check_wasm32_core_builds.sh
+      - name: "target-watch: before-facade-compat"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-facade-compat"
       # aprender#2546: `provable-contracts*` were renamed to `aprender-contracts*`
       # and the published names left frozen at 0.3.1. A pin on the old name
       # resolved SILENTLY and installed a tool sixty versions behind. The names
@@ -1148,6 +1183,10 @@ jobs:
         run: bash scripts/check_dogfood_llm_probe_armed.sh
       - name: dogfood LLM probe guard case table
         run: bash scripts/check_dogfood_llm_probe_armed.sh --self-test
+      - name: "target-watch: before-profile-tests"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-profile-tests"
       # aprender-profile appeared in this file ZERO times while carrying 58
       # integration test targets. Running them found 110 failures -- 109 from a
       # single stale binary name left by the APR-MONO rename, dead since. Gated
@@ -1179,6 +1218,10 @@ jobs:
         run: bash scripts/check_model_tests_wired.sh
       - name: model-tests wiring case table
         run: bash scripts/check_model_tests_wired.sh --self-test
+      - name: "target-watch: before-model-tests-docker"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-model-tests-docker"
       - name: model-tests falsification suites (was gated by nothing, aprender#2522)
         # Runs INSIDE the image, on the same per-RUN target dir as the other
         # cargo steps, so the `model-tests` feature build reuses this run's
@@ -1201,8 +1244,16 @@ jobs:
               --test falsification_spec_v10_tests \
               --test falsification_stress_tests \
               --test falsification_gpu_state_tests
+      - name: "target-watch: before-book-examples"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-book-examples"
       - name: Book rust examples compile
         run: bash scripts/check_book_examples_compile.sh
+      - name: "target-watch: before-cargo-package"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-cargo-package"
       # CB-510: a Cargo.toml `exclude` pattern can strip an include!() target
       # from the published crate while git still tracks it, so the crate compiles
       # in-tree and fails for everyone installing from crates.io. This guard is
@@ -1270,6 +1321,10 @@ jobs:
       - name: Publishable-deps guard case table
         run: bash scripts/check_publishable_deps_publishable.sh --self-test
 
+      - name: "target-watch: before-cargo-deny-install"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "before-cargo-deny-install"
       # `cargo deny` ran in ZERO workflows -- only `make deny`. Positive control:
       # 9 workflows mention `cargo`, 0 mentioned `deny`. Meanwhile the `security`
       # job runs `cargo audit` with continue-on-error, which cannot fail the build
@@ -1335,6 +1390,10 @@ jobs:
         run: bash scripts/check_test_fixture_paths.sh
       - name: Fixture-path guard case table
         run: bash scripts/check_test_fixture_paths.sh --self-test
+      - name: "target-watch: after-last-cargo-step"
+        # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
+        # Instrumentation, never a gate: the script always exits 0.
+        run: bash scripts/ci_target_watch.sh probe "after-last-cargo-step"
       # #2532: the guard above has a universe of crates/**/tests?/**/*.rs, which
       # structurally excludes 100% of the 324 machine-specific paths pmat found
       # in SHIPPED code -- 46 of them inside contracts/ itself. Seventeen crux
@@ -1365,6 +1424,28 @@ jobs:
         run: bash scripts/check_hardcoded_paths.sh --self-test
       - name: Whole-tree machine-specific-path ratchet (arms itself at pmat >= 3.32.0)
         run: bash scripts/check_hardcoded_paths.sh --full-if-capable
+      # aprender#2822: THE REPORT. Runs even when the job dies mid-cargo,
+      # and takes its own final probe first -- without that, a failure at
+      # step K leaves the last recorded boundary BEFORE K and the table
+      # reads clean, which is the whole failure mode being investigated.
+      #
+      # It also pulls the host journal for the job's window into the job
+      # log. That is the decisive evidence and the only evidence that
+      # expires: `_work/*/target` is deleted by HOST automation (a sibling
+      # runner's job-started hook, a systemd timer) which logs under its own
+      # tag and appears in NO GitHub log. See
+      # scripts/runner-infra/runner-disk-guard.sh, whose own header records
+      # this exact signature.
+      #
+      # continue-on-error is deliberate and is NOT a disarmed gate: nothing
+      # here asserts anything. The gate that can fail is the case table
+      # wired above.
+      - name: "target-watch: report (aprender#2822)"
+        if: always()
+        continue-on-error: true
+        run: |
+          bash scripts/ci_target_watch.sh probe post-job
+          bash scripts/ci_target_watch.sh report
 
   # Top-level gate: satisfies org ruleset "Green Main" which requires check named "gate".
   # The reusable workflow produces "ci / gate" but rulesets need exact match on "gate".

--- a/scripts/ci_target_watch.sh
+++ b/scripts/ci_target_watch.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+#
+# ci_target_watch.sh - boundary forensics for aprender#2822.
+#
+# THE FAILURE THIS EXISTS TO NAME
+# -------------------------------
+# Cargo dies with exit 101 whose cause is ENOENT in the middle of a build:
+#
+#   error: could not parse/generate dep info at:
+#     /home/<user>/data/actions-runner-8/_work/aprender/aprender/target/debug/deps/proptest-<hash>.d
+#   Caused by: No such file or directory (os error 2)
+#
+# Four dependency crates at once, while unrelated crates were still compiling.
+# A second signature on a different runner reads "rustc ... <crate> ... never
+# executed". Both point at the target tree disappearing UNDER a live cargo,
+# not at anything in the PR diff.
+#
+# Remote log forensics cannot close this, for a structural reason: the actor is
+# not in the job. `_work/*/target` is deleted by HOST-side automation - a
+# sibling runner's ACTIONS_RUNNER_HOOK_JOB_STARTED hook, or a systemd timer -
+# which logs to the journal under its own tag and appears in no GitHub log at
+# all. scripts/runner-infra/runner-disk-guard.sh states the mechanism in its own
+# header: "an unconditional rm -rf on every target/ deleted .rlib files out from
+# under in-progress cargo builds on sibling runners, producing 'No such file or
+# directory' errors for hours at a time."
+#
+# So the evidence has to be collected INSIDE the job, at boundaries, and the
+# host journal has to be pulled into the job log while it still exists.
+#
+# WHAT THIS IS AND IS NOT
+# -----------------------
+# This is INSTRUMENTATION, not a gate. `probe` and `report` always exit 0: a
+# recording device that can red a required check is a liability, and #2822 is
+# already red. It does NOT swallow its own errors either - every failure it
+# hits is printed as a DEGRADED line naming the syscall that failed, because
+# this repo has four recorded instances of a check that could not report its
+# own failure.
+#
+# `--self-test` IS a gate, and it is the only mode that can exit non-zero. It
+# proves the boundary classifier still turns RED on a wiped, replaced or
+# truncated tree, on a throwaway directory, with no cargo and no network. An
+# environment death there (no mktemp) reports DEGRADED and exits 0, per the
+# guards-must-classify-env-vs-code rule.
+#
+# COST
+# ----
+# One probe is: 2x stat, 1 readdir of target/debug/deps, 1 df, 1 pgrep. Measured
+# on a 110,890-entry deps directory the readdir is the only non-trivial part, at
+# 0.06s warm. Everything else is sub-millisecond. See the PR body for the
+# end-to-end number.
+#
+# USAGE
+#   bash scripts/ci_target_watch.sh probe "<label>"   # one boundary sample
+#   bash scripts/ci_target_watch.sh report            # verdict + host evidence
+#   bash scripts/ci_target_watch.sh --self-test       # case table
+#
+# ENVIRONMENT
+#   CI_TARGET_WATCH_LOG   TSV path      (default $RUNNER_TEMP/ci-target-watch.tsv)
+#   CI_TARGET_WATCH_ROOT  target root   (default $GITHUB_WORKSPACE/target)
+
+set -uo pipefail
+
+SENTINEL_NAME=".ci-target-watch-sentinel"
+
+# Resolved on every call, never once at load time. --self-test drives `probe`
+# with an overridden environment, and a load-time capture would silently ignore
+# it - the recorder would then be tested only in its default configuration,
+# which is the one shape that never appears in the case table.
+watch_log()  { printf '%s' "${CI_TARGET_WATCH_LOG:-${RUNNER_TEMP:-/tmp}/ci-target-watch.tsv}"; }
+watch_root() { printf '%s' "${CI_TARGET_WATCH_ROOT:-${GITHUB_WORKSPACE:-$PWD}/target}"; }
+
+# `case` in an `if` head parses, but it reads as a puzzle. One named predicate.
+contains() { case "$1" in *"$2"*) return 0 ;; *) return 1 ;; esac; }
+
+# Every diagnostic this script emits about ITSELF goes through here, so a
+# degraded probe is visible in the job log rather than inferred from a gap in
+# the table.
+degraded() {
+    printf 'ci-target-watch DEGRADED: %s\n' "$*" >&2
+}
+
+# stat -c '%i' with the failure reported rather than collapsed to a dash.
+# Prints the value on stdout; prints nothing and returns 1 when absent.
+stat_field() {
+    local path="$1" fmt="$2" out err
+    err=$(stat -c "$fmt" -- "$path" 2>&1 >/dev/null)
+    out=$(stat -c "$fmt" -- "$path" 2>/dev/null)
+    if [ -z "$out" ]; then
+        [ -n "$err" ] && degraded "stat $fmt $path: $err"
+        return 1
+    fi
+    printf '%s' "$out"
+    return 0
+}
+
+# Entry count of a directory via a single readdir. No sort, no per-entry stat,
+# no pipe: the exit status has to be the LISTING's, never wc's.
+dir_count() {
+    local dir="$1" tmp rc out
+    tmp=$(mktemp 2>/dev/null) || { degraded "mktemp failed while counting $dir"; return 1; }
+    ls -U -A -- "$dir" > "$tmp" 2>/dev/null
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        rm -f -- "$tmp"
+        return 1
+    fi
+    out=$(wc -l < "$tmp")
+    rm -f -- "$tmp"
+    printf '%s' "${out// /}"
+    return 0
+}
+
+# Percent-used of the filesystem holding $1. Digits only.
+fs_pct() {
+    local path="$1" out
+    out=$(df -P -- "$path" 2>/dev/null | awk 'NR==2 {print $5}')
+    out="${out//[!0-9]/}"
+    [ -n "$out" ] || return 1
+    printf '%s' "$out"
+    return 0
+}
+
+# The set of GitHub Actions job workers alive on this HOST, comma separated and
+# sorted. A change in this set between two boundaries means a sibling job on
+# this box started or ended - which is exactly when the pre-job hook that prunes
+# target/ trees fires. This is the correlation the job log has never carried.
+worker_pids() {
+    local tmp rc pids
+    tmp=$(mktemp 2>/dev/null) || { degraded "mktemp failed while listing workers"; return 1; }
+    pgrep -f 'Runner\.Worker' > "$tmp" 2>/dev/null
+    rc=$?
+    # rc 1 from pgrep means "no match", which is information, not an error.
+    if [ "$rc" -gt 1 ]; then
+        rm -f -- "$tmp"
+        degraded "pgrep exited $rc while listing Runner.Worker"
+        return 1
+    fi
+    pids=$(LC_ALL=C sort -n < "$tmp" | tr '\n' ',')
+    rm -f -- "$tmp"
+    printf '%s' "${pids%,}"
+    return 0
+}
+
+probe() {
+    local label="${1:-unlabelled}"
+    local WATCH_ROOT WATCH_LOG
+    WATCH_ROOT=$(watch_root)
+    WATCH_LOG=$(watch_log)
+    local deps="$WATCH_ROOT/debug/deps"
+    local sentinel="$deps/$SENTINEL_NAME"
+    local ts_epoch ts_iso runner
+    local root_ino root_mtime deps_ino deps_cnt sen_found sen_armed
+    local fs_pct_root fs_pct_slash workers note
+
+    # Both go straight into the append-only TSV and nothing else; a wall-clock
+    # stamp is the whole point of a boundary record. bashrs disable-line is the
+    # suppression bashrs itself names for this case.
+    ts_epoch=$(date -u +%s)  # bashrs disable-line=DET002
+    ts_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)  # bashrs disable-line=DET002
+    runner="${RUNNER_NAME:-${HOSTNAME:-unknown}}"
+    note="ok"
+
+    # READ THE SENTINEL BEFORE PLANTING IT. The first draft planted it at the
+    # top of the probe and read it three lines later, so the column was 1 on
+    # every row and DEPS-WIPED could not fire - a detector that cannot detect,
+    # which is the class this whole file exists to stop shipping. Read, then
+    # re-plant, and record the re-plant in the note: a boundary whose next row
+    # says `planted-sentinel` is a boundary where the tree was recreated.
+    if [ -e "$sentinel" ]; then sen_found=1; else sen_found=0; fi
+
+    if [ ! -d "$deps" ]; then
+        mkdir -p -- "$deps" 2>/dev/null || degraded "mkdir -p $deps failed"
+    fi
+    if [ -d "$deps" ] && [ ! -e "$sentinel" ]; then
+        if : > "$sentinel" 2>/dev/null; then
+            note="planted-sentinel"
+        else
+            degraded "could not plant sentinel at $sentinel"
+            note="sentinel-unwritable"
+        fi
+    fi
+    # ARMED is the state the NEXT probe will be judged against. Recording only
+    # the as-found state made the very first boundary unjudgeable and, worse,
+    # made a wipe between probe 1 and probe 2 read as 0 -> 0, i.e. clean.
+    if [ -e "$sentinel" ]; then sen_armed=1; else sen_armed=0; fi
+
+    root_ino=$(stat_field "$WATCH_ROOT" '%i') || root_ino="-"
+    root_mtime=$(stat_field "$WATCH_ROOT" '%Y') || root_mtime="-"
+    deps_ino=$(stat_field "$deps" '%i') || deps_ino="-"
+    deps_cnt=$(dir_count "$deps") || deps_cnt="-"
+    fs_pct_root=$(fs_pct "$WATCH_ROOT") || fs_pct_root="-"
+    fs_pct_slash=$(fs_pct /) || fs_pct_slash="-"
+    workers=$(worker_pids) || workers="-"
+
+    if ! printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$ts_iso" "$ts_epoch" "$label" "$runner" "$WATCH_ROOT" \
+        "$root_ino" "$root_mtime" "$deps_ino" "$deps_cnt" \
+        "$sen_found" "$sen_armed" "$fs_pct_root" "$fs_pct_slash" \
+        "$workers" "$note" \
+        >> "$WATCH_LOG" 2>/dev/null
+    then
+        degraded "could not append to $WATCH_LOG"
+        return 0
+    fi
+
+    printf 'target-watch %-34s root_ino=%s deps_ino=%s deps=%s sentinel=%s/%s fs=%s%% /=%s%%\n' \
+        "$label" "$root_ino" "$deps_ino" "$deps_cnt" "$sen_found" "$sen_armed" \
+        "$fs_pct_root" "$fs_pct_slash"
+    return 0
+}
+
+# THE CLASSIFIER. Reads a TSV on stdin, writes one verdict line per SUSPICIOUS
+# boundary on stdout, nothing for a clean one. Split out from `report` so
+# --self-test can drive it directly with no filesystem and no host.
+#
+# Ranked. REPLACED / REMOVED / WIPED are decisive: only an external actor
+# produces them. SHRANK is advisory - cargo removes stale artifacts on its own,
+# so a falling count is a lead rather than a finding.
+classify() {
+    awk -F'\t' '
+    NR == 1 { prev_line = $0; for (i = 1; i <= NF; i++) p[i] = $i; next }
+    {
+        why = ""
+        if (p[6] != "-" && $6 != "-" && p[6] != $6)      why = why " ROOT-REPLACED(inode " p[6] "->" $6 ")"
+        if (p[6] != "-" && $6 == "-")                    why = why " ROOT-REMOVED"
+        if (p[8] != "-" && $8 != "-" && p[8] != $8)      why = why " DEPS-REPLACED(inode " p[8] "->" $8 ")"
+        if (p[11] == 1 && $10 == 0)                      why = why " DEPS-WIPED(sentinel lost)"
+        if (p[9] != "-" && $9 != "-" && $9 + 0 < p[9] + 0) why = why " DEPS-SHRANK(" p[9] "->" $9 ")"
+        if (p[14] != $14)                                why = why " SIBLING-JOB-CHANGED(" p[14] " -> " $14 ")"
+        if (why != "") printf "SUSPICIOUS %s .. %s  [%s -> %s]%s\n", p[1], $1, p[3], $3, why
+        for (i = 1; i <= NF; i++) p[i] = $i
+    }'
+}
+
+# Pull the host-side actor into the job log while the journal still has it.
+# Everything here is best effort and every failure is printed, because the whole
+# point is that a silent absence of evidence is what made #2822 unfalsifiable.
+host_evidence() {
+    local since_epoch="$1" verdict="${2:-clean}" tmp rc WATCH_ROOT
+    WATCH_ROOT=$(watch_root)
+
+    printf '\n--- filesystem ---\n'
+    df -P -h -- "$WATCH_ROOT" / 2>&1 || degraded "df failed"
+
+    printf '\n--- job workers alive on this host now ---\n'
+    pgrep -a -f 'Runner\.Worker' 2>/dev/null
+    rc=$?
+    [ "$rc" -gt 1 ] && degraded "pgrep -a exited $rc"
+
+    printf '\n--- host journal for this job window (the deleting actor lives here) ---\n'
+    tmp=$(mktemp 2>/dev/null) || { degraded "mktemp failed for journal dump"; return 0; }
+    journalctl --since "@${since_epoch}" --no-pager -o short-iso -n 400 > "$tmp" 2>"$tmp.err"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        degraded "journalctl exited $rc: $(tr '\n' ' ' < "$tmp.err")"
+        printf 'NO HOST JOURNAL. This is the single most valuable line in the dump and it\n'
+        printf 'is missing. The runner user needs read access to the journal (group\n'
+        printf 'systemd-journal) for #2822 to be attributable from inside a job.\n'
+    else
+        # The alternation deliberately does NOT spell the two-word remove
+        # command: bashrs reads that literal inside a quoted pattern as a real
+        # invocation and raises SEC011 on a grep. 'prune', 'remov' and 'delet'
+        # cover the same journal lines.
+        grep -inE 'reaper|disk-guard|prune|remov|delet|_work|target' "$tmp" > "$tmp.hit" 2>/dev/null
+        rc=$?
+        if [ "$rc" -eq 0 ]; then
+            cat "$tmp.hit"
+        elif [ "$rc" -eq 1 ]; then
+            printf 'journal readable, no reaper/prune/target line in the window.\n'
+        else
+            degraded "grep over journal exited $rc"
+        fi
+        # A filter is a guess about who the actor is, and the actor here is
+        # UNIDENTIFIED. Measured on mac-server 2026-08-31: ci-reaper logged
+        # `swept 0 stale runner _work checkouts` on all 36 of its runs in 24h,
+        # and runner-disk-guard's --pre-job mode is invoked by no runner. So
+        # when a boundary actually went bad, print the WHOLE window rather than
+        # only what the filter already expected to find.
+        if [ "$verdict" = "suspicious" ]; then
+            printf '\n--- unfiltered journal window (verdict was SUSPICIOUS) ---\n'
+            cat "$tmp"
+        fi
+    fi
+    rm -f "${tmp:?refusing to rm an empty path}"
+    rm -f "${tmp:?}.err"
+    rm -f "${tmp:?}.hit"
+    return 0
+}
+
+report() {
+    local WATCH_ROOT WATCH_LOG
+    WATCH_ROOT=$(watch_root)
+    WATCH_LOG=$(watch_log)
+    printf '=== ci-target-watch report (aprender#2822) ===\n'
+    if [ ! -s "$WATCH_LOG" ]; then
+        degraded "no probes recorded at $WATCH_LOG - the instrumentation did not run"
+        return 0
+    fi
+
+    printf 'log: %s\n' "$WATCH_LOG"
+    printf 'root: %s\n' "$WATCH_ROOT"
+    printf 'runner(s) seen: %s\n' \
+        "$(awk -F'\t' '{print $4}' "$WATCH_LOG" | LC_ALL=C sort -u | tr '\n' ' ')"
+
+    printf '\n--- boundaries ---\n'
+    printf '%-21s %-34s %-11s %-8s %-7s %s\n' TIME LABEL DEPS_INO DEPS SEN_F/A 'FS% /%'
+    awk -F'\t' '{ printf "%-21s %-34s %-11s %-8s %-7s %s %s\n", $1, $3, $8, $9, $10 "/" $11, $12, $13 }' \
+        "$WATCH_LOG"
+
+    printf '\n--- verdict ---\n'
+    local tmp n rows
+    rows=$(wc -l < "$WATCH_LOG")
+    rows="${rows// /}"
+    if [ "${rows:-0}" -lt 2 ]; then
+        degraded "only ${rows:-0} probe row(s); a verdict over fewer than two boundaries is vacuous"
+        printf 'NO VERDICT (need at least 2 probes to have a boundary).\n'
+        return 0
+    fi
+    tmp=$(mktemp 2>/dev/null) || { degraded "mktemp failed for verdict"; return 0; }
+    classify < "$WATCH_LOG" > "$tmp" 2>/dev/null
+    n=$(wc -l < "$tmp")
+    n="${n// /}"
+    local verdict=clean
+    if [ "$n" -eq 0 ]; then
+        printf 'CLEAN across %s boundaries: nothing lost, replaced or truncated the target tree.\n' \
+            "$(( rows - 1 ))"
+    else
+        verdict=suspicious
+        printf '::warning::ci-target-watch found %s suspicious boundary/boundaries - see below\n' "$n"
+        cat "$tmp"
+    fi
+    rm -f "${tmp:?refusing to rm an empty path}"
+
+    local first
+    first=$(awk -F'\t' 'NR==1 {print $2}' "$WATCH_LOG")
+    [ -n "$first" ] || first=$(date -u +%s)  # bashrs disable-line=DET002
+    host_evidence "$first" "$verdict"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# THE CASE TABLE. Six rows over a throwaway TSV. Rows 1-2 are the controls: if a
+# "fix" makes the classifier report everything, or nothing, they fail. Rows 3-6
+# are the four shapes #2822 can take, INCLUDING the second signature seen on
+# intel-clean-room-12, where the tree is replaced rather than emptied and no .d
+# file is involved at all.
+self_test() {
+    local td fails=0 got want
+    td=$(mktemp -d 2>/dev/null)
+    if [ -z "$td" ] || [ ! -d "$td" ]; then
+        degraded "mktemp -d unusable - cannot run the case table on this box"
+        printf 'ENVIRONMENT, not a detector regression. Exiting 0 without a verdict.\n'
+        return 0
+    fi
+    # shellcheck disable=SC2064
+    trap "rm -rf '$td'" EXIT
+
+    # row: <name> <prev-row-tail> <next-row-tail> <expect-substring-or-CLEAN>
+    row() {
+        local name="$1" a="$2" b="$3" expect="$4"
+        {
+            printf 'T0\t100\tbefore\tr8\t/t\t%b\n' "$a"
+            printf 'T1\t200\tafter\tr8\t/t\t%b\n' "$b"
+        } > "$td/rows.tsv"
+        got=$(classify < "$td/rows.tsv")
+        if [ "$expect" = "CLEAN" ]; then
+            if [ -z "$got" ]; then
+                printf 'ok    %s\n' "$name"
+            else
+                printf 'FAIL  %s: expected CLEAN, got [%s]\n' "$name" "$got"; fails=$((fails + 1))
+            fi
+        elif contains "$got" "$expect"; then
+            printf 'ok    %s\n' "$name"
+        else
+            printf 'FAIL  %s: expected %s, got [%s]\n' "$name" "$expect" "$got"; fails=$((fails + 1))
+        fi
+    }
+
+    # Columns 6..15:
+    #   root_ino root_mtime deps_ino deps_cnt sen_found sen_armed fs / workers note
+    row 'R1 control: nothing moved' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' CLEAN
+    row 'R2 control: deps GREW, as a build does' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '11\t901\t22\t900\t1\t1\t70\t70\t101\tok' CLEAN
+    row 'R3 deps emptied under a live cargo (sentinel lost)' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '11\t901\t22\t0\t0\t1\t70\t70\t101\tplanted-sentinel' 'DEPS-WIPED'
+    row 'R4 whole target root replaced (the runner-12 shape)' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '77\t901\t88\t3\t0\t1\t70\t70\t101\tplanted-sentinel' 'ROOT-REPLACED'
+    row 'R5 target root removed outright' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '-\t-\t-\t-\t0\t0\t70\t70\t101\tok' 'ROOT-REMOVED'
+    row 'R6 a sibling job started on this host between boundaries' \
+        '11\t900\t22\t500\t1\t1\t70\t70\t101\tok' \
+        '11\t901\t22\t600\t1\t1\t70\t70\t101,202\tok' 'SIBLING-JOB-CHANGED'
+
+    # R7 is the end-to-end row: a real probe against a real directory that is
+    # then wiped. It proves the RECORDER and the classifier agree, which no
+    # amount of synthetic TSV can.
+    local realroot
+    realroot="$td/target"
+    mkdir -p "$realroot/debug/deps"
+    CI_TARGET_WATCH_LOG="$td/live.tsv" CI_TARGET_WATCH_ROOT="$realroot" probe before >/dev/null 2>&1
+    rm -rf "${realroot:?refusing to rm an empty path}"
+    mkdir -p "$realroot/debug/deps"
+    CI_TARGET_WATCH_LOG="$td/live.tsv" CI_TARGET_WATCH_ROOT="$realroot" probe after >/dev/null 2>&1
+    got=$(classify < "$td/live.tsv")
+    # NOT ROOT-REPLACED. Measured on this box: `rm -rf dir && mkdir dir` REUSES
+    # the inode on tmpfs, so an inode comparison alone silently misses a real
+    # wipe. That is why the sentinel exists, and why this row asserts on it.
+    want='DEPS-WIPED'
+    if contains "$got" "$want"; then
+        printf 'ok    R7 live probe: rm -rf between two real probes is detected\n'
+    else
+        printf 'FAIL  R7 live probe: expected %s, got [%s]\n' "$want" "$got"; fails=$((fails + 1))
+    fi
+
+    if [ "$fails" -gt 0 ]; then
+        printf '\nSELF-TEST FAILED: %s of 7 rows\n' "$fails" >&2
+        return 1
+    fi
+    printf '\nSELF-TEST PASSED: 7 rows\n'
+    return 0
+}
+
+case "${1:-}" in
+    probe)       shift; probe "${1:-unlabelled}" ;;
+    report)      report ;;
+    --self-test) self_test; exit $? ;;
+    *)
+        printf 'usage: %s probe <label> | report | --self-test\n' "$0" >&2
+        exit 2
+        ;;
+esac
+exit 0


### PR DESCRIPTION
Instrumentation for #2822, plus the negative result the coordinator asked for first.

## 1. No cargo-sharing or backgrounding mechanism inside `guard-runner-labels`

Searched and came up empty, so the investigation does **not** end here:

* **No backgrounding anywhere in `.github/workflows/`.** Zero `&`-at-EOL, `nohup`, `setsid`, `disown`, `docker run -d` or `--detach` across all 13 workflows. Every `docker run` in the job is foreground and `--rm`.
* **No backgrounded cargo in the 74 scripts the job invokes.** The only `&` backgrounding in that set is `parity_host_receipt.sh`, which starts servers, not cargo, and is not run by this job.
* **No wrapper redirects the target dir on the host side.** `RUSTC_WRAPPER`/`sccache` appear only inside `docker run -e` lines. The dev-box `cargo` shell function that force-overrides `CARGO_TARGET_DIR` has no CI analogue; `scripts/pv_bin.sh` and `check_pv_bin_resolution.sh` already account for it.
* **`cargo` steps in this job build into `$GITHUB_WORKSPACE/target`, i.e. the `_work` path in the traceback**, and they are sequential steps of a single-job-at-a-time runner.

Two real target-dir sharing facts surfaced on the way. **Neither explains #2822** (both are on the nvme array, not `_work`), but both are live:

* `/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}` is keyed on the **run**, not the job, and is bind-mounted as `CARGO_TARGET_DIR` by four *concurrent* jobs of the same run on the same host: `workspace-test` (4 cargo steps), `guard-runner-labels` (the model-tests step), `mutants`, and the reusable `ci` job. The #1693 fix moved the sharing from across-runs to across-jobs-within-a-run rather than removing it.
* The model-tests step's own comment says it runs "on the same per-RUN target dir as the other cargo steps" of its job. It does not - the other cargo steps in `guard-runner-labels` build into `_work/.../target`. The comment describes `workspace-test`, which it was copied from (the same copy that caused #2627).
* `workspace-test`'s cancel-damage step mounts the **per-PR parent** (`.../aprender-ci/${PR_OR_REF}`, no run id) and runs `rm -rf /workspace/target/*`. That wipes `run-<RUN_ID>` directories belonging to any other in-flight run for the same PR. It is the only in-repo `rm -rf` that can hit a live cargo target dir.

## 2. The `_work` deleter is host-side, and both known reapers currently look exonerated

`_work/*/target` is deleted by host automation that logs to the journal and appears in no GitHub log. `scripts/runner-infra/runner-disk-guard.sh` records this exact signature in its own header ("an unconditional rm -rf on every target/ deleted .rlib files out from under in-progress cargo builds on sibling runners, producing 'No such file or directory' errors for hours at a time").

Read-only measurements on `mac-server`, 2026-08-31, so the next person does not repeat them:

| fact | value |
|---|---|
| `/` on mac-server | **93% used, 272 GB free** - `/mnt/nvme-raid0` is a plain directory on `/`, not a separate device |
| `ci-reaper` runs, last 24h | **36** (~1.5/h), all logged `logger -t ci-reaper` |
| `sweep_runner_work_checkouts` removals, last 24h | **0** on all 36 runs (`swept 0 stale runner _work checkouts (ttl=7d, skipped=36 internal)`) |
| `Runner.Worker` liveness check in `ci-reaper.sh` | **absent** - 0 occurrences; its only `_work` protection is an mtime TTL |
| `/usr/local/bin/runner-disk-guard.sh` | **Apr 23, 7152 bytes** - four months behind the in-tree copy, predating the 2026-08-22 `tree_is_idle` fix |
| `runner-disk-guard --pre-job` | invoked by **no runner** (all 17 drop-ins point at `/home/noah/data/actions-runner/pre-job.sh`); only the 04:00 `--nightly` timer runs |
| `journalctl` readable by the runner user | **yes**, without `systemd-journal` group membership |

So the two obvious suspects are both exonerated for `_work` as of today, which strengthens the coordinator's exclusion for `intel-clean-room-8` rather than overturning it. **The actor remains unidentified.** That is exactly why the last row matters: the report step below can pull the host journal into the job log at zero host change.

I did **not** re-run the timestamp correlation for the `intel-clean-room-12` occurrence - I do not have its window. The instrumentation makes that automatic from the next occurrence on.

## 3. What this PR adds

`scripts/ci_target_watch.sh` with three modes, and 14 probe steps plus one `if: always()` report step in `guard-runner-labels`.

**Per boundary:** target root existence, inode and mtime; `debug/deps` inode and entry count; a sentinel file's as-found and armed state; percent-used of the target filesystem **and** of `/`; and the set of `Runner.Worker` pids alive on the host.

That last column is the correlation the job log has never carried: a sibling job starting on this box is exactly when the pre-job hook that prunes target trees fires.

**Deliberately not `.d`-specific,** per the coordinator's note about the runner-12 signature. `ROOT-REPLACED` / `ROOT-REMOVED` catch a tree that was swapped or removed rather than emptied, and `runner` is a column so "roams vs. specific runner" is answerable from the log.

**The report takes its own final probe before reporting.** Without that, a failure at step K leaves the last recorded boundary *before* K and the table reads clean - the exact shape being investigated.

**On a suspicious verdict it prints the unfiltered journal window**, not just the lines matching `reaper|disk-guard|prune|...`. A filter is a guess about who the actor is, and the actor is unidentified.

## 4. Non-fatal, but not silent

`probe` and `report` always exit 0. They do not swallow their own errors: every failure prints a `DEGRADED` line naming the call that failed (`stat`, `mktemp`, `pgrep`, the log append, `journalctl`). When the journal is unreadable the report says so in as many words, because a silent absence of evidence is what made #2822 unfalsifiable.

The one part that **can** fail a required check is `--self-test`. That is the right way round: a recorder that can red a required check is a liability, and #2822 is already red.

## 5. Verification, in the order it actually happened

* The first draft **planted the sentinel three lines before reading it**, so the column was `1` on every row and `DEPS-WIPED` could never fire. Read first, plant second, record both as-found and armed.
* `rm -rf dir && mkdir dir` **reuses the inode** on tmpfs, measured. An inode comparison alone silently misses a real wipe. The live row asserts on the sentinel instead.
* The report printed **`CLEAN` while every `awk` read had failed** with ``cannot open file `--` `` - gawk treats `--` as a filename. A verdict over fewer than two rows now says `NO VERDICT`.
* Three mutations take the case table RED: delete the sentinel rule (R3+R7 fail), delete the inode rule (R4 fails), restore the read-after-plant ordering (R7 fails). Restored: 7/7.

Guards run locally, all rc=0: `check_guards_are_wired`, `check_workflow_env_defined`, `check_pass_grep_anchored`, `check_no_timing_in_required`, `check_apr_bin_pinned`, `check_shell_lint_ratchet`, `check_baseline_ratchets`, `check_runner_labels`, `check_beats_gated`, `check_workflow_path_filters`. bashrs: **0 errors on the new file, and 0 delta on the combined `scripts/*.sh` count** (50 with, 50 without - checked both alone and combined, per the cross-contamination lesson).

## 6. Measured overhead

Measured on lambda against a real 110,890-entry `debug/deps`:

| item | cost |
|---|---|
| one probe | **0.154s** mean over 10 (2 `stat`, 1 readdir, 1 `df`, 1 `pgrep`) |
| case table | 0.17s, once |
| report | 0.07s, once (journal dump included) |
| **14 probes + case table + report** | **~2.4s of script time** |

Plus GitHub's own per-step bookkeeping on 14 new steps, call it another 3-7s. On a job that runs ~21 minutes that is under 0.1%. No `du`, no recursive walk, no per-entry `stat`.

## 7. fanotify / auditd assessment - recommendation only, no host change made

`mac-server` hosts all 16 runners for every repo, so nothing here was applied.

* **fanotify cannot be done unprivileged.** Directory-entry events (`FAN_DELETE`, `FAN_MOVED_FROM`) require `FAN_REPORT_FID`, and both that and `FAN_MARK_FILESYSTEM` require `CAP_SYS_ADMIN`. There is no per-job unprivileged form. It would report the deleting PID, which is decisive - but only as root, so it is a host change either way.
* **inotify is unprivileged but PID-blind.** `IN_DELETE_SELF` on `target/debug/deps` needs three watches (flat directory) and would give an exact wall-clock for the deletion, which is most of the value - but it needs a background process inside the job, which is the very hazard under investigation, and `inotifywait` is not guaranteed present.
* **auditd is the decisive one.** A syscall-scoped rule keyed to removals only, e.g. `auditctl -w /home/noah/data/actions-runner-8/_work/aprender/aprender/target -p wa -k apr2822`, records pid, ppid, comm, exe and auid of the deleter. Cost is not free: a `-p wa` watch fires on every artifact write during a build. If this is wanted, scope it to `unlinkat`/`rmdir` rather than `w`, and arm it on one runner rather than all 17.

**The cheap recommendation first:** the report step's journal dump already works - `journalctl` is readable by the runner user on `mac-server` today, verified above. Land this, wait for the next occurrence, and read the actor out of the job log. Reach for auditd only if the actor turns out not to log at all.

## 8. Known gaps

* Probes bracket the cargo-invoking steps, not all 127. A wipe during a fast text-only guard is attributed to the interval, not the exact step. Widening that means either 127 more steps or a background sampler; neither is worth it while the journal dump carries a wall-clock timestamp.
* `scripts/perf-matrix.yaml` untouched. Nothing in `crates/aprender-test-lib`, `scripts/perf_gate.sh` or root `[profile.dev]` touched.
* The two array-side sharing facts in section 1 are real defects but out of scope here; they want their own PR, and one of them (`workspace-test`'s per-PR-parent `rm -rf`) is a live rm-vs-build race.

Refs #2822
