### PR TITLE
fix(C0-2): pin sovereign-ci.yml by sha; CB-2100 reachability finding filed (#3029) — PMAT-976

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # checks with no owning ticket in the PP-066 DAG — so wiring it into a
     # required context would red every PR's merge on unrelated, untracked
     # debt. See #2891 for the finding and the follow-up this blocks on.
-    uses: paiml/.github/.github/workflows/sovereign-ci.yml@4453399ee3794714800ff8db316ea7e1d3705a00
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,30 @@ concurrency:
 
 jobs:
   ci:
-    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
+    # Pinned to a commit sha, not @main (PMAT-976, C0-2, #2891, CB-2100/CB-2101
+    # supply-chain provenance). @main is a moving target: whatever paiml/.github
+    # merges next runs on this repo's next push with no review here. A sha is
+    # immutable, matches the content diffed against @main at pin time (identical
+    # at 4453399ee3794714800ff8db316ea7e1d3705a00 on 2026-09-06), and gives a
+    # reviewable diff on every re-pin.
+    #
+    # This alone does NOT make CB-2100 (`pmat comply check`) read the callee's
+    # steps: `paiml/.github/.../sovereign-ci.yml@<anything>` is an external
+    # `uses:` reference (not `./...`), and pmat's gate-effect analyzer
+    # (services/gate_effect/resolve.rs::local_reusable_path, pmat 3.39.0)
+    # treats every such reference — branch, tag, or sha alike — as `Opaque`:
+    # unreadable, never "readable". Verified directly against the source (not
+    # inferred from behavior). Closing CB-2100 needs one of: (a) paiml/.github
+    # starts emitting a manifest pmat can read through an opaque `uses:`, which
+    # requires a matching read-path in pmat itself (neither exists in 3.39.0 —
+    # both are out of aprender's scope), or (b) a required, LOCAL job in this
+    # repo runs `pmat comply check`/`comply status` unsuppressed. (b) is
+    # possible today but not yet landable: a bare, unfiltered run currently
+    # fails on CB-040, CB-081, CB-400, CB-1305, CB-1308 and CB-1650 — six
+    # checks with no owning ticket in the PP-066 DAG — so wiring it into a
+    # required context would red every PR's merge on unrelated, untracked
+    # debt. See #2891 for the finding and the follow-up this blocks on.
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@4453399ee3794714800ff8db316ea7e1d3705a00
     with:
       repo: ${{ github.event.repository.name }}
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
@@ -1583,6 +1606,13 @@ jobs:
         run: bash scripts/check_test_fixture_paths.sh
       - name: Fixture-path guard case table
         run: bash scripts/check_test_fixture_paths.sh --self-test
+      # PMAT-976 (C0-2, #2891, epic #2873): the sovereign-ci.yml reusable
+      # workflow ci.yml calls must be pinned to a commit sha, never a branch.
+      # Text-only, no build.
+      - name: sovereign-ci.yml pin guard case table
+        run: bash scripts/check_ci_reusable_workflow_pinned.sh --self-test
+      - name: ci.yml must pin sovereign-ci.yml by commit sha, not @main
+        run: bash scripts/check_ci_reusable_workflow_pinned.sh
       - name: "target-watch: after-last-cargo-step"
         # aprender#2822 boundary probe (2 stat, 1 readdir, 1 df, 1 pgrep).
         # Instrumentation, never a gate: the script always exits 0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # checks with no owning ticket in the PP-066 DAG — so wiring it into a
     # required context would red every PR's merge on unrelated, untracked
     # debt. See #2891 for the finding and the follow-up this blocks on.
-    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@4453399ee3794714800ff8db316ea7e1d3705a00
     with:
       repo: ${{ github.event.repository.name }}
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.

--- a/contracts/apr-required-checks-v1.yaml
+++ b/contracts/apr-required-checks-v1.yaml
@@ -66,15 +66,22 @@
 #          Kani harness to inflate the level would be theater.
 # ─────────────────────────────────────────────────────────────────────────────
 name: apr-required-checks
-version: "1.0.0"
+version: "1.1.0"
 scope: >
   The workflow that invokes scripts/check_pr_review_arm4.sh without
   --self-test (today: .github/workflows/pr-review-quorum.yml, job `present`),
   its top-level `on:` and job-level `if:`, and the `gate` job of
-  .github/workflows/ci.yml. Out of scope: whether any status-check context is
-  a REQUIRED context in branch protection or a ruleset — that is an operator
-  decision recorded in a pull request body, never applied by this contract or
-  by the session that authors it.
+  .github/workflows/ci.yml. Also (v1.1.0, C0-2): the `uses:` reference in
+  .github/workflows/ci.yml's `ci` job, which calls the paiml/.github
+  sovereign-ci.yml reusable workflow — that reference must name an immutable
+  commit sha, never a branch or tag. Out of scope, both areas: whether any
+  status-check context is a REQUIRED context in branch protection or a
+  ruleset — that is an operator decision recorded in a pull request body,
+  never applied by this contract or by the session that authors it. Also out
+  of scope: whether pinning the sha makes `pmat comply check`'s CB-2100 rule
+  reachable — verified against pmat 3.39.0 source that it does not (see
+  scripts/check_ci_reusable_workflow_pinned.sh's header); that is a separate,
+  still-open question tracked in issue #2891, not a claim this contract makes.
 status: active
 
 metadata:
@@ -237,6 +244,36 @@ equations:
     postconditions:
     - 'a PR that reverts either step is caught by guard-runner-labels before gate can pass'
 
+  c0_2_reusable_workflow_pinned_by_sha:
+    formula: |
+      let UP = uses_ref(ci.yml, job = "ci")   -- the ref after `@` on the
+                                               -- `uses: paiml/.github/.../sovereign-ci.yml@...` line
+      UP is defined
+      and len(UP) = 40
+      and forall c in UP: c in {0..9, a..f}
+    domain: 'the `uses:` line of job `ci` in .github/workflows/ci.yml naming paiml/.github/.github/workflows/sovereign-ci.yml'
+    codomain: 'bool — the ref is a full 40-char lowercase-hex commit sha; a branch, tag, or short sha is a FAIL'
+    invariants:
+    - >-
+      A MUTABLE REF RE-RESOLVES ON EVERY PUSH. `@main` means whatever
+      paiml/.github merges next runs on this repo's next CI invocation, with
+      no diff in THIS repository's history to review. A sha is immutable: the
+      callee's content at pin time is exactly what re-runs until a human
+      deliberately re-pins it, and re-pinning is then a reviewable one-line
+      diff (PMAT-976, C0-2, #2891).
+    - >-
+      PINNING ALONE DOES NOT CLOSE CB-2100. Read directly from pmat 3.39.0
+      source (services/gate_effect/resolve.rs::local_reusable_path): any
+      external `uses:` reference — branch, tag, or sha alike — resolves to
+      `Resolution::Opaque`, never `Resolution::Job`; only `uses: ./...`
+      (local to this repository) is readable. This equation proves pin
+      hygiene only, not gate-effect reachability — conflating the two would
+      misrepresent what closing CB-2100 actually requires.
+    preconditions:
+    - 'ci.yml exists and parses; a missing or unparsable workflow is a FAIL, never a vacuous pass'
+    postconditions:
+    - 'a PR that re-points the ref at @main, @master, or any tag is caught before merge, in CI, by the same guard that proves the current pin (registered mutation)'
+
 proof_obligations:
   - id: RC-OB-001
     statement: "Exactly one workflow job invokes check_pr_review_arm4.sh without --self-test."
@@ -259,6 +296,9 @@ proof_obligations:
   - id: RC-OB-007
     statement: "Re-adding pr-review-present to gate's needs: (under either its own name or a renamed job invoking the same guard) turns the guard RED."
     discharged_by: falsification_tests[6]
+  - id: RC-OB-008
+    statement: "ci.yml job `ci`'s `uses:` reference to paiml/.github/.github/workflows/sovereign-ci.yml names a full 40-char lowercase-hex commit sha, never a branch or tag."
+    discharged_by: falsification_tests[7]
 
 falsification_tests:
 
@@ -399,10 +439,32 @@ falsification_tests:
       scripts/check_pr_review_arm4.sh` and list it in gate.needs;
       check_receipt_gate_base_owned.sh must turn RED naming "custom-receipt".
 
+  - id: RC-F-008
+    rule: "ci.yml's `ci` job pins the sovereign-ci.yml `uses:` reference to a full commit sha (C0-2, PMAT-976)"
+    prediction: >-
+      A `uses:` line naming a 40-char lowercase-hex ref PASSES; `@main`,
+      `@master`, a tag (`@v1.2.3`), a short/abbreviated sha, and a 40-char ref
+      containing a non-hex character all FAIL. A missing `uses:` line for the
+      named callee, and a missing ci.yml, both FAIL closed (never a vacuous
+      pass). Verified both in synthetic fixtures (--self-test) and against the
+      real tree: the guard reports FAIL against origin/main's ci.yml (which
+      carries `@main`) and PASS against this PR's ci.yml (which carries the
+      pinned sha), on the same command with only the file swapped.
+    test: 'bash scripts/check_ci_reusable_workflow_pinned.sh --self-test'
+    if_fails: >-
+      the reusable-workflow reference could silently re-resolve to whatever
+      paiml/.github merges next, on every push, with no diff in this
+      repository's history — and nothing here would say so
+    mutation: >-
+      change ci.yml's `uses: paiml/.github/.github/workflows/sovereign-ci.yml@<sha>`
+      back to `@main`; check_ci_reusable_workflow_pinned.sh must turn RED
+      naming "not a full 40-char commit sha".
+
 non_goals:
   - "Verifying the CONTENT of scripts/check_pr_review_arm4.sh's receipt judgement (Arm 4 itself) — that is pr-review-skill-v2's subject; this contract governs only WHERE and UNDER WHICH TRIGGER that judgement is invoked."
   - "Deciding whether pr-review-quorum / present is a REQUIRED branch-protection or ruleset context. That is an operator decision recorded in the pull request body."
   - "Auditing every workflow in .github/workflows/ for pull_request_target security hygiene beyond the one job this contract's scope names; the checkout-permissions comment in pr-review-quorum.yml is the security note, not a claim this contract re-verifies."
+  - "Making CB-2100 (pmat comply check's gate-effect rule) reachable. Pinning the ref does not do this — verified against pmat 3.39.0 source, see scripts/check_ci_reusable_workflow_pinned.sh's header and issue #2891. That needs a required, local job invoking `pmat comply check` unsuppressed, which is not landable today without first clearing six untracked, pre-existing comply failures (CB-040, CB-081, CB-400, CB-1305, CB-1308, CB-1650) that own no ticket in the PP-066 DAG."
 
 binding_registry:
   guard: scripts/check_receipt_gate_base_owned.sh

--- a/docs/audits/impl-PMAT-976-receipt.md
+++ b/docs/audits/impl-PMAT-976-receipt.md
@@ -1,0 +1,94 @@
+---
+status: partial
+ticket: PMAT-976
+row: C0-2
+issue: 2891
+epic: 2873
+model: claude-sonnet-5
+tokens_used: "[U] — not instrumented this session"
+wall_clock_s: "[U] — not instrumented this session"
+turns: "[U] — not instrumented this session"
+---
+# impl-PMAT-976 — C0-2 · sovereign-ci.yml pinned by sha; CB-2100 reachability NOT closed (finding filed)
+
+## Identity
+ticket PMAT-976 · kind code · branch `agent/C0-2` (worktree) · base `origin/main` @ `3792afa3d` · quorum `teamwork` (per DAG row).
+
+## What this PR does
+1. Pins `.github/workflows/ci.yml`'s `ci` job `uses:` reference from
+   `paiml/.github/.github/workflows/sovereign-ci.yml@main` to
+   `@4453399ee3794714800ff8db316ea7e1d3705a00` — content-diffed identical to
+   `@main` at pin time (`gh api` content comparison, both directions).
+2. Adds `scripts/check_ci_reusable_workflow_pinned.sh` (14-row self-test, both
+   polarities) and wires it into `guard-runner-labels` (self-test then
+   live-check, existing convention), which is itself in `gate.needs`.
+3. Extends `contracts/apr-required-checks-v1.yaml` (the contract the DAG names
+   for this row) with equation `c0_2_reusable_workflow_pinned_by_sha`, proof
+   obligation RC-OB-008, falsification test RC-F-008.
+4. Files #3029: a finding that pinning by sha does **not** make CB-2100 pass,
+   contrary to the ticket's own registered mutation premise. Linked from #2891.
+
+## Acceptance — A_i (from the DAG row / issue #2891), both re-run at HEAD
+
+| A_i | command | result |
+|---|---|---|
+| A1 | `pmat comply check \| grep CB-2100` shows ✓, naming the nine rules under a required context | **NOT MET.** Still `✗`: `9 severity=error rule(s) unreachable … required context \`ci / gate\` resolves into \`…sovereign-ci.yml@4453399ee…\`, whose steps are not readable from this repository`. Verified against pmat 3.39.0 source (`services/gate_effect/resolve.rs::local_reusable_path`): any external `uses:` ref — branch, tag, or sha alike — is `Resolution::Opaque`. See #3029 for the full finding and why closing it today would red every PR on six untracked debts. |
+| A2 | `.github/workflows/ci.yml` references `…sovereign-ci.yml@<sha>`, not `@main` | **MET.** `grep -n "sovereign-ci.yml@" .github/workflows/ci.yml` → `@4453399ee3794714800ff8db316ea7e1d3705a00`. |
+
+Because A1 is not met, this row's DONE-IF condition is not satisfied. Status is
+`partial`, not `complete`; the DAG's derived status (G-11: status comes from
+receipts, not written by row PRs) should read this row as open pending #3029.
+
+## Verification (this session, re-run directly — not delegated)
+| check | result |
+|---|---|
+| `bash scripts/check_ci_reusable_workflow_pinned.sh --self-test` | rc 0, 14/14 rows, both polarities |
+| `bash scripts/check_ci_reusable_workflow_pinned.sh` (live, HEAD) | rc 0, PASS |
+| same script against `git show HEAD~1:.github/workflows/ci.yml` (RED commit, unpinned) | rc 1, FAIL naming `@main` |
+| same script against `git show origin/main:.github/workflows/ci.yml` | rc 1, FAIL naming `@main` — reproduces the mutation directly on the real tree, not only in synthetic fixtures |
+| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` | OK |
+| `bashrs lint scripts/check_ci_reusable_workflow_pinned.sh` | 0 errors, 8 warnings / 34 info — parity with sibling guards (e.g. `check_no_ghsa_banned_crates.sh`: 0 errors, 10 warnings / 42 info) |
+| `bash -c 'source scripts/pv_bin.sh; "$PV" validate contracts/apr-required-checks-v1.yaml'` | 0 errors, 0 warnings — valid |
+| `bash -c 'source scripts/pv_bin.sh; "$PV" lint contracts/ --diff origin/main'` | Diff-aware: 1 contract changed (`apr-required-checks-v1`); Gate 4 verify 26/26 refs found (0 missing); overall 0 errors, PASS |
+| `bash scripts/check_contract_test_binding.sh` | rc 0, PASS (baseline unchanged, 27 pre-existing dangling refs elsewhere, none new) |
+| `bash scripts/check_row_pr_write_set.sh --base origin/main --head HEAD --branch agent/C0-2` | PASS — 3 changed paths, no shared file (DAG/roadmap/spec/README) touched |
+| `cargo fmt --all -- --check` | exit 0 |
+
+## Mutation (RED, then the remedy) — commit-level, not just self-test
+Commit 1 (`test(C0-2): RED …`) adds only the guard script, before the pin: the
+live check against that commit's `ci.yml` fails, naming `@main`. Commit 2
+(`fix(C0-2): pin …`) pins the ref and wires the guard: the live check passes.
+Both states verified directly (table above), not asserted. The registered
+mutation in the contract (RC-F-008: revert the `uses:` line to `@main`) is
+identical to reverting commit 2 — verified by running the guard against
+`origin/main`'s actual (still-`@main`) `ci.yml`, which is the real pre-fix
+state, not a synthetic stand-in.
+
+CI-level RED→GREEN (push the mutant, observe the PR's own required checks turn
+red, revert, observe green, record both run ids) is **not yet done** — pending
+this PR opening and its first CI run. Will be added to the PR body before
+auto-merge is armed, per driver protocol.
+
+## Quorum
+Dispatched `paiml-agy-delegate` (lane=teamwork, width=1) with the full finding
+and proposed plan (pin now, file #3029, receipt partial, continue to C0-4).
+Both the primary run and a mechanism-check retry returned PROCEED/PASS with no
+dissent, but the delegate's own receipt flags this as a **weak** quorum: agy
+1.1.27's headless `-p` mode did not engage true `/teamwork-preview` fan-out
+(2 turns, ~27s, zero child agents, every finding `grounding=asserted`, no repo
+files read by the lane itself). Recorded as `feedback_teamwork_lane_does_not_fan_out.md`
+in the delegate's own agent-memory for future sessions. The load-bearing
+evidence in this receipt is the orchestrator's own direct source-reading and
+empirical reproduction (tables above), not the quorum lane.
+
+## Gaps / follow-up
+- #3029: the real remedy for A1 — either (a) ratchet-baseline CB-040/081/400/
+  1305/1308/1650 (new DAG rows) so a bare `pmat comply check` exits 0, then wire
+  it into a required job, or (b) cross-repo manifest tooling (`paiml/.github` +
+  pmat). Not scoped to this PR.
+- CI-level mutation run ids: added to the PR body once the PR's first CI run
+  completes (see above).
+
+## Verdict
+PARTIAL (`status: partial`). A2 lands with real, independent value (supply-chain
+provenance). A1 remains open; #3029 is the tracked remedy. C0-2 is not DONE.

--- a/scripts/check_ci_reusable_workflow_pinned.sh
+++ b/scripts/check_ci_reusable_workflow_pinned.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# check_ci_reusable_workflow_pinned.sh — the `uses:` reference to the
+# paiml/.github sovereign-ci.yml reusable workflow in .github/workflows/ci.yml
+# is pinned to a full 40-hex-char commit sha, never a branch or tag ref.
+#
+# WHY THIS EXISTS (PMAT-976, C0-2, #2891, epic #2873)
+# ----------------------------------------------------
+# `uses: paiml/.github/.github/workflows/sovereign-ci.yml@main` re-resolves on
+# every push: whatever paiml/.github merges next runs on this repo's very next
+# CI run, with no diff in THIS repository to review. A commit sha is
+# immutable — the callee's content at pin time is exactly what re-runs until
+# someone deliberately re-pins it, and re-pinning shows up as a reviewable
+# one-line diff.
+#
+# WHAT THIS DOES NOT DO (read before wiring more onto it)
+# ---------------------------------------------------------
+# Pinning by sha does NOT make `pmat comply check`'s CB-2100 (Comply Gate
+# Effect) reachability rule pass. Verified directly against pmat 3.39.0's
+# source (services/gate_effect/resolve.rs::local_reusable_path): an external
+# `uses:` reference — `owner/repo/...@<anything>`, branch, tag, or sha alike —
+# is always `Resolution::Opaque`, never `Resolution::Job`. Only a workflow
+# referenced as `./...` (local to this repository) is readable. Confirmed
+# empirically too: pinning ci.yml's `uses:` to a real, content-identical sha
+# left CB-2100's output byte-for-byte the same (still "whose steps this
+# repository cannot read"). Closing CB-2100 needs a required, LOCAL job that
+# actually invokes `pmat comply check`/`comply status` unsuppressed — see the
+# comment above `uses:` in ci.yml and #2891 for why that isn't wired here yet
+# (it would red every PR on six untracked pre-existing failures).
+#
+# Text-only: reads .github/workflows/ci.yml, builds nothing.
+#
+#   bash scripts/check_ci_reusable_workflow_pinned.sh
+#   bash scripts/check_ci_reusable_workflow_pinned.sh --self-test
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW_REL=".github/workflows/ci.yml"
+CALLEE_REPO="paiml/.github"
+CALLEE_PATH=".github/workflows/sovereign-ci.yml"
+
+# ref_is_pinned_sha <ref> -> 0 when ref is a full 40-char lowercase-hex commit
+# sha, 1 otherwise (a branch name, a tag, a short sha, or garbage).
+ref_is_pinned_sha() {
+  ref="$1"
+  [ "${#ref}" -eq 40 ] && case "$ref" in
+    *[!0-9a-f]*) return 1 ;;
+    *) return 0 ;;
+  esac
+  return 1
+}
+
+# find_uses_ref <file> -> prints the ref after `@` on the line whose `uses:`
+# names $CALLEE_REPO/$CALLEE_PATH, or nothing (and a non-zero return) when no
+# such line exists in the file.
+find_uses_ref() {
+  file="$1"
+  [ -r "$file" ] || return 2
+  line="$(grep -E "^\s*uses:\s*${CALLEE_REPO}/${CALLEE_PATH}@" "$file" | head -n1)" || true
+  [ -n "$line" ] || return 1
+  printf '%s\n' "${line##*@}" | tr -d ' \t\r'
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: both polarities of ref_is_pinned_sha, plus find_uses_ref
+# against synthetic workflow files — including the exact mutation this guard
+# exists to catch (re-pointing at @main).
+# ---------------------------------------------------------------------------
+self_test() {
+  printf '=== case table: check_ci_reusable_workflow_pinned.sh ===\n'
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp:?}"' RETURN
+
+  fails=0
+  assert() {  # assert <label> <expected_rc> <actual_rc>
+    if [ "$2" -eq "$3" ]; then
+      printf '  ok   %-46s rc=%s\n' "$1" "$3"
+    else
+      printf '  FAIL %-46s expected rc=%s got rc=%s\n' "$1" "$2" "$3"
+      fails=$((fails + 1))
+    fi
+  }
+
+  # ref_is_pinned_sha: MUST PASS (rc=0) — a real 40-char lowercase hex sha.
+  ref_is_pinned_sha "4453399ee3794714800ff8db316ea7e1d3705a00"; assert 'ref: 40-char lowercase hex sha'   0 $?
+  zeros="$(printf '0%.0s' $(seq 1 40))"
+  ref_is_pinned_sha "$zeros"; assert 'ref: all-zero but valid 40-hex sha' 0 $?
+
+  # ref_is_pinned_sha: MUST FAIL (rc=1) — the mutation this guard exists for,
+  # plus every other shape a `uses:` ref can take.
+  ref_is_pinned_sha "main";                                    assert 'ref: @main (the registered mutation)' 1 $?
+  ref_is_pinned_sha "master";                                  assert 'ref: @master'                          1 $?
+  ref_is_pinned_sha "v1.2.3";                                  assert 'ref: a tag'                             1 $?
+  ref_is_pinned_sha "4453399";                                 assert 'ref: a short (abbreviated) sha'         1 $?
+  ref_is_pinned_sha "4453399ee3794714800ff8db316ea7e1d3705a0G"; assert 'ref: 40 chars but non-hex tail'        1 $?
+  ref_is_pinned_sha "";                                        assert 'ref: empty'                             1 $?
+
+  # find_uses_ref: MUST FIND (rc=0), extracting exactly the ref after `@`.
+  cat > "$tmp/pinned.yml" <<'EOF'
+jobs:
+  ci:
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@4453399ee3794714800ff8db316ea7e1d3705a00
+EOF
+  got="$(find_uses_ref "$tmp/pinned.yml")"; rc=$?
+  assert 'find_uses_ref: locates the pinned line' 0 "$rc"
+  [ "$got" = "4453399ee3794714800ff8db316ea7e1d3705a00" ] && assert 'find_uses_ref: extracts the exact sha' 0 0 || assert 'find_uses_ref: extracts the exact sha' 0 1
+
+  # find_uses_ref: MUST FIND but return the mutant ref (the check on top of it fails, not this parser).
+  cat > "$tmp/unpinned.yml" <<'EOF'
+jobs:
+  ci:
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
+EOF
+  got="$(find_uses_ref "$tmp/unpinned.yml")"; rc=$?
+  assert 'find_uses_ref: locates the @main line too' 0 "$rc"
+  [ "$got" = "main" ] && assert 'find_uses_ref: extracts "main" verbatim' 0 0 || assert 'find_uses_ref: extracts "main" verbatim' 0 1
+
+  # find_uses_ref: MUST NOT FIND (rc=1) — no such uses: line, or an unrelated caller.
+  cat > "$tmp/other-caller.yml" <<'EOF'
+jobs:
+  pr-gate:
+    uses: paiml/.github/.github/workflows/pr-gate.yml@main
+EOF
+  find_uses_ref "$tmp/other-caller.yml" > /dev/null 2>&1; assert 'find_uses_ref: unrelated callee is not a match' 1 $?
+
+  # find_uses_ref: MUST FAIL CLOSED (rc=2) — a missing file certifies nothing.
+  find_uses_ref "$tmp/does-not-exist.yml" > /dev/null 2>&1; assert 'find_uses_ref: missing file is not clean'    2 $?
+
+  if [ "$fails" -gt 0 ]; then
+    printf '\nFAIL: %s case(s) failed. The guard does not do what it claims.\n' "$fails"
+    return 1
+  fi
+  printf 'PASS: all cases behave as declared.\n'
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+printf '=== sovereign-ci.yml is pinned by commit sha in %s (check_ci_reusable_workflow_pinned.sh) ===\n' "$WORKFLOW_REL"
+
+ref="$(find_uses_ref "$REPO_ROOT/$WORKFLOW_REL")"
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  printf 'FAIL: %s is unreadable -- a check that read nothing certifies nothing.\n' "$WORKFLOW_REL"
+  exit 1
+fi
+if [ "$rc" -eq 1 ]; then
+  printf 'FAIL: no `uses: %s/%s@...` line found in %s.\n' "$CALLEE_REPO" "$CALLEE_PATH" "$WORKFLOW_REL"
+  exit 1
+fi
+
+if ! ref_is_pinned_sha "$ref"; then
+  printf 'FAIL: %s references %s/%s@%s -- not a full 40-char commit sha.\n' "$WORKFLOW_REL" "$CALLEE_REPO" "$CALLEE_PATH" "$ref"
+  printf 'A branch or tag ref re-resolves on every push; only a sha is immutable and reviewable.\n'
+  exit 1
+fi
+
+printf 'PASS: %s references %s/%s@%s (a pinned commit sha).\n' "$WORKFLOW_REL" "$CALLEE_REPO" "$CALLEE_PATH" "$ref"
+exit 0


### PR DESCRIPTION
## Ticket
PMAT-976 · DAG row C0-2 · epic #2873 · issue #2891 · `pp-066` `inst:C` `C0-2`

## Claim
Pins `.github/workflows/ci.yml`'s sovereign-ci.yml reference to a commit sha
(real, independent supply-chain-provenance value) and wires a guard proving it
stays pinned. **Does not** close CB-2100 — filed as #3029 with the full finding
(pinning does not change pmat's gate-effect reachability verdict; closing it for
real needs either six new ratchet-baseline rows for untracked comply debt, or
cross-repo manifest tooling in `paiml/.github` + `pmat`, neither in scope here).
Receipt is `status: partial`.

## RED test (sha)
`f46824526` — `scripts/check_ci_reusable_workflow_pinned.sh` added standalone
(ci.yml still `@main`); live check fails naming `@main` as "not a full 40-char
commit sha".

## Acceptance (accept.sh output — re-run at HEAD)
| A_i | command | result |
|---|---|---|
| A1 | `pmat comply check \| grep CB-2100` shows ✓ | **NOT MET** — still ✗, "whose steps this repository cannot read" (unchanged by the pin; see #3029) |
| A2 | ci.yml references `…sovereign-ci.yml@<sha>`, not `@main` | **MET** — `@4453399ee3794714800ff8db316ea7e1d3705a00` |

```
$ bash scripts/check_ci_reusable_workflow_pinned.sh --self-test
=== case table: check_ci_reusable_workflow_pinned.sh ===
  ok   ref: 40-char lowercase hex sha                 rc=0
  ok   ref: all-zero but valid 40-hex sha             rc=0
  ok   ref: @main (the registered mutation)           rc=1
  ok   ref: @master                                   rc=1
  ok   ref: a tag                                     rc=1
  ok   ref: a short (abbreviated) sha                 rc=1
  ok   ref: 40 chars but non-hex tail                 rc=1
  ok   ref: empty                                     rc=1
  ok   find_uses_ref: locates the pinned line         rc=0
  ok   find_uses_ref: extracts the exact sha          rc=0
  ok   find_uses_ref: locates the @main line too      rc=0
  ok   find_uses_ref: extracts "main" verbatim        rc=0
  ok   find_uses_ref: unrelated callee is not a match rc=1
  ok   find_uses_ref: missing file is not clean       rc=2
PASS: all cases behave as declared.

$ bash scripts/check_ci_reusable_workflow_pinned.sh
PASS: .github/workflows/ci.yml references paiml/.github/.github/workflows/sovereign-ci.yml@4453399ee3794714800ff8db316ea7e1d3705a00 (a pinned commit sha).
```

Reproduced against the real pre-fix tree directly (not only synthetic fixtures):
`git show origin/main:.github/workflows/ci.yml` swapped in → guard FAILs naming
`@main`; restored → PASSes.

## Mutation (RED → GREEN)
Commit-level: `f46824526` (guard only, ci.yml unpinned) is RED;
`2e6a3805b` (pin + wiring) is GREEN. CI-level: mutant commit `a642a6077`
(reverted the pin to `@main`) → `guard-runner-labels` job
[101535304151](https://github.com/paiml/aprender/actions/runs/34050962601/job/101535304151)
RED, step "ci.yml must pin sovereign-ci.yml by commit sha, not @main" failed
naming `@main`. Reverted at `d06b21dc5` → `guard-runner-labels` job
[101548517884](https://github.com/paiml/aprender/actions/runs/34055954239/job/101548517884)
GREEN, both new steps passed.

## Contract
`contracts/apr-required-checks-v1.yaml` (the DAG's named contract for this row)
— extended, not replaced: equation `c0_2_reusable_workflow_pinned_by_sha`,
proof obligation `RC-OB-008`, falsification test `RC-F-008` bound to
`check_ci_reusable_workflow_pinned.sh --self-test`.

```
$ bash -c 'source scripts/pv_bin.sh; "$PV" validate contracts/apr-required-checks-v1.yaml'
0 error(s), 0 warning(s)
Contract is valid.

$ bash -c 'source scripts/pv_bin.sh; "$PV" lint contracts/ --diff origin/main'
Diff-aware: 1 contracts changed since origin/main
  apr-required-checks-v1
...
  Gate 4: verify               ✓  (26 refs, 26 found, 0 missing)
...
Summary: 0 errors, 1082 warnings, 0 suppressed
Result: PASS

$ bash scripts/check_contract_test_binding.sh
ok    ratchet  scripts/contract_test_binding_baseline.txt did not grow (0 removed) vs 3792afa3d
Resolved 530 test references; 27 dangling across 13 contract(s).
PASS: no contract cites more nonexistent tests than its baseline allows.
```

## Quorum (teamwork, per DAG)
`paiml-agy-delegate`, lane=teamwork width=1, two runs (primary + mechanism-check
retry): both **PROCEED/PASS**, no dissent, on the plan (pin now, file the CB-2100
finding, receipt partial, continue to C0-4). The delegate's own receipt flags
this as a **weak** quorum — agy 1.1.27 headless `-p` mode did not engage true
`/teamwork-preview` fan-out (2 turns, ~27s each, zero child agents, every
finding `grounding=asserted`). Load-bearing evidence in this PR is the
orchestrator's own direct pmat-source reading and empirical reproduction (RED
against `origin/main`'s real `ci.yml`, GREEN against the fix), not the quorum
lane. Recorded as a lesson in the delegate's agent-memory
(`feedback_teamwork_lane_does_not_fan_out.md`) for future sessions.

## Receipt
`docs/audits/impl-PMAT-976-receipt.md` — `status: partial`. A2 met, A1 not;
follow-up tracked in #3029.

## Writes
- `.github/workflows/ci.yml` (sha pin + guard wiring)
- `contracts/apr-required-checks-v1.yaml` (extended)
- `scripts/check_ci_reusable_workflow_pinned.sh` (new)
- `docs/audits/impl-PMAT-976-receipt.md` (new)

No shared file touched (`check_row_pr_write_set.sh` PASS): not
`docs/specifications/pp-066-dag.yaml`, not `docs/roadmaps/roadmap.yaml`, not
`docs/specifications/PP-066-release-spec.md`, no README count line.

## Follow-up
#3029 — CB-2100 remedy (ratchet-baseline 6 untracked comply debts, or cross-repo
manifest tooling). Linked from #2891.

