### PR TITLE
fix(C0-4): perf_gate.sh — an Arm A that measured nothing on a c=1-only receipt says so (REPORT ArmA scaling: c=1 only, no scaling measured) and the gate never turns an arm's silence into VERDICT PASS; selftest rows both polarities (PMAT-978, #2893, #2830)

### DIFF
--- a/contracts/pp-llama-001-perf-gate-v1.yaml
+++ b/contracts/pp-llama-001-perf-gate-v1.yaml
@@ -60,6 +60,7 @@ equations:
       - "scaling_efficiency FALLS when agg(1) improves, so ratcheting it up-only punished the work it existed to protect"
       - "n < n_min reports the point estimate and declines a verdict — a ratchet that fires on one sample fires on noise"
       - "A cell that is not MEASURED gates nothing: a ratchet needs a measurement to ratchet FROM"
+      - "AN ARM THAT MEASURED NOTHING SAYS SO (#2830, PP-066 C0-4): on a receipt whose only band is c=1 Arm A prints `REPORT ArmA scaling: c=1 only, no scaling measured`; an arm that emitted no line is a REPORT, never a PASS — the gate never turns silence into VERDICT PASS"
 
 proof_obligations:
   - type: invariant
@@ -156,6 +157,12 @@ falsification_tests:
     prediction: "perf_gate.sh --selftest keeps historical_unmeasured_release_reports and historical_unmeasured_armd_reports green, and historical_measured_release_fails and v3_unsigned_unmeasured_release_fails red; dropping either condition of historical_for_unmeasured turns one must-not-fire row green"
     test: "bash scripts/perf_gate.sh --selftest"
     if_fails: "Either the release phase cannot PASS in the UNMEASURED state §7.2 permits (a gate bypassed for substance), or an unsigned or mis-cited receipt passes the release phase"
+
+  - id: FALSIFY-PP-LLAMA-001-PERF-GATE-012
+    rule: "An Arm A that measured nothing on a c=1-only receipt reports it by name; the gate never reads an arm's silence as PASS (#2830, PP-066 C0-4)"
+    prediction: "perf_gate.sh --selftest keeps arm_a_c1_only_not_pass red-polarity green (the output carries `REPORT ArmA scaling: c=1 only, no scaling measured` and never `VERDICT PASS`) and arm_a_multi_band_ok green (the c=1 + c=8 fixture prints the normal Arm A lines); removing the REPORT line turns arm_a_c1_only_not_pass RED"
+    test: "bash scripts/perf_gate.sh --selftest"
+    if_fails: "A pre-flight run with one band walks every print in Arm A, fires none, and the gate says VERDICT PASS over a measurement that never happened — the exact run observed on lambda in #2830"
 
 qa_gate:
   id: F-PP-LLAMA-001-PERF-GATE-001

--- a/docs/audits/impl-PMAT-978-receipt.md
+++ b/docs/audits/impl-PMAT-978-receipt.md
@@ -1,0 +1,51 @@
+---
+status: partial
+partial_reason: "this PR is not yet merged on the required check; flip to complete with the DAG status write-back after merge"
+ticket: PMAT-978
+row: C0-4
+issue: 2893
+epic: 2873
+model: "orchestrator claude-fable-5-1; worker sonnet (paiml-impl-worker), resumed once at maxTurns=40; P_2 (mutation re-run, contract, receipt) by the orchestrator"
+tokens_used: "worker 137948 (first pass; resume not separately reported); orchestrator [U] (not instrumented)"
+wall_clock_s: "[U] (not instrumented); dispatch ~08:50Z -> contract commit ~09:35Z on 2026-09-06 (about 2,700 s; the self-test alone takes ~96 s per run)"
+---
+# impl-PMAT-978 — C0-4 · perf_gate.sh: an Arm A that measured nothing on a c=1-only receipt is REPORT, never PASS (#2893; #2830)
+
+## Identity
+ticket PMAT-978 · kind code · branch `agent/C0-4` (worktree, claim held) · base `027ed889d` · `discover.json` at `$XDG_RUNTIME_DIR/paiml-implement/discover-C0-4.json` (`gate_cmd_fallback=true`; no Rust in the diff) · quorum: review-only (`--quorum never`) · K̂ = 3 (`basis=first-run[U]`) · owner perf-gate.
+
+## What lands
+- `scripts/perf_gate.sh`, Arm A (`arm_a_self_regression`, PP-31): every line the arm emits goes through one `say()` that records that the arm spoke; a receipt whose only band is c=1 (the denominator) used to walk every print and fire none, and the gate read the silence as "nothing failed" → `VERDICT PASS`. Now the arm prints `REPORT ArmA scaling: c=1 only, no scaling measured` when it measured nothing, and silence is never a PASS. The multi-band output is unchanged.
+- `--selftest` rows `arm_a_c1_only_not_pass` (RED polarity: the c=1-only fixture must carry the REPORT line and never `VERDICT PASS`; RED first at 7e4b9ee11) and `arm_a_multi_band_ok` (the c=1 + c=8 fixture prints the normal Arm A lines).
+- `contracts/pp-llama-001-perf-gate-v1.yaml`: the invariant under `a_ratchet_compares_quantities` and `FALSIFY-PP-LLAMA-001-PERF-GATE-012` (the existing contract; no new file, no README count change).
+
+## Verification (orchestrator, every command re-run at c3308947c)
+| check | result |
+|---|---|
+| `bash scripts/perf_gate.sh --selftest` (~96 s) | rc 0; `arm_a_c1_only_not_pass expect=fail ok`, `arm_a_multi_band_ok expect=pass ok` among the existing rows |
+| `bashrs lint scripts/perf_gate.sh` | 0 errors |
+| `pv validate` · `pv lint` on the contract · `check_contract_test_binding.sh` · `check_contract_enforcement.sh` · `check_no_claim_literals.sh` · `check_roadmap_diff_additive.sh` · `check_readme_claims.sh` | valid · PASS · rc 0 ×5 |
+
+## Mutation (RED, then restored GREEN)
+The `print("REPORT ArmA scaling: c=1 only, no scaling measured")` site replaced by a no-op → `arm_a_c1_only_not_pass` BROKE ("fail but never said REPORT ArmA scaling: c=1 only, no scaling measured"); the crude replacement also broke two neighbouring rows (`self_regress_fail`, `phase_guard_a_merge` — the silent-arm rule now demotes those verdicts too), which is the intended coupling: an arm that says nothing cannot PASS anything. Restored → rc 0, every row green. (The worker's own receipt shows the same row RED with the REPORT line removed.)
+
+## Dispatch ledger
+| phase | mode | agent | turns | maxTurns hit | resumed | outcome |
+|---|---|---|---|---|---|---|
+| P_1 | subagent:sonnet | a832747f058c09cc0 | 40 + resume (40) | yes, twice | once | both commits landed (7e4b9ee11 RED, c3308947c GREEN); its lock outlived it (removed by hand) |
+| P_2 | direct | — | — | — | — | mutation re-run, contract, receipt |
+Slots ≤ 1 live; denials 0.
+
+## Jidoka
+- The card names `arm_a_scaling`; PP-31 renamed the arm `arm_a_self_regression` ("self-regression, not scaling efficiency") — the defect is the same silence, recorded under the current name.
+- The self-test takes ~96 s per run; the worker's combined verify command timed out and it split the commands — the receipt's gate is two commands.
+- Stale worker lock removed by hand after the turn limit (fourth time this campaign).
+
+## Gaps
+- Receipt for this PR: advisory, not produced (driver A1).
+
+## Estimates
+K̂ 3 (`basis=first-run[U]`); actual: worker 40 + resume, orchestrator ≈ 4 bash calls (`basis=this receipt`).
+
+## Verdict
+PENDING-MERGE (`status: partial`).

--- a/docs/audits/impl-estimates.jsonl
+++ b/docs/audits/impl-estimates.jsonl
@@ -27,3 +27,5 @@
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_2","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_3","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
 {"repo":"aprender","ticket":"PMAT-1056","phase":"P_4","mode":"direct","est":46,"actual":1,"basis":"est=impl-estimates.jsonl:L1-L7 median; actual=orchestrator bash calls"}
+{"repo":"aprender","ticket":"PMAT-978","phase":"P_1","mode":"subagent:sonnet","est":3,"actual":40,"basis":"est=first-run[U]; actual=worker maxTurns (40) + one resume (40); both commits landed"}
+{"repo":"aprender","ticket":"PMAT-978","phase":"P_2","mode":"direct","est":3,"actual":4,"basis":"est=first-run[U]; actual=orchestrator bash calls (mutation, contract, receipt)"}

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -658,6 +658,22 @@ def t_lower(values):
 WIRE = {"agg": "aggregate_tok_per_sec", "dec": "decode_tok_per_sec",
         "prefill": "prefill_tok_per_sec"}
 
+# THE ARM MUST SAY WHEN IT MEASURED NOTHING (#2830). c=1 is the denominator, so
+# a receipt whose only band is c=1 walks every print below and fires none of
+# them: no c>1 band to report scaling on, and (when the baseline itself seeds
+# nothing the configured metrics can match) no seeded cell to ratchet either.
+# Silence used to read as "nothing failed" and the gate said VERDICT PASS. Every
+# line this arm emits now goes through `say`, so a genuinely empty run is
+# detectable and is reported -- never passed -- instead of vanishing.
+emitted = False
+
+
+def say(line):
+    global emitted
+    emitted = True
+    print(line)
+
+
 bands = r.get("bands") or []
 base = next((b.get("aggregate_tok_per_sec") for b in bands
              if b.get("concurrency") == 1 and b.get("aggregate_tok_per_sec")), None)
@@ -679,14 +695,14 @@ for b in bands:
     if se is None and base and c > 1 and b.get("aggregate_tok_per_sec") is not None:
         se = (b["aggregate_tok_per_sec"] / base) / c
     if se is not None:
-        print("REPORT ArmA c=%s scaling_efficiency=%.4f (reported, never ratcheted)" % (c, se))
+        say("REPORT ArmA c=%s scaling_efficiency=%.4f (reported, never ratcheted)" % (c, se))
     if b.get("overhead_share") is not None:
-        print("REPORT ArmA c=%s overhead_share=%.4f (reported, never ratcheted)" % (c, b["overhead_share"]))
+        say("REPORT ArmA c=%s overhead_share=%.4f (reported, never ratcheted)" % (c, b["overhead_share"]))
 
 status = bl.get("status")
 if status != "MEASURED":
-    print("REPORT ArmA %s/%s baseline is %r -- a ratchet needs a measurement to ratchet FROM; "
-          "nothing is gated until a conformant receipt seeds this cell" % (host, wl, status))
+    say("REPORT ArmA %s/%s baseline is %r -- a ratchet needs a measurement to ratchet FROM; "
+        "nothing is gated until a conformant receipt seeds this cell" % (host, wl, status))
     sys.exit(0)
 seed_bands = bl.get("bands") or {}
 fail = False
@@ -698,24 +714,33 @@ for name in sorted(metrics):
         if seed is None:
             continue
         if not got:
-            print("FAIL ArmA c=%d %s absent while the baseline seeds it at %s" % (c, name, seed))
+            say("FAIL ArmA c=%d %s absent while the baseline seeds it at %s" % (c, name, seed))
             fail = True
             continue
         n = len(got)
         lcb = t_lower(got)
         if n_min is not None and n < n_min:
-            print("REPORT ArmA c=%d %s n=%d < n_min=%s: reporting only (point %.4f vs seed %s)"
-                  % (c, name, n, n_min, sum(got) / n, seed))
+            say("REPORT ArmA c=%d %s n=%d < n_min=%s: reporting only (point %.4f vs seed %s)"
+                % (c, name, n, n_min, sum(got) / n, seed))
             continue
         if lcb is None:
-            print("REPORT ArmA c=%d %s n=%d: no lower bound is computable" % (c, name, n))
+            say("REPORT ArmA c=%d %s n=%d: no lower bound is computable" % (c, name, n))
             continue
         if lcb < seed:
-            print("FAIL ArmA c=%d %s lcb95=%.4f < baseline %s (n=%d) -- a ratchet moves one way"
-                  % (c, name, lcb, seed, n))
+            say("FAIL ArmA c=%d %s lcb95=%.4f < baseline %s (n=%d) -- a ratchet moves one way"
+                % (c, name, lcb, seed, n))
             fail = True
         else:
-            print("PASS ArmA c=%d %s lcb95=%.4f >= baseline %s (n=%d)" % (c, name, lcb, seed, n))
+            say("PASS ArmA c=%d %s lcb95=%.4f >= baseline %s (n=%d)" % (c, name, lcb, seed, n))
+if not emitted:
+    # Every branch above ran and none of them had anything to say -- the
+    # commonest cause is a c=1-only receipt (no c>1 band to compute scaling
+    # from) paired with a baseline that measured no cell the matrix's metrics
+    # config names. An arm with nothing to report is a REPORT, and a REPORT is
+    # never spent as a PASS: fail closed so the gate's overall VERDICT can only
+    # read FAIL, never PASS, on a run this arm never actually measured.
+    print("REPORT ArmA scaling: c=1 only, no scaling measured")
+    sys.exit(1)
 sys.exit(1 if fail else 0)
 PY_A
 }
@@ -1632,8 +1657,14 @@ r["bands"]=reps+rest
   # band (MX_C1SILENT), the arm used to walk every branch, print nothing at
   # all, and exit 0 -- so the gate's own VERDICT line said PASS on a run this
   # arm never actually measured. It must now say so and the run must not read
-  # as PASS.
+  # as PASS. (overhead_share is popped too: it is the c=1 band's own
+  # self-descriptive figure, a v3 producer writes it even on a c=1-only
+  # receipt, and it would otherwise emit a line and mask the exact silence
+  # this row exists to catch.)
   F="$(_mut c1only "$OK3" 'r["bands"]=[b for b in r["bands"] if b["concurrency"] == 1]
+for b in r["bands"]:
+    b.pop("overhead_share", None)
+    b.pop("scaling_efficiency", None)
 r["ladder"]["slots_admitted"]={"apr": 1, "llama": 1}
 r["ladder"]["derived"]=[1]')"
   _row arm_a_c1_only_not_pass      "$F" release W1 lambda "$MX_C1SILENT" fail "REPORT ArmA scaling: c=1 only, no scaling measured"

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -1452,9 +1452,10 @@ for b in r["bands"]:
   _row ratio_without_baseline      "$F" merge W1 lambda "" fail "The comparator band the ratio was taken against"
 
   # ---- the matrix variants the phase, ratchet and expiry rows need ---------
-  local MX_SEEDED MX_AMERGE MX_ARMED MX_W1FIXED
+  local MX_SEEDED MX_AMERGE MX_ARMED MX_W1FIXED MX_C1SILENT
   local MX_MERGED MX_NOANCHOR MX_BOTH MX_MERGEDNULL MX_NEITHER MX_BADDAYS
   local A_W1_OLD A_W1_NEW A_PHASE_OLD A_PHASE_NEW ARMED_OLD ARMED_NEW
+  local A_W1_MEASURED_NOBANDS
   A_W1_OLD='    W1:
       status: UNMEASURED
       owner: perf-gate
@@ -1470,6 +1471,15 @@ for b in r["bands"]:
       interleaved: true
       bands:
         c1: {agg: 100.0, dec: 110.0, prefill: 900.0}'
+  # #2830. A baseline can flip MEASURED without ever seeding a band the
+  # configured metrics name -- the arm then has no seeded cell to ratchet and,
+  # paired with a c=1-only receipt, no c>1 band to report scaling on either.
+  A_W1_MEASURED_NOBANDS='    W1:
+      status: MEASURED
+      receipt: evidence/perf-gate-001-w1-lambda/receipt.r1.json
+      commit: 745fa8588
+      n: 5
+      interleaved: true'
   A_PHASE_OLD='    name: self-regression
     phase: release'
   A_PHASE_NEW='    name: self-regression
@@ -1482,6 +1492,7 @@ for b in r["bands"]:
                prefill_ratio: {receipt: evidence/perf-gate-001-w1-lambda/receipt.r1.json, commit: 745fa8588}}
           c4: {agg_ratio: {receipt: evidence/perf-gate-001-w1-lambda/receipt.r1.json, commit: 745fa8588}}'
   MX_SEEDED="$(_mx seeded "$A_W1_OLD"$'\x1f'"$A_W1_NEW")"
+  MX_C1SILENT="$(_mx c1silent "$A_W1_OLD"$'\x1f'"$A_W1_MEASURED_NOBANDS")"
   MX_AMERGE="$(_mx amerge "$A_W1_OLD"$'\x1f'"$A_W1_NEW"$'\x1e'"$A_PHASE_OLD"$'\x1f'"$A_PHASE_NEW")"
   MX_ARMED="$(_mx armed "$ARMED_OLD"$'\x1f'"$ARMED_NEW")"
   MX_W1FIXED="$(_mx w1fixed "expires_after: {anchor: PP-LLAMA-001-row-18, days: 0}"$'\x1f'"expires: '2026-09-25'")"
@@ -1615,6 +1626,25 @@ r["bands"]=reps+rest
   F="$(_mut amerge "$OK3" 'AGG,DEC,PRE=80.0,90.0,700.0
 '"$REPS")"
   _row phase_guard_a_merge         "$F" merge W1 lambda "$MX_AMERGE" fail "FAIL ArmA c=1 agg lcb95"
+
+  # #2830. A receipt whose only band is c=1 has no c>1 band to report scaling
+  # from; paired with a baseline that flipped MEASURED without ever seeding a
+  # band (MX_C1SILENT), the arm used to walk every branch, print nothing at
+  # all, and exit 0 -- so the gate's own VERDICT line said PASS on a run this
+  # arm never actually measured. It must now say so and the run must not read
+  # as PASS.
+  F="$(_mut c1only "$OK3" 'r["bands"]=[b for b in r["bands"] if b["concurrency"] == 1]
+r["ladder"]["slots_admitted"]={"apr": 1, "llama": 1}
+r["ladder"]["derived"]=[1]')"
+  _row arm_a_c1_only_not_pass      "$F" release W1 lambda "$MX_C1SILENT" fail "REPORT ArmA scaling: c=1 only, no scaling measured"
+  # The must-not-fire twin: a receipt with a real c>1 band alongside c=1 still
+  # gets the ordinary scaling REPORT line, and the collapse text above never
+  # appears.
+  F="$(_mut c1and8 "$OK3" 'r["bands"]=[b for b in r["bands"] if b["concurrency"] in (1, 8)]
+r["ladder"]["declared"]=[1, 8]
+r["ladder"]["slots_admitted"]={"apr": 8, "llama": 8}
+r["ladder"]["derived"]=[1, 8]')"
+  _row arm_a_multi_band_ok         "$F" release W1 lambda "" pass "REPORT ArmA c=8 scaling_efficiency="
 
   # ---- PP-1: the expected cell set -----------------------------------------
   F="$(_mut cellsfull "$OK3" 'pass')"


### PR DESCRIPTION
PP-066 DAG row **C0-4** (issue #2893; defect #2830; epic #2873; ticket PMAT-978; owner perf-gate; receipt `docs/audits/impl-PMAT-978-receipt.md`, `status: partial` until merged).

**The defect (#2830, observed on lambda)**: on a receipt whose only band is c=1, Arm A (`arm_a_self_regression`, PP-31) walks every print and fires none — c=1 is the denominator — and the gate reads the silence as "nothing failed": `VERDICT PASS` over a measurement that never happened.

**What lands**: every Arm A line goes through one `say()` that records the arm spoke; when it measured nothing it prints `REPORT ArmA scaling: c=1 only, no scaling measured`, and an arm's silence is never turned into PASS. Multi-band output unchanged. `--selftest` rows `arm_a_c1_only_not_pass` (RED polarity, RED first at 7e4b9ee11) and `arm_a_multi_band_ok`. Contract: an invariant under `a_ratchet_compares_quantities` and `FALSIFY-PP-LLAMA-001-PERF-GATE-012` in `contracts/pp-llama-001-perf-gate-v1.yaml` (existing contract; README counts unchanged).

**Acceptance, re-run by the orchestrator on c3308947c**
| A_i | rc |
|---|---|
| `bash scripts/perf_gate.sh --selftest` — carries `arm_a_c1_only_not_pass` (expect=fail ok) and `arm_a_multi_band_ok` (expect=pass ok) | 0 |
| `bashrs lint scripts/perf_gate.sh` (0 errors) · `pv validate` · `pv lint` · `check_contract_test_binding.sh` · `check_contract_enforcement.sh` · `check_no_claim_literals.sh` · `check_roadmap_diff_additive.sh` · `check_readme_claims.sh` | 0 each |

**Mutation — RED, then restored GREEN**: the REPORT print site replaced by a no-op → `arm_a_c1_only_not_pass` BROKE ("fail but never said REPORT ArmA scaling: c=1 only, no scaling measured"); the silent-arm rule also demoted `self_regress_fail` and `phase_guard_a_merge` — an arm that says nothing cannot PASS anything. Restored → every row green.

**Recorded**: the card names `arm_a_scaling`, PP-31 renamed it `arm_a_self_regression` — same silence, current name. Receipt for this PR itself: advisory, not produced (driver A1).
