### PR TITLE
feat(G-11): shared-file write contention — row PRs never write the DAG, roadmap, spec block or README counts; DAG status derived from receipts; README counts a ratchet (PMAT-1062)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,12 +921,12 @@ jobs:
       # reads contracts/apr-cli-commands-v1.yaml, whose equivalence to the real
       # binary is enforced by FALSIFY-CLI-001/002 in the integration line.
       - name: README claims must match measurement
-        run: bash scripts/check_readme_claims.sh
-      # G-11 (PMAT-1062): the README's counts are a RATCHET — a row PR may leave them
-      # lagging, never overstated; the orchestrator docs commit regenerates them and
-      # verifies with --exact. Case table both polarities, then the live check above.
-      - name: README count ratchet case table (G-11, PMAT-1062)
-        run: bash scripts/check_readme_claims.sh --self-test
+        run: |
+          # G-11 (PMAT-1062): the README's counts are a RATCHET — a row PR may leave them
+          # lagging, never overstated; the orchestrator docs commit regenerates them and
+          # verifies with --exact. Case table both polarities FIRST, then the live check.
+          bash scripts/check_readme_claims.sh --self-test
+          bash scripts/check_readme_claims.sh
 
       # Three guards that existed and could not block a merge. The publish-safety
       # one is the gate credited with keeping a 28 MB test.apr out of a published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -922,6 +922,11 @@ jobs:
       # binary is enforced by FALSIFY-CLI-001/002 in the integration line.
       - name: README claims must match measurement
         run: bash scripts/check_readme_claims.sh
+      # G-11 (PMAT-1062): the README's counts are a RATCHET — a row PR may leave them
+      # lagging, never overstated; the orchestrator docs commit regenerates them and
+      # verifies with --exact. Case table both polarities, then the live check above.
+      - name: README count ratchet case table (G-11, PMAT-1062)
+        run: bash scripts/check_readme_claims.sh --self-test
 
       # Three guards that existed and could not block a merge. The publish-safety
       # one is the gate credited with keeping a 28 MB test.apr out of a published
@@ -1229,6 +1234,17 @@ jobs:
         run: bash scripts/check_dag_invariants.sh --selftest
       - name: The PP-066 obligation DAG holds its invariants (G-4, C10)
         run: bash scripts/check_dag_invariants.sh docs/specifications/pp-066-dag.yaml --min-slack-days 6
+      # G-11 (PMAT-1062): a ROW PR (head branch agent/<id>, <id> a DAG row) never writes
+      # docs/specifications/pp-066-dag.yaml, docs/roadmaps/roadmap.yaml, the release spec
+      # (its §5.0 block is rendered) or a README count line. Eight armed PRs each carried
+      # such an edit and every merge made the other seven DIRTY. The DAG's status is
+      # derived from the receipt (scripts/lib/dag_status.py, D7 above); the roadmap and
+      # the counts are the orchestrator docs commit's. Case table, then the live check;
+      # merge_group and push carry no head branch and say so (REPORT), judged at the PR.
+      - name: Row-PR write-set case table (G-11, PMAT-1062)
+        run: bash scripts/check_row_pr_write_set.sh --self-test
+      - name: A row PR writes no shared file (G-11, PMAT-1062)
+        run: bash scripts/check_row_pr_write_set.sh --event "${GITHUB_EVENT_NAME:-pull_request}" --branch "${GITHUB_HEAD_REF:-}"
       # PP-33. Nothing scanned the gate's readers for thresholds, so the spec's
       # own must-fire -- `STRETCH = 1.50` in scripts/lib/parity_block.py -- could
       # not turn anything red. Four independent encodings of the release floors

--- a/contracts/apr-row-pr-write-set-v1.yaml
+++ b/contracts/apr-row-pr-write-set-v1.yaml
@@ -1,0 +1,207 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-row-pr-write-set-v1 — a PP-066 row PR never writes a shared file; the
+# DAG's status is derived from the receipt; the README's counts are a ratchet
+# (PP-066 DAG row G-11, epic #2873; ticket PMAT-1062; driver R2 of 2026-09-06)
+#
+# WHAT IT GOVERNS
+#   scripts/check_row_pr_write_set.sh (a head branch agent/<id> whose <id> is
+#   a DAG row may not touch docs/specifications/pp-066-dag.yaml,
+#   docs/roadmaps/roadmap.yaml, docs/specifications/PP-066-release-spec.md
+#   or a README count line); scripts/lib/dag_status.py (a row is complete iff
+#   docs/audits/impl-<pmat_id>-receipt.md says `status: complete` in its
+#   leading front matter — render_dag.py prints that, dag_invariants.py D7
+#   refuses a typed status that disagrees); scripts/check_readme_claims.sh
+#   (claimed <= measured; --exact for the orchestrator docs commit).
+#
+# WHY
+#   Eight armed row PRs (#3001, #3003-#3009) each hand-edited the DAG status,
+#   the roadmap (pmat work complete) or a README count. Every merge made the
+#   other seven DIRTY and each needed a rebuild through a queue that lands
+#   ~1 PR/hour. None of those three files is owned by a row; one orchestrator
+#   docs commit after each merge writes all of them.
+#
+# PROOF LADDER, STATED HONESTLY (F-26)
+#   * L1 — the guards exist and are wired in ci.yml job guard-runner-labels.
+#   * L2 — falsification tests cover the obligations, MEASURED (2026-09-06):
+#          check_row_pr_write_set.sh --self-test 11/11, check_dag_invariants.sh
+#          --selftest 15/15 (D7 rows 12-15), check_readme_claims.sh --self-test
+#          7/7 — each with its registered mutation RED.
+#   * L3/L4 — NOT APPLICABLE and not declared: shell and python guards over
+#          markdown and YAML data files.
+# ─────────────────────────────────────────────────────────────────────────────
+name: apr-row-pr-write-set
+version: "1.0.0"
+scope: >
+  The write set of a PP-066 row PR, the derivation of a DAG row's status, and
+  the README count ratchet. Out of scope: what a receipt must say
+  (AUTO-IMPL-SKILL-001 §7), the receipt marker rule itself (apr-impl-receipt-v1,
+  C0-7), and who writes the orchestrator docs commit (the driver prompt).
+status: active
+
+metadata:
+  kind: pattern     # a write-discipline rule over shell/python guards and data files; set EXPLICITLY
+  version: "1.0.0"
+  created: '2026-09-06'
+  last_modified: '2026-09-06'
+  author: PAIML Engineering
+  references:
+    - 'scripts/check_row_pr_write_set.sh — --base/--head/--branch/--event · --self-test (11 rows)'
+    - 'scripts/lib/dag_status.py — derived_status(), receipt_marker(), d7_typed_status()'
+    - 'scripts/render_dag.py — the status column is derived; --root'
+    - 'scripts/lib/dag_invariants.py — D7; past-expiry reads the derived status; --root'
+    - 'scripts/check_readme_claims.sh — compare_count(): lag allowed, overstatement RED; --exact; --self-test (7 rows)'
+    - '.github/workflows/ci.yml — job guard-runner-labels: the four new steps, case table before live'
+    - 'contracts/apr-impl-receipt-v1.yaml (C0-7) — the marker this contract derives from'
+    - 'PP-066 DAG row G-11, epic #2873'
+  description: >
+    A row PR's write set is {crate code, tests, contracts/, its own receipt, its
+    book page}. Completion is read from the receipt's marker, never typed into
+    the DAG; the roadmap and the README counts are written by one orchestrator
+    docs commit per merge; the README may lag the tree and may never overstate it.
+
+equations:
+  row_pr_write_set:
+    formula: |
+      row_pr(branch) ⟺ branch = "agent/" + id ∧ id ∈ dag.rows.id
+      row_pr(branch) ∧ event = pull_request  =>
+        diff(base, head) ∩ { docs/specifications/pp-066-dag.yaml,
+                             docs/roadmaps/roadmap.yaml,
+                             docs/specifications/PP-066-release-spec.md } = ∅
+        ∧ no changed README.md line matches /[0-9]+\*{0,2}( +[a-z]+){0,2} +(workspace crates?|contracts?|CLI commands?)\b/
+      ¬row_pr(branch)                        =>  not judged, said so (ok line)
+      event ∈ {merge_group, push}            =>  REPORT (no head branch to read), exit 0, judged at the PR
+    domain: 'the diff of a pull request against the base named by scripts/lib/resolve_base.sh'
+    codomain: 'PASS | FAIL | REPORT | ENV'
+    invariants:
+    - 'THE SHARED FILES ARE NAMED, NOT PATTERNED (rows 2-4): a new shared file is a contract bump, not a regex.'
+    - 'A COUNT LINE, NOT THE README (rows 5-6): prose edits to README.md are a row''s to make.'
+    - 'AN ORCHESTRATOR BRANCH IS NOT A ROW (rows 7-8): agent/pp-066-spec names no row; fix/… is not agent/.'
+    - 'A SHAPE WITHOUT A HEAD BRANCH SAYS SO (rows 9-10): a REPORT line, never a silent exit 0.'
+    - 'A MISSING DAG IS ENV, EXIT 2 (row 11).'
+    preconditions:
+    - 'base is named by scripts/lib/resolve_base.sh (PR-A, PMAT-1059) or passed as --base'
+    postconditions:
+    - 'a FAIL names the file or the README line'
+
+  status_is_derived:
+    formula: |
+      status(row) := "complete" if marker(docs/audits/impl-<row.pmat_id>-receipt.md) = complete else "open"
+      render_dag.py prints status(row); it never reads row.status
+      row.status present ∧ row.status ≠ status(row)  =>  D7 violation
+      expired(row) ⟺ expiry(row) < today ∧ status(row) ≠ complete
+    domain: 'every row of docs/specifications/pp-066-dag.yaml'
+    codomain: 'complete | open'
+    invariants:
+    - 'THE RECEIPT IS THE RECORD (D7 rows 12-15): a typed status is a cache, tolerated only while it agrees.'
+    - 'ONE MARKER RULE: receipt_marker() is the same function as scripts/check_receipt_complete.sh (leading front matter, quotes stripped, .tmp is torn).'
+    preconditions: []
+    postconditions:
+    - 'python3 scripts/render_dag.py --check is byte-identical to the committed block without reading any status: key'
+
+  readme_counts_ratchet:
+    formula: |
+      claimed(README) > measured(tree)                =>  FAIL (never overstate)
+      claimed(README) < measured(tree) ∧ ¬exact       =>  PASS, lag reported
+      claimed(README) < measured(tree) ∧ exact        =>  FAIL (the orchestrator regenerates)
+      |{distinct contract counts in README}| > 1      =>  FAIL (self-contradiction)
+    domain: 'the three README count claims vs cargo metadata, find contracts/, the CLI registry'
+    codomain: 'PASS | FAIL'
+    invariants:
+    - 'LAG IS ALLOWED, OVERSTATEMENT IS NOT (rows 3, 5, 6).'
+    - '--exact IS THE ORCHESTRATOR''S CHECK (rows 2, 4), never a CI step on a row PR.'
+    preconditions: []
+    postconditions:
+    - 'the PASS line names the lag when there is one'
+
+  enforcement_is_wired:
+    formula: |
+      ci.yml job "guard-runner-labels" contains, each case table before its live step:
+        bash scripts/check_readme_claims.sh --self-test        bash scripts/check_readme_claims.sh
+        bash scripts/check_dag_invariants.sh --selftest         bash scripts/check_dag_invariants.sh docs/specifications/pp-066-dag.yaml --min-slack-days 6
+        bash scripts/check_row_pr_write_set.sh --self-test      bash scripts/check_row_pr_write_set.sh --event … --branch …
+    domain: 'the step list of job guard-runner-labels'
+    codomain: 'bool'
+    invariants:
+    - 'CASE TABLE BEFORE THE LIVE CHECK (Verification Discipline #7).'
+    preconditions:
+    - 'guard-runner-labels is in gate.needs'
+    postconditions:
+    - 'check_guards_are_wired.sh names check_row_pr_write_set.sh as wired'
+
+proof_obligations:
+  - id: WS-OB-001
+    statement: "A row PR's diff touches none of the three shared files and no README count line; non-row branches are not judged and say so; shapes without a head branch REPORT."
+    discharged_by: falsification_tests[0]
+  - id: WS-OB-002
+    statement: "A DAG row's status is derived from its receipt's marker; a typed status that disagrees is D7; past-expiry reads the derived status."
+    discharged_by: falsification_tests[1]
+  - id: WS-OB-003
+    statement: "The README's counts may lag and may never overstate; --exact restores equality for the orchestrator; a self-contradicting README fails."
+    discharged_by: falsification_tests[2]
+  - id: WS-OB-004
+    statement: "The three guards are wired in ci.yml's guard-runner-labels, case table before live."
+    discharged_by: falsification_tests[3]
+
+falsification_tests:
+  - id: WS-F-001
+    rule: a row PR writes no shared file
+    prediction: >-
+      rows 2-5 RED naming the file or line (DAG, roadmap, spec, README count);
+      rows 1 and 6 PASS (crate code; README prose); rows 7-8 not judged (an
+      orchestrator branch; a fix/ branch); rows 9-10 REPORT with exit 0
+      (merge_group, push); row 11 exit 2 (missing DAG). One --self-test run
+      exercises every row.
+    test: 'bash scripts/check_row_pr_write_set.sh --self-test'
+    if_fails: >-
+      every merge makes every other armed PR DIRTY again (the eight-PR rebuild storm of 2026-09-06)
+    mutation: >-
+      drop docs/specifications/pp-066-dag.yaml from the forbidden list; row 2
+      must turn RED (it passes at rc 0).
+
+  - id: WS-F-002
+    rule: status is derived from the receipt
+    prediction: >-
+      D7 row 12: typed complete with no receipt is RED (the registered mutation);
+      row 13: typed complete over a complete receipt PASSES; row 14: typed
+      complete over a partial receipt is RED; row 15: no typed status, a
+      complete receipt, a past expiry — NOT expired.
+    test: 'bash scripts/check_dag_invariants.sh --selftest'
+    if_fails: >-
+      the DAG becomes the record of completion and a row PR must edit it to be counted
+    mutation: >-
+      make derived_status() return row.get("status", "open"); rows 12 and 15
+      must turn RED.
+
+  - id: WS-F-003
+    rule: README counts are a ratchet
+    prediction: >-
+      rows 1-2 equal PASS (default and --exact); row 3 lag PASS with the lag
+      reported; row 4 lag under --exact RED; rows 5-6 overstatement RED (the
+      registered mutation); row 7 two contract counts RED.
+    test: 'bash scripts/check_readme_claims.sh --self-test'
+    if_fails: >-
+      a row PR that adds a contract must bump the README and collides with every other such PR
+    mutation: >-
+      restore the equality compare in compare_count; row 3 must turn RED.
+
+  - id: WS-F-004
+    rule: wired, case table then live
+    prediction: >-
+      check_guards_are_wired.sh names no unwired guard while ci.yml carries the six steps.
+    test: 'bash scripts/check_guards_are_wired.sh'
+    if_fails: >-
+      a guard that exists and gates nothing (class #2878)
+    mutation: >-
+      delete the two check_row_pr_write_set.sh steps from ci.yml;
+      check_guards_are_wired.sh must turn RED naming the script.
+
+non_goals:
+  - "Who writes the orchestrator docs commit and when (the PP-066 driver prompt: once per merge)."
+  - "Regenerating the README counts automatically (the orchestrator edits and verifies with --exact)."
+  - "Stripping the typed status: keys from the DAG (tolerated as a cache; the orchestrator may drop them)."
+
+binding_registry:
+  guard: scripts/check_row_pr_write_set.sh
+  ci_job: guard-runner-labels
+  make_target: tier3
+  issue: "https://github.com/paiml/aprender/issues/2873"

--- a/crates/aprender-core/tests/readme_contract.rs
+++ b/crates/aprender-core/tests/readme_contract.rs
@@ -127,15 +127,31 @@ fn test_readme_crate_count_matches_workspace() {
         "FALSIFY-README-005: parsed {crate_count} packages from cargo metadata — parser is wrong"
     );
 
-    let expected_row = format!("| Workspace crates | **{crate_count}** workspace crates |");
+    // G-11 (PMAT-1062): the README's counts are a RATCHET, not an equality. A row PR
+    // that adds a crate may leave the README LAGGING (claimed < measured); it may never
+    // OVERSTATE. The orchestrator docs commit regenerates the counts after each merge
+    // and verifies them exactly with `scripts/check_readme_claims.sh --exact`.
+    let claimed = number_before(&readme, "** workspace crates |")
+        .expect("FALSIFY-README-005: README claims-table row `| Workspace crates | **N** workspace crates |` is missing");
     assert!(
-        readme.contains(&expected_row),
-        "FALSIFY-README-005: README claims-table row does not match cargo.\n\
-         expected: {expected_row}\n\
-         `cargo metadata --no-deps` reports {crate_count} workspace packages. Note that\n\
-         `ls crates/` is NOT the same number — some crates/ entries are `exclude`d in the\n\
-         root Cargo.toml and one has no Cargo.toml at all. A directory is not a crate."
+        claimed <= crate_count,
+        "FALSIFY-README-005: README claims {claimed} workspace crates but `cargo metadata --no-deps`\n\
+         reports {crate_count} — the README may lag, never overstate. Note that `ls crates/` is NOT\n\
+         the same number — some crates/ entries are `exclude`d in the root Cargo.toml and one has\n\
+         no Cargo.toml at all. A directory is not a crate."
     );
+}
+
+/// The number immediately before `suffix` in `text` (digits only; markdown bold `**`
+/// between the digits and the suffix is part of the suffix the caller passes).
+fn number_before(text: &str, suffix: &str) -> Option<usize> {
+    let idx = text.find(suffix)?;
+    let digits: String = text[..idx]
+        .chars()
+        .rev()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.chars().rev().collect::<String>().parse().ok()
 }
 
 /// FALSIFY-README-007: Contract count in README matches `find contracts/ -name '*.yaml'`.
@@ -168,11 +184,13 @@ fn test_readme_contract_count_matches_workspace() {
     }
 
     let contract_count = count_yaml(&contracts_dir);
-    let count_str = format!("**{contract_count}** provable contracts");
+    // G-11 (PMAT-1062): lag allowed, overstatement RED (see FALSIFY-README-005 above).
+    let claimed = number_before(&readme, "** provable contracts")
+        .expect("FALSIFY-README-007: README lacks a `**M** provable contracts` claim");
     assert!(
-        readme.contains(&count_str),
-        "FALSIFY-README-007: README lacks `**{contract_count}** provable contracts` \
-         matching `find contracts/ -name '*.yaml'` — update the README claims table row"
+        claimed <= contract_count,
+        "FALSIFY-README-007: README claims {claimed} provable contracts but `find contracts/ -name '*.yaml'` \
+         counts {contract_count} — the README may lag, never overstate; the orchestrator docs commit regenerates it"
     );
 }
 

--- a/docs/audits/impl-PMAT-1062-receipt.md
+++ b/docs/audits/impl-PMAT-1062-receipt.md
@@ -1,10 +1,10 @@
 ---
-status: partial
+status: complete
 ticket: PMAT-1062
 row: G-11
 epic: 2873
 branch: agent/G-11
-pr: opened after PR-A (#3011) merges — the only PR in the queue until then (driver PHASE 1)
+pr: "#3020 — rebased onto main b0a0a51b2; three mutant RED legs at CI, then this revert = the GREEN leg (run id in the PR body)"
 model: claude-fable-5-1 (orchestrator, direct) · review quorum on agy lanes recorded below when run
 tokens_used: 82736 (review delegate, measured by the harness) + orchestrator [U] (not exposed to the orchestrator)
 wall_clock_s: 4500 (basis=session clock, G-11 claim to the fold commit; [U] precision)
@@ -76,5 +76,14 @@ slots used 1/3 · denials 0 · I-3: attempted=1 denied=0 running_peak=1 slots=3.
 - Rebase onto main after #3011; the untracked `scripts/lib/resolve_base.sh` copy then becomes tracked.
 - `check_receipt_complete.sh --dag` still reads typed `status: complete` rows; it stays (redundant with D7, both must hold) — the orchestrator may drop the typed keys once every consumer derives.
 
+## Mutation evidence at CI (I3) — one guard per RED run, each on the PR branch, never in the queue
+| leg | commit | run | job | failing step |
+|---|---|---|---|---|
+| RED (README ratchet, row 3) | 053eee448 + c245dc24c (semantic) | 34038067035 | 101499760324 | README claims must match measurement |
+| RED (D7, rows 12/14/15/16) | 2a9ab0df6 (README mutant reverted, D7 + write-set kept) | 34038496093 | 101500915181 | DAG-invariants guard case table (11 rows, both polarities) |
+| RED (write-set, rows 2/9/11) | eda2ea746 (D7 reverted, write-set kept) | 34040294692 | 101505945716 | Row-PR write-set case table (G-11, PMAT-1062) |
+| GREEN | this commit (the last revert) | the run of this commit (cited in the PR body) | — | 14/14 · 16/16 · 7/7 expected |
+A first RED run (34037532260) failed earlier at the bashrs shrink-only step (8 → 11 error lines: SC2075 ×2 in the new guard, SEC011 ×1 in the README self-test) — a real defect of this branch, fixed in 9a997e653; the job stops at its first failing step, which is why the three guards needed three runs.
+
 ## Verdict
-PARTIAL — awaiting the review lanes, the rebase onto main after #3011, `ci / gate` + `workspace-test`, and the merge.
+DONE on the branch: every A_i re-run by the orchestrator, each guard's mutation RED at CI and reverted; complete = this receipt ∧ the merge of #3020 (v4/v5 rule: the receipt says complete inside the PR before auto-merge is armed).

--- a/docs/audits/impl-PMAT-1062-receipt.md
+++ b/docs/audits/impl-PMAT-1062-receipt.md
@@ -1,0 +1,55 @@
+---
+status: partial
+ticket: PMAT-1062
+row: G-11
+epic: 2873
+branch: agent/G-11
+pr: opened after PR-A (#3011) merges — the only PR in the queue until then (driver PHASE 1)
+model: claude-fable-5-1 (orchestrator, direct) · review quorum on agy lanes recorded below when run
+tokens_used: orchestrator [U] (not exposed to the orchestrator)
+wall_clock_s: 2100 (basis=session clock, G-11 claim to the receipt commit; [U] precision)
+turns: 9 (orchestrator turns on this ticket, counted from the transcript)
+---
+# impl receipt — PMAT-1062 (PP-066 row G-11): shared-file write contention
+
+## Identity
+- kind: code · branch `agent/G-11` off `origin/main` 027ed889d · this receipt is the second commit
+- depends on PR-A (#3011, PMAT-1059): `scripts/check_row_pr_write_set.sh` names its base through `scripts/lib/resolve_base.sh`, which PR-A adds. Until #3011 merges the worktree carries an UNTRACKED copy for local runs; the branch is rebased onto main after the merge and the copy becomes the tracked file.
+- write set: `scripts/lib/dag_status.py` (new), `scripts/render_dag.py`, `scripts/lib/dag_invariants.py`, `scripts/check_dag_invariants.sh`, `scripts/check_row_pr_write_set.sh` (new), `scripts/check_readme_claims.sh`, `contracts/apr-row-pr-write-set-v1.yaml` (new), `.github/workflows/ci.yml` (four steps in guard-runner-labels), this receipt. **No DAG, roadmap, spec or README edit** — the rule this row installs, obeyed by its own PR (the README lags by one contract, which the new ratchet permits).
+
+## Why (five whys, short)
+Eight armed row PRs each hand-edited the DAG status, the roadmap or a README count → every merge made the other seven DIRTY → each needed a rebuild through a ~1 PR/hour queue → because completion was recorded in three shared files no row owns → because nothing derived it from the artifact the row does own (its receipt). The fix moves the record to the receipt and forbids the shared writes mechanically.
+
+## Plan and routing (all direct; the row is `quorum: review-only`, so a 3-lane agy review of the diff precedes the PR)
+| phase | content | A_i | result |
+|---|---|---|---|
+| P1 | `dag_status.py`: status derived from the receipt marker (same rule as `check_receipt_complete.sh`); `render_dag.py` prints it; `dag_invariants.py` D7 refuses a disagreeing typed status; past-expiry reads the derived status | `bash scripts/check_dag_invariants.sh --selftest` · `python3 scripts/render_dag.py --check` | 15/15 (D7 rows 12–15) · byte-identical, 91 rows |
+| P2 | `check_row_pr_write_set.sh`: row PR = `agent/<id>` with `<id>` a DAG row; forbidden = the DAG, the roadmap, the spec, README count lines; non-row branches say so; merge_group/push REPORT; missing DAG = exit 2 | `bash scripts/check_row_pr_write_set.sh --self-test` | 11/11 |
+| P3 | `check_readme_claims.sh`: `compare_count()` lag allowed, overstatement RED, `--exact` for the orchestrator, self-contradiction RED; `README_PATH` fixture; `--self-test` | `bash scripts/check_readme_claims.sh --self-test` · live | 7/7 · PASS ×5 |
+| P4 | ci.yml: README case table before its live step; write-set case table + live after the DAG invariants | `bash scripts/check_guards_are_wired.sh` | PASS (ratcheted) |
+| P5 | contract `apr-row-pr-write-set-v1.yaml` (kind: pattern; WS-OB-001..004 ↔ WS-F-001..004) | `pv validate` (via `scripts/pv_bin.sh`) | valid |
+
+K̂ [U] (second receipt of the guard class; PMAT-1059 is the first; a basis needs three).
+
+## Mutations observed RED → GREEN
+| mutation | RED | GREEN |
+|---|---|---|
+| a row branch appends to `pp-066-dag.yaml` (write-set row 2, the registered mutation) | `FAIL … writes the shared file docs/specifications/pp-066-dag.yaml` rc=1 | crate-code-only diff (row 1) PASS |
+| a row branch bumps `1812` → `1813` in README (row 5) | RED naming the line | README prose edit (row 6) PASS |
+| typed `status: complete` with no receipt (D7 row 12) | rc=1 naming the row and the receipt path | typed complete over a complete receipt (row 13) PASS; no typed status + complete receipt + past expiry → not expired (row 15) |
+| README overstates the crate count by one (README row 5) | `FAIL … the README may lag, never overstate` | lag by one (row 3) PASS with `lags at N` reported; `--exact` RED (row 4) |
+| the merge_group / push shapes (rows 9–10) | — | REPORT line asserted present (a silent exit 0 is RED in the table) |
+
+## Verification (claimed vs re-run by the orchestrator)
+No worker or lane ran on this row before this commit; every number above is the orchestrator's own run (`.pr/G-11-verify.log`). Also PASS: `check_shell_lint_ratchet.sh`, `check_sourced_libs_option_neutral.sh`, `check_no_claim_literals.sh`, `check_receipt_complete.sh --dag`. The live write-set run on the local worktree refused its base by name (HEAD was the origin/main tip in a shallow clone: "never the tree against itself") — the PR-A rule working as designed; with `--base origin/main` it reports `names no DAG row` until the orchestrator commit adds row G-11.
+
+## Dispatch ledger
+none yet (direct). The pre-PR 3-lane review is appended below by the orchestrator after it runs.
+
+## Gaps
+- Orchestrator docs commit (agent/pp-066-spec): DAG row G-11 (+ G-10b, G-10c, U-1, S-0), the P-1.1/P-1.2 lane amendment (D-11), the C0-3 → U-1 edge, the roadmap mint of PMAT-1061..1064, the re-rendered §5.0 block, README counts regenerated and verified with `--exact`.
+- Rebase onto main after #3011; the untracked `scripts/lib/resolve_base.sh` copy then becomes tracked.
+- `check_receipt_complete.sh --dag` still reads typed `status: complete` rows; it stays (redundant with D7, both must hold) — the orchestrator may drop the typed keys once every consumer derives.
+
+## Verdict
+PARTIAL — awaiting the review lanes, the rebase onto main after #3011, `ci / gate` + `workspace-test`, and the merge.

--- a/docs/audits/impl-PMAT-1062-receipt.md
+++ b/docs/audits/impl-PMAT-1062-receipt.md
@@ -6,9 +6,9 @@ epic: 2873
 branch: agent/G-11
 pr: opened after PR-A (#3011) merges — the only PR in the queue until then (driver PHASE 1)
 model: claude-fable-5-1 (orchestrator, direct) · review quorum on agy lanes recorded below when run
-tokens_used: orchestrator [U] (not exposed to the orchestrator)
-wall_clock_s: 2100 (basis=session clock, G-11 claim to the receipt commit; [U] precision)
-turns: 9 (orchestrator turns on this ticket, counted from the transcript)
+tokens_used: 82736 (review delegate, measured by the harness) + orchestrator [U] (not exposed to the orchestrator)
+wall_clock_s: 4500 (basis=session clock, G-11 claim to the fold commit; [U] precision)
+turns: 16 (orchestrator turns on this ticket, counted from the transcript)
 ---
 # impl receipt — PMAT-1062 (PP-066 row G-11): shared-file write contention
 
@@ -23,8 +23,8 @@ Eight armed row PRs each hand-edited the DAG status, the roadmap or a README cou
 ## Plan and routing (all direct; the row is `quorum: review-only`, so a 3-lane agy review of the diff precedes the PR)
 | phase | content | A_i | result |
 |---|---|---|---|
-| P1 | `dag_status.py`: status derived from the receipt marker (same rule as `check_receipt_complete.sh`); `render_dag.py` prints it; `dag_invariants.py` D7 refuses a disagreeing typed status; past-expiry reads the derived status | `bash scripts/check_dag_invariants.sh --selftest` · `python3 scripts/render_dag.py --check` | 15/15 (D7 rows 12–15) · byte-identical, 91 rows |
-| P2 | `check_row_pr_write_set.sh`: row PR = `agent/<id>` with `<id>` a DAG row; forbidden = the DAG, the roadmap, the spec, README count lines; non-row branches say so; merge_group/push REPORT; missing DAG = exit 2 | `bash scripts/check_row_pr_write_set.sh --self-test` | 11/11 |
+| P1 | `dag_status.py`: status derived from the receipt marker (same rule as `check_receipt_complete.sh`); `render_dag.py` prints it; `dag_invariants.py` D7 refuses a disagreeing typed status; past-expiry reads the derived status | `bash scripts/check_dag_invariants.sh --selftest` · `python3 scripts/render_dag.py --check` | 16/16 (D7 rows 12–16) · byte-identical, 91 rows |
+| P2 | `check_row_pr_write_set.sh`: the DAG and the spec orchestrator-only on every branch; a row PR (`agent/<id>`, `<id>` a DAG row) also not the roadmap or a README count line; `--no-renames`, DAG read at the base; non-row branches say so; merge_group/push REPORT; DAG missing at the base = exit 2 | `bash scripts/check_row_pr_write_set.sh --self-test` | 14/14 (after the fold) |
 | P3 | `check_readme_claims.sh`: `compare_count()` lag allowed, overstatement RED, `--exact` for the orchestrator, self-contradiction RED; `README_PATH` fixture; `--self-test` | `bash scripts/check_readme_claims.sh --self-test` · live | 7/7 · PASS ×5 |
 | P4 | ci.yml: README case table before its live step; write-set case table + live after the DAG invariants | `bash scripts/check_guards_are_wired.sh` | PASS (ratcheted) |
 | P5 | contract `apr-row-pr-write-set-v1.yaml` (kind: pattern; WS-OB-001..004 ↔ WS-F-001..004) | `pv validate` (via `scripts/pv_bin.sh`) | valid |
@@ -44,7 +44,32 @@ K̂ [U] (second receipt of the guard class; PMAT-1059 is the first; a basis need
 No worker or lane ran on this row before this commit; every number above is the orchestrator's own run (`.pr/G-11-verify.log`). Also PASS: `check_shell_lint_ratchet.sh`, `check_sourced_libs_option_neutral.sh`, `check_no_claim_literals.sh`, `check_receipt_complete.sh --dag`. The live write-set run on the local worktree refused its base by name (HEAD was the origin/main tip in a shallow clone: "never the tree against itself") — the PR-A rule working as designed; with `--base origin/main` it reports `names no DAG row` until the orchestrator commit adds row G-11.
 
 ## Dispatch ledger
-none yet (direct). The pre-PR 3-lane review is appended below by the orchestrator after it runs.
+| dispatch | agent | lane | width | agy conversations | child | turns | note |
+|---|---|---|---|---|---|---|---|
+| P6 review | paiml-agy-delegate `a6945921a70850177` (opus) | quorum, mode plan | 3 | 6b26a481-2126-442f-b5cf-91d8e1f7c5b2 · 0991a3bb-08da-491d-b410-c3113f4d02c4 · 89d65a03-6ba6-4b52-8cb9-44ded95a6d49 | 0 | 1 per lane | first launch killed at ~117 s by the harness timeout (3 conversations discarded); NO lane ran the four required commands — every `measured` tag in the lane files is a claim |
+
+slots used 1/3 · denials 0 · I-3: attempted=1 denied=0 running_peak=1 slots=3. Lane files: `/run/user/1000/paiml-implement/agy/G-11-review/lane-{1,2,3}.json`.
+
+## Review quorum: 3/3 implement-with-changes — every finding re-verified by the orchestrator, then folded
+| Q | lane finding | my verification | disposition |
+|---|---|---|---|
+| Q1 | a PR from a branch not named `agent/<id>` walks through (3/3) | correct as written | **folded**: the DAG and the spec are orchestrator-only on EVERY branch (allow-list `agent/pp-066-*`, `agent/pr-triage*`); the roadmap/README-count rule stays row-only because other work mints tickets in the roadmap; rows 9–10 added (a `fix/` branch writing the DAG → RED; `agent/<not-a-row>` writing the spec → RED) |
+| Q1 | `git diff --name-only` hides a rename's source path (2/3) | correct: rename detection collapses old→new | **folded**: `--no-renames`; the DAG is read at the BASE commit so a renamed/deleted DAG is a write, not ENV; row 11 (rename → RED naming the file) |
+| Q1 | the README count regex is escaped by >2 words | true, and by design: the regex IS check_readme_claims.sh's extractor — a line it does not read is not a claim | comment added; no change |
+| Q2 | the pull_request run is not required (lane 2) vs it is (lane 3) | **lane 3 is right**: ruleset "Green Main" (13878864) requires the context `gate`; the local `gate` job (ci.yml) `needs: [ci, workspace-test, mutants, guard-runner-labels]`; branch protection adds `ci / gate` + `workspace-test` | REPORT-and-exit-0 on merge_group/push stands, and the header now cites the two mechanisms |
+| Q2 | a row PR could delete the step from ci.yml (lane 1) | true of every guard; `scripts/check_guards_are_wired.sh` names an unwired guard RED (class #2878) | noted in the header; no change |
+| Q3 | CRLF: bash keeps `\r` (no front matter), python universal newlines drop it (3/3) | reproduced | **folded**: `open(..., newline="")`; D7 row 16 (a CRLF receipt, typed complete → RED); parity checked by hand: bash `none`, python `none` |
+| Q3 | awk strips quotes anywhere, python only at the edges (lane 3) | reproduced (`co"mpl"ete`) | **folded**: `re.sub(r'[\s"\']', '', v)` |
+| Q3 | render_dag drift on a receipt flip is a Catch-22 for a row PR | correct reading; the discipline was implicit | **folded**: the drift message states it — a row PR ships `status: partial` and never edits the spec; the orchestrator flips and re-renders in one commit |
+| Q4 | `cli_command_count` bypassed `compare_count` (3/3) | correct | **folded**: routed through `compare_count` (lag reported) |
+| Q4 | the exact behaviour survives in `crates/aprender-core/tests/readme_contract.rs` (lane 2) | **correct and load-bearing**: FALSIFY-README-005/007 asserted equality and ride `workspace-test`, so a lagging README would have failed every row PR | **folded**: both tests now assert claimed ≤ measured (`number_before()`), lag stated in the message; `cargo test -p aprender-core --test readme_contract` → 15 passed |
+| Q4 | claimed==measured==0 passes vacuously (lane 1) vs cannot (lane 3) | lane 3 is right: the measurement functions exit 1 on an empty/zero count before any compare | no change |
+| Q5 | `resolve_base.sh` untracked here → live step exit 2 in CI | correct until the rebase onto main after PR-A (#3011) | documented; the rebase is a gap below |
+| Q5 | README case table AFTER its live step (lane 3) | correct: I appended the self-test after the live run line | **folded**: one `run:` block, case table first |
+| Q6 | obligations 1:1, every `test:` real | holds | — |
+
+## Verification after the fold (orchestrator's own runs, `.pr/G-11-verify2.log`)
+`check_row_pr_write_set.sh --self-test` 14/14 · `check_dag_invariants.sh --selftest` 16/16 · `check_readme_claims.sh --self-test` 7/7 · live README PASS ×5 · `render_dag.py --check` byte-identical · `check_guards_are_wired.sh` PASS · `check_shell_lint_ratchet.sh` PASS · `check_sourced_libs_option_neutral.sh` OK · `cargo test -p aprender-core --test readme_contract` 15 passed (own target dir, pinned cargo path) · clippy on that target: see the follow-up commit if it changed anything.
 
 ## Gaps
 - Orchestrator docs commit (agent/pp-066-spec): DAG row G-11 (+ G-10b, G-10c, U-1, S-0), the P-1.1/P-1.2 lane amendment (D-11), the C0-3 → U-1 edge, the roadmap mint of PMAT-1061..1064, the re-rendered §5.0 block, README counts regenerated and verified with `--exact`.

--- a/scripts/check_dag_invariants.sh
+++ b/scripts/check_dag_invariants.sh
@@ -146,6 +146,8 @@ PY
     mut d7c 'rows["R-4"]["pmat_id"] = "PMAT-8"; rows["R-4"]["status"] = "complete"';    row D7 1 "typed status: complete over a receipt that says partial" "$TD/d7c.yaml"
     mut d7d 'del rows["R-4"]["status"]; rows["R-4"]["pmat_id"] = "PMAT-7"; rows["R-4"]["expiry"] = "2026-09-01"'; row D7 0 "no typed status: a complete receipt makes a past-expiry row NOT expired (derived)" "$TD/d7d.yaml"
     if grep -q 'expired' "$TD/out.$n"; then printf 'FAIL  row %-2s D7     the complete receipt was not read: the row still reports as expired\n' "$n"; fails=1; fi
+    printf -- '---\r\nstatus: complete\r\n---\r\n' > "$TD/root/docs/audits/impl-PMAT-9-receipt.md"
+    mut d7e 'rows["R-4"]["pmat_id"] = "PMAT-9"; rows["R-4"]["status"] = "complete"';    row D7 1 "a CRLF receipt is no front matter for bash (head -n1 keeps the CR) and none for python too: typed complete is RED" "$TD/d7e.yaml"
     printf '%s/%s rows\n' "$((n - red))" "$n"
     [ "$red" = 0 ] || exit 1
     exit 0

--- a/scripts/check_dag_invariants.sh
+++ b/scripts/check_dag_invariants.sh
@@ -105,10 +105,10 @@ rows:
   status: open
 EOF
     n=0; red=0
-    row() { # row <id> <want rc> <label> <fixture>
-        local id=$1 want=$2 label=$3 f=$4 rc=0
+    row() { # row <id> <want rc> <label> <fixture> [<root holding docs/audits/impl-*-receipt.md>]
+        local id=$1 want=$2 label=$3 f=$4 root=${5:-$TD/root} rc=0
         n=$((n + 1))
-        python3 "$LIB" check "$f" --min-slack-days 6 --today 2026-09-05 >"$TD/out.$n" 2>&1 || rc=$?
+        python3 "$LIB" check "$f" --min-slack-days 6 --today 2026-09-05 --root "$root" >"$TD/out.$n" 2>&1 || rc=$?
         if [ "$rc" = "$want" ]; then
             printf 'ok    row %-2s %-6s rc=%s  %s\n' "$n" "$id" "$rc" "$label"
         else
@@ -139,6 +139,13 @@ PY
     mut d6c 'rows["I-15"]["expiry"] = {"anchor": "GHOST", "days": 7}';     row D6 1 "an anchor that is not a row" "$TD/d6c.yaml"
     mut rep 'rows["R-4"]["expiry"] = "2026-09-01"';                        row REP 0 "a past-expiry row is REPORTED, not a violation here" "$TD/rep.yaml"
     grep -q "REPORT past-expiry" "$TD/out.$n" || { printf 'FAIL  row %-2s the past-expiry report line is missing\n' "$n"; red=1; }
+    # D7 (G-11, PMAT-1062): status is DERIVED from docs/audits/impl-<pmat_id>-receipt.md; a typed status is at most a cache
+    mkdir -p "$TD/root/docs/audits"; printf -- '---\nstatus: complete\n---\n' > "$TD/root/docs/audits/impl-PMAT-7-receipt.md"; printf -- '---\nstatus: partial\n---\n' > "$TD/root/docs/audits/impl-PMAT-8-receipt.md"
+    mut d7a 'rows["R-4"]["status"] = "complete"';                                       row D7 1 "typed status: complete on a row with no receipt (the registered mutation)" "$TD/d7a.yaml"
+    mut d7b 'rows["R-4"]["pmat_id"] = "PMAT-7"; rows["R-4"]["status"] = "complete"';    row D7 0 "typed status: complete agrees with a complete receipt (a cache, tolerated)" "$TD/d7b.yaml"
+    mut d7c 'rows["R-4"]["pmat_id"] = "PMAT-8"; rows["R-4"]["status"] = "complete"';    row D7 1 "typed status: complete over a receipt that says partial" "$TD/d7c.yaml"
+    mut d7d 'del rows["R-4"]["status"]; rows["R-4"]["pmat_id"] = "PMAT-7"; rows["R-4"]["expiry"] = "2026-09-01"'; row D7 0 "no typed status: a complete receipt makes a past-expiry row NOT expired (derived)" "$TD/d7d.yaml"
+    if grep -q 'expired' "$TD/out.$n"; then printf 'FAIL  row %-2s D7     the complete receipt was not read: the row still reports as expired\n' "$n"; fails=1; fi
     printf '%s/%s rows\n' "$((n - red))" "$n"
     [ "$red" = 0 ] || exit 1
     exit 0
@@ -161,7 +168,7 @@ done
 rc=0
 python3 "$LIB" check "$DAG" "${ARGS[@]+"${ARGS[@]}"}" || rc=$?
 if [ "$rc" = 0 ]; then
-    printf 'PASS  every DAG invariant holds (D1 edges, D2 acyclic, D3 slack, D4 queues, D5 owner, D6 expiry form)\n'
+    printf 'PASS  every DAG invariant holds (D1 edges, D2 acyclic, D3 slack, D4 queues, D5 owner, D6 expiry form, D7 status derived from receipts)\n'
 else
     printf 'FAIL  a DAG invariant is violated (rc=%s). Amend the DAG with a dated row under `amendments:` naming who, why, date — never by editing a blocker away.\n' "$rc" >&2
 fi

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -308,7 +308,11 @@ check_install_line() {
 case "$mode" in
   selftest)
     # G-11 case table: the counts are a ratchet (lag allowed, overstatement RED; --exact for the orchestrator)
-    TD=$(mktemp -d "${TMPDIR:-/tmp}/readme-selftest.XXXXXX"); trap 'rm -rf -- "$TD"' EXIT
+    TD=$(mktemp -d "${TMPDIR:-/tmp}/readme-selftest.XXXXXX")
+    safe_rm_scratch() { local victim=${1:-} must=${2:-}; [ -n "$victim" ] || return 0; [ -n "$must" ] || return 0; [ "$victim" != "/" ] || return 0
+      case "$victim" in *"$must"*) if [ -n "$victim" ] && [ "$victim" != "/" ]; then rm -rf -- "$victim"; fi ;; *) return 0 ;; esac; }
+    cleanup() { safe_rm_scratch "$TD" 'readme-selftest.'; }
+    trap cleanup EXIT
     mc=$(measured_crate_count) || { echo "FAIL self-test: cannot measure the crate count" >&2; exit 1; }
     cc=$(measured_contract_count)
     fx() { printf '# apr\n\n**%s** workspace crates, **%s** provable contracts.\n%s\n' "$1" "$2" "${3:-}" > "$TD/README.md"; }

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -28,7 +28,7 @@ compare_count() { # compare_count <falsify id> <name> <claimed> <measured> <what
     echo "FAIL $fid $name: README claims $claimed, $what has $measured — the README may lag, never overstate" >&2; return 1
   fi
   if [[ "$claimed" -lt "$measured" ]]; then
-    if [[ "$EXACT" = 1 ]]; then echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi
+    if true; then   # MUTANT: equality restored (lag is RED again) echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi
     echo "PASS $fid $name: $measured (README lags at $claimed; the orchestrator docs commit regenerates it)"; return 0
   fi
   echo "PASS $fid $name: $measured"

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -16,7 +16,23 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-README="$REPO_ROOT/README.md"
+README="${README_PATH:-$REPO_ROOT/README.md}"   # README_PATH: a fixture, for --self-test
+# G-11 (PMAT-1062, driver R2 2026-09-06): the README's counts are a RATCHET, not an
+# equality. A row PR that adds a contract may leave the README LAGGING (claimed <
+# measured); it may never OVERSTATE (claimed > measured). The orchestrator docs commit
+# regenerates the counts after each merge and verifies them with --exact.
+EXACT="${README_EXACT:-0}"
+compare_count() { # compare_count <falsify id> <name> <claimed> <measured> <what measured is>
+  local fid=$1 name=$2 claimed=$3 measured=$4 what=$5
+  if [[ "$claimed" -gt "$measured" ]]; then
+    echo "FAIL $fid $name: README claims $claimed, $what has $measured — the README may lag, never overstate" >&2; return 1
+  fi
+  if [[ "$claimed" -lt "$measured" ]]; then
+    if [[ "$EXACT" = 1 ]]; then echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi
+    echo "PASS $fid $name: $measured (README lags at $claimed; the orchestrator docs commit regenerates it)"; return 0
+  fi
+  echo "PASS $fid $name: $measured"
+}
 
 # A cargo exit is classified before any verdict names the README. See
 # scripts/cargo_classify.sh. The case table is armed on the normal path because
@@ -174,11 +190,7 @@ check_crate_count() {
     echo "FAIL FALSIFY-README-001 crate_count: README lacks '**N** workspace crates' claim (pattern mismatch)" >&2
     return 1
   fi
-  if [[ "$measured" != "$claimed" ]]; then
-    echo "FAIL FALSIFY-README-001 crate_count: README claims $claimed, cargo metadata --no-deps has $measured workspace members" >&2
-    return 1
-  fi
-  echo "PASS FALSIFY-README-001 crate_count: $measured"
+  compare_count FALSIFY-README-001 crate_count "$claimed" "$measured" "cargo metadata --no-deps"
 }
 
 check_contract_count() {
@@ -192,17 +204,14 @@ check_contract_count() {
   # EVERY claim must agree with the filesystem, not just the first one found.
   # The README is also not allowed to contradict itself: three different counts
   # in one file is a drift the reader cannot resolve.
-  while IFS= read -r c; do
-    [[ -n "$c" ]] || continue
-    n=$((n + 1))
-    if [[ "$measured" != "$c" ]]; then
-      echo "FAIL FALSIFY-README-002 contract_count: README claims $c, filesystem has $measured" >&2
-      grep -niE "\\b$c\\*{0,2}( +[a-z]+){0,2} +contracts?\\b" "$README" | sed 's|^|       |' >&2
-      rc=1
-    fi
-  done <<< "$claimed"
-  [[ "$rc" -eq 0 ]] || return 1
-  echo "PASS FALSIFY-README-002 contract_count: $measured ($n claim(s) checked)"
+  # The README may not contradict ITSELF: three different counts in one file is a
+  # drift the reader cannot resolve, whatever the filesystem says.
+  if [[ "$(printf '%s\n' "$claimed" | grep -c .)" -gt 1 ]]; then
+    echo "FAIL FALSIFY-README-002 contract_count: the README carries several different contract counts: $(printf '%s' "$claimed" | tr '\n' ' ')" >&2
+    return 1
+  fi
+  n=1
+  compare_count FALSIFY-README-002 contract_count "$claimed" "$measured" "the filesystem (find contracts/ -name '*.yaml')" || return 1
 }
 
 check_cli_command_count() {
@@ -224,7 +233,7 @@ check_cli_command_count() {
     echo "FAIL FALSIFY-README-003 cli_command_count: README lacks '**K** CLI commands' claim" >&2
     return 1
   fi
-  if [[ "$measured" != "$claimed" ]]; then
+  if [[ "$claimed" -gt "$measured" || ( "$EXACT" = 1 && "$claimed" -ne "$measured" ) ]]; then
     echo "FAIL FALSIFY-README-003 cli_command_count: README claims $claimed," \
          "contracts/apr-cli-commands-v1.yaml lists $measured commands" >&2
     return 1
@@ -250,6 +259,8 @@ for arg in "$@"; do
   case "$arg" in
     --claim) mode="one" ;;
     --regen) mode="regen" ;;
+    --exact) EXACT=1 ;;
+    --self-test) mode="selftest" ;;
     crate_count|contract_count|cli_command_count|cookbook_link) claim="$arg" ;;
     *) echo "unknown arg: $arg" >&2; exit 2 ;;
   esac
@@ -300,6 +311,32 @@ check_install_line() {
 }
 
 case "$mode" in
+  selftest)
+    # G-11 case table: the counts are a ratchet (lag allowed, overstatement RED; --exact for the orchestrator)
+    TD=$(mktemp -d "${TMPDIR:-/tmp}/readme-selftest.XXXXXX"); trap 'rm -rf -- "$TD"' EXIT
+    mc=$(measured_crate_count) || { echo "FAIL self-test: cannot measure the crate count" >&2; exit 1; }
+    cc=$(measured_contract_count)
+    fx() { printf '# apr\n\n**%s** workspace crates, **%s** provable contracts.\n%s\n' "$1" "$2" "${3:-}" > "$TD/README.md"; }
+    n=0; red=0
+    row() { # row <want rc> <label> <claim> [<extra env>]
+      local want=$1 label=$2 claim=$3 env=${4:-} rc=0
+      n=$((n + 1))
+      env README_PATH="$TD/README.md" $env bash "$0" --claim "$claim" >"$TD/out.$n" 2>&1 || rc=$?
+      if [ "$rc" = "$want" ]; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+      else printf 'FAIL  row %-2s rc=%s (wanted %s)  %s\n' "$n" "$rc" "$want" "$label"; sed 's/^/        /' "$TD/out.$n"; red=1; fi
+    }
+    fx "$mc" "$cc";                    row 0 "claims equal the measurement: PASS"                              crate_count
+    fx "$mc" "$cc";                    row 0 "equal, --exact: PASS"                                            contract_count README_EXACT=1
+    fx "$((mc - 1))" "$((cc - 1))";    row 0 "README lags by one (a row PR added a crate): PASS, lag reported" crate_count
+    grep -q 'lags at' "$TD/out.$n" || { printf 'FAIL  row %-2s the lag was not reported\n' "$n"; red=1; }
+    fx "$((mc - 1))" "$((cc - 1))";    row 1 "lags by one under --exact (the orchestrator docs commit): RED"  contract_count README_EXACT=1
+    fx "$((mc + 1))" "$((cc + 1))";    row 1 "README OVERSTATES the crate count by one: RED (the registered mutation)" crate_count
+    fx "$mc" "$((cc + 1))";            row 1 "README overstates the contract count: RED"                       contract_count
+    fx "$mc" "$cc" "and $((cc - 1)) contracts elsewhere"; row 1 "two different contract counts in one README: RED (self-contradiction)" contract_count
+    printf '%s/%s rows\n' "$((n - red))" "$n"
+    [ "$red" = 0 ] || exit 1
+    exit 0
+    ;;
   regen)
     echo "workspace members:     $(measured_crate_count)"
     echo "contracts/ *.yaml:     $(measured_contract_count)"

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -28,7 +28,7 @@ compare_count() { # compare_count <falsify id> <name> <claimed> <measured> <what
     echo "FAIL $fid $name: README claims $claimed, $what has $measured — the README may lag, never overstate" >&2; return 1
   fi
   if [[ "$claimed" -lt "$measured" ]]; then
-    if true; then   # MUTANT: equality restored (lag is RED again) echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi
+    if [[ 1 = 1 ]]; then echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi   # MUTANT: equality restored (lag is RED again)
     echo "PASS $fid $name: $measured (README lags at $claimed; the orchestrator docs commit regenerates it)"; return 0
   fi
   echo "PASS $fid $name: $measured"

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -28,7 +28,7 @@ compare_count() { # compare_count <falsify id> <name> <claimed> <measured> <what
     echo "FAIL $fid $name: README claims $claimed, $what has $measured — the README may lag, never overstate" >&2; return 1
   fi
   if [[ "$claimed" -lt "$measured" ]]; then
-    if [[ 1 = 1 ]]; then echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi   # MUTANT: equality restored (lag is RED again)
+    if [[ "$EXACT" = 1 ]]; then echo "FAIL $fid $name: README claims $claimed, $what has $measured (--exact: the orchestrator docs commit regenerates counts)" >&2; return 1; fi
     echo "PASS $fid $name: $measured (README lags at $claimed; the orchestrator docs commit regenerates it)"; return 0
   fi
   echo "PASS $fid $name: $measured"

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -233,12 +233,7 @@ check_cli_command_count() {
     echo "FAIL FALSIFY-README-003 cli_command_count: README lacks '**K** CLI commands' claim" >&2
     return 1
   fi
-  if [[ "$claimed" -gt "$measured" || ( "$EXACT" = 1 && "$claimed" -ne "$measured" ) ]]; then
-    echo "FAIL FALSIFY-README-003 cli_command_count: README claims $claimed," \
-         "contracts/apr-cli-commands-v1.yaml lists $measured commands" >&2
-    return 1
-  fi
-  echo "PASS FALSIFY-README-003 cli_command_count: $measured"
+  compare_count FALSIFY-README-003 cli_command_count "$claimed" "$measured" "contracts/apr-cli-commands-v1.yaml"
 }
 
 check_cookbook_link() {

--- a/scripts/check_row_pr_write_set.sh
+++ b/scripts/check_row_pr_write_set.sh
@@ -16,32 +16,38 @@
 #   bash scripts/check_row_pr_write_set.sh --base <ref> --head <ref> [--branch <name>] [--event <name>] [--dag <yaml>] [--readme <md>]
 #   bash scripts/check_row_pr_write_set.sh --self-test
 #
-# A ROW PR is a head branch `agent/<id>` whose <id> is a row of the DAG. Anything else
-# (an orchestrator branch such as agent/pp-066-spec, a fix/… branch) is not judged here
-# and says so. On the merge_group and push shapes there is no head branch to read, so
-# the guard REPORTs that the write set was judged on the pull_request run (which is a
-# required check) and exits 0 — stated, not silent.
-#
-# FORBIDDEN in a row PR (the diff base..head must not touch):
-#   docs/specifications/pp-066-dag.yaml
-#   docs/roadmaps/roadmap.yaml
-#   docs/specifications/PP-066-release-spec.md      (its §5.0 block is rendered from the DAG)
-#   README.md lines that carry a count claim         (N workspace crates / N contracts / N CLI commands)
+# Two rules, two universes (the G-11 review quorum, 2026-09-06: a row PR opened from a
+# branch NOT named agent/<id> must not walk through):
+#   * the DAG and the release spec are the ORCHESTRATOR's on EVERY branch: only an
+#     orchestrator branch (agent/pp-066-*, agent/pr-triage*) may write
+#     docs/specifications/pp-066-dag.yaml or docs/specifications/PP-066-release-spec.md
+#     (its §5.0 block is rendered from the DAG);
+#   * a ROW PR — head branch `agent/<id>` whose <id> is a row of the DAG — may in
+#     addition not write docs/roadmaps/roadmap.yaml (other work mints tickets there)
+#     or a README.md line carrying a count claim (N workspace crates / N contracts /
+#     N CLI commands — the same extractor patterns scripts/check_readme_claims.sh reads).
+# On the merge_group and push shapes there is no head branch to read, so the guard
+# REPORTs that the write set was judged on the pull_request run — which IS required:
+# job guard-runner-labels is in the local `gate` job's needs and the ruleset "Green
+# Main" requires the context `gate` — and exits 0, stated, not silent.
+# Renames are never collapsed (--no-renames): a rename's SOURCE path is a write.
+# ci.yml itself is guarded by scripts/check_guards_are_wired.sh (a deleted step is RED).
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROG=check_row_pr_write_set
 DAG_DEFAULT="docs/specifications/pp-066-dag.yaml"
-COUNT_RE='[0-9]+\*{0,2}( +[a-z]+){0,2} +(workspace crates?|contracts?|CLI commands?)\b'
+COUNT_RE='[0-9]+\*{0,2}( +[a-z]+){0,2} +(workspace crates?|contracts?|CLI commands?)\b'   # = check_readme_claims.sh's claim extractors: a line they do not read is not a claim
+ORCHESTRATOR_RE='^agent/(pp-066-|pr-triage)'
 
 usage() { printf 'usage: %s --base <ref> --head <ref> [--branch <name>] [--event <name>] [--dag <yaml>] [--readme <md>] | --self-test\n' "$PROG" >&2; exit 2; }
 
-row_ids() { # row_ids <dag> -> one id per line
-    python3 - "$1" <<'PY'
+row_ids() { # row_ids <repo> <base> <dag relpath> -> one id per line; the DAG is read at the BASE (a PR that renames or deletes it still has a base)
+    git -C "$1" show "$2:$3" 2>/dev/null | python3 -c '
 import sys, yaml
-d = yaml.safe_load(open(sys.argv[1], encoding="utf-8")) or {}
+d = yaml.safe_load(sys.stdin) or {}
 for r in d.get("rows") or []:
     print(r.get("id"))
-PY
+'
 }
 
 judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clean / 1 RED / 2 usage-env
@@ -50,20 +56,28 @@ judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clea
         merge_group|push)
             printf 'REPORT %s: the %s shape carries no head branch; the write set was judged on the pull_request run (a required check). Not a verdict.\n' "$PROG" "$event"; return 0 ;;
     esac
-    case "$branch" in
-        agent/*) id=${branch#agent/} ;;
-        *) printf 'ok    %s: `%s` is not an agent/<row> branch; the write-set rule binds row PRs only\n' "$PROG" "${branch:-<none>}"; return 0 ;;
-    esac
-    [ -f "$dag" ] || { printf '%s: ENV - %s is missing (the box cannot answer)\n' "$PROG" "$dag" >&2; return 2; }
-    if ! row_ids "$dag" | grep -qxF -- "$id"; then
-        printf 'ok    %s: `%s` names no DAG row (an orchestrator or other branch); the write-set rule binds row PRs only\n' "$PROG" "$branch"; return 0
+    git -C "$repo" cat-file -e "$base:$dag" 2>/dev/null || { printf '%s: ENV - %s is missing at the base %.9s (the box cannot answer)\n' "$PROG" "$dag" "$base" >&2; return 2; }
+    local changed; changed=$(git -C "$repo" diff --no-renames --name-only "$base" "$head" --) || { printf '%s: ENV - git diff %s %s failed\n' "$PROG" "$base" "$head" >&2; return 2; }
+    if printf '%s' "$branch" | grep -qE -- "$ORCHESTRATOR_RE"; then
+        printf 'ok    %s: `%s` is an orchestrator branch; it owns the DAG, the spec block, the roadmap and the README counts\n' "$PROG" "$branch"; return 0
     fi
-    local changed; changed=$(git -C "$repo" diff --name-only "$base" "$head" --) || { printf '%s: ENV - git diff %s %s failed\n' "$PROG" "$base" "$head" >&2; return 2; }
-    for f in docs/specifications/pp-066-dag.yaml docs/roadmaps/roadmap.yaml docs/specifications/PP-066-release-spec.md; do
+    # rule 1: the DAG and the spec are orchestrator-only on EVERY branch
+    for f in docs/specifications/pp-066-dag.yaml docs/specifications/PP-066-release-spec.md; do
         if printf '%s\n' "$changed" | grep -qxF -- "$f"; then
-            printf 'FAIL  %s: row PR %s writes the shared file %s — the DAG status is derived from the receipt, the roadmap and the spec block are the orchestrator docs commit'\''s\n' "$PROG" "$branch" "$f"; rc=1
+            printf 'FAIL  %s: branch %s writes %s — orchestrator-only (agent/pp-066-*); a row'\''s status is derived from its receipt and the spec block is rendered\n' "$PROG" "${branch:-<none>}" "$f"; rc=1
         fi
     done
+    # rule 2: a ROW PR (agent/<id>, <id> a DAG row) may not write the roadmap or a README count line
+    case "$branch" in
+        agent/*) id=${branch#agent/} ;;
+        *) [ "$rc" = 0 ] && printf 'ok    %s: `%s` is not an agent/<row> branch; the roadmap/README-count rule binds row PRs only\n' "$PROG" "${branch:-<none>}"; return "$rc" ;;
+    esac
+    if ! row_ids "$repo" "$base" "$dag" | grep -qxF -- "$id"; then
+        [ "$rc" = 0 ] && printf 'ok    %s: `%s` names no DAG row; the roadmap/README-count rule binds row PRs only\n' "$PROG" "$branch"; return "$rc"
+    fi
+    if printf '%s\n' "$changed" | grep -qxF -- docs/roadmaps/roadmap.yaml; then
+        printf 'FAIL  %s: row PR %s writes docs/roadmaps/roadmap.yaml — pmat work complete and the ticket edits are the orchestrator docs commit'\''s\n' "$PROG" "$branch"; rc=1
+    fi
     if printf '%s\n' "$changed" | grep -qxF -- "$readme"; then
         local hits; hits=$(git -C "$repo" diff "$base" "$head" -- "$readme" | grep -E '^[-+][^-+]' | grep -E -- "$COUNT_RE" || true)
         if [ -n "$hits" ]; then
@@ -106,7 +120,7 @@ if [ "${1:-}" = "--self-test" ]; then
         local want=$1 label=$2 branch=$3 event=$4 mut=$5 rc=0
         n=$((n + 1))
         ( cd "$R" && git checkout -q --detach "$BASE" && bash -c "$mut" && git add -A && git commit -qm "$label" --allow-empty ) >/dev/null 2>&1
-        judge "$R" "$BASE" "$(git -C "$R" rev-parse HEAD)" "$branch" "$event" "$R/docs/specifications/pp-066-dag.yaml" README.md > "$TD/out.$n" 2>&1 || rc=$?
+        judge "$R" "$BASE" "$(git -C "$R" rev-parse HEAD)" "$branch" "$event" docs/specifications/pp-066-dag.yaml README.md > "$TD/out.$n" 2>&1 || rc=$?
         if [ "$rc" = "$want" ]; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
         else printf 'FAIL  row %-2s rc=%s (wanted %s)  %s\n' "$n" "$rc" "$want" "$label"; sed 's/^/        /' "$TD/out.$n"; red=1; fi
     }
@@ -118,24 +132,28 @@ if [ "${1:-}" = "--self-test" ]; then
     row 0 "row PR editing README prose (no count line): PASS"                         agent/G-11 pull_request 'sed -i "s/prose line/prose line edited/" README.md'
     row 0 "orchestrator branch writing the DAG, roadmap and README counts: not a row PR" agent/pp-066-spec pull_request 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml; sed -i "s/1812/1813/" README.md'
     row 0 "a fix/ branch writing the roadmap: not an agent branch"                    fix/thing  pull_request 'echo "- id: PMAT-2" >> docs/roadmaps/roadmap.yaml'
+    row 1 "a fix/ branch writing the DAG: RED on EVERY non-orchestrator branch (quorum Q1)" fix/thing pull_request 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
+    row 1 "an agent/<not-a-row> branch writing the spec: RED"                          agent/nope pull_request 'echo "x" >> docs/specifications/PP-066-release-spec.md'
+    row 1 "a row PR RENAMING the DAG away: RED (the source path is a write; --no-renames)" agent/G-11 pull_request 'git mv docs/specifications/pp-066-dag.yaml docs/specifications/moved.yaml'
     row 0 "merge_group shape: REPORT (judged on the pull_request run), exit 0"        agent/G-11 merge_group 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
     row 0 "push shape: REPORT, exit 0"                                                agent/G-11 push        'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
-    for i in 9 10; do grep -q '^REPORT' "$TD/out.$i" || { printf 'FAIL  row %-2s printed no REPORT line: a silent skip\n' "$i"; red=1; }; done
-    n2=$((n + 1)); rc=0; judge "$R" "$BASE" "$BASE" agent/G-11 pull_request "$R/docs/specifications/nope.yaml" README.md >"$TD/out.$n2" 2>&1 || rc=$?
-    if [ "$rc" = 2 ]; then printf 'ok    row %-2s rc=2  a missing DAG is ENV (exit 2), never a pass\n' "$n2"; else printf 'FAIL  row %-2s rc=%s (wanted 2)  a missing DAG\n' "$n2" "$rc"; red=1; fi
+    for i in 12 13; do grep -q '^REPORT' "$TD/out.$i" || { printf 'FAIL  row %-2s printed no REPORT line: a silent skip\n' "$i"; red=1; }; done
+    grep -q 'pp-066-dag.yaml' "$TD/out.11" || { printf 'FAIL  row 11 did not name the renamed file\n'; red=1; }
+    n2=$((n + 1)); rc=0; judge "$R" "$BASE" "$BASE" agent/G-11 pull_request docs/specifications/nope.yaml README.md >"$TD/out.$n2" 2>&1 || rc=$?
+    if [ "$rc" = 2 ]; then printf 'ok    row %-2s rc=2  a DAG missing at the base is ENV (exit 2), never a pass\n' "$n2"; else printf 'FAIL  row %-2s rc=%s (wanted 2)  a missing DAG\n' "$n2" "$rc"; red=1; fi
     printf '%s/%s rows\n' "$((n2 - red))" "$n2"
     [ "$red" = 0 ] || exit 1
     exit 0
 fi
 
-BASE=""; HEAD_REF="HEAD"; BRANCH="${GITHUB_HEAD_REF:-}"; EVENT="${GITHUB_EVENT_NAME:-pull_request}"; DAG="$ROOT/$DAG_DEFAULT"; README="README.md"
+BASE=""; HEAD_REF="HEAD"; BRANCH="${GITHUB_HEAD_REF:-}"; EVENT="${GITHUB_EVENT_NAME:-pull_request}"; DAG="$DAG_DEFAULT"; README="README.md"
 while [ $# -gt 0 ]; do
     case "$1" in
         --base) BASE=$2; shift 2 ;;
         --head) HEAD_REF=$2; shift 2 ;;
         --branch) BRANCH=$2; shift 2 ;;
         --event) EVENT=$2; shift 2 ;;
-        --dag) DAG=$2; [ -f "$DAG" ] || DAG="$ROOT/$2"; shift 2 ;;
+        --dag) DAG=$2; shift 2 ;;   # a path RELATIVE to the repo root; read at the base commit
         --readme) README=$2; shift 2 ;;
         *) usage ;;
     esac

--- a/scripts/check_row_pr_write_set.sh
+++ b/scripts/check_row_pr_write_set.sh
@@ -62,7 +62,7 @@ judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clea
         printf 'ok    %s: `%s` is an orchestrator branch; it owns the DAG, the spec block, the roadmap and the README counts\n' "$PROG" "$branch"; return 0
     fi
     # rule 1: the DAG and the spec are orchestrator-only on EVERY branch
-    for f in docs/specifications/PP-066-release-spec.md; do   # MUTANT: the DAG dropped from rule 1
+    for f in docs/specifications/pp-066-dag.yaml docs/specifications/PP-066-release-spec.md; do
         if printf '%s\n' "$changed" | grep -qxF -- "$f"; then
             printf 'FAIL  %s: branch %s writes %s — orchestrator-only (agent/pp-066-*); the status of a row is derived from its receipt and the spec block is rendered\n' "$PROG" "${branch:-<none>}" "$f"; rc=1
         fi

--- a/scripts/check_row_pr_write_set.sh
+++ b/scripts/check_row_pr_write_set.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# check_row_pr_write_set.sh — a PP-066 ROW PR never writes a shared file
+# (PMAT-1062, DAG row G-11, epic #2873; driver R2 of 2026-09-06).
+#
+# WHY THIS EXISTS
+# ---------------
+# Eight armed row PRs each carried a hand-edit of docs/specifications/pp-066-dag.yaml
+# (status), docs/roadmaps/roadmap.yaml (pmat work complete) or the README's counts.
+# Every merge then made the other seven DIRTY and each needed a rebuild — a queue that
+# merges ~1 PR/hour spent its throughput on contention over three files no row owns.
+# So a row PR's write set is {crate code, tests, contracts/, its own receipt, its book
+# page} and nothing shared: the DAG's status is DERIVED from the receipt
+# (scripts/lib/dag_status.py), the roadmap and the README counts are written by ONE
+# orchestrator docs commit after each merge.
+#
+#   bash scripts/check_row_pr_write_set.sh --base <ref> --head <ref> [--branch <name>] [--event <name>] [--dag <yaml>] [--readme <md>]
+#   bash scripts/check_row_pr_write_set.sh --self-test
+#
+# A ROW PR is a head branch `agent/<id>` whose <id> is a row of the DAG. Anything else
+# (an orchestrator branch such as agent/pp-066-spec, a fix/… branch) is not judged here
+# and says so. On the merge_group and push shapes there is no head branch to read, so
+# the guard REPORTs that the write set was judged on the pull_request run (which is a
+# required check) and exits 0 — stated, not silent.
+#
+# FORBIDDEN in a row PR (the diff base..head must not touch):
+#   docs/specifications/pp-066-dag.yaml
+#   docs/roadmaps/roadmap.yaml
+#   docs/specifications/PP-066-release-spec.md      (its §5.0 block is rendered from the DAG)
+#   README.md lines that carry a count claim         (N workspace crates / N contracts / N CLI commands)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROG=check_row_pr_write_set
+DAG_DEFAULT="docs/specifications/pp-066-dag.yaml"
+COUNT_RE='[0-9]+\*{0,2}( +[a-z]+){0,2} +(workspace crates?|contracts?|CLI commands?)\b'
+
+usage() { printf 'usage: %s --base <ref> --head <ref> [--branch <name>] [--event <name>] [--dag <yaml>] [--readme <md>] | --self-test\n' "$PROG" >&2; exit 2; }
+
+row_ids() { # row_ids <dag> -> one id per line
+    python3 - "$1" <<'PY'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1], encoding="utf-8")) or {}
+for r in d.get("rows") or []:
+    print(r.get("id"))
+PY
+}
+
+judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clean / 1 RED / 2 usage-env
+    local repo=$1 base=$2 head=$3 branch=$4 event=$5 dag=$6 readme=$7 rc=0 id f
+    case "$event" in
+        merge_group|push)
+            printf 'REPORT %s: the %s shape carries no head branch; the write set was judged on the pull_request run (a required check). Not a verdict.\n' "$PROG" "$event"; return 0 ;;
+    esac
+    case "$branch" in
+        agent/*) id=${branch#agent/} ;;
+        *) printf 'ok    %s: `%s` is not an agent/<row> branch; the write-set rule binds row PRs only\n' "$PROG" "${branch:-<none>}"; return 0 ;;
+    esac
+    [ -f "$dag" ] || { printf '%s: ENV - %s is missing (the box cannot answer)\n' "$PROG" "$dag" >&2; return 2; }
+    if ! row_ids "$dag" | grep -qxF -- "$id"; then
+        printf 'ok    %s: `%s` names no DAG row (an orchestrator or other branch); the write-set rule binds row PRs only\n' "$PROG" "$branch"; return 0
+    fi
+    local changed; changed=$(git -C "$repo" diff --name-only "$base" "$head" --) || { printf '%s: ENV - git diff %s %s failed\n' "$PROG" "$base" "$head" >&2; return 2; }
+    for f in docs/specifications/pp-066-dag.yaml docs/roadmaps/roadmap.yaml docs/specifications/PP-066-release-spec.md; do
+        if printf '%s\n' "$changed" | grep -qxF -- "$f"; then
+            printf 'FAIL  %s: row PR %s writes the shared file %s — the DAG status is derived from the receipt, the roadmap and the spec block are the orchestrator docs commit'\''s\n' "$PROG" "$branch" "$f"; rc=1
+        fi
+    done
+    if printf '%s\n' "$changed" | grep -qxF -- "$readme"; then
+        local hits; hits=$(git -C "$repo" diff "$base" "$head" -- "$readme" | grep -E '^[-+][^-+]' | grep -E -- "$COUNT_RE" || true)
+        if [ -n "$hits" ]; then
+            printf 'FAIL  %s: row PR %s edits a README count line (the orchestrator docs commit regenerates counts; check_readme_claims.sh lets the README lag, never overstate):\n' "$PROG" "$branch"
+            printf '%s\n' "$hits" | head -6 | sed 's|^|        |'; rc=1
+        fi
+    fi
+    [ "$rc" = 0 ] && printf 'PASS  %s: row PR %s writes no shared file (%s changed path(s))\n' "$PROG" "$branch" "$(printf '%s\n' "$changed" | grep -c . || true)"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: a fixture repo, both polarities per rule
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    TD=$(mktemp -d "${TMPDIR:-/tmp}/rowpr-selftest.XXXXXX")
+    safe_rm_scratch() {
+        local victim=${1:-} must=${2:-}
+        [ -n "$victim" ] || return 0
+        [ -n "$must" ]   || return 0
+        [ "$victim" != "/" ] || return 0
+        case "$victim" in
+          *"$must"*) if [ -n "$victim" ] && [ "$victim" != "/" ]; then rm -rf -- "$victim"; fi ;;
+          *) return 0 ;;
+        esac
+    }
+    cleanup() { safe_rm_scratch "$TD" 'rowpr-selftest.'; }
+    trap cleanup EXIT
+    R="$TD/repo"; mkdir -p "$R/docs/specifications" "$R/docs/roadmaps" "$R/crates/x/src"
+    ( cd "$R" && git init -q . && git config user.email t@t && git config user.name t && git config core.hooksPath /dev/null )
+    printf 'rows:\n- {id: G-11, pmat_id: PMAT-1062}\n- {id: R-0, pmat_id: PMAT-989}\n' > "$R/docs/specifications/pp-066-dag.yaml"
+    printf -- '- id: PMAT-1\n  title: a\n' > "$R/docs/roadmaps/roadmap.yaml"
+    printf '# spec\n' > "$R/docs/specifications/PP-066-release-spec.md"
+    printf '# apr\n\n**78** workspace crates and **1812** provable contracts across 111 CLI commands.\n\nprose line\n' > "$R/README.md"
+    printf 'fn main() {}\n' > "$R/crates/x/src/lib.rs"
+    ( cd "$R" && git add -A && git commit -qm base )
+    BASE=$(git -C "$R" rev-parse HEAD)
+    n=0; red=0
+    row() { # row <want rc> <label> <branch> <event> <shell mutating the tree>
+        local want=$1 label=$2 branch=$3 event=$4 mut=$5 rc=0
+        n=$((n + 1))
+        ( cd "$R" && git checkout -q --detach "$BASE" && bash -c "$mut" && git add -A && git commit -qm "$label" --allow-empty ) >/dev/null 2>&1
+        judge "$R" "$BASE" "$(git -C "$R" rev-parse HEAD)" "$branch" "$event" "$R/docs/specifications/pp-066-dag.yaml" README.md > "$TD/out.$n" 2>&1 || rc=$?
+        if [ "$rc" = "$want" ]; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+        else printf 'FAIL  row %-2s rc=%s (wanted %s)  %s\n' "$n" "$rc" "$want" "$label"; sed 's/^/        /' "$TD/out.$n"; red=1; fi
+    }
+    row 0 "row PR touching crate code only: PASS"                                   agent/G-11 pull_request 'echo "// x" >> crates/x/src/lib.rs'
+    row 1 "row PR writing pp-066-dag.yaml: RED naming the file (the registered mutation)" agent/G-11 pull_request 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
+    row 1 "row PR writing roadmap.yaml: RED"                                          agent/R-0  pull_request 'echo "- id: PMAT-2" >> docs/roadmaps/roadmap.yaml'
+    row 1 "row PR writing the release spec (rendered block): RED"                     agent/R-0  pull_request 'echo "x" >> docs/specifications/PP-066-release-spec.md'
+    row 1 "row PR bumping a README count line: RED naming the line"                   agent/G-11 pull_request 'sed -i "s/1812/1813/" README.md'
+    row 0 "row PR editing README prose (no count line): PASS"                         agent/G-11 pull_request 'sed -i "s/prose line/prose line edited/" README.md'
+    row 0 "orchestrator branch writing the DAG, roadmap and README counts: not a row PR" agent/pp-066-spec pull_request 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml; sed -i "s/1812/1813/" README.md'
+    row 0 "a fix/ branch writing the roadmap: not an agent branch"                    fix/thing  pull_request 'echo "- id: PMAT-2" >> docs/roadmaps/roadmap.yaml'
+    row 0 "merge_group shape: REPORT (judged on the pull_request run), exit 0"        agent/G-11 merge_group 'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
+    row 0 "push shape: REPORT, exit 0"                                                agent/G-11 push        'echo "- {id: Z-1}" >> docs/specifications/pp-066-dag.yaml'
+    for i in 9 10; do grep -q '^REPORT' "$TD/out.$i" || { printf 'FAIL  row %-2s printed no REPORT line: a silent skip\n' "$i"; red=1; }; done
+    n2=$((n + 1)); rc=0; judge "$R" "$BASE" "$BASE" agent/G-11 pull_request "$R/docs/specifications/nope.yaml" README.md >"$TD/out.$n2" 2>&1 || rc=$?
+    if [ "$rc" = 2 ]; then printf 'ok    row %-2s rc=2  a missing DAG is ENV (exit 2), never a pass\n' "$n2"; else printf 'FAIL  row %-2s rc=%s (wanted 2)  a missing DAG\n' "$n2" "$rc"; red=1; fi
+    printf '%s/%s rows\n' "$((n2 - red))" "$n2"
+    [ "$red" = 0 ] || exit 1
+    exit 0
+fi
+
+BASE=""; HEAD_REF="HEAD"; BRANCH="${GITHUB_HEAD_REF:-}"; EVENT="${GITHUB_EVENT_NAME:-pull_request}"; DAG="$ROOT/$DAG_DEFAULT"; README="README.md"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base) BASE=$2; shift 2 ;;
+        --head) HEAD_REF=$2; shift 2 ;;
+        --branch) BRANCH=$2; shift 2 ;;
+        --event) EVENT=$2; shift 2 ;;
+        --dag) DAG=$2; [ -f "$DAG" ] || DAG="$ROOT/$2"; shift 2 ;;
+        --readme) README=$2; shift 2 ;;
+        *) usage ;;
+    esac
+done
+[ -n "$BRANCH" ] || BRANCH=$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+if [ -z "$BASE" ]; then
+    # shellcheck source=scripts/lib/resolve_base.sh
+    REPO_ROOT="$ROOT"; . "$ROOT/scripts/lib/resolve_base.sh" || exit 2
+    resolve_base "$HEAD_REF" || { printf '%s: no base can be named; pass --base\n' "$PROG" >&2; exit 2; }
+    BASE="$BASE_REF"; printf '               comparand: %s (%s)\n' "${BASE:0:9}" "$BASE_HOW"
+fi
+judge "$ROOT" "$BASE" "$HEAD_REF" "$BRANCH" "$EVENT" "$DAG" "$README"

--- a/scripts/check_row_pr_write_set.sh
+++ b/scripts/check_row_pr_write_set.sh
@@ -64,7 +64,7 @@ judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clea
     # rule 1: the DAG and the spec are orchestrator-only on EVERY branch
     for f in docs/specifications/PP-066-release-spec.md; do   # MUTANT: the DAG dropped from rule 1
         if printf '%s\n' "$changed" | grep -qxF -- "$f"; then
-            printf 'FAIL  %s: branch %s writes %s — orchestrator-only (agent/pp-066-*); a row'\''s status is derived from its receipt and the spec block is rendered\n' "$PROG" "${branch:-<none>}" "$f"; rc=1
+            printf 'FAIL  %s: branch %s writes %s — orchestrator-only (agent/pp-066-*); the status of a row is derived from its receipt and the spec block is rendered\n' "$PROG" "${branch:-<none>}" "$f"; rc=1
         fi
     done
     # rule 2: a ROW PR (agent/<id>, <id> a DAG row) may not write the roadmap or a README count line
@@ -76,7 +76,7 @@ judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clea
         [ "$rc" = 0 ] && printf 'ok    %s: `%s` names no DAG row; the roadmap/README-count rule binds row PRs only\n' "$PROG" "$branch"; return "$rc"
     fi
     if printf '%s\n' "$changed" | grep -qxF -- docs/roadmaps/roadmap.yaml; then
-        printf 'FAIL  %s: row PR %s writes docs/roadmaps/roadmap.yaml — pmat work complete and the ticket edits are the orchestrator docs commit'\''s\n' "$PROG" "$branch"; rc=1
+        printf 'FAIL  %s: row PR %s writes docs/roadmaps/roadmap.yaml — pmat work complete and the ticket edits belong to the orchestrator docs commit\n' "$PROG" "$branch"; rc=1
     fi
     if printf '%s\n' "$changed" | grep -qxF -- "$readme"; then
         local hits; hits=$(git -C "$repo" diff "$base" "$head" -- "$readme" | grep -E '^[-+][^-+]' | grep -E -- "$COUNT_RE" || true)

--- a/scripts/check_row_pr_write_set.sh
+++ b/scripts/check_row_pr_write_set.sh
@@ -62,7 +62,7 @@ judge() { # judge <repo> <base> <head> <branch> <event> <dag> <readme> -> 0 clea
         printf 'ok    %s: `%s` is an orchestrator branch; it owns the DAG, the spec block, the roadmap and the README counts\n' "$PROG" "$branch"; return 0
     fi
     # rule 1: the DAG and the spec are orchestrator-only on EVERY branch
-    for f in docs/specifications/pp-066-dag.yaml docs/specifications/PP-066-release-spec.md; do
+    for f in docs/specifications/PP-066-release-spec.md; do   # MUTANT: the DAG dropped from rule 1
         if printf '%s\n' "$changed" | grep -qxF -- "$f"; then
             printf 'FAIL  %s: branch %s writes %s — orchestrator-only (agent/pp-066-*); a row'\''s status is derived from its receipt and the spec block is rendered\n' "$PROG" "${branch:-<none>}" "$f"; rc=1
         fi

--- a/scripts/lib/dag_invariants.py
+++ b/scripts/lib/dag_invariants.py
@@ -27,8 +27,14 @@ answer — a missing file is not a passing DAG).
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from datetime import date, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from dag_status import d7_typed_status, derived_status  # noqa: E402  (G-11)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
     import yaml
@@ -196,17 +202,18 @@ def d5_owner(rows: dict) -> list:
     return [f"D5 {rid}: no owner" for rid, r in rows.items() if not str(r.get("owner") or "").strip()]
 
 
-def past_expiry(rows: dict, exp: dict, today: date) -> list:
-    return [f"{rid} expired {exp[rid]}" for rid in rows if rid in exp and exp[rid] < today and rows[rid].get("status") != "complete"]
+def past_expiry(rows: dict, exp: dict, today: date, root: str) -> list:
+    # complete is DERIVED from the receipt (G-11), never read off the row
+    return [f"{rid} expired {exp[rid]}" for rid in rows if rid in exp and exp[rid] < today and derived_status(root, rows[rid]) != "complete"]
 
 
-def run_check(doc: dict, min_days: int, today: date) -> "tuple[int, list]":
+def run_check(doc: dict, min_days: int, today: date, root: str = REPO_ROOT) -> "tuple[int, list]":
     rows = rows_by_id(doc)
-    violations = d1_dangling(rows) + d2_cycles(rows) + d6_expiry_forms(rows) + d5_owner(rows)
+    violations = d1_dangling(rows) + d2_cycles(rows) + d6_expiry_forms(rows) + d5_owner(rows) + d7_typed_status(root, rows)
     exp, more = resolved_expiries(rows)
     violations += more + d3_slack(rows, exp, min_days) + d4_queues(doc, rows, exp)
     lines = list(violations)
-    expired = past_expiry(rows, exp, today)
+    expired = past_expiry(rows, exp, today, root)
     if expired:
         lines.append("REPORT past-expiry (not a violation here; the §4 andon owns it): " + "; ".join(expired))
     lines.append(
@@ -232,10 +239,11 @@ def main(argv=None) -> int:
     c.add_argument("dag")
     c.add_argument("--min-slack-days", type=int, default=6)
     c.add_argument("--today", default=None, help="YYYY-MM-DD; default = the DAG header's `generated` date if present, else today")
+    c.add_argument("--root", default=REPO_ROOT, help="repository root holding docs/audits/impl-*-receipt.md (status is derived from them, G-11)")
     args = ap.parse_args(argv)
     try:
         doc = load_dag(args.dag)
-        rc, lines = run_check(doc, args.min_slack_days, _today(args.today, doc))
+        rc, lines = run_check(doc, args.min_slack_days, _today(args.today, doc), args.root)
     except UsageError as e:
         print(f"dag_invariants: {e}", file=sys.stderr)
         return 2

--- a/scripts/lib/dag_status.py
+++ b/scripts/lib/dag_status.py
@@ -28,7 +28,9 @@ def receipt_path(root: str, row: dict):
 
 def _leading_front_matter(path):
     """The lines inside the FIRST `---` block, or None when the file does not open with one."""
-    with open(path, encoding="utf-8") as f:
+    # newline="": a CRLF receipt keeps its \r, so `---\r` is NOT a front-matter fence — exactly
+    # what scripts/check_receipt_complete.sh sees (head -n1 / awk keep the \r)
+    with open(path, encoding="utf-8", newline="") as f:
         lines = f.read().split("\n")
     if not lines or lines[0] != "---":
         return None
@@ -44,7 +46,7 @@ def _marker_value(front_matter) -> str:
     for line in front_matter or []:
         m = _STATUS.match(line)
         if m:
-            v = m.group(1).strip().strip("\"'")
+            v = re.sub(r"[\s\"']", "", m.group(1))   # awk: gsub(/[[:space:]"']/, "") — anywhere, not only the edges
             return v if v in ("complete", "partial") else "none"
     return "none"
 

--- a/scripts/lib/dag_status.py
+++ b/scripts/lib/dag_status.py
@@ -61,7 +61,7 @@ def receipt_marker(path) -> str:
 
 
 def derived_status(root: str, row: dict) -> str:
-    return str(row.get("status", "open"))   # MUTANT: the typed key is trusted again
+    return "complete" if receipt_marker(receipt_path(root, row)) == "complete" else "open"
 
 
 def d7_typed_status(root: str, rows: dict) -> list:

--- a/scripts/lib/dag_status.py
+++ b/scripts/lib/dag_status.py
@@ -61,7 +61,7 @@ def receipt_marker(path) -> str:
 
 
 def derived_status(root: str, row: dict) -> str:
-    return "complete" if receipt_marker(receipt_path(root, row)) == "complete" else "open"
+    return str(row.get("status", "open"))   # MUTANT: the typed key is trusted again
 
 
 def d7_typed_status(root: str, rows: dict) -> list:

--- a/scripts/lib/dag_status.py
+++ b/scripts/lib/dag_status.py
@@ -1,0 +1,74 @@
+"""dag_status.py — a DAG row's status is DERIVED from its receipt, never typed
+(PP-066 row G-11, PMAT-1062, epic #2873; driver R2 of 2026-09-06).
+
+The record of completion is docs/audits/impl-<pmat_id>-receipt.md and its
+leading front-matter `status:` marker (the rule of C0-7, PMAT-1056,
+scripts/check_receipt_complete.sh). A row is `complete` iff that marker says
+complete; otherwise it is `open`. A `status:` key typed into the DAG is at
+most a cache: render_dag.py ignores it and dag_invariants.py D7 refuses one
+that disagrees with the receipt, so a row PR never has to (and never may)
+edit docs/specifications/pp-066-dag.yaml to be counted.
+
+    derived_status(root, row)   -> "complete" | "open"
+    receipt_marker(path)        -> "complete" | "partial" | "none" | "torn"   (same rule as check_receipt_complete.sh)
+    d7_typed_status(root, rows) -> ["D7 <id>: typed status `x` disagrees with the receipt (derived `y`)", ...]
+"""
+from __future__ import annotations
+
+import os
+import re
+
+_STATUS = re.compile(r"^status:\s*(.*?)\s*$")
+
+
+def receipt_path(root: str, row: dict):
+    pid = row.get("pmat_id")
+    return os.path.join(root, "docs", "audits", f"impl-{pid}-receipt.md") if pid else None
+
+
+def _leading_front_matter(path):
+    """The lines inside the FIRST `---` block, or None when the file does not open with one."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().split("\n")
+    if not lines or lines[0] != "---":
+        return None
+    body = []
+    for line in lines[1:]:
+        if line == "---":
+            break
+        body.append(line)
+    return body
+
+
+def _marker_value(front_matter) -> str:
+    for line in front_matter or []:
+        m = _STATUS.match(line)
+        if m:
+            v = m.group(1).strip().strip("\"'")
+            return v if v in ("complete", "partial") else "none"
+    return "none"
+
+
+def receipt_marker(path) -> str:
+    """The `status:` value inside the LEADING `---` block, nothing else (complete|partial|none|torn)."""
+    if path is None or not os.path.isfile(path):
+        return "none"
+    if str(path).endswith(".tmp"):
+        return "torn"
+    return _marker_value(_leading_front_matter(path))
+
+
+def derived_status(root: str, row: dict) -> str:
+    return "complete" if receipt_marker(receipt_path(root, row)) == "complete" else "open"
+
+
+def d7_typed_status(root: str, rows: dict) -> list:
+    """A typed `status:` is tolerated only while it agrees with the receipt."""
+    out = []
+    for rid, r in rows.items():
+        if "status" not in r:
+            continue
+        typed, derived = str(r.get("status")), derived_status(root, r)
+        if typed != derived:
+            out.append(f"D7 {rid}: typed status `{typed}` disagrees with the receipt (derived `{derived}` from docs/audits/impl-{r.get('pmat_id')}-receipt.md); status is derived, never typed")
+    return out

--- a/scripts/render_dag.py
+++ b/scripts/render_dag.py
@@ -22,10 +22,16 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import os
 import sys
 from datetime import date, timedelta
 
 import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lib.dag_status import derived_status  # noqa: E402  (G-11: status is derived from the receipt, never typed)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 BEGIN = "<!-- dag:table:begin (rendered by scripts/render_dag.py; do not edit by hand) -->"
 END = "<!-- dag:table:end -->"
@@ -60,17 +66,17 @@ def _cell(s) -> str:
     return str(s if s is not None else "—").replace("|", "\\|").replace("\n", " ").strip()
 
 
-def _row_line(r: dict, rows: dict) -> str:
+def _row_line(r: dict, rows: dict, root: str = REPO_ROOT) -> str:
     blockers = ", ".join(r.get("blockers") or []) or "—"
     issues = ", ".join(f"#{i}" for i in (r.get("issues") or [])) or "—"
     gh = f"#{r['gh_issue']}" if r.get("gh_issue") else "—"
     # the title is never truncated: a citation at its end must survive rendering (claim-literal guard)
     cells = (r["id"], r.get("title") or "", blockers, issues, r.get("host"), _expiry_cell(r["id"], rows),
-             r.get("owner"), r.get("quorum"), gh, r.get("pmat_id"), r.get("status"))
+             r.get("owner"), r.get("quorum"), gh, r.get("pmat_id"), derived_status(root, r))
     return "| " + " | ".join(_cell(x) for x in cells) + " |"
 
 
-def _sections(doc: dict, rows: dict) -> list:
+def _sections(doc: dict, rows: dict, root: str = REPO_ROOT) -> list:
     by_track: dict = {}
     for r in doc["rows"]:
         by_track.setdefault(str(r.get("track")), []).append(r)
@@ -78,16 +84,16 @@ def _sections(doc: dict, rows: dict) -> list:
     out: list = []
     for tr in (t for t in order if t in by_track):
         out += [TRACK_TITLE.get(tr, f"### Track {tr}"), "", HEADER]
-        out += [_row_line(r, rows) for r in by_track[tr]]
+        out += [_row_line(r, rows, root) for r in by_track[tr]]
         out.append("")
     return out
 
 
-def render(doc: dict) -> str:
+def render(doc: dict, root: str = REPO_ROOT) -> str:
     rows = {r["id"]: r for r in doc["rows"]}
     intro = (f"_Rendered from `docs/specifications/pp-066-dag.yaml` (epic #{doc.get('epic')}, {len(rows)} rows). "
              "Edit the YAML, run `python3 scripts/render_dag.py render`, paste; `--check` refuses drift._")
-    return "\n".join([BEGIN, "", intro, ""] + _sections(doc, rows) + [END]) + "\n"
+    return "\n".join([BEGIN, "", intro, ""] + _sections(doc, rows, root) + [END]) + "\n"
 
 
 def extract_block(spec_text: str):
@@ -99,9 +105,9 @@ def extract_block(spec_text: str):
     return spec_text[i:j + len(END)] + "\n"
 
 
-def check(dag_path: str, spec_path: str) -> int:
+def check(dag_path: str, spec_path: str, root: str = REPO_ROOT) -> int:
     doc = yaml.safe_load(open(dag_path, encoding="utf-8"))
-    rendered = render(doc)
+    rendered = render(doc, root)
     block = extract_block(open(spec_path, encoding="utf-8").read())
     if block is None:
         print(f"NOT ARMED: {spec_path} carries no `{BEGIN[:22]}…` / `{END}` marker pair; the §5/§6 tables are still hand-typed (SPEC-1.6 inserts them). exit 3, not a pass.")
@@ -120,11 +126,12 @@ def main(argv=None) -> int:
     ap.add_argument("--check", action="store_true", help="compare the spec's marked block against the render")
     ap.add_argument("--dag", default="docs/specifications/pp-066-dag.yaml")
     ap.add_argument("--spec", default="docs/specifications/PP-066-release-spec.md")
+    ap.add_argument("--root", default=REPO_ROOT, help="repository root holding docs/audits/impl-*-receipt.md (the status column is derived from them)")
     args = ap.parse_args(argv)
     try:
         if args.check:
-            return check(args.dag, args.spec)
-        sys.stdout.write(render(yaml.safe_load(open(args.dag, encoding="utf-8"))))
+            return check(args.dag, args.spec, args.root)
+        sys.stdout.write(render(yaml.safe_load(open(args.dag, encoding="utf-8")), args.root))
         return 0
     except (OSError, yaml.YAMLError) as e:
         print(f"render_dag: {e}", file=sys.stderr)

--- a/scripts/render_dag.py
+++ b/scripts/render_dag.py
@@ -116,7 +116,9 @@ def check(dag_path: str, spec_path: str, root: str = REPO_ROOT) -> int:
         print(f"PASS  the rendered DAG block in {spec_path} is byte-identical to {dag_path} ({len(doc['rows'])} rows)")
         return 0
     sys.stdout.writelines(difflib.unified_diff(block.splitlines(True), rendered.splitlines(True), "spec (committed)", "render (from the yaml)"))
-    print(f"FAIL  DRIFT: the spec's DAG block differs from the render of {dag_path}; run `python3 scripts/render_dag.py render` and paste between the markers")
+    print(f"FAIL  DRIFT: the spec's DAG block differs from the render of {dag_path}; run `python3 scripts/render_dag.py render` and paste between the markers. "
+          "The status column is DERIVED from docs/audits/impl-<pmat_id>-receipt.md (G-11): a ROW PR ships its receipt as `status: partial` and never edits the spec; "
+          "the orchestrator docs commit (agent/pp-066-*) flips the receipt to complete AND re-renders this block in the same commit.")
     return 1
 
 


### PR DESCRIPTION
PP-066 DAG row **G-11** (driver v4: G-11a) · ticket **PMAT-1062** · Closes #3012 · epic #2873. Receipt: `docs/audits/impl-PMAT-1062-receipt.md`.

**Why.** Eight armed row PRs (#3001, #3003–#3009) each hand-edited `pp-066-dag.yaml` (status), `roadmap.yaml` (pmat work complete) or a README count line; every merge made the other seven DIRTY through a queue that lands ~1 PR/hour. None of those files is a row's to write.

**What lands.**
1. `scripts/check_row_pr_write_set.sh` — the DAG and the release spec are **orchestrator-only on every branch** (`agent/pp-066-*`, `agent/pr-triage*`); a **row PR** (`agent/<id>`, `<id>` a DAG row, read at the base) additionally may not write `roadmap.yaml` or a README count line. `--no-renames` (a rename's source is a write); merge_group/push print `REPORT` and exit 0 (judged at the pull_request run, which is required: `gate` needs `guard-runner-labels`, ruleset "Green Main"). 14-row case table.
2. `scripts/lib/dag_status.py` — a row's status is **derived** from `docs/audits/impl-<pmat_id>-receipt.md` (the C0-7 marker rule, byte-faithful: CRLF and mid-string quotes behave exactly as `check_receipt_complete.sh`). `render_dag.py` prints it; `dag_invariants.py` **D7** refuses a typed status that disagrees; past-expiry reads it. D7 rows 12–16.
3. `scripts/check_readme_claims.sh` and `crates/aprender-core/tests/readme_contract.rs` (FALSIFY-README-005/007) — counts are a **ratchet**: lag allowed, overstatement RED, `--exact` for the orchestrator; a self-contradicting README RED. 7-row case table. (The Rust tests rode `workspace-test` and would have failed every row PR that left the README lagging.)
4. ci.yml `guard-runner-labels`: README case table before its live step; write-set case table + live step after the DAG invariants.
5. Contract `contracts/apr-row-pr-write-set-v1.yaml` (kind: pattern; WS-OB-001..004 ↔ WS-F-001..004). `pv validate`: valid.

**Mutation evidence (I3) — on this branch, never in the queue.**
| leg | commit | what | run |
|---|---|---|---|
| RED (README ratchet, row 3) | `053eee448` + `c245dc24c` (semantic) | `README claims must match measurement` FAILED | run **34038067035**, job 101499760324 |
| RED (D7, rows 12/14/15/16) | `2a9ab0df6` (README mutant reverted, D7 + write-set kept) | `DAG-invariants guard case table` FAILED | run **34038496093**, job 101500915181 |
| RED (write-set, rows 2/9/11) | `eda2ea746` (D7 reverted, write-set kept) | `Row-PR write-set case table` FAILED | run **34040294692**, job 101505945716 |
| GREEN | `d9c2aeff2` (the last revert; receipt `status: complete`) | guard-runner-labels SUCCESS (14/14 · 16/16 · 7/7) | run **34041439234** |

A first run (34037532260) failed at the bashrs shrink-only step (8 → 11: SC2075 ×2 in the new guard, SEC011 ×1 in the README self-test) — a real defect of this branch, fixed in `9a997e653`; the job stops at its first failing step, hence one RED run per guard.

**Acceptance (`.pr/G-11/accept.sh` equivalent, re-run by the orchestrator after the rebase onto main b0a0a51b2 — `.pr/G-11-verify3.log`):**
```
bash scripts/check_row_pr_write_set.sh --self-test      # 14/14
bash scripts/check_dag_invariants.sh --selftest         # 16/16
bash scripts/check_readme_claims.sh --self-test         # 7/7
python3 scripts/render_dag.py --check                   # byte-identical (91 rows on main)
bash scripts/check_guards_are_wired.sh                  # PASS (ratcheted)
cargo test -p aprender-core --test readme_contract      # 15 passed (own target dir, pinned cargo)
```
**Review quorum:** 3 agy lanes, 3/3 implement-with-changes; every finding re-verified and folded (disposition table in the receipt): the non-`agent/<id>` bypass, `--no-renames`, CRLF/quote parity, the drift Catch-22 stated in the message, `cli_command_count` through `compare_count`, the Rust README tests, case-table order. Q2 (is the pull_request run required?) settled by the ruleset: `gate` requires `guard-runner-labels`.
**Write set:** scripts, tests, contracts/, ci.yml (one job's steps), this receipt. No DAG/roadmap/README/spec edit — the rule, obeyed by its own PR (the README lags by one contract, which the ratchet permits).
