### PR TITLE
probe(09b): u1 append, merge=union (throwaway) (Refs PMAT-1065)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/roadmaps/roadmap.yaml merge=union

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16422,3 +16422,19 @@ roadmap:
   - kind:code
   - pp-066
   notes: null
+- id: PROBE-09B-u1
+  github_issue: null
+  item_type: task
+  title: 'BSE-09b probe u1 — throwaway, never merged to main'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-09-07T00:00:00Z
+  updated: 2026-09-07T00:00:00Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null


### PR DESCRIPTION
BSE-09b probe: two PRs append to roadmap.yaml with .gitattributes merge=union; one merges into a throwaway base; the other's mergeable state is the answer. Deleted after. Pmat-Ticket: PMAT-1065