### PR TITLE
fix(R-3): the cuBLAS-backward training banner is an event (launch counter), and --gpu-backend cuda on a cpu-only build is FeatureDisabled exit 9 — never a silent CPU run (PMAT-991, #2906)

### DIFF
--- a/contracts/apr-train-banner-truth-v1.yaml
+++ b/contracts/apr-train-banner-truth-v1.yaml
@@ -43,7 +43,7 @@ metadata:
   author: PAIML Engineering
   references:
     - 'crates/aprender-train/src/autograd/mod.rs — BACKWARD_KERNEL_LAUNCHES, backward_kernel_launches(), reset_backward_kernel_launches(), training_backend_banner()'
-    - 'crates/aprender-train/src/autograd/cuda_forward/matmul.rs, matmul_f16.rs — note_backward_kernel_launch() at every cuBLAS backward launch (a, a_accumulate, b; f16 a, b)'
+    - 'crates/aprender-train/src/autograd/cuda_forward/matmul.rs, matmul_f16.rs — note_backward_kernel_launch() at every device-side backward launch: cuBLAS a, a_accumulate, b; f16 a, b; f16->f32 a; NF4 cuBLAS a; NF4 PTX a; NF4 tensor-core a (the last four found by the review quorum and the orchestrator, 2026-09-06)'
     - 'crates/aprender-train/tests/banner_truth.rs — the RED-first test (both feature arms)'
     - 'crates/apr-cli/src/commands/finetune.rs — gpu_backend_decision, pre_training_notice, post_training_banner, GpuBackendChoice'
     - 'crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs — the request×build case table (both polarities)'
@@ -59,23 +59,24 @@ metadata:
 equations:
   banner_is_derived_from_launches:
     formula: |
-      training_backend_banner(requested) = Some(_)  <=>  requested == "cuda" ∧ backward_kernel_launches() > 0
+      training_backend_banner(requested, at_start) = Some(_)  <=>  requested == "cuda" ∧ backward_kernel_launches() > at_start
       "cuBLAS backward" ∉ pre_training_notice(choice)   for every choice
     domain: 'requested ∈ {cuda, wgpu, cpu, auto}; counter ∈ ℕ'
     codomain: 'Option<String>'
     invariants:
     - 'THE COUNTER IS THE ONLY PREDICATE: no cfg! read, no request-only branch decides the banner (banner_truth.rs, both cfg arms; finetune_gpu_backend_truth_tests::post_training_banner_is_none_with_zero_launches).'
-    - 'RESET RESTORES SILENCE: after reset_backward_kernel_launches() the cuda banner is None again — a banner without a launch is the defect.'
+    - 'SINCE-START, NO RESET (R-3 review quorum 2026-09-06, 3/3): the counter is process-wide and monotonic; the caller snapshots it before its run and the banner speaks only about launches since then, so a second fine-tune in one process, or a long-lived server, inherits nothing. There is deliberately no reset API and the tests never reset — a race-free case table.'
     preconditions: []
     postconditions:
     - 'on a cuda build after one cuBLAS backward the counter is > 0 and the banner names the count'
 
   gpu_request_meets_the_build:
     formula: |
-      gpu_backend_decision("cuda", build_has_cuda=false, _) = Err(FeatureDisabled)   with exit_code_value() = 9
-      gpu_backend_decision("wgpu", _, build_has_wgpu=false) = Err(FeatureDisabled)
+      gpu_backend_decision("cuda", _, build_has_cuda=false, _) = Err(FeatureDisabled)   with exit_code_value() = 9
+      gpu_backend_decision("cuda", method_has_cuda_path=false, true, _) = Err(ValidationFailed)   with exit_code_value() = 5   (plain LoRA: refuse, never a CPU run under a GPU flag)
+      gpu_backend_decision("wgpu", _, _, build_has_wgpu=false) = Err(FeatureDisabled)
       gpu_backend_decision("auto", …) ∈ Ok(_)   always;   gpu_backend_decision("cpu", …) ∈ Ok(cpu)
-    domain: 'requested × {build_has_cuda, build_has_wgpu}'
+    domain: 'requested × method_has_cuda_path × {build_has_cuda, build_has_wgpu}'
     codomain: 'Result<GpuBackendChoice, CliError>'
     invariants:
     - 'REFUSE, NEVER DOWNGRADE (finetune_gpu_backend_truth_tests::gpu_backend_decision_case_table, cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback): the exit code is read from error.rs, not declared here.'
@@ -92,7 +93,7 @@ proof_obligations:
     statement: "The pre-training notice never claims a cuBLAS backward; the post-training banner is derived from the counter only."
     discharged_by: falsification_tests[1]
   - id: TBT-OB-003
-    statement: "--gpu-backend cuda (wgpu) on a build without that feature is CliError::FeatureDisabled, exit 9; auto and cpu never refuse."
+    statement: "--gpu-backend cuda (wgpu) on a build without that feature is CliError::FeatureDisabled, exit 9; cuda for a method with no CUDA path (plain LoRA) is ValidationFailed, exit 5; auto and cpu never refuse."
     discharged_by: falsification_tests[1]
 
 falsification_tests:
@@ -102,9 +103,10 @@ falsification_tests:
     prediction: >-
       Without the cuda feature the counter is 0 and the banner is None for
       "cuda" and "cpu"; with --features cuda one cuBLAS backward makes the
-      counter > 0 and the banner Some(contains "cuBLAS backward"); reset makes
-      it None again (registered mutation: print the banner unconditionally ->
-      banner_is_none_for_cuda_with_zero_launches turns RED).
+      counter above the start snapshot and the banner Some(contains "backward
+      engaged"); a later snapshot makes it None again (registered mutation:
+      print the banner unconditionally -> banner_is_none_for_cuda_with_zero_launches
+      turns RED).
     test: 'cargo test -p aprender-train --test banner_truth'
     if_fails: >-
       a banner claims GPU training while every backward ran on the CPU
@@ -119,7 +121,9 @@ falsification_tests:
     prediction: >-
       gpu_backend_decision_case_table PASSES every row of {cuda, wgpu, auto,
       cpu} × {build flags}; the cuda request on a cpu-only build is
-      FeatureDisabled with exit_code_value() == 9;
+      FeatureDisabled with exit_code_value() == 9; plain LoRA with an explicit cuda
+      request is ValidationFailed with exit_code_value() == 5
+      (plain_lora_with_explicit_cuda_is_a_refusal_not_a_cpu_run);
       pre_training_notice_never_claims_cublas_backward PASSES;
       post_training_banner_is_none_with_zero_launches PASSES.
     test: 'cargo test -p apr-cli --lib gpu_backend_truth'

--- a/contracts/apr-train-banner-truth-v1.yaml
+++ b/contracts/apr-train-banner-truth-v1.yaml
@@ -1,0 +1,141 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-train-banner-truth-v1 — the cuBLAS-backward training banner is an EVENT,
+# never a claim off the request; a GPU request the build cannot honour is a
+# refusal, never a silent CPU run (PP-066 DAG row R-3 / spec §5 T-6, issue
+# #2906, ticket PMAT-991; feedback_apr_finetune_lora_cpu_only)
+#
+# WHAT IT GOVERNS
+#   entrenar::backward_kernel_launches() / reset_backward_kernel_launches() /
+#   training_backend_banner(requested) in crates/aprender-train, and the CLI
+#   seam in crates/apr-cli/src/commands/finetune.rs: gpu_backend_decision
+#   (request × build facts -> choice | CliError::FeatureDisabled, exit 9 per
+#   crates/apr-cli/src/error.rs:106), pre_training_notice (may not claim a
+#   backward that has not run), post_training_banner (derived from the
+#   counter only).
+#
+# PROOF LADDER, STATED HONESTLY (PP-066 §5 contract discipline, F-26)
+#   * L1 — the resolver exists: the two test targets named below.
+#   * L2 — falsification tests cover obligations, MEASURED 2026-09-06: the
+#          entrenar integration test passes with and without --features cuda
+#          on lambda (RTX 4090, sm_89); the apr-cli case table passes in the
+#          default feature set (training, no cuda).
+#   * L3/L4 — NOT APPLICABLE and deliberately not declared: a counter and a
+#          string predicate, not a kernel. No self-exemption flag, no
+#          hand-typed proof summary, no Kani, no Lean.
+# ─────────────────────────────────────────────────────────────────────────────
+name: apr-train-banner-truth
+version: "1.0.0"
+scope: >
+  The training-backend banner and the --gpu-backend refusal of `apr finetune`.
+  Out of scope: which backend is fastest (PP-066 Track T measures that), the
+  QLoRA/NF4 kernels themselves, and the wgpu pipeline's own notices (they
+  keep their meaning; only the cuBLAS claim is governed here).
+status: active
+
+metadata:
+  kind: pattern     # a process-wide counter and a string predicate over it,
+                    # plus a request×build decision table — not a math kernel.
+                    # Set EXPLICITLY so `pv validate`'s `kernel` default never
+                    # silently applies.
+  version: "1.0.0"
+  created: '2026-09-06'
+  last_modified: '2026-09-06'
+  author: PAIML Engineering
+  references:
+    - 'crates/aprender-train/src/autograd/mod.rs — BACKWARD_KERNEL_LAUNCHES, backward_kernel_launches(), reset_backward_kernel_launches(), training_backend_banner()'
+    - 'crates/aprender-train/src/autograd/cuda_forward/matmul.rs, matmul_f16.rs — note_backward_kernel_launch() at every cuBLAS backward launch (a, a_accumulate, b; f16 a, b)'
+    - 'crates/aprender-train/tests/banner_truth.rs — the RED-first test (both feature arms)'
+    - 'crates/apr-cli/src/commands/finetune.rs — gpu_backend_decision, pre_training_notice, post_training_banner, GpuBackendChoice'
+    - 'crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs — the request×build case table (both polarities)'
+    - 'crates/apr-cli/src/error.rs:106 — CliError::FeatureDisabled => exit code 9 (D-7: read, never invented)'
+    - 'PP-066 DAG row R-3 (docs/specifications/pp-066-dag.yaml), spec §5 T-6; issue #2906; ticket PMAT-991'
+  description: >
+    A device-side backward launch increments a process-wide counter at the
+    launch site. The banner that says "cuBLAS backward" is Some only when the
+    request named cuda AND that counter is above zero; the pre-training notice
+    never contains the claim. A request for a backend the build did not
+    compile is CliError::FeatureDisabled (exit 9), never a fallback.
+
+equations:
+  banner_is_derived_from_launches:
+    formula: |
+      training_backend_banner(requested) = Some(_)  <=>  requested == "cuda" ∧ backward_kernel_launches() > 0
+      "cuBLAS backward" ∉ pre_training_notice(choice)   for every choice
+    domain: 'requested ∈ {cuda, wgpu, cpu, auto}; counter ∈ ℕ'
+    codomain: 'Option<String>'
+    invariants:
+    - 'THE COUNTER IS THE ONLY PREDICATE: no cfg! read, no request-only branch decides the banner (banner_truth.rs, both cfg arms; finetune_gpu_backend_truth_tests::post_training_banner_is_none_with_zero_launches).'
+    - 'RESET RESTORES SILENCE: after reset_backward_kernel_launches() the cuda banner is None again — a banner without a launch is the defect.'
+    preconditions: []
+    postconditions:
+    - 'on a cuda build after one cuBLAS backward the counter is > 0 and the banner names the count'
+
+  gpu_request_meets_the_build:
+    formula: |
+      gpu_backend_decision("cuda", build_has_cuda=false, _) = Err(FeatureDisabled)   with exit_code_value() = 9
+      gpu_backend_decision("wgpu", _, build_has_wgpu=false) = Err(FeatureDisabled)
+      gpu_backend_decision("auto", …) ∈ Ok(_)   always;   gpu_backend_decision("cpu", …) ∈ Ok(cpu)
+    domain: 'requested × {build_has_cuda, build_has_wgpu}'
+    codomain: 'Result<GpuBackendChoice, CliError>'
+    invariants:
+    - 'REFUSE, NEVER DOWNGRADE (finetune_gpu_backend_truth_tests::gpu_backend_decision_case_table, cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback): the exit code is read from error.rs, not declared here.'
+    - 'THE BUILD FACTS ARE READ ONCE at the call site that produces the two bools; the decision itself is a pure function (the R-0 registry replaces those reads in 0.66).'
+    preconditions: []
+    postconditions:
+    - 'the refusal message names the missing feature and the rebuild flag --features cuda'
+
+proof_obligations:
+  - id: TBT-OB-001
+    statement: "The cuBLAS-backward banner is Some iff cuda was requested and at least one device-side backward launched; reset makes it None again."
+    discharged_by: falsification_tests[0]
+  - id: TBT-OB-002
+    statement: "The pre-training notice never claims a cuBLAS backward; the post-training banner is derived from the counter only."
+    discharged_by: falsification_tests[1]
+  - id: TBT-OB-003
+    statement: "--gpu-backend cuda (wgpu) on a build without that feature is CliError::FeatureDisabled, exit 9; auto and cpu never refuse."
+    discharged_by: falsification_tests[1]
+
+falsification_tests:
+
+  - id: TBT-F-001
+    rule: the banner is derived from launches
+    prediction: >-
+      Without the cuda feature the counter is 0 and the banner is None for
+      "cuda" and "cpu"; with --features cuda one cuBLAS backward makes the
+      counter > 0 and the banner Some(contains "cuBLAS backward"); reset makes
+      it None again (registered mutation: print the banner unconditionally ->
+      banner_is_none_for_cuda_with_zero_launches turns RED).
+    test: 'cargo test -p aprender-train --test banner_truth'
+    if_fails: >-
+      a banner claims GPU training while every backward ran on the CPU
+      (feedback_apr_finetune_lora_cpu_only)
+    mutation: >-
+      make training_backend_banner return Some for requested == "cuda"
+      regardless of the counter; banner_is_none_for_cuda_with_zero_launches
+      must turn RED.
+
+  - id: TBT-F-002
+    rule: the request meets the build; the notice never claims
+    prediction: >-
+      gpu_backend_decision_case_table PASSES every row of {cuda, wgpu, auto,
+      cpu} × {build flags}; the cuda request on a cpu-only build is
+      FeatureDisabled with exit_code_value() == 9;
+      pre_training_notice_never_claims_cublas_backward PASSES;
+      post_training_banner_is_none_with_zero_launches PASSES.
+    test: 'cargo test -p apr-cli --lib gpu_backend_truth'
+    if_fails: >-
+      a cpu-only binary accepts --gpu-backend cuda and silently trains on the
+      CPU, or prints "cuBLAS backward" before any step ran
+    mutation: >-
+      make gpu_backend_decision return Ok(cpu) for "cuda" when build_has_cuda
+      is false; cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback must
+      turn RED.
+
+non_goals:
+  - "Deciding which backend is fastest, or whether plain LoRA should move to the GPU (PP-066 Track T; 0.67 training levers)."
+  - "Runtime discovery of the device (R-0's registry replaces the cfg! reads at the call site; this contract only governs what is printed and refused)."
+
+binding_registry:
+  library_test: crates/aprender-train/tests/banner_truth.rs
+  cli_test: crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs
+  issue: "https://github.com/paiml/aprender/issues/2906"

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -2541,6 +2541,10 @@ fn display_classify_next_steps(json_output: bool) {
 mod tests;
 
 #[cfg(test)]
+#[path = "finetune_gpu_backend_truth_tests.rs"]
+mod gpu_backend_truth_tests;
+
+#[cfg(test)]
 #[path = "finetune_contract_tests.rs"]
 mod contract_tests;
 

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -311,6 +311,128 @@ fn gpu_backend_notice(
     }
 }
 
+/// The training backend a run will actually use — decided ONCE from the
+/// caller's request plus what this binary was built with (PMAT-991, #2906).
+#[cfg(feature = "training")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuBackendChoice {
+    /// CUDA/cuBLAS. Whether a cuBLAS backward actually launches is only
+    /// known after training — see [`post_training_banner`].
+    Cuda,
+    /// WGPU/WGSL compute shader path.
+    Wgpu,
+    /// CPU F32 path.
+    Cpu,
+}
+
+impl GpuBackendChoice {
+    /// The name `entrenar::training_backend_banner` expects as `requested`.
+    fn requested_name(self) -> &'static str {
+        match self {
+            Self::Cuda => "cuda",
+            Self::Wgpu => "wgpu",
+            Self::Cpu => "cpu",
+        }
+    }
+}
+
+/// Decide the effective training backend from the request and the build.
+///
+/// This is the ONLY place the request meets the build: `build_has_cuda` /
+/// `build_has_wgpu` MUST be `cfg!(feature = "cuda")` / `cfg!(feature =
+/// "wgpu")` read once at the call site.
+///
+/// Root cause (feedback_apr_finetune_lora_cpu_only / PMAT-991): `--gpu-backend
+/// cuda` on a binary built without the `cuda` feature used to fall through to
+/// the CPU path silently. Requesting a backend this binary cannot provide is
+/// a refusal, not a silent downgrade.
+///
+/// # Errors
+///
+/// [`CliError::FeatureDisabled`] (exit code 9) when `"cuda"`/`"wgpu"` is
+/// requested but the corresponding feature was not compiled in. `"auto"`
+/// never errors — it picks the best compiled-in backend, else the CPU path.
+#[cfg(feature = "training")]
+pub fn gpu_backend_decision(
+    requested: &str,
+    build_has_cuda: bool,
+    build_has_wgpu: bool,
+) -> Result<GpuBackendChoice> {
+    match requested {
+        "cuda" => {
+            if build_has_cuda {
+                Ok(GpuBackendChoice::Cuda)
+            } else {
+                Err(CliError::FeatureDisabled(
+                    "--gpu-backend cuda was requested but this apr binary was built without \
+                     the `cuda` feature — it cannot engage a cuBLAS backward. Rebuild with \
+                     `--features cuda`, or drop --gpu-backend to run the CPU F32 path."
+                        .to_string(),
+                ))
+            }
+        }
+        "wgpu" => {
+            if build_has_wgpu {
+                Ok(GpuBackendChoice::Wgpu)
+            } else {
+                Err(CliError::FeatureDisabled(
+                    "--gpu-backend wgpu was requested but this apr binary was built without \
+                     the `wgpu` feature. Rebuild with `--features wgpu`, or drop \
+                     --gpu-backend to run the CPU F32 path."
+                        .to_string(),
+                ))
+            }
+        }
+        "cpu" => Ok(GpuBackendChoice::Cpu),
+        _ => {
+            // "auto": never refuses. Prefer CUDA's cuBLAS backward when
+            // compiled in, else WGPU, else the CPU F32 path.
+            if build_has_cuda {
+                Ok(GpuBackendChoice::Cuda)
+            } else if build_has_wgpu {
+                Ok(GpuBackendChoice::Wgpu)
+            } else {
+                Ok(GpuBackendChoice::Cpu)
+            }
+        }
+    }
+}
+
+/// Pre-training banner text.
+///
+/// Root cause (Defect 1, PMAT-991): the old banner printed
+/// `[gpu-backend] CUDA selected — using cuBLAS backward path` purely off the
+/// `--gpu-backend` flag, before any training step ran. Whether a cuBLAS
+/// backward actually launches is only known AFTER training, from
+/// `entrenar::backward_kernel_launches()` — see [`post_training_banner`]. This
+/// text must never claim a cuBLAS backward has happened.
+#[cfg(feature = "training")]
+pub fn pre_training_notice(choice: &GpuBackendChoice) -> String {
+    match choice {
+        GpuBackendChoice::Wgpu => {
+            "[gpu-backend] WGPU selected — using WGSL compute shader path".to_string()
+        }
+        GpuBackendChoice::Cuda => "[gpu-backend] CUDA requested — whether a cuBLAS-driven \
+                                    backward pass engages is reported AFTER training, from the \
+                                    observed device-side launch count."
+            .to_string(),
+        GpuBackendChoice::Cpu => {
+            "[gpu-backend] CPU — training runs on the CPU F32 path".to_string()
+        }
+    }
+}
+
+/// Post-training banner (PMAT-991, #2906): `Some` iff a cuBLAS backward
+/// actually launched during training. Delegates to
+/// `entrenar::training_backend_banner`, which is itself driven strictly by
+/// `entrenar::backward_kernel_launches()` — never by `choice` alone. The
+/// registered mutation "print the banner unconditionally for the cuda choice"
+/// is exactly what this forecloses.
+#[cfg(feature = "training")]
+pub fn post_training_banner(choice: &GpuBackendChoice) -> Option<String> {
+    entrenar::training_backend_banner(choice.requested_name())
+}
+
 /// Build the `InstructConfig` for the default LoRA/QLoRA training path.
 ///
 /// Root cause (Defect 2): the old inline construction hardcoded
@@ -425,17 +547,15 @@ fn execute_training(
         println!("  Data: {} samples", corpus.len());
     }
 
-    // PMAT-494 FIX / Defect 1: Route based on --gpu-backend flag with a TRUTHFUL
-    // notice. The CUDA/cuBLAS backward path is only engaged when NF4 (QLoRA) is
-    // active, since InstructPipeline::from_apr only calls init_cuda then; for
-    // plain LoRA we must NOT claim GPU — gpu_backend_notice warns it runs on CPU.
-    let backend_plan = gpu_backend_notice(
-        gpu_backend,
-        instruct_config.quantize_nf4,
-        cfg!(feature = "wgpu"),
-    );
-    eprintln!("{}", backend_plan.notice);
-    let use_wgpu = backend_plan.use_wgpu;
+    // PMAT-991 (#2906): the request meets the build ONCE, here. "cuda"/"wgpu"
+    // requested on a build missing that feature is a refusal (exit 9), never
+    // a silent CPU fallback. The pre-training notice may say CUDA was
+    // requested; it must not claim a cuBLAS backward ran — that is only known
+    // after training (`post_training_banner`, below).
+    let backend_choice =
+        gpu_backend_decision(gpu_backend, cfg!(feature = "cuda"), cfg!(feature = "wgpu"))?;
+    eprintln!("{}", pre_training_notice(&backend_choice));
+    let use_wgpu = matches!(backend_choice, GpuBackendChoice::Wgpu);
 
     #[cfg(feature = "wgpu")]
     if use_wgpu {
@@ -481,6 +601,13 @@ fn execute_training(
         .map_err(|e| CliError::ValidationFailed(format!("Failed to create trainer: {e}")))?;
 
     let result = trainer.train();
+
+    // PMAT-991 (#2906): the cuBLAS-backward line is an EVENT, printed only
+    // now — after training — derived from the observed device-side backward
+    // launch count, never from `gpu_backend` alone.
+    if let Some(banner) = post_training_banner(&backend_choice) {
+        eprintln!("{banner}");
+    }
 
     // PMAT-512: Print training result to both stdout (human) and stderr (canary parser).
     // Canary parser reads stderr for loss extraction.

--- a/crates/apr-cli/src/commands/finetune.rs
+++ b/crates/apr-cli/src/commands/finetune.rs
@@ -232,85 +232,6 @@ fn display_memory_breakdown(req: &MemoryRequirement, vram_gb: f64) {
     }
 }
 
-/// Effective compute backend plus a *truthful* user-facing notice for a run.
-///
-/// Root cause (Defect 1): the old banner printed
-/// `[gpu-backend] CUDA selected — using cuBLAS backward path` purely off the
-/// `--gpu-backend` flag. But `InstructPipeline::from_apr` only calls `init_cuda`
-/// when `quantize_nf4 == true` (i.e. QLoRA — see
-/// `aprender-train/src/finetune/instruct_pipeline/constructors.rs`). For plain
-/// `-m lora` the model trains on the CPU F32 path, so the CUDA banner was a
-/// false claim that cost real debugging time. This keeps the GPU/cuBLAS claim
-/// gated on `quantize_nf4`, and otherwise warns that plain LoRA runs on CPU.
-#[cfg(feature = "training")]
-#[derive(Debug, PartialEq, Eq)]
-struct GpuBackendPlan {
-    /// Whether to route to the WGPU pipeline (`execute_training_wgpu`).
-    use_wgpu: bool,
-    /// Human-readable, accurate notice describing the effective backend.
-    notice: String,
-}
-
-/// Decide the effective training backend and an accurate notice.
-///
-/// * `quantize_nf4` — true only for QLoRA; the sole condition under which
-///   `InstructPipeline::from_apr` initializes CUDA/cuBLAS.
-/// * `wgpu_available` — pass `cfg!(feature = "wgpu")` from the call site.
-#[cfg(feature = "training")]
-fn gpu_backend_notice(
-    gpu_backend: &str,
-    quantize_nf4: bool,
-    wgpu_available: bool,
-) -> GpuBackendPlan {
-    match gpu_backend {
-        "wgpu" => GpuBackendPlan {
-            use_wgpu: true,
-            notice: "[gpu-backend] WGPU selected — using WGSL compute shader path".to_string(),
-        },
-        "cuda" => {
-            if quantize_nf4 {
-                GpuBackendPlan {
-                    use_wgpu: false,
-                    notice: "[gpu-backend] CUDA selected — using cuBLAS backward path (QLoRA/NF4)"
-                        .to_string(),
-                }
-            } else {
-                GpuBackendPlan {
-                    use_wgpu: false,
-                    notice: "[gpu-backend] WARNING: plain LoRA (-m lora) runs on the CPU F32 \
-                             path — --gpu-backend cuda does NOT engage the GPU here \
-                             (CUDA is only initialized for QLoRA/NF4). Use -m qlora for the \
-                             cuBLAS backward path."
-                        .to_string(),
-                }
-            }
-        }
-        _ => {
-            // "auto": prefer WGPU for NF4 (fast Q4K load) when compiled in;
-            // full/plain LoRA has no GPU init, so it stays on the CPU F32 path.
-            if quantize_nf4 && wgpu_available {
-                GpuBackendPlan {
-                    use_wgpu: true,
-                    notice: "[gpu-backend] auto → WGPU (NF4 fast load path)".to_string(),
-                }
-            } else if quantize_nf4 {
-                GpuBackendPlan {
-                    use_wgpu: false,
-                    notice: "[gpu-backend] auto → CUDA cuBLAS backward path (QLoRA/NF4)"
-                        .to_string(),
-                }
-            } else {
-                GpuBackendPlan {
-                    use_wgpu: false,
-                    notice: "[gpu-backend] auto → plain LoRA (-m lora) runs on the CPU F32 \
-                             path. Use -m qlora for GPU (CUDA cuBLAS / WGPU) training."
-                        .to_string(),
-                }
-            }
-        }
-    }
-}
-
 /// The training backend a run will actually use — decided ONCE from the
 /// caller's request plus what this binary was built with (PMAT-991, #2906).
 #[cfg(feature = "training")]
@@ -352,16 +273,31 @@ impl GpuBackendChoice {
 /// [`CliError::FeatureDisabled`] (exit code 9) when `"cuda"`/`"wgpu"` is
 /// requested but the corresponding feature was not compiled in. `"auto"`
 /// never errors — it picks the best compiled-in backend, else the CPU path.
+/// [`CliError::ValidationFailed`] (exit code 5) when `"cuda"` is requested for a
+/// method with no CUDA training path (`method_has_cuda_path == false`: plain
+/// LoRA); `-m lora --gpu-backend cuda` refuses or trains on the GPU, never a
+/// silent CPU run (PP-066 R-3).
 #[cfg(feature = "training")]
 pub fn gpu_backend_decision(
     requested: &str,
+    method_has_cuda_path: bool,
     build_has_cuda: bool,
     build_has_wgpu: bool,
 ) -> Result<GpuBackendChoice> {
     match requested {
         "cuda" => {
-            if build_has_cuda {
+            if build_has_cuda && method_has_cuda_path {
                 Ok(GpuBackendChoice::Cuda)
+            } else if build_has_cuda {
+                // R-3 rule: `-m lora --gpu-backend cuda` REFUSES or trains on the
+                // GPU — never a CPU run under a GPU flag. Plain LoRA has no cuBLAS
+                // backward path; only QLoRA/NF4 does.
+                Err(CliError::ValidationFailed(
+                    "--gpu-backend cuda was requested for a method with no CUDA training path: \
+                     plain LoRA (-m lora) runs on the CPU F32 path. Use -m qlora for the \
+                     cuBLAS/NF4 GPU path, or --gpu-backend cpu to say what will happen."
+                        .to_string(),
+                ))
             } else {
                 Err(CliError::FeatureDisabled(
                     "--gpu-backend cuda was requested but this apr binary was built without \
@@ -386,8 +322,12 @@ pub fn gpu_backend_decision(
         "cpu" => Ok(GpuBackendChoice::Cpu),
         _ => {
             // "auto": never refuses. Prefer CUDA's cuBLAS backward when
-            // compiled in, else WGPU, else the CPU F32 path.
-            if build_has_cuda {
+            // compiled in AND the method has a CUDA path (QLoRA/NF4), else
+            // WGPU, else the CPU F32 path. Plain LoRA on auto is the CPU path
+            // and the notice says so.
+            if !method_has_cuda_path {
+                Ok(GpuBackendChoice::Cpu)
+            } else if build_has_cuda {
                 Ok(GpuBackendChoice::Cuda)
             } else if build_has_wgpu {
                 Ok(GpuBackendChoice::Wgpu)
@@ -412,12 +352,16 @@ pub fn pre_training_notice(choice: &GpuBackendChoice) -> String {
         GpuBackendChoice::Wgpu => {
             "[gpu-backend] WGPU selected — using WGSL compute shader path".to_string()
         }
-        GpuBackendChoice::Cuda => "[gpu-backend] CUDA requested — whether a cuBLAS-driven \
-                                    backward pass engages is reported AFTER training, from the \
-                                    observed device-side launch count."
-            .to_string(),
+        GpuBackendChoice::Cuda => {
+            "[gpu-backend] CUDA requested for the QLoRA/NF4 path — whether a \
+                                    device-side backward engages is reported AFTER training, from \
+                                    the observed launch count."
+                .to_string()
+        }
         GpuBackendChoice::Cpu => {
-            "[gpu-backend] CPU — training runs on the CPU F32 path".to_string()
+            "[gpu-backend] CPU — training runs on the CPU F32 path (plain LoRA \
+                                   has no GPU path; use -m qlora for cuBLAS/NF4 or WGPU training)"
+                .to_string()
         }
     }
 }
@@ -425,12 +369,13 @@ pub fn pre_training_notice(choice: &GpuBackendChoice) -> String {
 /// Post-training banner (PMAT-991, #2906): `Some` iff a cuBLAS backward
 /// actually launched during training. Delegates to
 /// `entrenar::training_backend_banner`, which is itself driven strictly by
-/// `entrenar::backward_kernel_launches()` — never by `choice` alone. The
+/// `entrenar::backward_kernel_launches()` since `launches_at_start` — never by
+/// `choice` alone. The
 /// registered mutation "print the banner unconditionally for the cuda choice"
 /// is exactly what this forecloses.
 #[cfg(feature = "training")]
-pub fn post_training_banner(choice: &GpuBackendChoice) -> Option<String> {
-    entrenar::training_backend_banner(choice.requested_name())
+pub fn post_training_banner(choice: &GpuBackendChoice, launches_at_start: u64) -> Option<String> {
+    entrenar::training_backend_banner(choice.requested_name(), launches_at_start)
 }
 
 /// Build the `InstructConfig` for the default LoRA/QLoRA training path.
@@ -552,8 +497,12 @@ fn execute_training(
     // a silent CPU fallback. The pre-training notice may say CUDA was
     // requested; it must not claim a cuBLAS backward ran — that is only known
     // after training (`post_training_banner`, below).
-    let backend_choice =
-        gpu_backend_decision(gpu_backend, cfg!(feature = "cuda"), cfg!(feature = "wgpu"))?;
+    let backend_choice = gpu_backend_decision(
+        gpu_backend,
+        matches!(config.method, Method::QLoRA),
+        cfg!(feature = "cuda"),
+        cfg!(feature = "wgpu"),
+    )?;
     eprintln!("{}", pre_training_notice(&backend_choice));
     let use_wgpu = matches!(backend_choice, GpuBackendChoice::Wgpu);
 
@@ -600,12 +549,15 @@ fn execute_training(
     let mut trainer = InstructTrainer::new(pipeline, corpus, train_config)
         .map_err(|e| CliError::ValidationFailed(format!("Failed to create trainer: {e}")))?;
 
+    // R-3: snapshot the process-wide launch counter so the banner speaks only
+    // about THIS run (a second fine-tune in one process inherits nothing).
+    let launches_at_start = entrenar::backward_kernel_launches();
     let result = trainer.train();
 
     // PMAT-991 (#2906): the cuBLAS-backward line is an EVENT, printed only
     // now — after training — derived from the observed device-side backward
     // launch count, never from `gpu_backend` alone.
-    if let Some(banner) = post_training_banner(&backend_choice) {
+    if let Some(banner) = post_training_banner(&backend_choice, launches_at_start) {
         eprintln!("{banner}");
     }
 

--- a/crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs
@@ -147,7 +147,7 @@ fn gpu_backend_decision_case_table() {
     ];
 
     for (i, row) in rows.iter().enumerate() {
-        let got = gpu_backend_decision(row.requested, row.build_has_cuda, row.build_has_wgpu);
+        let got = gpu_backend_decision(row.requested, true, row.build_has_cuda, row.build_has_wgpu);
         match &row.expect {
             Expect::Ok(choice) => {
                 assert_eq!(
@@ -182,7 +182,7 @@ fn gpu_backend_decision_case_table() {
 /// defect scenario) refuses; it never silently falls back to CPU.
 #[test]
 fn cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback() {
-    let err = gpu_backend_decision("cuda", false, false)
+    let err = gpu_backend_decision("cuda", true, false, false)
         .expect_err("cuda requested on a cpu-only build must refuse");
     assert!(matches!(err, CliError::FeatureDisabled(_)));
     assert_eq!(err.exit_code_value(), 9);
@@ -220,11 +220,13 @@ fn pre_training_notice_never_claims_cublas_backward() {
 /// launches, `post_training_banner` must be `None` for the cuda choice.
 #[test]
 fn post_training_banner_is_none_with_zero_launches() {
-    entrenar::reset_backward_kernel_launches();
     assert_eq!(entrenar::backward_kernel_launches(), 0);
 
     assert_eq!(
-        post_training_banner(&GpuBackendChoice::Cuda),
+        post_training_banner(
+            &GpuBackendChoice::Cuda,
+            entrenar::backward_kernel_launches()
+        ),
         None,
         "zero device-side backward launches observed — the cuBLAS banner must not print"
     );
@@ -234,7 +236,52 @@ fn post_training_banner_is_none_with_zero_launches() {
 /// `entrenar::training_backend_banner` gates on `requested == "cuda"`.
 #[test]
 fn post_training_banner_is_none_for_non_cuda_choices() {
-    entrenar::reset_backward_kernel_launches();
-    assert_eq!(post_training_banner(&GpuBackendChoice::Cpu), None);
-    assert_eq!(post_training_banner(&GpuBackendChoice::Wgpu), None);
+    assert_eq!(post_training_banner(&GpuBackendChoice::Cpu, 0), None);
+    assert_eq!(post_training_banner(&GpuBackendChoice::Wgpu, 0), None);
+}
+
+/// R-3 rule: `-m lora --gpu-backend cuda` REFUSES or trains on the GPU — never
+/// a CPU run under a GPU flag. Plain LoRA has no cuBLAS path, so the explicit
+/// request is `ValidationFailed` (exit code 5, read from error.rs), even on a
+/// build that has the cuda feature.
+#[test]
+fn plain_lora_with_explicit_cuda_is_a_refusal_not_a_cpu_run() {
+    let err = gpu_backend_decision("cuda", false, true, true)
+        .expect_err("cuda for a method with no cuda path must refuse");
+    assert!(matches!(err, CliError::ValidationFailed(_)), "got {err:?}");
+    assert_eq!(err.exit_code_value(), 5);
+}
+
+/// `auto` never refuses: plain LoRA on auto is the CPU path whatever the
+/// build carries; QLoRA on auto prefers cuda, then wgpu, then cpu.
+#[test]
+fn auto_follows_the_method_then_the_build() {
+    assert_eq!(
+        gpu_backend_decision("auto", false, true, true).expect("auto"),
+        GpuBackendChoice::Cpu
+    );
+    assert_eq!(
+        gpu_backend_decision("auto", true, true, true).expect("auto"),
+        GpuBackendChoice::Cuda
+    );
+    assert_eq!(
+        gpu_backend_decision("auto", true, false, true).expect("auto"),
+        GpuBackendChoice::Wgpu
+    );
+    assert_eq!(
+        gpu_backend_decision("auto", true, false, false).expect("auto"),
+        GpuBackendChoice::Cpu
+    );
+}
+
+/// The banner is about THIS run: a launch count snapshot taken now makes a
+/// later banner None even if earlier runs in this process launched kernels.
+#[test]
+fn post_training_banner_is_scoped_to_the_run() {
+    let now = entrenar::backward_kernel_launches();
+    assert_eq!(post_training_banner(&GpuBackendChoice::Cuda, now), None);
+    assert_eq!(
+        post_training_banner(&GpuBackendChoice::Cuda, now.saturating_add(1)),
+        None
+    );
 }

--- a/crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_gpu_backend_truth_tests.rs
@@ -17,16 +17,14 @@
 //!    (`entrenar::backward_kernel_launches()`), never from the request.
 //!
 //! These three functions are pure and gate through
-//! `apr_cli::finetune_test_support` (the crate-private `commands` tree is not
+//! `super` (this file is a `#[cfg(test)]` module of `commands::finetune`; the crate-private `commands` tree is not
 //! reachable from an integration test, same seam as `serve_test_support` /
 //! `qa_types`).
 
 #![allow(clippy::unwrap_used)]
 
-use apr_cli::finetune_test_support::{
-    gpu_backend_decision, post_training_banner, pre_training_notice, GpuBackendChoice,
-};
-use apr_cli::CliError;
+use super::{gpu_backend_decision, post_training_banner, pre_training_notice, GpuBackendChoice};
+use crate::CliError;
 
 /// Every row of {cuda, wgpu, auto, cpu} x {build_has_cuda} x {build_has_wgpu} —
 /// both polarities of both build flags, for every requested string.

--- a/crates/apr-cli/src/commands/finetune_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_tests.rs
@@ -311,7 +311,7 @@ fn test_run_training_creates_adapter() {
         None,
         false,
         None,
-        "cuda",
+        "cpu", /* PMAT-991: "cuda" on a cpu-only build is now FeatureDisabled (exit 9), not a silent CPU fallback; this test exercises the CPU adapter path and says so */
         None,
         None,
         None,

--- a/crates/apr-cli/src/commands/finetune_tests.rs
+++ b/crates/apr-cli/src/commands/finetune_tests.rs
@@ -1225,58 +1225,6 @@ fn build_instruct_config_defaults_max_seq_len_to_512_when_absent() {
     assert!(cfg.quantize_nf4, "QLoRA method → NF4 on");
 }
 
-// ── gpu_backend_notice (Defect 1: truthful GPU banner) ──────────────────────
-
-#[test]
-fn gpu_backend_notice_cuda_plain_lora_warns_cpu() {
-    // --gpu-backend cuda + plain LoRA (quantize_nf4=false) must NOT claim cuBLAS;
-    // it must WARN that training actually runs on CPU (init_cuda is QLoRA-only).
-    let p = gpu_backend_notice("cuda", false, false);
-    assert!(!p.use_wgpu);
-    assert!(p.notice.contains("WARNING"), "must warn: {}", p.notice);
-    assert!(p.notice.to_lowercase().contains("cpu"));
-    assert!(
-        !p.notice.contains("using cuBLAS backward path (QLoRA/NF4)"),
-        "must not make a false cuBLAS claim for plain LoRA: {}",
-        p.notice
-    );
-}
-
-#[test]
-fn gpu_backend_notice_cuda_qlora_claims_cublas() {
-    let p = gpu_backend_notice("cuda", true, false);
-    assert!(!p.use_wgpu);
-    assert!(
-        p.notice.contains("cuBLAS"),
-        "QLoRA on CUDA truthfully engages cuBLAS: {}",
-        p.notice
-    );
-    assert!(!p.notice.contains("WARNING"));
-}
-
-#[test]
-fn gpu_backend_notice_wgpu_selects_wgpu() {
-    let p = gpu_backend_notice("wgpu", false, true);
-    assert!(p.use_wgpu);
-    assert!(p.notice.contains("WGPU"));
-}
-
-#[test]
-fn gpu_backend_notice_auto_plain_lora_is_cpu() {
-    let p = gpu_backend_notice("auto", false, true);
-    assert!(!p.use_wgpu, "plain LoRA under auto stays on the CPU path");
-    assert!(p.notice.to_lowercase().contains("cpu"));
-}
-
-#[test]
-fn gpu_backend_notice_auto_qlora_prefers_wgpu_when_available() {
-    let with_wgpu = gpu_backend_notice("auto", true, true);
-    assert!(with_wgpu.use_wgpu, "NF4 + wgpu available → WGPU fast path");
-    let without_wgpu = gpu_backend_notice("auto", true, false);
-    assert!(!without_wgpu.use_wgpu, "no wgpu feature → CUDA path");
-    assert!(without_wgpu.notice.contains("cuBLAS"));
-}
-
 // ── run (top-level dispatch) error paths ────────────────────────────────────
 
 #[test]

--- a/crates/apr-cli/tests/finetune_gpu_backend_truth.rs
+++ b/crates/apr-cli/tests/finetune_gpu_backend_truth.rs
@@ -1,0 +1,242 @@
+//! finetune_gpu_backend_truth (PMAT-991, #2906, PP-066 R-3 P_2): the CLI must
+//! meet the request against the BUILD, not print a claim off the request
+//! alone.
+//!
+//! Two defects this pins:
+//!
+//! 1. `--gpu-backend cuda` on a binary built WITHOUT the `cuda` feature used
+//!    to fall through to the CPU path silently
+//!    (feedback_apr_finetune_lora_cpu_only). It must instead REFUSE —
+//!    `CliError::FeatureDisabled`, exit code 9 (see `error.rs`), naming the
+//!    missing feature and the rebuild flag.
+//! 2. The pre-training banner used to print
+//!    "[gpu-backend] CUDA selected — using cuBLAS backward path" straight
+//!    from the request, before any training step ran. The cuBLAS-backward
+//!    claim is an EVENT, derived after training from
+//!    `entrenar::training_backend_banner`
+//!    (`entrenar::backward_kernel_launches()`), never from the request.
+//!
+//! These three functions are pure and gate through
+//! `apr_cli::finetune_test_support` (the crate-private `commands` tree is not
+//! reachable from an integration test, same seam as `serve_test_support` /
+//! `qa_types`).
+
+#![allow(clippy::unwrap_used)]
+
+use apr_cli::finetune_test_support::{
+    gpu_backend_decision, post_training_banner, pre_training_notice, GpuBackendChoice,
+};
+use apr_cli::CliError;
+
+/// Every row of {cuda, wgpu, auto, cpu} x {build_has_cuda} x {build_has_wgpu} —
+/// both polarities of both build flags, for every requested string.
+#[test]
+fn gpu_backend_decision_case_table() {
+    struct Row {
+        requested: &'static str,
+        build_has_cuda: bool,
+        build_has_wgpu: bool,
+        expect: Expect,
+    }
+    enum Expect {
+        Ok(GpuBackendChoice),
+        FeatureDisabled,
+    }
+
+    let rows = [
+        // requested = "cuda": Ok(Cuda) iff build_has_cuda, else a refusal —
+        // NEVER a silent CPU fallback — regardless of wgpu.
+        Row {
+            requested: "cuda",
+            build_has_cuda: true,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Cuda),
+        },
+        Row {
+            requested: "cuda",
+            build_has_cuda: true,
+            build_has_wgpu: false,
+            expect: Expect::Ok(GpuBackendChoice::Cuda),
+        },
+        Row {
+            requested: "cuda",
+            build_has_cuda: false,
+            build_has_wgpu: true,
+            expect: Expect::FeatureDisabled,
+        },
+        Row {
+            requested: "cuda",
+            build_has_cuda: false,
+            build_has_wgpu: false,
+            expect: Expect::FeatureDisabled,
+        },
+        // requested = "wgpu": symmetric on build_has_wgpu, regardless of cuda.
+        Row {
+            requested: "wgpu",
+            build_has_cuda: true,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Wgpu),
+        },
+        Row {
+            requested: "wgpu",
+            build_has_cuda: false,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Wgpu),
+        },
+        Row {
+            requested: "wgpu",
+            build_has_cuda: true,
+            build_has_wgpu: false,
+            expect: Expect::FeatureDisabled,
+        },
+        Row {
+            requested: "wgpu",
+            build_has_cuda: false,
+            build_has_wgpu: false,
+            expect: Expect::FeatureDisabled,
+        },
+        // requested = "cpu": always Ok(Cpu), whatever the build.
+        Row {
+            requested: "cpu",
+            build_has_cuda: true,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Cpu),
+        },
+        Row {
+            requested: "cpu",
+            build_has_cuda: true,
+            build_has_wgpu: false,
+            expect: Expect::Ok(GpuBackendChoice::Cpu),
+        },
+        Row {
+            requested: "cpu",
+            build_has_cuda: false,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Cpu),
+        },
+        Row {
+            requested: "cpu",
+            build_has_cuda: false,
+            build_has_wgpu: false,
+            expect: Expect::Ok(GpuBackendChoice::Cpu),
+        },
+        // requested = "auto": NEVER errors; picks the best compiled-in
+        // backend, else CPU.
+        Row {
+            requested: "auto",
+            build_has_cuda: true,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Cuda),
+        },
+        Row {
+            requested: "auto",
+            build_has_cuda: true,
+            build_has_wgpu: false,
+            expect: Expect::Ok(GpuBackendChoice::Cuda),
+        },
+        Row {
+            requested: "auto",
+            build_has_cuda: false,
+            build_has_wgpu: true,
+            expect: Expect::Ok(GpuBackendChoice::Wgpu),
+        },
+        Row {
+            requested: "auto",
+            build_has_cuda: false,
+            build_has_wgpu: false,
+            expect: Expect::Ok(GpuBackendChoice::Cpu),
+        },
+    ];
+
+    for (i, row) in rows.iter().enumerate() {
+        let got = gpu_backend_decision(row.requested, row.build_has_cuda, row.build_has_wgpu);
+        match &row.expect {
+            Expect::Ok(choice) => {
+                assert_eq!(
+                    got.as_ref().ok(),
+                    Some(choice),
+                    "row {i} ({}, cuda={}, wgpu={}): expected Ok({choice:?}), got {got:?}",
+                    row.requested,
+                    row.build_has_cuda,
+                    row.build_has_wgpu,
+                );
+            }
+            Expect::FeatureDisabled => {
+                let err = got.expect_err(&format!(
+                    "row {i} ({}, cuda={}, wgpu={}): expected a refusal, got Ok",
+                    row.requested, row.build_has_cuda, row.build_has_wgpu,
+                ));
+                assert!(
+                    matches!(err, CliError::FeatureDisabled(_)),
+                    "row {i}: expected CliError::FeatureDisabled, got {err:?}"
+                );
+                assert_eq!(
+                    err.exit_code_value(),
+                    9,
+                    "row {i}: FeatureDisabled must exit 9 (error.rs)"
+                );
+            }
+        }
+    }
+}
+
+/// A cuda request on a cpu-only build (the exact `-m lora --gpu-backend cuda`
+/// defect scenario) refuses; it never silently falls back to CPU.
+#[test]
+fn cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback() {
+    let err = gpu_backend_decision("cuda", false, false)
+        .expect_err("cuda requested on a cpu-only build must refuse");
+    assert!(matches!(err, CliError::FeatureDisabled(_)));
+    assert_eq!(err.exit_code_value(), 9);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cuda"),
+        "refusal must name the missing feature: {msg}"
+    );
+    assert!(
+        msg.contains("--features cuda"),
+        "refusal must name the rebuild flag: {msg}"
+    );
+}
+
+/// The pre-training notice must never CLAIM a cuBLAS backward — that is only
+/// known after training. Every choice, both polarities.
+#[test]
+fn pre_training_notice_never_claims_cublas_backward() {
+    for choice in [
+        GpuBackendChoice::Cuda,
+        GpuBackendChoice::Wgpu,
+        GpuBackendChoice::Cpu,
+    ] {
+        let notice = pre_training_notice(&choice);
+        assert!(
+            !notice.contains("cuBLAS backward"),
+            "pre-training notice for {choice:?} claims a cuBLAS backward before training ran: \
+             {notice}"
+        );
+    }
+}
+
+/// Registered mutation: "print the cuBLAS banner unconditionally for a cuda
+/// choice" must go RED here. With zero observed device-side backward
+/// launches, `post_training_banner` must be `None` for the cuda choice.
+#[test]
+fn post_training_banner_is_none_with_zero_launches() {
+    entrenar::reset_backward_kernel_launches();
+    assert_eq!(entrenar::backward_kernel_launches(), 0);
+
+    assert_eq!(
+        post_training_banner(&GpuBackendChoice::Cuda),
+        None,
+        "zero device-side backward launches observed — the cuBLAS banner must not print"
+    );
+}
+
+/// The cpu and wgpu choices never print the cuBLAS banner, launches or not —
+/// `entrenar::training_backend_banner` gates on `requested == "cuda"`.
+#[test]
+fn post_training_banner_is_none_for_non_cuda_choices() {
+    entrenar::reset_backward_kernel_launches();
+    assert_eq!(post_training_banner(&GpuBackendChoice::Cpu), None);
+    assert_eq!(post_training_banner(&GpuBackendChoice::Wgpu), None);
+}

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
@@ -970,7 +970,7 @@ pub fn gemm_nf4_backward_a_cublas(
 
     // grad_in[M,K] = grad_out[M,N] @ W[N,K]
     // col-major: C_cm[K,M] = W_cm[K,N] @ A_cm[N,M]
-    cublas
+    let result = cublas
         .gemm_f32(
             GemmOp::NoTrans, // W_cm[K,N] as-is
             GemmOp::NoTrans, // grad_out_cm[N,M] as-is
@@ -986,7 +986,11 @@ pub fn gemm_nf4_backward_a_cublas(
             grad_input.as_ptr(), // grad_in: row-major [M,K] = col-major [K,M], ldc=K
             k as i32,            // ldc = K
         )
-        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS NF4 backward_a failed: {e:?}")))
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS NF4 backward_a failed: {e:?}")));
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// NF4 transposed GEMM for backward pass (ENT-153: QLoRA backward).
@@ -1065,6 +1069,7 @@ pub fn gemm_nf4_backward_a(
         stream.launch_kernel(module, "nf4_gemm_transpose", &config, &mut args).map_err(|e| {
             CudaTensorError::KernelError(format!("NF4 GEMM transpose launch failed: {e:?}"))
         })?;
+        crate::autograd::note_backward_kernel_launch();
     }
 
     Ok(())
@@ -1140,6 +1145,7 @@ pub fn gemm_nf4_tc_backward_a(
                     "NF4 tensor core GEMM backward_a launch failed: {e:?}"
                 ))
             })?;
+        crate::autograd::note_backward_kernel_launch();
     }
 
     Ok(())

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul.rs
@@ -250,7 +250,7 @@ pub(crate) fn cublas_gemm_backward_a(
     k: u32,
     n: u32,
 ) -> Result<()> {
-    cublas
+    let result = cublas
         .gemm_f32(
             GemmOp::Trans,
             GemmOp::NoTrans,
@@ -266,7 +266,11 @@ pub(crate) fn cublas_gemm_backward_a(
             grad_a.as_ptr(),
             k as i32,
         )
-        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS GEMM backward_a failed: {e:?}")))
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS GEMM backward_a failed: {e:?}")));
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// cuBLAS backward A with accumulation: grad_A += grad_C @ B^T (PMAT-484)
@@ -284,7 +288,7 @@ pub(crate) fn cublas_gemm_backward_a_accumulate(
     k: u32,
     n: u32,
 ) -> Result<()> {
-    cublas
+    let result = cublas
         .gemm_f32(
             GemmOp::Trans,
             GemmOp::NoTrans,
@@ -302,7 +306,11 @@ pub(crate) fn cublas_gemm_backward_a_accumulate(
         )
         .map_err(|e| {
             CudaTensorError::KernelError(format!("cuBLAS GEMM backward_a accumulate failed: {e:?}"))
-        })
+        });
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// cuBLAS backward B: grad_B[K,N] = A[M,K]^T @ grad_C[M,N]
@@ -316,7 +324,7 @@ pub(crate) fn cublas_gemm_backward_b(
     k: u32,
     n: u32,
 ) -> Result<()> {
-    cublas
+    let result = cublas
         .gemm_f32(
             GemmOp::NoTrans,
             GemmOp::Trans,
@@ -332,7 +340,11 @@ pub(crate) fn cublas_gemm_backward_b(
             grad_b.as_ptr(),
             n as i32,
         )
-        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS GEMM backward_b failed: {e:?}")))
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS GEMM backward_b failed: {e:?}")));
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// Batched 4D GEMM forward pass on GPU for multi-head attention

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
@@ -87,7 +87,7 @@ pub(crate) fn cublas_gemm_backward_a_f16(
     k: u32,
     n: u32,
 ) -> Result<()> {
-    cublas
+    let result = cublas
         .gemm_f16(
             GemmOp::Trans,
             GemmOp::NoTrans,
@@ -103,7 +103,11 @@ pub(crate) fn cublas_gemm_backward_a_f16(
             grad_a.as_ptr(),
             k as i32,
         )
-        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS fp16 backward_a failed: {e:?}")))
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS fp16 backward_a failed: {e:?}")));
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// FP16 cuBLAS backward B: grad_B[K,N] = A[M,K]^T @ grad_C[M,N] (tensor cores)
@@ -119,7 +123,7 @@ pub(crate) fn cublas_gemm_backward_b_f16(
     k: u32,
     n: u32,
 ) -> Result<()> {
-    cublas
+    let result = cublas
         .gemm_f16(
             GemmOp::NoTrans,
             GemmOp::Trans,
@@ -135,7 +139,11 @@ pub(crate) fn cublas_gemm_backward_b_f16(
             grad_b.as_ptr(),
             n as i32,
         )
-        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS fp16 backward_b failed: {e:?}")))
+        .map_err(|e| CudaTensorError::KernelError(format!("cuBLAS fp16 backward_b failed: {e:?}")));
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// Mixed-precision backward_a: grad_A(fp32) = grad_C(fp16) @ B(fp16)^T (tensor cores)

--- a/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
+++ b/crates/aprender-train/src/autograd/cuda_forward/matmul_f16.rs
@@ -169,7 +169,7 @@ pub fn gemm_f16_to_f32_backward_a(
         CudaTensorError::KernelError("cuBLAS handle required for fp16→fp32 backward".to_string())
     })?;
     super::matmul::bind_cublas_stream(cublas, stream)?;
-    cublas
+    let result = cublas
         .gemm_f16_to_f32(
             GemmOp::Trans,
             GemmOp::NoTrans,
@@ -187,7 +187,11 @@ pub fn gemm_f16_to_f32_backward_a(
         )
         .map_err(|e| {
             CudaTensorError::KernelError(format!("cuBLAS fp16→fp32 backward_a failed: {e:?}"))
-        })
+        });
+    if result.is_ok() {
+        crate::autograd::note_backward_kernel_launch();
+    }
+    result
 }
 
 /// Mixed-precision GEMM: C(fp32) = A(fp16) @ B(fp16) using tensor cores

--- a/crates/aprender-train/src/autograd/mod.rs
+++ b/crates/aprender-train/src/autograd/mod.rs
@@ -87,11 +87,6 @@ pub fn backward_kernel_launches() -> u64 {
     BACKWARD_KERNEL_LAUNCHES.load(std::sync::atomic::Ordering::SeqCst)
 }
 
-/// Reset the device-side backward kernel launch counter to zero.
-pub fn reset_backward_kernel_launches() {
-    BACKWARD_KERNEL_LAUNCHES.store(0, std::sync::atomic::Ordering::SeqCst);
-}
-
 /// Record one device-side backward kernel launch (PMAT-991). Called from
 /// every cuBLAS backward GEMM call site in `cuda_forward::matmul` /
 /// `cuda_forward::matmul_f16`, only after the launch itself succeeded.
@@ -108,16 +103,23 @@ pub(crate) fn note_backward_kernel_launch() {
 /// observed device-side backward kernel launches (PMAT-991, #2906) — never
 /// from `requested` alone. A banner claiming a cuBLAS backward path with
 /// zero launched backward kernels is exactly the defect this forecloses.
-pub fn training_backend_banner(requested: &str) -> Option<String> {
+/// `launches_at_start` is the caller's snapshot of [`backward_kernel_launches`]
+/// taken before its training run; there is deliberately no reset.
+pub fn training_backend_banner(requested: &str, launches_at_start: u64) -> Option<String> {
     if requested != "cuda" {
         return None;
     }
-    let launches = backward_kernel_launches();
+    // Since-start semantics (R-3 review quorum 2026-09-06, 3/3): the counter is
+    // process-wide and monotonic, so a second fine-tune in the same process, or
+    // a long-lived server, must not inherit an earlier run's launches. The
+    // caller snapshots `backward_kernel_launches()` before its run and the
+    // banner speaks only about launches observed since then.
+    let launches = backward_kernel_launches().saturating_sub(launches_at_start);
     if launches == 0 {
         return None;
     }
     Some(format!(
-        "[gpu-backend] CUDA — cuBLAS backward engaged ({launches} device-side backward launches)"
+        "[gpu-backend] CUDA — device-side backward engaged ({launches} device-side backward launches this run)"
     ))
 }
 

--- a/crates/aprender-train/src/autograd/mod.rs
+++ b/crates/aprender-train/src/autograd/mod.rs
@@ -71,6 +71,56 @@ pub use precision::{
 };
 pub use tensor::Tensor;
 
+/// Process-wide counter of device-side backward kernel launches observed so
+/// far — cuBLAS backward GEMM calls (`cuda_forward::matmul`/`matmul_f16`).
+///
+/// PMAT-991 (#2906): this counter, not the caller's request string, is the
+/// ONLY source of truth for whether a cuBLAS backward path actually engaged.
+/// The old CLI banner was derived from the request alone and could claim GPU
+/// training while every backward ran on the CPU.
+static BACKWARD_KERNEL_LAUNCHES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Number of device-side backward kernel launches observed since process
+/// start (or the last [`reset_backward_kernel_launches`]).
+pub fn backward_kernel_launches() -> u64 {
+    BACKWARD_KERNEL_LAUNCHES.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Reset the device-side backward kernel launch counter to zero.
+pub fn reset_backward_kernel_launches() {
+    BACKWARD_KERNEL_LAUNCHES.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Record one device-side backward kernel launch (PMAT-991). Called from
+/// every cuBLAS backward GEMM call site in `cuda_forward::matmul` /
+/// `cuda_forward::matmul_f16`, only after the launch itself succeeded.
+///
+/// Only reachable when the `cuda` feature is compiled in — every call site
+/// lives behind `#[cfg(feature = "cuda")]`, so a `cpu-fallback` build never
+/// calls this and must not be warned/denied as dead code for it.
+#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
+pub(crate) fn note_backward_kernel_launch() {
+    BACKWARD_KERNEL_LAUNCHES.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Derive the "cuBLAS backward engaged" training banner strictly from
+/// observed device-side backward kernel launches (PMAT-991, #2906) — never
+/// from `requested` alone. A banner claiming a cuBLAS backward path with
+/// zero launched backward kernels is exactly the defect this forecloses.
+pub fn training_backend_banner(requested: &str) -> Option<String> {
+    if requested != "cuda" {
+        return None;
+    }
+    let launches = backward_kernel_launches();
+    if launches == 0 {
+        return None;
+    }
+    Some(format!(
+        "[gpu-backend] CUDA — cuBLAS backward engaged ({launches} device-side backward launches)"
+    ))
+}
+
 /// Perform backward pass on a tensor
 pub fn backward(tensor: &mut Tensor, grad_output: Option<ndarray::Array1<f32>>) {
     if let Some(grad) = grad_output {

--- a/crates/aprender-train/src/lib.rs
+++ b/crates/aprender-train/src/lib.rs
@@ -136,5 +136,8 @@ pub mod yaml_mode;
 pub mod error;
 
 // Re-export commonly used types
-pub use autograd::{backward, Context, Tensor};
+pub use autograd::{
+    backward, backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
+    Context, Tensor,
+};
 pub use error::{Error, Result};

--- a/crates/aprender-train/src/lib.rs
+++ b/crates/aprender-train/src/lib.rs
@@ -136,8 +136,5 @@ pub mod yaml_mode;
 pub mod error;
 
 // Re-export commonly used types
-pub use autograd::{
-    backward, backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
-    Context, Tensor,
-};
+pub use autograd::{backward, backward_kernel_launches, training_backend_banner, Context, Tensor};
 pub use error::{Error, Result};

--- a/crates/aprender-train/tests/banner_truth.rs
+++ b/crates/aprender-train/tests/banner_truth.rs
@@ -1,0 +1,135 @@
+//! banner_truth (PMAT-991, #2906, PP-066 R-3): the "cuBLAS backward" training
+//! banner MUST be derived from device-side backward kernel launches actually
+//! observed, never from the caller's request alone.
+//!
+//! The defect (measured 2026-09-05): the CLI printed
+//! "[gpu-backend] CUDA selected — using cuBLAS backward path" straight from
+//! the request, with nothing in `entrenar` recording whether a device-side
+//! cuBLAS backward kernel ever launched. A banner could claim GPU training
+//! while every backward ran on the CPU. This test pins the library-side
+//! contract: `training_backend_banner(requested)` is `Some` iff
+//! `requested == "cuda"` AND `backward_kernel_launches() > 0`.
+
+#![allow(clippy::unwrap_used)]
+
+use entrenar::{backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner};
+
+/// Registered mutation: "print the banner unconditionally" must go RED here.
+/// A banner claiming cuBLAS backward with a zero launch count is exactly the
+/// defect this ticket forecloses.
+#[test]
+fn banner_is_none_for_cuda_with_zero_launches() {
+    reset_backward_kernel_launches();
+    assert_eq!(backward_kernel_launches(), 0);
+    assert_eq!(
+        training_backend_banner("cuda"),
+        None,
+        "a cuBLAS-backward banner with ZERO observed device-side backward launches is the \
+         defect PMAT-991 exists to forbid — the banner must never be printed unconditionally"
+    );
+}
+
+#[cfg(not(feature = "cuda"))]
+mod cpu_only {
+    use entrenar::autograd::{backward, matmul, Tensor};
+    use entrenar::{
+        backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
+    };
+
+    /// With no `cuda` feature compiled in, there is no device-side backward
+    /// kernel that could ever launch — so the counter must stay at 0 even
+    /// after driving a real (CPU) backward pass through the public autograd
+    /// API, and the banner must be `None` for BOTH "cuda" (nothing to claim)
+    /// and "cpu" (the banner is a cuBLAS claim, not a generic device claim).
+    #[test]
+    fn cpu_backward_never_increments_the_device_counter() {
+        reset_backward_kernel_launches();
+
+        // Smallest public backward drivable through the autograd API: a 2x2
+        // matmul forward + backward (entrenar::autograd::ops::matmul).
+        let a = Tensor::from_vec(vec![1.0, 2.0, 3.0, 4.0], true);
+        let b = Tensor::from_vec(vec![5.0, 6.0, 7.0, 8.0], true);
+        let mut c = matmul(&a, &b, 2, 2, 2);
+        backward(&mut c, None);
+
+        assert_eq!(
+            backward_kernel_launches(),
+            0,
+            "no cuda feature is compiled in, so NOTHING can have launched a device-side \
+             backward kernel — a CPU-only backward must never move this counter"
+        );
+        assert_eq!(training_backend_banner("cuda"), None);
+        assert_eq!(training_backend_banner("cpu"), None);
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod cuda_only {
+    use std::sync::Arc;
+
+    use trueno_gpu::driver::{cuda_available, CudaContext, CudaStream, GpuBuffer};
+
+    use entrenar::autograd::cuda_backward::{gemm_backward_a, init_kernel_cache};
+    use entrenar::{
+        backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
+    };
+
+    /// Runs a real cuBLAS backward GEMM (2x2) through the smallest public
+    /// CUDA entry point and asserts the counter — and hence the banner — is
+    /// driven by that launch, not by the string "cuda".
+    #[test]
+    fn cuda_backward_launch_drives_the_banner() {
+        if !cuda_available() {
+            eprintln!("no CUDA device visible — skipping cuda_backward_launch_drives_the_banner");
+            return;
+        }
+        let ctx = Arc::new(CudaContext::new(0).expect("CUDA device 0 required"));
+        init_kernel_cache(ctx.clone()).expect("init_kernel_cache failed");
+        let stream = CudaStream::new(&ctx).expect("CudaStream::new failed");
+
+        reset_backward_kernel_launches();
+        assert_eq!(backward_kernel_launches(), 0);
+        assert_eq!(training_backend_banner("cuda"), None);
+
+        // C = A @ B, A/B/grad_C all 2x2 — same fixture as
+        // cuda_backward::tests::gemm::test_gemm_backward_a_basic.
+        let m = 2u32;
+        let k = 2u32;
+        let n = 2u32;
+        let grad_output_data: Vec<f32> = vec![1.0, 0.0, 0.0, 1.0];
+        let b_data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+        let grad_a_data: Vec<f32> = vec![0.0; (m * k) as usize];
+
+        let grad_output = GpuBuffer::from_host(&ctx, &grad_output_data).expect("grad_output");
+        let b = GpuBuffer::from_host(&ctx, &b_data).expect("b");
+        let mut grad_a = GpuBuffer::from_host(&ctx, &grad_a_data).expect("grad_a");
+
+        gemm_backward_a(&grad_output, &b, &mut grad_a, m, k, n, &stream)
+            .expect("gemm_backward_a failed");
+        stream.synchronize().expect("stream.synchronize failed");
+
+        let launches = backward_kernel_launches();
+        assert!(
+            launches > 0,
+            "a cuBLAS backward GEMM just launched on-device; the counter must reflect it"
+        );
+
+        let banner = training_backend_banner("cuda");
+        assert!(banner.is_some(), "backward launched — the banner must now be Some");
+        let banner = banner.expect("checked is_some above");
+        assert!(
+            banner.contains("cuBLAS backward"),
+            "banner must name the cuBLAS backward engagement, got: {banner}"
+        );
+
+        // Reset and re-check: a banner without ANY launch since the reset is
+        // the defect again — the predicate must track the counter, not a
+        // sticky "we've seen CUDA before" flag.
+        reset_backward_kernel_launches();
+        assert_eq!(
+            training_backend_banner("cuda"),
+            None,
+            "after reset, zero launches have been observed — banner must be None again"
+        );
+    }
+}

--- a/crates/aprender-train/tests/banner_truth.rs
+++ b/crates/aprender-train/tests/banner_truth.rs
@@ -12,17 +12,16 @@
 
 #![allow(clippy::unwrap_used)]
 
-use entrenar::{backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner};
+use entrenar::{backward_kernel_launches, training_backend_banner};
 
 /// Registered mutation: "print the banner unconditionally" must go RED here.
 /// A banner claiming cuBLAS backward with a zero launch count is exactly the
 /// defect this ticket forecloses.
 #[test]
 fn banner_is_none_for_cuda_with_zero_launches() {
-    reset_backward_kernel_launches();
-    assert_eq!(backward_kernel_launches(), 0);
+    let start = backward_kernel_launches();
     assert_eq!(
-        training_backend_banner("cuda"),
+        training_backend_banner("cuda", start),
         None,
         "a cuBLAS-backward banner with ZERO observed device-side backward launches is the \
          defect PMAT-991 exists to forbid — the banner must never be printed unconditionally"
@@ -32,9 +31,7 @@ fn banner_is_none_for_cuda_with_zero_launches() {
 #[cfg(not(feature = "cuda"))]
 mod cpu_only {
     use entrenar::autograd::{backward, matmul, Tensor};
-    use entrenar::{
-        backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
-    };
+    use entrenar::{backward_kernel_launches, training_backend_banner};
 
     /// With no `cuda` feature compiled in, there is no device-side backward
     /// kernel that could ever launch — so the counter must stay at 0 even
@@ -43,7 +40,7 @@ mod cpu_only {
     /// and "cpu" (the banner is a cuBLAS claim, not a generic device claim).
     #[test]
     fn cpu_backward_never_increments_the_device_counter() {
-        reset_backward_kernel_launches();
+        let start = backward_kernel_launches();
 
         // Smallest public backward drivable through the autograd API: a 2x2
         // matmul forward + backward (entrenar::autograd::ops::matmul).
@@ -54,12 +51,12 @@ mod cpu_only {
 
         assert_eq!(
             backward_kernel_launches(),
-            0,
+            start,
             "no cuda feature is compiled in, so NOTHING can have launched a device-side \
              backward kernel — a CPU-only backward must never move this counter"
         );
-        assert_eq!(training_backend_banner("cuda"), None);
-        assert_eq!(training_backend_banner("cpu"), None);
+        assert_eq!(training_backend_banner("cuda", start), None);
+        assert_eq!(training_backend_banner("cpu", start), None);
     }
 }
 
@@ -70,9 +67,7 @@ mod cuda_only {
     use trueno_gpu::driver::{cuda_available, CudaContext, CudaStream, GpuBuffer};
 
     use entrenar::autograd::cuda_backward::{gemm_backward_a, init_kernel_cache};
-    use entrenar::{
-        backward_kernel_launches, reset_backward_kernel_launches, training_backend_banner,
-    };
+    use entrenar::{backward_kernel_launches, training_backend_banner};
 
     /// Runs a real cuBLAS backward GEMM (2x2) through the smallest public
     /// CUDA entry point and asserts the counter — and hence the banner — is
@@ -87,9 +82,8 @@ mod cuda_only {
         init_kernel_cache(ctx.clone()).expect("init_kernel_cache failed");
         let stream = CudaStream::new(&ctx).expect("CudaStream::new failed");
 
-        reset_backward_kernel_launches();
-        assert_eq!(backward_kernel_launches(), 0);
-        assert_eq!(training_backend_banner("cuda"), None);
+        let start = backward_kernel_launches();
+        assert_eq!(training_backend_banner("cuda", start), None);
 
         // C = A @ B, A/B/grad_C all 2x2 — same fixture as
         // cuda_backward::tests::gemm::test_gemm_backward_a_basic.
@@ -108,28 +102,28 @@ mod cuda_only {
             .expect("gemm_backward_a failed");
         stream.synchronize().expect("stream.synchronize failed");
 
-        let launches = backward_kernel_launches();
         assert!(
-            launches > 0,
+            backward_kernel_launches() > start,
             "a cuBLAS backward GEMM just launched on-device; the counter must reflect it"
         );
 
-        let banner = training_backend_banner("cuda");
+        let banner = training_backend_banner("cuda", start);
         assert!(banner.is_some(), "backward launched — the banner must now be Some");
         let banner = banner.expect("checked is_some above");
         assert!(
-            banner.contains("cuBLAS backward"),
-            "banner must name the cuBLAS backward engagement, got: {banner}"
+            banner.contains("backward engaged"),
+            "banner must name the device-side backward engagement, got: {banner}"
         );
 
         // Reset and re-check: a banner without ANY launch since the reset is
         // the defect again — the predicate must track the counter, not a
         // sticky "we've seen CUDA before" flag.
-        reset_backward_kernel_launches();
+        let later_run_start = backward_kernel_launches();
         assert_eq!(
-            training_backend_banner("cuda"),
+            training_backend_banner("cuda", later_run_start),
             None,
-            "after reset, zero launches have been observed — banner must be None again"
+            "a run that observed no new launches gets no banner, whatever earlier runs in this \
+             process launched — the process-wide counter must not leak across runs"
         );
     }
 }

--- a/docs/audits/impl-PMAT-991-receipt.md
+++ b/docs/audits/impl-PMAT-991-receipt.md
@@ -7,7 +7,7 @@ issue: 2906
 epic: 2873
 model: "orchestrator claude-fable-5-1; workers sonnet (paiml-impl-worker) x2 (P_1, P_2), each resumed once at maxTurns=40; P_2's last mile and P_3 by the orchestrator"
 tokens_used: "workers 120478 + 120623 = 241101 (P_1, P_2 first passes; resumes not separately reported); orchestrator [U] (not instrumented)"
-wall_clock_s: "[U] (not instrumented); P_1 dispatch ~02:52Z -> P_3 contract commit ~04:20Z on 2026-09-06 (about 5,300 s of orchestration, two worker runs inside)"
+wall_clock_s: "[U] (not instrumented); P_1 dispatch ~02:52Z -> review-round commit ~04:45Z on 2026-09-06 (about 6,800 s of orchestration, two worker runs and one 3-lane review inside)"
 ---
 # impl-PMAT-991 — R-3 · T-6 honest training banner (#2906; spec §5 R-3, D-7; feedback_apr_finetune_lora_cpu_only)
 
@@ -15,8 +15,8 @@ wall_clock_s: "[U] (not instrumented); P_1 dispatch ~02:52Z -> P_3 contract comm
 ticket PMAT-991 · kind code · branch `agent/R-3` (worktree, claim held) · base `65680cdf8` · `discover.json` at `$XDG_RUNTIME_DIR/paiml-implement/discover-R-3.json` (`gate_cmd_fallback=true`: `cargo test --workspace` is CI's job; crate-level `--lib` gates were run here) · quorum: 3-lane review-only at P3 (agy delegate) · K̂ = 3 (`basis=first-run[U]`, estimate.sh: 0 rows for this row class).
 
 ## What lands
-- `entrenar` (crates/aprender-train): `BACKWARD_KERNEL_LAUNCHES` (AtomicU64) with `backward_kernel_launches()`, `reset_backward_kernel_launches()`, `pub(crate) note_backward_kernel_launch()` called at every cuBLAS backward launch (`cuda_forward/matmul.rs`: a, a_accumulate, b; `matmul_f16.rs`: a, b); `training_backend_banner(requested) -> Option<String>` is Some iff `requested == "cuda"` and the counter > 0. Test `tests/banner_truth.rs` (RED first at 51bdb5b66: the three symbols did not exist; GREEN at 7c1701431; both `--features cuda` and default arms).
-- `apr finetune` (crates/apr-cli): `gpu_backend_decision(requested, build_has_cuda, build_has_wgpu) -> Result<GpuBackendChoice, CliError>` — `cuda`/`wgpu` on a build without that feature is `CliError::FeatureDisabled` (exit code 9, read from `error.rs:106`), `auto`/`cpu` never refuse; `pre_training_notice` never contains "cuBLAS backward"; `post_training_banner` delegates to `entrenar::training_backend_banner`, printed after training. The case table lives in `commands/finetune_gpu_backend_truth_tests.rs` (5 tests; RED first at c8d1cd386).
+- `entrenar` (crates/aprender-train): `BACKWARD_KERNEL_LAUNCHES` (AtomicU64, monotonic, no reset API) with `backward_kernel_launches()` and `pub(crate) note_backward_kernel_launch()` at every device-side backward launch — `cuda_forward/matmul.rs`: cuBLAS a, a_accumulate, b, NF4 cuBLAS a, NF4 PTX a, NF4 tensor-core a; `matmul_f16.rs`: f16 a, b, f16→f32 a (nine sites); `training_backend_banner(requested, launches_at_start) -> Option<String>` is Some iff `requested == "cuda"` and the counter rose above the caller's start snapshot — the banner is scoped to THIS run. Test `tests/banner_truth.rs` (RED first at 51bdb5b66: the three symbols did not exist; GREEN at 7c1701431; both `--features cuda` and default arms).
+- `apr finetune` (crates/apr-cli): `gpu_backend_decision(requested, method_has_cuda_path, build_has_cuda, build_has_wgpu) -> Result<GpuBackendChoice, CliError>` — `cuda`/`wgpu` on a build without that feature is `CliError::FeatureDisabled` (exit code 9, `error.rs:106`); `cuda` for plain LoRA (no cuBLAS path) is `CliError::ValidationFailed` (exit code 5) — `-m lora --gpu-backend cuda` refuses or trains on the GPU, never a CPU run under a GPU flag; `auto`/`cpu` never refuse (auto + plain LoRA is the CPU path, the notice says so); `pre_training_notice` never contains "cuBLAS backward"; `post_training_banner(choice, launches_at_start)` delegates to `entrenar`, snapshot taken before `trainer.train()`. The dead request-derived `gpu_backend_notice`/`GpuBackendPlan` (still carrying the literal "CUDA selected — using cuBLAS backward path") and its five tests are removed. The case table lives in `commands/finetune_gpu_backend_truth_tests.rs` (8 tests; RED first at c8d1cd386).
 - `contracts/apr-train-banner-truth-v1.yaml` (kind: pattern; TBT-OB-001..003; tests = the two commands above); README contract count 1811 → 1812.
 - `test_run_training_creates_adapter` (pre-existing) hard-coded `gpu_backend = "cuda"` and asserted the old silent CPU fallback; it now names the CPU path it always exercised (`"cpu"`). A test that asserts `is_ok()` on a request the build cannot honour locks the defect in (dogfood 0.63.0 lesson).
 
@@ -25,15 +25,16 @@ ticket PMAT-991 · kind code · branch `agent/R-3` (worktree, claim held) · bas
 |---|---|
 | `cargo test -p aprender-train --test banner_truth` | rc 0 (2 passed) |
 | `cargo test -p aprender-train --test banner_truth --features cuda` (lambda, RTX 4090) | rc 0 (2 passed; the cuda arm drives one cuBLAS backward and sees the counter move) |
-| `cargo test -p apr-cli --lib gpu_backend_truth` | rc 0 (5 passed) |
-| `cargo test -p apr-cli --lib` (gate proxy) | rc 0: 7213 passed, 0 failed, 12 ignored |
+| `cargo test -p apr-cli --lib gpu_backend_truth` | rc 0 (8 passed) |
+| `cargo test -p apr-cli --lib` (gate proxy, after the review round) | rc 0: 7211 passed, 0 failed, 12 ignored (the five dead-notice tests removed) |
 | `cargo test -p aprender-train --lib` (gate proxy) | rc 101: 7621 passed, 3 failed — `prune::snapshot_tests::tests::{snapshot_all_prune_methods, snapshot_pipeline_stages, snapshot_schedule_validation_errors}`; **ENV, not this diff**: the same three fail identically on a pristine `origin/main` worktree at 65680cdf8 while CI's `workspace-test` on that commit is green (insta snapshot drift local to this box; `crates/aprender-train/src/prune` untouched by this branch) |
 | `cargo fmt --all -- --check` · `cargo clippy -p aprender-train --lib -- -D warnings` · `cargo clippy -p apr-cli --lib -- -D warnings` | rc 0 · 0 · 0 |
 | `pv validate` · `pv lint` on the contract · `check_contract_test_binding.sh` · `check_contract_enforcement.sh` · `check_readme_claims.sh` · `check_no_claim_literals.sh` | valid · 0/0 · rc 0 ×4 |
 
-## Mutations (RED, then restored GREEN)
-1. `training_backend_banner` returns Some for "cuda" regardless of the counter → `banner_truth`: `banner_is_none_for_cuda_with_zero_launches` FAILED and `cpu_only::cpu_backward_never_increments_the_device_counter` FAILED (0 passed, 2 failed). Restored → 2 passed.
-2. `gpu_backend_decision` returns `Ok(Cpu)` for "cuda" when the build has no cuda → `cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback` FAILED and `gpu_backend_decision_case_table` FAILED (3 passed, 2 failed). Restored → 5 passed.
+## Mutations (RED, then restored GREEN — re-run after the review round, at a137ba684)
+1. `training_backend_banner` returns Some for "cuda" regardless of the counter → `banner_truth`: `banner_is_none_for_cuda_with_zero_launches` FAILED, `cpu_only::cpu_backward_never_increments_the_device_counter` FAILED (0 passed, 2 failed). Restored → 2 passed.
+2. `gpu_backend_decision` returns `Ok(Cpu)` for "cuda" when the build has no cuda → `cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback` FAILED, `gpu_backend_decision_case_table` FAILED (6 passed, 2 failed). Restored → 8 passed.
+3. `gpu_backend_decision` returns `Ok(Cuda)` for plain LoRA + cuda (no refusal) → `plain_lora_with_explicit_cuda_is_a_refusal_not_a_cpu_run` FAILED (7 passed, 1 failed). Restored → 8 passed.
 
 ## Dispatch ledger
 | phase | mode | agent | turns | maxTurns hit | resumed | outcome |
@@ -41,8 +42,11 @@ ticket PMAT-991 · kind code · branch `agent/R-3` (worktree, claim held) · bas
 | P_1 | subagent:sonnet | a798f959da57eb45b | 40 + resume | yes | once | receipt partial=false; every command re-run green by the orchestrator |
 | P_2 | subagent:sonnet | a5710155b2d926446 | 40 + resume | yes | once | receipt partial=true (two blockers below); finished by the orchestrator |
 | P_3 | direct | — | — | — | — | contract, README, mutations, receipt |
-| P3 review | delegate (agy quorum, width 3) | see the PR body | — | — | — | review-only |
+| P3 review | delegate (agy quorum, width 3) | ab097fc576df910b1 (agy conversations 5f8882ec…, 5a62974e…, f333e610…) | — | — | — | 3/3 FAIL = mergeable-with-changes; changes applied at a137ba684 (below) |
 Slots: ≤ 2 live at any instant (worker + delegate); denials 0.
+
+## Review quorum (3-lane, review-only, 2026-09-06) and what changed
+3/3 lanes: mergeable with changes (no lane: do-not-implement). All three accepted the core design (banner from a launch counter, never the request) and verified the evidence section (tests exist, mutations match, README 1812 = `find contracts -name '*.yaml' | wc -l`, `src/prune` untouched). Unanimous defects, both fixed at a137ba684: (a) the process-wide `AtomicU64` with a test-only reset leaked across fine-tunes — a second run in one process, or a long-lived server, would inherit `launches > 0` and re-introduce the ticket's own defect → since-run-start semantics (`training_backend_banner(requested, launches_at_start)`, snapshot before `trainer.train()`, no reset API); (b) `banner_truth.rs` reset the static under cargo's parallel tests → the tests now snapshot and compare, race-free. 2/3: dead `gpu_backend_notice`/`GpuBackendPlan` still carried the request-derived "CUDA selected — using cuBLAS backward path" → removed with its five tests. **Lane 1 alone claimed `gemm_f16_to_f32_backward_a` (matmul_f16.rs:155) launches without the counter; lanes 2 and 3 said all five named sites were covered — lane 1 was right (the function calls `cublas.gemm_f16_to_f32` directly), and the orchestrator found three more uncounted device-side backward launches in `matmul.rs` (`gemm_nf4_backward_a_cublas`, `gemm_nf4_backward_a` PTX, `gemm_nf4_tc_backward_a`) — the QLoRA path itself.** Nine sites are counted now. Lane 1's other singleton (the pre-training notice lost the plain-LoRA CPU warning) was also right in substance: the row's own rule ("-m lora --gpu-backend cuda refuses or trains on the GPU") is now enforced by `gpu_backend_decision` (ValidationFailed, exit 5) and the CPU notice names the plain-LoRA path. Lane 3's "banner on the error path" is moot: `trainer.train()` returns a result struct, and the banner prints after it returns; a training failure that propagates with `?` never reaches the banner.
 
 ## Jidoka
 - **The brief named the crate `aprender_train`; its `[lib] name` is `entrenar`** (S0-10 class: the crate dir and the lib name differ). The worker used `entrenar::` and said so.
@@ -51,12 +55,12 @@ Slots: ≤ 2 live at any instant (worker + delegate); denials 0.
 - The three prune snapshot failures are an environment finding (see the table); no ticket filed from this row — they belong to whoever owns the insta snapshots, and CI does not see them.
 
 ## Gaps
-- Not instrumented: custom-PTX backward kernels under `autograd/cuda_backward/` (gemm.rs PTX fallback, elementwise.rs, structured.rs) — P_1 counted the cuBLAS sites the spec names; a PTX-only backward would leave the banner None. Recorded as the row's open question for the 3-lane review.
+- Not yet instrumented: the elementwise/structured backward kernels under `autograd/cuda_backward/` (`elementwise.rs`, `structured.rs`); every GEMM-class device backward (cuBLAS f32/f16, NF4 cuBLAS/PTX/tensor-core) is counted. A run whose only device work is elementwise would leave the banner None — it under-reports, never over-claims.
 - The gx10 leg (`host: lambda, gx10`) is not run here: the cuda arm was measured on lambda only. The dogfood row (C4) covers gx10.
 - Receipt for this PR: advisory, not produced (driver A1).
 
 ## Estimates
-K̂ 3 (`basis=first-run[U]`); actual: P_1 worker 40 turns + resume, P_2 worker 40 turns + resume, orchestrator ≈ 9 bash calls for P_2's last mile and P_3 (`basis=this receipt`). Rows appended to `docs/audits/impl-estimates.jsonl`.
+K̂ 3 (`basis=first-run[U]`); actual: P_1 worker 40 turns + resume, P_2 worker 40 turns + resume, orchestrator ≈ 9 bash calls for P_2's last mile and P_3, ≈ 9 more for the review round (`basis=this receipt`). Rows appended to `docs/audits/impl-estimates.jsonl`.
 
 ## Verdict
 PENDING-MERGE (`status: partial`).

--- a/docs/audits/impl-PMAT-991-receipt.md
+++ b/docs/audits/impl-PMAT-991-receipt.md
@@ -1,0 +1,62 @@
+---
+status: partial
+partial_reason: "this PR is not yet merged on the required check; flip to complete with the DAG status write-back after merge"
+ticket: PMAT-991
+row: R-3
+issue: 2906
+epic: 2873
+model: "orchestrator claude-fable-5-1; workers sonnet (paiml-impl-worker) x2 (P_1, P_2), each resumed once at maxTurns=40; P_2's last mile and P_3 by the orchestrator"
+tokens_used: "workers 120478 + 120623 = 241101 (P_1, P_2 first passes; resumes not separately reported); orchestrator [U] (not instrumented)"
+wall_clock_s: "[U] (not instrumented); P_1 dispatch ~02:52Z -> P_3 contract commit ~04:20Z on 2026-09-06 (about 5,300 s of orchestration, two worker runs inside)"
+---
+# impl-PMAT-991 — R-3 · T-6 honest training banner (#2906; spec §5 R-3, D-7; feedback_apr_finetune_lora_cpu_only)
+
+## Identity
+ticket PMAT-991 · kind code · branch `agent/R-3` (worktree, claim held) · base `65680cdf8` · `discover.json` at `$XDG_RUNTIME_DIR/paiml-implement/discover-R-3.json` (`gate_cmd_fallback=true`: `cargo test --workspace` is CI's job; crate-level `--lib` gates were run here) · quorum: 3-lane review-only at P3 (agy delegate) · K̂ = 3 (`basis=first-run[U]`, estimate.sh: 0 rows for this row class).
+
+## What lands
+- `entrenar` (crates/aprender-train): `BACKWARD_KERNEL_LAUNCHES` (AtomicU64) with `backward_kernel_launches()`, `reset_backward_kernel_launches()`, `pub(crate) note_backward_kernel_launch()` called at every cuBLAS backward launch (`cuda_forward/matmul.rs`: a, a_accumulate, b; `matmul_f16.rs`: a, b); `training_backend_banner(requested) -> Option<String>` is Some iff `requested == "cuda"` and the counter > 0. Test `tests/banner_truth.rs` (RED first at 51bdb5b66: the three symbols did not exist; GREEN at 7c1701431; both `--features cuda` and default arms).
+- `apr finetune` (crates/apr-cli): `gpu_backend_decision(requested, build_has_cuda, build_has_wgpu) -> Result<GpuBackendChoice, CliError>` — `cuda`/`wgpu` on a build without that feature is `CliError::FeatureDisabled` (exit code 9, read from `error.rs:106`), `auto`/`cpu` never refuse; `pre_training_notice` never contains "cuBLAS backward"; `post_training_banner` delegates to `entrenar::training_backend_banner`, printed after training. The case table lives in `commands/finetune_gpu_backend_truth_tests.rs` (5 tests; RED first at c8d1cd386).
+- `contracts/apr-train-banner-truth-v1.yaml` (kind: pattern; TBT-OB-001..003; tests = the two commands above); README contract count 1811 → 1812.
+- `test_run_training_creates_adapter` (pre-existing) hard-coded `gpu_backend = "cuda"` and asserted the old silent CPU fallback; it now names the CPU path it always exercised (`"cpu"`). A test that asserts `is_ok()` on a request the build cannot honour locks the defect in (dogfood 0.63.0 lesson).
+
+## Verification (orchestrator, every command re-run)
+| check | result |
+|---|---|
+| `cargo test -p aprender-train --test banner_truth` | rc 0 (2 passed) |
+| `cargo test -p aprender-train --test banner_truth --features cuda` (lambda, RTX 4090) | rc 0 (2 passed; the cuda arm drives one cuBLAS backward and sees the counter move) |
+| `cargo test -p apr-cli --lib gpu_backend_truth` | rc 0 (5 passed) |
+| `cargo test -p apr-cli --lib` (gate proxy) | rc 0: 7213 passed, 0 failed, 12 ignored |
+| `cargo test -p aprender-train --lib` (gate proxy) | rc 101: 7621 passed, 3 failed — `prune::snapshot_tests::tests::{snapshot_all_prune_methods, snapshot_pipeline_stages, snapshot_schedule_validation_errors}`; **ENV, not this diff**: the same three fail identically on a pristine `origin/main` worktree at 65680cdf8 while CI's `workspace-test` on that commit is green (insta snapshot drift local to this box; `crates/aprender-train/src/prune` untouched by this branch) |
+| `cargo fmt --all -- --check` · `cargo clippy -p aprender-train --lib -- -D warnings` · `cargo clippy -p apr-cli --lib -- -D warnings` | rc 0 · 0 · 0 |
+| `pv validate` · `pv lint` on the contract · `check_contract_test_binding.sh` · `check_contract_enforcement.sh` · `check_readme_claims.sh` · `check_no_claim_literals.sh` | valid · 0/0 · rc 0 ×4 |
+
+## Mutations (RED, then restored GREEN)
+1. `training_backend_banner` returns Some for "cuda" regardless of the counter → `banner_truth`: `banner_is_none_for_cuda_with_zero_launches` FAILED and `cpu_only::cpu_backward_never_increments_the_device_counter` FAILED (0 passed, 2 failed). Restored → 2 passed.
+2. `gpu_backend_decision` returns `Ok(Cpu)` for "cuda" when the build has no cuda → `cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback` FAILED and `gpu_backend_decision_case_table` FAILED (3 passed, 2 failed). Restored → 5 passed.
+
+## Dispatch ledger
+| phase | mode | agent | turns | maxTurns hit | resumed | outcome |
+|---|---|---|---|---|---|---|
+| P_1 | subagent:sonnet | a798f959da57eb45b | 40 + resume | yes | once | receipt partial=false; every command re-run green by the orchestrator |
+| P_2 | subagent:sonnet | a5710155b2d926446 | 40 + resume | yes | once | receipt partial=true (two blockers below); finished by the orchestrator |
+| P_3 | direct | — | — | — | — | contract, README, mutations, receipt |
+| P3 review | delegate (agy quorum, width 3) | see the PR body | — | — | — | review-only |
+Slots: ≤ 2 live at any instant (worker + delegate); denials 0.
+
+## Jidoka
+- **The brief named the crate `aprender_train`; its `[lib] name` is `entrenar`** (S0-10 class: the crate dir and the lib name differ). The worker used `entrenar::` and said so.
+- **`crates/apr-cli/src/lib.rs` cannot be committed here**: the repo's pre-commit complexity hook follows lib.rs's `include!()` graph and refuses on three PRE-EXISTING violations (`dispatch.rs:103` cognitive 41, `dispatch.rs:508` cognitive 30, `help_producer_truth.rs:51` cognitive 73), none touched by this ticket. The integration-test seam the worker added there was dropped; the case table lives in `commands::finetune`'s own `#[cfg(test)]` module instead, reached as `cargo test -p apr-cli --lib gpu_backend_truth`. The debt is out of scope and is not discharged with `#[allow]` or `--no-verify`.
+- **`git add` with one non-existent pathspec adds nothing** — the relocation commit first landed with only the deletion staged; amended (bae8a988e) with the three files.
+- The three prune snapshot failures are an environment finding (see the table); no ticket filed from this row — they belong to whoever owns the insta snapshots, and CI does not see them.
+
+## Gaps
+- Not instrumented: custom-PTX backward kernels under `autograd/cuda_backward/` (gemm.rs PTX fallback, elementwise.rs, structured.rs) — P_1 counted the cuBLAS sites the spec names; a PTX-only backward would leave the banner None. Recorded as the row's open question for the 3-lane review.
+- The gx10 leg (`host: lambda, gx10`) is not run here: the cuda arm was measured on lambda only. The dogfood row (C4) covers gx10.
+- Receipt for this PR: advisory, not produced (driver A1).
+
+## Estimates
+K̂ 3 (`basis=first-run[U]`); actual: P_1 worker 40 turns + resume, P_2 worker 40 turns + resume, orchestrator ≈ 9 bash calls for P_2's last mile and P_3 (`basis=this receipt`). Rows appended to `docs/audits/impl-estimates.jsonl`.
+
+## Verdict
+PENDING-MERGE (`status: partial`).

--- a/docs/audits/impl-estimates.jsonl
+++ b/docs/audits/impl-estimates.jsonl
@@ -27,3 +27,6 @@
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_2","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_3","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_4","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
+{"repo":"aprender","ticket":"PMAT-991","phase":"P_1","mode":"subagent:sonnet","est":3,"actual":40,"basis":"est=first-run[U]; actual=worker maxTurns (40) + one resume"}
+{"repo":"aprender","ticket":"PMAT-991","phase":"P_2","mode":"subagent:sonnet","est":3,"actual":40,"basis":"est=first-run[U]; actual=worker maxTurns (40) + one resume; last mile by the orchestrator"}
+{"repo":"aprender","ticket":"PMAT-991","phase":"P_3","mode":"direct","est":3,"actual":9,"basis":"est=first-run[U]; actual=orchestrator bash calls (relocation, contract, mutations, receipt)"}

--- a/docs/audits/impl-estimates.jsonl
+++ b/docs/audits/impl-estimates.jsonl
@@ -30,3 +30,4 @@
 {"repo":"aprender","ticket":"PMAT-991","phase":"P_1","mode":"subagent:sonnet","est":3,"actual":40,"basis":"est=first-run[U]; actual=worker maxTurns (40) + one resume"}
 {"repo":"aprender","ticket":"PMAT-991","phase":"P_2","mode":"subagent:sonnet","est":3,"actual":40,"basis":"est=first-run[U]; actual=worker maxTurns (40) + one resume; last mile by the orchestrator"}
 {"repo":"aprender","ticket":"PMAT-991","phase":"P_3","mode":"direct","est":3,"actual":9,"basis":"est=first-run[U]; actual=orchestrator bash calls (relocation, contract, mutations, receipt)"}
+{"repo":"aprender","ticket":"PMAT-991","phase":"P3-review","mode":"delegate(quorum:3)+direct","est":3,"actual":9,"basis":"est=first-run[U]; actual=orchestrator bash calls applying the 3/3 mergeable-with-changes verdict (since-start banner, 4 more launch sites, plain-LoRA refusal, dead notice)"}


### PR DESCRIPTION
PP-066 DAG row **R-3** (spec §5 T-6, D-7; epic #2873; ticket PMAT-991; receipt `docs/audits/impl-PMAT-991-receipt.md`, `status: partial` until merged). `feedback_apr_finetune_lora_cpu_only`: the "cuBLAS backward" training banner was printed from the request, before any step, on any build; `--gpu-backend cuda` on a cpu-only build fell through to the CPU silently. Now the banner is an **event** and the impossible request is a **refusal**.

**What lands**
- `entrenar` (crates/aprender-train): `backward_kernel_launches()` / `reset_backward_kernel_launches()` — an `AtomicU64` bumped at every cuBLAS backward launch (`cuda_forward/matmul.rs` a, a_accumulate, b; `matmul_f16.rs` a, b); `training_backend_banner(requested) -> Option<String>` is `Some` iff `requested == "cuda"` and the counter > 0. RED-first test `tests/banner_truth.rs` (both feature arms; the cuda arm drives one cuBLAS backward on this box's RTX 4090 and watches the counter move).
- `apr finetune`: `gpu_backend_decision(requested, build_has_cuda, build_has_wgpu)` — `cuda`/`wgpu` on a build without the feature is `CliError::FeatureDisabled` (exit code **9**, read from `error.rs:106`); `auto`/`cpu` never refuse; `pre_training_notice` never says "cuBLAS backward"; `post_training_banner` prints `entrenar`'s line after training. Case table `commands/finetune_gpu_backend_truth_tests.rs` (5 tests, both polarities).
- `contracts/apr-train-banner-truth-v1.yaml` (kind: pattern, TBT-OB-001..003; `pv validate` valid, `pv lint` 0/0). README contract count 1811 → 1812.
- `test_run_training_creates_adapter` hard-coded `"cuda"` and asserted the old silent fallback; it now names the CPU path it always ran.

**Acceptance, re-run by the orchestrator on eaea47652**
| A_i | rc |
|---|---|
| `cargo test -p aprender-train --test banner_truth` | 0 (2 passed) |
| `cargo test -p aprender-train --test banner_truth --features cuda` (lambda, sm_89) | 0 (2 passed) |
| `cargo test -p apr-cli --lib gpu_backend_truth` | 0 (5 passed) |
| `cargo test -p apr-cli --lib` | 0 (7213 passed, 12 ignored) |
| `cargo test -p aprender-train --lib` | 101: 7621 passed, 3 failed in `prune::snapshot_tests` — **identical on a pristine origin/main worktree at 65680cdf8** while CI's workspace-test there is green: local insta drift, `src/prune` untouched here |
| `cargo fmt --all -- --check` · `cargo clippy -p {aprender-train,apr-cli} --lib -- -D warnings` | 0 · 0 · 0 |
| `check_contract_test_binding.sh` · `check_contract_enforcement.sh` · `check_readme_claims.sh` · `check_no_claim_literals.sh` · `check_roadmap_diff_additive.sh` | 0 ×5 |

**Mutations — RED, then restored GREEN**
| mutation | result |
|---|---|
| `training_backend_banner` returns Some for "cuda" regardless of the counter | `banner_is_none_for_cuda_with_zero_launches` FAILED, `cpu_only::cpu_backward_never_increments_the_device_counter` FAILED (0 passed, 2 failed) → restored 2 passed |
| `gpu_backend_decision` returns `Ok(Cpu)` for "cuda" on a build without cuda | `cuda_request_on_cpu_only_build_is_a_refusal_not_a_fallback` FAILED, `gpu_backend_decision_case_table` FAILED (3 passed, 2 failed) → restored 5 passed |

**Findings recorded in the receipt**
- The crate dir is `aprender-train`, the lib is `entrenar` (S0-10 class).
- `crates/apr-cli/src/lib.rs` cannot be committed on this box: the pre-commit complexity hook follows its `include!()` graph and refuses on pre-existing debt (`dispatch.rs:103` cognitive 41, `dispatch.rs:508` cognitive 30, `help_producer_truth.rs:51` cognitive 73). The integration-test seam was dropped; the case table lives in `commands::finetune`'s own test module. Not discharged with `#[allow]` or `--no-verify`.
- Not instrumented: custom-PTX backward kernels under `autograd/cuda_backward/` — a PTX-only backward would leave the banner `None` (open question for the 3-lane review; the spec names the cuBLAS sites).
- gx10 leg not run here (lambda only); C4 dogfood covers it.

**Review round (3-lane quorum, 2026-09-06 — 3/3 mergeable with changes; applied at a137ba684, re-verified)**
- Unanimous: the process-wide counter with a test-only reset leaked across fine-tunes → the banner is now scoped to the run (`training_backend_banner(requested, launches_at_start)`, snapshot before `trainer.train()`, no reset API); the tests snapshot and compare (race-free under parallel tests).
- Lane 1 alone said `gemm_f16_to_f32_backward_a` launched uncounted; lanes 2/3 said all sites were covered. Lane 1 was right, and three more uncounted device backward launches were found in `matmul.rs` (`gemm_nf4_backward_a_cublas`, the NF4 PTX and tensor-core backward_a — the QLoRA path). **Nine** launch sites are counted now.
- `-m lora --gpu-backend cuda` now REFUSES (`ValidationFailed`, exit 5) instead of running the CPU path under a GPU flag; `auto` + plain LoRA is the CPU path and the notice says so (`gpu_backend_decision` gained `method_has_cuda_path`).
- Dead `gpu_backend_notice`/`GpuBackendPlan` (still holding the request-derived cuBLAS string) and their five tests removed.
- Re-run on a137ba684: `banner_truth` 2/2 (default and `--features cuda`), `gpu_backend_truth` 8/8, `cargo test -p apr-cli --lib` 7211 passed, `cargo test -p aprender-train --lib` 7621 passed + the same three pre-existing prune snapshot failures, clippy/fmt clean, `pv validate` valid. Mutations: 1 (banner unconditional) 0/2 passed; 2 (cuda on a cpu-only build → Cpu) 6/8; 3 (plain LoRA + cuda → Cuda, no refusal) 7/8; all restored GREEN.

Quorum verdicts and the adjudication are in the receipt. Receipt for this PR itself: advisory, not produced (driver A1).

no-close: #2873 is the epic this row implements one part of; an epic is not closed by one of its rows.
