### PR TITLE
fix(security): RUSTSEC-2026-0273 (manzana stubbed crypto) reds ci/security on every open PR

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -137,4 +137,39 @@ ignore = [
     #   cargo tree --workspace                   | grep -cE "h2 v0.3"              -> 0
     # REMOVE WHEN aws-smithy-http-client drops hyper 0.14.
     "RUSTSEC-2026-0258",  # h2 0.3.27 via optional s3 feature only
+
+    # manzana 0.2.0 stubbed cryptography. CONTAINMENT ONLY - remove per the
+    # condition at the bottom of this block, which is NOT "when a new manzana
+    # ships".
+    #
+    # The advisory is about `manzana::secure_enclave::SecureEnclaveSigner`, whose
+    # sign() derives a "signature" from public values only and whose verify()
+    # merely recomputes sign() and compares. aprender does not touch any of it.
+    # Reachability measured on a clean origin/main worktree, x86_64 Linux, using
+    # the absolute cargo binary (a `cargo` shell function on the dev box shadows
+    # it and silently redirects CARGO_TARGET_DIR):
+    #   cargo tree -p aprender-gpu                  | grep -c manzana -> 0
+    #   cargo tree -p aprender-gpu --features metal | grep -c manzana -> 0
+    #   cargo tree --workspace                      | grep -c manzana -> 0
+    #   git grep -l 'secure_enclave|SecureEnclave' -- '*.rs'          -> 0 files
+    # The middle line is the load-bearing one: manzana is BOTH optional and
+    # declared under [target.'cfg(target_os = "macos")'.dependencies], so
+    # enabling `metal` on Linux still pulls in nothing. aprender's only three
+    # call sites are `manzana::metal::*` in aprender-gpu/src/backend/mod.rs,
+    # every one behind cfg(all(target_os = "macos", feature = "metal")).
+    # As with the h2 entry above, cargo-deny already passes without an exemption
+    # because it walks the ACTIVATED graph; cargo-audit scans Cargo.lock, which
+    # lists target- and feature-gated deps unconditionally.
+    #
+    # WHY AN IGNORE RATHER THAN AN UPGRADE. Both published versions (0.1.0 and
+    # 0.2.0) are YANKED, so there is nothing to bump to - `max_version` on
+    # crates.io reads 0.0.0. More importantly the advisory carries
+    # `[versions] patched = []`, which means NO version is considered fixed:
+    # publishing a corrected manzana does NOT clear this gate on its own. Only
+    # amending the upstream advisory to name a patched range does.
+    #
+    # REMOVE WHEN either the advisory gains a patched range and this workspace is
+    # on a version inside it, or the manzana dependency is dropped from
+    # aprender-gpu entirely. Publishing a new manzana alone is NOT the condition.
+    "RUSTSEC-2026-0273",  # manzana 0.2.0 stubbed crypto; unreachable here, see above
 ]


### PR DESCRIPTION
Same signature as #2805: **all PRs red, nothing changed in-repo.** The advisory was committed to the RustSec DB at `2026-09-01T07:50:30Z` — two seconds after crates.io yanked manzana at `07:50:28Z`. `ci / security` passed on #2825 at 06:44Z and has failed on #2836/#2837/#2838 from 09:56Z. An advisory-DB catch-up, not a regression.

## Reachability: zero, measured

```
cargo tree -p aprender-gpu                  | grep -c manzana -> 0
cargo tree -p aprender-gpu --features metal | grep -c manzana -> 0
cargo tree --workspace                      | grep -c manzana -> 0
git grep -l 'secure_enclave|SecureEnclave' -- '*.rs'          -> 0 files
```

The middle line is the load-bearing one: manzana is **both** optional **and** declared under `[target.'cfg(target_os = "macos")'.dependencies]`, so enabling `metal` on Linux pulls in nothing. aprender's only three call sites are `manzana::metal::*`, all behind `cfg(all(target_os = "macos", feature = "metal"))`. The advisory is about `secure_enclave::SecureEnclaveSigner`, which this workspace never names.

As with the h2 entry above it, `cargo deny check advisories` passes **without** an exemption (it walks the *activated* graph); `cargo-audit` scans `Cargo.lock`, which lists target- and feature-gated deps unconditionally. So the ignore goes in `.cargo/audit.toml` **only** — adding it to `deny.toml` would be a dead exemption and fail `check_deny_exemptions_live.sh`.

## Why an ignore and not an upgrade

Both published versions (0.1.0, 0.2.0) are **yanked** — crates.io reports `max_version: 0.0.0`, so there is nothing to bump to. More importantly the advisory carries:

```toml
[versions]
patched = []
```

**No version is considered fixed.** Publishing a corrected manzana does **not** clear this gate on its own — only amending the upstream advisory to name a patched range does. The removal condition in the file says exactly that, because "when the new manzana ships" is the wrong trigger and would leave someone puzzled when CI stayed red.

## Verification, stated honestly

**This is not locally verified green.** `cargo-audit` 0.22.1 on an x86_64 host does not report RUSTSEC-2026-0273 at all — manzana surfaces only as `Warning: yanked` — so a local run passes **with or without** this ignore and proves nothing.

I ran the negative control and **it failed to fail**, which is how the vacuity was found rather than shipped. The fix is sound by construction — CI errors on that exact id, and `--ignore <id>` suppresses that id — and **CI is the verifier here, not my box.**

Refs #2805.