### PR TITLE
fix(roadmap): PMAT-1072 — main RED: drop 12 legacy nested subtask records pmat 3.39.0 refuses as duplicate ids; in-repo pin-independent id-uniqueness guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,6 +1139,14 @@ jobs:
         run: bash scripts/check_roadmap_completion_is_cited.sh
       - name: Roadmap-citation guard can still go RED (case table)
         run: bash scripts/check_roadmap_completion_is_cited.sh --selftest
+      # PMAT-1072 (#3028): every `id:` in the roadmap is unique, nested subtask
+      # records included — pmat >= 3.39.0's `work validate` rule, enforced here
+      # through the parsed tree so the fleet's PATH pmat version is never the only
+      # thing standing between main and a duplicate id. Case table first.
+      - name: "Roadmap-id-uniqueness guard case table (6 rows, both polarities)"
+        run: bash scripts/check_roadmap_ids_unique.sh --self-test
+      - name: Every roadmap id is unique, nested records included (PMAT-1072)
+        run: bash scripts/check_roadmap_ids_unique.sh
       # C0-7 (PP-066, #2984): an implementation receipt is complete only when its
       # leading front matter says `status: complete` (a marker the writer sets
       # LAST, written .tmp then mv'd); a DAG row may claim status: complete

--- a/contracts/apr-roadmap-ids-unique-v1.yaml
+++ b/contracts/apr-roadmap-ids-unique-v1.yaml
@@ -1,0 +1,150 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# apr-roadmap-ids-unique-v1 — every `id:` in docs/roadmaps/roadmap.yaml is
+# unique, nested records included (PMAT-1072, #3028; fleet drift infra#468)
+#
+# WHAT IT GOVERNS
+#   The id namespace of the roadmap as pmat >= 3.39.0 reads it: every `id:`
+#   key in the PARSED tree — top-level entries and any nested record (the
+#   legacy `subtasks:` child copies) — names one ticket once. An id that
+#   appears inside a block-scalar body is prose. The rule lives in the repo
+#   (scripts/check_roadmap_ids_unique.sh, wired in guard-runner-labels), so
+#   the version of pmat on a runner's PATH is never the only guard.
+#
+# PROOF LADDER, STATED HONESTLY
+#   * L1 — the guard exists and is wired (ci.yml, case table before the live run).
+#   * L2 — falsification MEASURED: `--self-test` 6/6 (2026-09-06); the live
+#          guard is RED on main @ 3792afa3d's roadmap (12 duplicates, the same
+#          12 pmat 3.39.0 names in run 34049248452) and GREEN after the fix.
+#   * L3/L4 — NOT APPLICABLE: a YAML data file, not a kernel. No self-exemption.
+# ─────────────────────────────────────────────────────────────────────────────
+name: apr-roadmap-ids-unique
+version: "1.0.0"
+scope: >
+  docs/roadmaps/roadmap.yaml, parsed. Out of scope: which ids are minted and
+  by whom (the PP-066 driver's minter rule), the additive-diff rule (G-6,
+  scripts/check_roadmap_diff_additive.sh), and pmat's own validator.
+status: active
+
+metadata:
+  kind: pattern     # a uniqueness rule over a YAML data file, not a math
+                    # kernel. Set EXPLICITLY so `pv validate`'s `kernel`
+                    # default never silently applies.
+  version: "1.0.0"
+  created: '2026-09-06'
+  last_modified: '2026-09-06'
+  author: PAIML Engineering
+  references:
+    - 'scripts/check_roadmap_ids_unique.sh — the guard: [<roadmap.yaml>] · --self-test (6 rows)'
+    - '.github/workflows/ci.yml — job guard-runner-labels (case table, then the live roadmap)'
+    - 'pmat 3.39.0 CHANGELOG (PMAT-674, pmat PR #1196): `work validate` refuses a duplicated id, subtask ids included'
+    - 'paiml/aprender#3028 — main RED on run 34049248452; paiml/infra#468 — the fleet PATH pmat pin drift'
+  description: >
+    A roadmap id names one ticket. pmat >= 3.39.0 refuses a file where any
+    `id:` line repeats; older pmat wrote nested child records under a parent's
+    `subtasks:` that repeat the child's id, and no in-repo check saw them
+    because the pinned analyser predates the rule. The guard walks the parsed
+    tree, reports every duplicate with its path and line, and fails closed on
+    an unparsable file.
+
+equations:
+  ids_are_unique_in_the_parsed_tree:
+    formula: |
+      ids(doc) = [ node.id | node ∈ mappings(doc), "id" ∈ keys(node) ]
+      valid(doc) ⇔ |ids(doc)| = |set(ids(doc))|
+      a scalar body (`spec: |` …) is text: its lines contribute no id
+    domain: 'docs/roadmaps/roadmap.yaml parsed by yaml.safe_load'
+    codomain: 'bool'
+    invariants:
+    - 'NESTED RECORDS COUNT (self-test row 2): a `subtasks:` child record with an id that also exists top-level is a duplicate — the #3028 shape.'
+    - 'PROSE DOES NOT COUNT (row 4): an `- id:` line inside a block scalar is not a node.'
+    preconditions: []
+    postconditions:
+    - 'exit 0 prints `PASS  <n> ids`; exit 1 names every duplicate id with path and line'
+
+  unparsable_is_a_defect_missing_is_env:
+    formula: |
+      yaml.safe_load fails  =>  exit 1 (a defect in the file)
+      file absent           =>  exit 2 (the box cannot answer; never a pass)
+    domain: 'the guard invocation'
+    codomain: '{0, 1, 2}'
+    invariants:
+    - 'A GUARD THAT CANNOT READ ITS INPUT DOES NOT PASS (rows 5, 6).'
+    preconditions: []
+    postconditions:
+    - 'the self-test exercises both exits'
+
+  enforcement_is_wired_case_table_then_live:
+    formula: |
+      ci.yml job "guard-runner-labels" contains, in order:
+        run "bash scripts/check_roadmap_ids_unique.sh --self-test"
+        run "bash scripts/check_roadmap_ids_unique.sh"
+    domain: 'the step list of job guard-runner-labels in .github/workflows/ci.yml'
+    codomain: 'bool'
+    invariants:
+    - 'CASE TABLE BEFORE THE LIVE CHECK (Verification Discipline #7).'
+    preconditions:
+    - 'guard-runner-labels is in gate.needs, so a RED here fails gate transitively'
+    postconditions:
+    - 'check_guards_are_wired.sh names the guard as wired'
+
+proof_obligations:
+  - id: RMID-OB-001
+    statement: "Every id in the parsed roadmap tree is unique; nested records count, block-scalar text does not."
+    discharged_by: falsification_tests[0]
+  - id: RMID-OB-002
+    statement: "An unparsable roadmap is exit 1 and a missing one exit 2; neither is a pass."
+    discharged_by: falsification_tests[1]
+  - id: RMID-OB-003
+    statement: "The guard is wired in ci.yml's guard-runner-labels, case table before the live run."
+    discharged_by: falsification_tests[2]
+
+falsification_tests:
+
+  - id: RMID-F-001
+    rule: ids are unique in the parsed tree
+    prediction: >-
+      Two unique ids PASS (row 1); a nested subtask record duplicating a
+      top-level id FAILS naming `A-2`, its path `subtasks[0]` and line 5
+      (row 2); two top-level entries with one id FAIL (row 3); an id inside a
+      block scalar PASSES (row 4).
+    test: 'bash scripts/check_roadmap_ids_unique.sh --self-test'
+    if_fails: >-
+      a duplicate id ships to main and the next pmat >= 3.39.0 on any runner's
+      PATH turns `ci / security` RED for every PR (#3028)
+    mutation: >-
+      make walk() skip list items (only top-level mappings scanned); row 2
+      must turn RED. Live twin: the guard on main @ 3792afa3d's roadmap is
+      RED with the 12 ids run 34049248452 names; on the fixed file GREEN.
+
+  - id: RMID-F-002
+    rule: unparsable is a defect, missing is ENV
+    prediction: >-
+      A broken YAML file is exit 1 with `does not parse` (row 5); an absent
+      path is exit 2 with `ENV` (row 6).
+    test: 'bash scripts/check_roadmap_ids_unique.sh --self-test'
+    if_fails: >-
+      a torn roadmap reads as clean
+    mutation: >-
+      catch YAMLError and print PASS; row 5 must turn RED.
+
+  - id: RMID-F-003
+    rule: the guard is wired, case table then live
+    prediction: >-
+      check_guards_are_wired.sh names no unwired guard while ci.yml carries
+      both steps; removing both lines makes it name check_roadmap_ids_unique.sh.
+    test: 'bash scripts/check_guards_are_wired.sh'
+    if_fails: >-
+      the guard exists and gates nothing (class #2878)
+    mutation: >-
+      delete the two `run: bash scripts/check_roadmap_ids_unique.sh` lines
+      from ci.yml; check_guards_are_wired.sh must turn RED naming the script.
+
+non_goals:
+  - "Who mints ids and in which PR (the PP-066 driver's minter rule; G-6 owns the additive diff)."
+  - "Replacing pmat's own validator: the fleet's pmat still runs; this guard makes its verdict reproducible in-repo at any pmat version."
+
+binding_registry:
+  guard: scripts/check_roadmap_ids_unique.sh
+  ci_job: guard-runner-labels          # inside gate.needs (.github/workflows/ci.yml)
+  make_target: tier3
+  issue: "https://github.com/paiml/aprender/issues/3028"

--- a/docs/audits/impl-PMAT-1072-receipt.md
+++ b/docs/audits/impl-PMAT-1072-receipt.md
@@ -1,0 +1,55 @@
+---
+status: complete
+ticket: PMAT-1072
+issue: 3028
+kind: code
+branch: agent/pp-066-roadmap-ids
+model: claude-fable-5-1
+tokens_used: ~120k (this andon, inside session 42763d92)
+wall_clock_s: ~2400
+turns: 14
+---
+# impl receipt — PMAT-1072: main RED on `roadmap-valid` (pmat 3.39.0 duplicate ids)
+
+**Andon.** main @ 3792afa3d push run 34049248452: `ci / security` failed at the upstream
+`roadmap-valid` step (paiml/.github sovereign-ci.yml:1207, bare `pmat work validate` from
+PATH) with 12 duplicate ids; `ci / gate` RED; merge queue evicted #3021 (auto-merge
+disarmed). Ticket #3028; fleet drift paiml/infra#468.
+
+## Root cause (measured)
+
+| claim | measurement |
+|---|---|
+| roadmap unchanged between green and red heads | `git diff --stat b0a0a51b2 3792afa3d -- docs/roadmaps/roadmap.yaml` empty |
+| the pin passes, the PATH pmat fails | `$PMAT work validate` (3.37.0) → passed; `pmat work validate` (3.39.0) → 12 duplicates, identical to the CI log |
+| PATH pmat moved today | intel `~/.cargo/bin/pmat` 3.39.0 mtime 17:30:02Z (auditd `cargo install pmat` 17:26–17:30Z); lambda 17:33:38Z; green PR run 34041439234 started 15:10Z, red main run 17:38Z |
+| the rule is deliberate | pmat 3.39.0 CHANGELOG, PMAT-674 / pmat PR #1196: every `id:` line, subtask ids included |
+| the duplicates are legacy nested records | 12 `subtasks:` child copies (`{id, github_issue, title: <id>, status, completion}`) under APR-ANTIGRAVITY-PARITY-001 (2), PMAT-710 (5), PMAT-716 (4), PMAT-719 (1); pmat 3.39.0 `work add` has no parent/subtask flag and never writes this shape |
+
+## Fix
+
+1. `docs/roadmaps/roadmap.yaml`: the 12 nested records dropped byte-exactly (four parents now `subtasks: []`); 64 deletions, 0 insertions; both pmat versions print `Validation passed`.
+2. `scripts/check_roadmap_ids_unique.sh` (+ `contracts/apr-roadmap-ids-unique-v1.yaml`, kind: pattern, `pv validate` via the pin: valid): every `id:` in the PARSED tree unique, nested included, block-scalar text excluded; `--self-test` 6 rows both polarities; wired in ci.yml `guard-runner-labels` (case table, then live).
+3. `scripts/lib/roadmap_diff.py`: `subtasks` joins `LIFECYCLE_KEYS` (structure the tooling maintains, not content); G-6 self-test row 3b added (18/18); live G-6 on this branch: `added=0 lifecycle=4 reserialised=0 deleted=0 PASS`.
+4. The PMAT-1072 mint rides the session docs commit (A is the only minter there); the hotfix roadmap diff is the dedup alone.
+
+## Verification (every command re-run by the orchestrator)
+
+| check | result |
+|---|---|
+| `bash scripts/check_roadmap_ids_unique.sh --self-test` | 6/6 rows |
+| `bash scripts/check_roadmap_ids_unique.sh` | PASS 809 ids, all unique |
+| live twin on main @ 3792afa3d's roadmap | FAIL 12 duplicate ids (the same 12 as run 34049248452) |
+| mutation RMID-F-001 (walk skips lists) | rows 1–4 RED, restored |
+| mutation RMID-F-003 (unwire both ci.yml lines) | `check_guards_are_wired.sh` RED: `NEW: check_roadmap_ids_unique.sh`, restored |
+| `check_roadmap_diff_additive.sh --self-test` / live | 18/18 · PASS (lifecycle=4) |
+| `check_guards_are_wired.sh`, `check_baseline_ratchets.sh`, `check_complexity_ratchet.sh`, `check_no_claim_literals.sh`, `check_perf_claims_cite_receipts.sh`, `check_roadmap_completion_is_cited.sh`, `check_row_pr_write_set.sh` (orchestrator branch), `check_shell_lint_ratchet.sh` | all PASS |
+| bashrs on the new script | 0 warnings, 0 errors (info-level SC1012/SC2316 remain: printf `\n` and `[ ]`, the repo's house style) |
+| `pv validate contracts/apr-roadmap-ids-unique-v1.yaml` (pin) | valid |
+
+CI mutation pair: main push run 34049248452 (RED, `roadmap-valid`) → this PR's run (GREEN, same step) — recorded in the PR body.
+
+## Gaps
+
+- The upstream step still runs bare PATH `pmat`; the pin it should use is infra#468's decision (3.37.0 declared vs 3.39.0 on the hosts). aprender's `scripts/pmat_bin.sh` PMAT_PIN=3.37.0 is now behind the fleet; moving it is a G-10a re-stamp, a separate ticket.
+- `docs/roadmaps/roadmap.yaml.lock` / `.bak` are tracked on main (pmat 3.39.0's high-water mark and a backup); untouched here.

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -153,17 +153,7 @@ roadmap:
   - contracts/apr-antigravity-parity-v1.yaml promotes DRAFT -> ENFORCED when the two wire surfaces ship
     and all four gates pass.
   phases: []
-  subtasks:
-  - id: APR-GEMINI-PROXY-001
-    github_issue: null
-    title: APR-GEMINI-PROXY-001
-    status: planned
-    completion: 0
-  - id: APR-ANTIGRAVITY-INTEGRATION-001
-    github_issue: null
-    title: APR-ANTIGRAVITY-INTEGRATION-001
-    status: planned
-    completion: 0
+  subtasks: []
   estimated_effort: null
   labels:
   - pillar-5
@@ -10312,32 +10302,7 @@ roadmap:
     already a benchmark in-tree (score.rs TRAINING_TOK_S=6000 unsloth-level; ch23_training_bench). Children:
     PMAT-711..715. Advances CRUX-D.'
   phases: []
-  subtasks:
-  - id: PMAT-711
-    github_issue: null
-    title: PMAT-711
-    status: planned
-    completion: 0
-  - id: PMAT-712
-    github_issue: null
-    title: PMAT-712
-    status: planned
-    completion: 0
-  - id: PMAT-713
-    github_issue: null
-    title: PMAT-713
-    status: planned
-    completion: 0
-  - id: PMAT-714
-    github_issue: null
-    title: PMAT-714
-    status: planned
-    completion: 0
-  - id: PMAT-715
-    github_issue: null
-    title: PMAT-715
-    status: planned
-    completion: 0
+  subtasks: []
   estimated_effort: null
   labels:
   - crux-d
@@ -10479,27 +10444,7 @@ roadmap:
     PMAT-718 (PyTorch), PMAT-710 (Unsloth), PMAT-719 (Ollama/llama.cpp). Each pillar ships FALSIFY-BEAT-*
     gates.'
   phases: []
-  subtasks:
-  - id: PMAT-717
-    github_issue: null
-    title: PMAT-717
-    status: planned
-    completion: 0
-  - id: PMAT-718
-    github_issue: null
-    title: PMAT-718
-    status: planned
-    completion: 0
-  - id: PMAT-710
-    github_issue: null
-    title: PMAT-710
-    status: planned
-    completion: 0
-  - id: PMAT-719
-    github_issue: null
-    title: PMAT-719
-    status: planned
-    completion: 0
+  subtasks: []
   estimated_effort: null
   labels:
   - mission
@@ -10575,12 +10520,7 @@ roadmap:
     output/dequant correctness (the CRUX-M verify wall / Q2_K-class) that ollama+llama.cpp LACK. CRUX-M-02
     (PMAT-671, active) is the correctness leg. Sub-targets from the beat-analysis.'
   phases: []
-  subtasks:
-  - id: PMAT-671
-    github_issue: null
-    title: PMAT-671
-    status: planned
-    completion: 0
+  subtasks: []
   estimated_effort: null
   labels:
   - pillar-ollama

--- a/scripts/check_roadmap_diff_additive.sh
+++ b/scripts/check_roadmap_diff_additive.sh
@@ -198,6 +198,21 @@ open(sys.argv[2], "w").write(head)
 PY
     assert_row 'status + updated change on one entry' PASS "$TD/lifecycle.yaml" 'lifecycle=1'
 
+    # Row 3b (PMAT-1072, #3028): a parent's nested subtask records dropped to
+    # `subtasks: []` -> PASS (lifecycle). The records are structure older pmat
+    # wrote, not content; their uniqueness is check_roadmap_ids_unique.sh's rule.
+    python3 - "$TD/base.yaml" "$TD/subtasks.yaml" <<'PY'
+import sys
+base = open(sys.argv[1]).read()
+head = base.replace(
+    "- id: A-1\n  title: 'first entry'\n  status: planned\n  phases: []\n  subtasks: []\n",
+    "- id: A-1\n  title: 'first entry'\n  status: planned\n  phases: []\n  subtasks:\n  - id: A-2\n    title: A-2\n    status: planned\n",
+)
+assert head != base
+open(sys.argv[2], "w").write(head)
+PY
+    assert_row 'a parent subtasks list changed (nested records <-> [])' PASS "$TD/subtasks.yaml" 'lifecycle=1'
+
     # Row 4: an existing entry's title changed -> FAIL.
     python3 - "$TD/base.yaml" "$TD/titlechg.yaml" <<'PY'
 import sys

--- a/scripts/check_roadmap_ids_unique.sh
+++ b/scripts/check_roadmap_ids_unique.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# check_roadmap_ids_unique.sh — every `id:` in docs/roadmaps/roadmap.yaml is
+# unique, NESTED records included (PMAT-1072, #3028).
+#
+# WHY THIS EXISTS
+# ---------------
+# pmat 3.39.0's `work validate` (PMAT-674, pmat PR #1196) refuses a roadmap
+# whose id appears twice — every `id:` line, subtask records included. The
+# fleet's PATH pmat moved 3.37.0 -> 3.39.0 by hand on 2026-09-06 and the
+# upstream `roadmap-valid` step (sovereign-ci.yml, bare `pmat` from PATH)
+# turned aprender main RED on 12 legacy nested subtask records — stale copies
+# of children under four parents — that the in-repo pin (G-10a, 3.37.0) can
+# never see. The rule is right and the data was wrong; but a rule that lives
+# only in whichever pmat happens to be on a runner's PATH is not a guard the
+# repo owns. This one reads the PARSED tree (an id inside a block-scalar
+# body is text, not an id), names every duplicate with its path and line,
+# and is wired in ci.yml's guard-runner-labels — case table first.
+#
+#   bash scripts/check_roadmap_ids_unique.sh [<roadmap.yaml>]   # 0 all unique · 1 duplicate(s)/unparsable · 2 usage or env
+#   bash scripts/check_roadmap_ids_unique.sh --self-test        # 6 rows, both polarities
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROG=check_roadmap_ids_unique
+DEFAULT_ROADMAP="$ROOT/docs/roadmaps/roadmap.yaml"
+
+usage() {
+    printf 'usage: %s [ROADMAP.yaml]  or  %s --self-test\n' "$PROG" "$PROG" >&2
+    exit 2
+}
+
+# scan FILE: prints PASS/FAIL lines; exit 0 unique, 1 duplicates or unparsable, 2 env
+scan() {
+    local f=$1
+    if [ ! -f "$f" ]; then
+        printf '%s: ENV - %s is missing (the box cannot answer)\n' "$PROG" "$f" >&2
+        return 2
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        printf '%s: ENV - python3 is missing\n' "$PROG" >&2
+        return 2
+    fi
+    python3 - "$f" <<'PY'
+import re
+import sys
+
+import yaml
+
+path = sys.argv[1]
+try:
+    doc = yaml.safe_load(open(path, encoding="utf-8"))
+except yaml.YAMLError as e:
+    print(f"FAIL  {path} does not parse as YAML: {e}")
+    sys.exit(1)
+
+# raw-text line index (reporting only; the verdict comes from the parsed tree)
+lines_of = {}
+for n, line in enumerate(open(path, encoding="utf-8"), 1):
+    m = re.match(r"^\s*-?\s*id:\s*['\"]?([^'\"\s]+)['\"]?\s*$", line)
+    if m:
+        lines_of.setdefault(m.group(1), []).append(n)
+
+seen = {}
+def walk(node, where):
+    if isinstance(node, dict):
+        rid = node.get("id")
+        if isinstance(rid, (str, int)):
+            seen.setdefault(str(rid), []).append(where)
+        for k, v in node.items():
+            walk(v, f"{where}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{where}[{i}]")
+
+walk(doc, "$")
+dups = {k: v for k, v in seen.items() if len(v) > 1}
+if dups:
+    for rid, wheres in sorted(dups.items()):
+        lns = lines_of.get(rid, [])
+        spots = ", ".join(f"{w} (line {lns[i]})" if i < len(lns) else w for i, w in enumerate(wheres))
+        print(f"FAIL  duplicate id {rid}: {spots}")
+    print(f"FAIL  {len(dups)} duplicate id(s) in {path} — every id must be unique, nested records included (pmat >= 3.39.0 work validate refuses this file)")
+    sys.exit(1)
+print(f"PASS  {len(seen)} ids in {path}, all unique (nested records included)")
+PY
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: fixtures under mktemp -d, both polarities
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    TD=$(mktemp -d "${TMPDIR:-/tmp}/rmids-selftest.XXXXXX")
+    # SEC011: validate the scratch path before rm -rf (non-empty, not /, carries the mktemp tag)
+    cleanup() {
+        local victim=${TD:-}
+        case "$victim" in
+            *rmids-selftest.*) if [ -n "$victim" ] && [ "$victim" != "/" ]; then rm -rf -- "$victim"; fi ;;
+            *) return 0 ;;
+        esac
+    }
+    trap cleanup EXIT
+    n=0; red=0
+    # row WANT_RC LABEL MUST_MATCH FILE
+    row() {
+        local want=$1 label=$2 pat=$3 f=$4 rc=0
+        n=$((n + 1))
+        bash "$0" "$f" >"$TD/out.$n" 2>&1 || rc=$?
+        if [ "$rc" = "$want" ] && grep -qE -- "$pat" "$TD/out.$n"; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+        else printf 'FAIL  row %-2s rc=%s (wanted %s, must match /%s/)  %s\n' "$n" "$rc" "$want" "$pat" "$label"; sed 's/^/        /' "$TD/out.$n"; red=1; fi
+    }
+    cat >"$TD/clean.yaml" <<'YAML'
+roadmap:
+- id: A-1
+  title: first
+  subtasks: []
+- id: A-2
+  title: second
+YAML
+    cat >"$TD/nested.yaml" <<'YAML'
+roadmap:
+- id: A-1
+  title: first
+  subtasks:
+  - id: A-2
+    title: A-2
+    status: planned
+- id: A-2
+  title: second
+YAML
+    cat >"$TD/toplevel.yaml" <<'YAML'
+roadmap:
+- id: A-1
+  title: first
+- id: A-1
+  title: first again
+YAML
+    cat >"$TD/scalar.yaml" <<'YAML'
+roadmap:
+- id: A-1
+  title: first
+  spec: |
+    a block scalar that mentions
+    - id: A-2
+    is prose, not an id
+- id: A-2
+  title: second
+YAML
+    printf 'roadmap:\n- id: A-1\n  title: [unclosed\n' >"$TD/broken.yaml"
+    row 0 "two unique ids, no nested records"                          'PASS  2 ids'                 "$TD/clean.yaml"
+    row 1 "a nested subtask record duplicating a top-level id (the #3028 shape)" 'duplicate id A-2: .*subtasks\[0\].*line 5' "$TD/nested.yaml"
+    row 1 "two top-level entries with the same id"                     'duplicate id A-1'            "$TD/toplevel.yaml"
+    row 0 "an id inside a block scalar is prose, not an id"            'PASS  2 ids'                 "$TD/scalar.yaml"
+    row 1 "an unparsable roadmap is a defect, never a pass"            'does not parse'              "$TD/broken.yaml"
+    row 2 "a missing file is ENV (exit 2), never a pass"               'ENV'                         "$TD/absent.yaml"
+    printf '%s/%s rows\n' "$((n - red))" "$n"
+    [ "$red" = 0 ] || exit 1
+    exit 0
+fi
+
+case "${1:-}" in
+    --help|-h|--*) usage ;;
+    '') scan "$DEFAULT_ROADMAP" ;;
+    *) scan "$1" ;;
+esac

--- a/scripts/lib/roadmap_diff.py
+++ b/scripts/lib/roadmap_diff.py
@@ -73,6 +73,12 @@ LIFECYCLE_KEYS = {
     "labels",
     "assigned_to",
     "priority",
+    # A parent's subtasks list is structure the tooling maintains, not the
+    # ticket's content: older pmat wrote nested child RECORDS here and pmat
+    # >= 3.39.0 `work validate` refuses those as duplicate ids (PMAT-1072,
+    # #3028). Dropping them is a lifecycle edit; uniqueness is
+    # scripts/check_roadmap_ids_unique.sh's rule, not this one's.
+    "subtasks",
 }
 
 # Keys `pmat work add` materialises onto every entry even when the entry never


### PR DESCRIPTION
Fixes #3028. Fleet drift: paiml/infra#468.

## Ticket
PMAT-1072 (mint rides the session docs commit — A is the only minter there). Andon: main @ 3792afa3d push run 34049248452 is RED at the upstream `roadmap-valid` step (sovereign-ci.yml:1207, bare PATH `pmat work validate`, now 3.39.0 on every runner host); the merge queue evicted #3021 and will evict every entry until main is green.

## Claim
Every `id:` in `docs/roadmaps/roadmap.yaml` names one ticket, nested records included — and the rule lives in the repo through the parsed tree, so the version of pmat on a runner's PATH is never the only guard between main and a duplicate id.

## Root cause (measured)
| fact | measurement |
|---|---|
| roadmap unchanged between the green and red main heads | `git diff --stat b0a0a51b2 3792afa3d -- docs/roadmaps/roadmap.yaml` empty |
| the 3.37.0 pin passes, PATH pmat 3.39.0 fails the same bytes | `$PMAT work validate` → passed · `pmat work validate` → 12 duplicates, the CI log verbatim |
| PATH pmat moved today | intel `~/.cargo/bin/pmat` 3.39.0 mtime 17:30:02Z (auditd `cargo install pmat` 17:26–17:30Z); lambda 17:33:38Z; green PR run 34041439234 at 15:10Z, red main run at 17:38Z |
| the rule is deliberate | pmat 3.39.0 CHANGELOG (PMAT-674 / pmat PR #1196): every `id:` line, subtask ids included |
| the duplicates are legacy nested child copies | 12 `subtasks:` records `{id, github_issue, title: <id>, status, completion}` under APR-ANTIGRAVITY-PARITY-001 (2), PMAT-710 (5), PMAT-716 (4), PMAT-719 (1); pmat 3.39.0 `work add` has no parent/subtask flag |

## RED test
`bash scripts/check_roadmap_ids_unique.sh` on main @ 3792afa3d's roadmap → `FAIL 12 duplicate id(s)` naming each path and line (e.g. `PMAT-719: $.roadmap[505].subtasks[3] (line 10498), $.roadmap[508] (line 10560)`). On this branch → `PASS 809 ids, all unique`.

## Acceptance
- `bash scripts/check_roadmap_ids_unique.sh --self-test` → 6/6 rows (nested dup RED, top-level dup RED, block-scalar id ignored, unparsable = 1, missing = 2)
- `pmat work validate` (3.39.0) and `$PMAT work validate` (3.37.0 pin) → `Validation passed`
- `bash scripts/check_roadmap_diff_additive.sh origin/main HEAD` → `added=0 lifecycle=4 reserialised=0 deleted=0 PASS`; its self-test 18/18 (row 3b new)
- `check_guards_are_wired.sh`, `check_baseline_ratchets.sh`, `check_complexity_ratchet.sh`, `check_shell_lint_ratchet.sh` (8 → 8), `check_no_claim_literals.sh`, `check_perf_claims_cite_receipts.sh`, `check_roadmap_completion_is_cited.sh`, `check_row_pr_write_set.sh` (orchestrator branch) → all PASS

## Mutation
- RMID-F-001 `walk()` skips lists → self-test rows 1–4 RED (restored)
- RMID-F-003 both ci.yml lines deleted → `check_guards_are_wired.sh` RED: `NEW: check_roadmap_ids_unique.sh` (restored)
- CI pair for the andon itself: main push run **34049248452** (RED, `roadmap-valid`) → this PR's run (GREEN, same step) — the second id lands in a comment when the run completes.

## Contract
`contracts/apr-roadmap-ids-unique-v1.yaml` (kind: pattern; RMID-OB-001..003 ↔ RMID-F-001..003); `pv validate` through `scripts/pv_bin.sh`: valid.

## Quorum
NOT RUN — andon hotfix to restore main (the queue is blocked); the case table and two RED mutations above are the evidence. A review-only lane on this diff is queued in the session docs.

## Receipt
`docs/audits/impl-PMAT-1072-receipt.md` — `status: complete` (written .tmp then mv).

## Writes
`docs/roadmaps/roadmap.yaml` (64 deletions, 0 insertions: the 12 nested records → `subtasks: []` on four parents), `scripts/check_roadmap_ids_unique.sh` (new), `contracts/apr-roadmap-ids-unique-v1.yaml` (new), `scripts/lib/roadmap_diff.py` (+`subtasks` in LIFECYCLE_KEYS), `scripts/check_roadmap_diff_additive.sh` (+row 3b), `.github/workflows/ci.yml` (+2 steps in guard-runner-labels, after the roadmap-citation case table), `docs/audits/impl-PMAT-1072-receipt.md`.

## Overlap with #3027
#3027 (`PMAT-246-roadmap-repair`, 17:12Z, the BSE-001 convergence brief's H4) carries the identical byte-for-byte dedup of the same twelve ids plus a PMAT-1060 mint; I opened this PR without re-listing PRs (an I0 miss, recorded). The two deletions are the same bytes, so they merge cleanly in either order. What only this PR carries: the pin-independent guard, its contract, the G-6 lifecycle change (which is also what #3027's guard-runner-labels currently fails on), and the receipt. PMAT-1060 collides with #3025's hand-minted PMAT-1060 (R-0b); #3025 renumbers its own.

## Not in this PR
The upstream step still runs bare PATH `pmat` (infra#468 decides the pin); `scripts/pmat_bin.sh` PMAT_PIN=3.37.0 is now behind the fleet — moving it is a G-10a re-stamp, its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
