### PR TITLE
BSE-17: two-tier tests — quick on the PR (touched crates + derived tree-reader targets), full behind it, tree-identity reuse on the queue ref (Refs PMAT-1077)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
     # the worst contended run, and a hang still fails at the step timeout.
     timeout-minutes: 150
     env:
+      # The sccache host directory, named ONCE per job: the machine-specific-path
+      # ratchet counts literals, and the quick-tier steps added two more copies
+      # of a path this job already spelled five times (PMAT-1077).
+      SCCACHE_HOST_DIR: /home/noah/data/sccache
       IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
@@ -384,7 +388,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/home/noah/data/sccache:/sccache" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
@@ -404,7 +408,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/home/noah/data/sccache:/sccache" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
@@ -457,7 +461,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/home/noah/data/sccache:/sccache" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
@@ -485,7 +489,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/home/noah/data/sccache:/sccache" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
@@ -529,7 +533,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/home/noah/data/sccache:/sccache" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
             -e RUSTC_WRAPPER=rustc-sccache \
@@ -1127,6 +1131,11 @@ jobs:
         run: bash scripts/ci_test_tier.sh --self-test
       - name: "Tree-reader registry guard case table (BSE-17)"
         run: bash scripts/check_tree_reader_tests.sh --self-test
+      # The registry is the WIRED half; the unwired half is a ledger of tests
+      # that read the tree and that no lane runs (39 on 2026-09-07, one of them
+      # red on main). Both halves are checked here: drift either way is RED.
+      - name: "Tree-reader registry and unwired ledger agree with the sources (BSE-17)"
+        run: bash scripts/check_tree_reader_tests.sh
       - name: bashrs must see every script in scripts/ (shrink-only)
         run: bash scripts/check_shell_lint_ratchet.sh
       # PMAT-746. The ONLY complexity gate in this repository was the LOCAL pmat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             -e CARGO_TERM_COLOR=never \
             "$IMAGE" \
-            bash -c "cargo nextest run --profile ci --lib --tests $pkgs"
+            bash -c "cargo nextest run --profile ci --lib --tests$pkgs"
       # BSE-17 quick tier, part 2: every test target that reads the tree, from
       # scripts/tree_reader_tests.txt (derived; the guard has already proved the
       # registry equals the sources in this run). Grouped per crate: one cargo
@@ -524,7 +524,7 @@ jobs:
                 "$crate:--test:"*) flags="$flags --test ${t#"$crate:--test:"}" ;;
               esac
             done
-            script="$script cargo test -p $crate$flags &&"
+            script="$script cargo nextest run --profile ci -p $crate$flags &&"
           done
           script="${script% &&}"
           printf '%s\n' "$script" | tr '&' '\n' | grep -v '^$' | sed 's/^/  + /'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,14 +278,29 @@ jobs:
       - name: Create this run's target dir and registry on the host (before any bind mount)
         run: |
           set -euo pipefail
+          # heal_path ROOT PATH: on a merge_group event PR_OR_REF is the queue
+          # ref (gh-readonly-queue/main/pr-N-<sha>), so the per-ref dir is NESTED
+          # and an ancestor may already be root-owned from a build whose bind
+          # mount let the docker daemon create it (#3037's queue build: mkdir
+          # EACCES on .../aprender-ci/gh-readonly-queue/...). Walk every
+          # component from ROOT down; chown each existing unwritable one through
+          # the image (that directory only, never its contents); then mkdir -p.
+          heal_path() {
+            local root=$1 path=$2 cur=$1 rel part
+            rel=${path#"$root"/}
+            IFS=/ read -ra parts <<< "$rel"
+            for part in "${parts[@]}"; do
+              cur="$cur/$part"
+              if [ -d "$cur" ] && [ ! -w "$cur" ]; then
+                docker run --rm -v "$(dirname "$cur"):/p" "$IMAGE" chown "$(id -u):$(id -g)" "/p/$(basename "$cur")"
+              fi
+            done
+            mkdir -p "$path"
+          }
           parent="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
           reg="/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}"
-          for d in "$parent" "$reg"; do
-            if [ -d "$d" ] && [ ! -w "$d" ]; then
-              docker run --rm -v "$(dirname "$d"):/p" "$IMAGE" chown "$(id -u):$(id -g)" "/p/$(basename "$d")"
-            fi
-          done
-          mkdir -p "${parent}/run-${GITHUB_RUN_ID}" "$reg"
+          heal_path /mnt/nvme-raid0/targets/aprender-ci "${parent}/run-${GITHUB_RUN_ID}"
+          heal_path /mnt/nvme-raid0/cargo-ci/registry "$reg"
           ls -ld "$parent" "${parent}/run-${GITHUB_RUN_ID}" "$reg"
       - name: Pre-build chown — fix per-RUN root ownership
         # Root cause (five-whys):
@@ -1001,13 +1016,27 @@ jobs:
           # A root-owned parent (created by the docker daemon for another job's
           # bind mount, #3039) is chowned through the image before the mkdir;
           # that one directory only, never its contents.
-          for d in "$(dirname "$GUARD_TARGET_DIR")" "$(dirname "$GUARD_CARGO_HOME")" "$GUARD_CARGO_HOME"; do
-            if [ -d "$d" ] && [ ! -w "$d" ]; then
-              docker run --rm -v "$(dirname "$d"):/p" "$IMAGE" chown "$(id -u):$(id -g)" "/p/$(basename "$d")"
-            fi
-          done
-          mkdir -p "$GUARD_TARGET_DIR"
-          mkdir -p "$GUARD_CARGO_HOME/registry"
+          # heal_path ROOT PATH: on a merge_group event PR_OR_REF is the queue
+          # ref (gh-readonly-queue/main/pr-N-<sha>), so the per-ref dir is NESTED
+          # and an ancestor may already be root-owned from a build whose bind
+          # mount let the docker daemon create it (#3037's queue build: mkdir
+          # EACCES on .../aprender-ci/gh-readonly-queue/...). Walk every
+          # component from ROOT down; chown each existing unwritable one through
+          # the image (that directory only, never its contents); then mkdir -p.
+          heal_path() {
+            local root=$1 path=$2 cur=$1 rel part
+            rel=${path#"$root"/}
+            IFS=/ read -ra parts <<< "$rel"
+            for part in "${parts[@]}"; do
+              cur="$cur/$part"
+              if [ -d "$cur" ] && [ ! -w "$cur" ]; then
+                docker run --rm -v "$(dirname "$cur"):/p" "$IMAGE" chown "$(id -u):$(id -g)" "/p/$(basename "$cur")"
+              fi
+            done
+            mkdir -p "$path"
+          }
+          heal_path /mnt/nvme-raid0/targets/aprender-ci "$GUARD_TARGET_DIR"
+          heal_path /mnt/nvme-raid0/cargo-ci/home "$GUARD_CARGO_HOME/registry"
           printf 'target dir: %s\n' "$GUARD_TARGET_DIR"
           printf 'cargo home: %s (registry/ .package-cache .package-cache-mutate travel together)\n' "$GUARD_CARGO_HOME"
       # Poka-yoke: a beat that no workflow executes reads as enforcement, is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,46 @@ jobs:
             -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
+      # BSE-17 (PMAT-1077): which tier this run owes. quick on pull_request —
+      # the touched crates + direct reverse dependents (BSE-16's selection, cap
+      # -> full) plus EVERY test target that reads the tree, derived and
+      # registry-checked (drift is ENV, never a quick tier over a stale list);
+      # full on push/schedule/dispatch and on a merge_group whose tree is not
+      # the tree a green PR head already ran; reuse on a merge_group whose
+      # HEAD^{tree} equals the PR head's and whose workspace-test succeeded.
+      # The touched set is the TIP diff against the base (shallow checkout: no
+      # merge-base; tip-vs-tip is a superset, the safe direction) and the diff
+      # command itself must succeed — an empty diff from a failed git would
+      # read as "nothing touched", the fail-open shape. Feature-gated suites
+      # (model-tests, setfit) stay in the full tier.
+      - name: Decide the test tier (BSE-17, PMAT-1077)
+        id: tier
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          args=(--event "${GITHUB_EVENT_NAME}")
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              git fetch --no-tags --depth=1 origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+              git diff --name-only "origin/${GITHUB_BASE_REF}" HEAD > "$RUNNER_TEMP/touched.txt"
+              printf 'touched (tip vs tip): %s path(s)\n' "$(wc -l < "$RUNNER_TEMP/touched.txt" | tr -d ' ')"
+              args+=(--diff-from "$RUNNER_TEMP/touched.txt")
+              ;;
+            merge_group)
+              pr=$(printf '%s' "${GITHUB_REF_NAME}" | sed -n 's|^gh-readonly-queue/[^/]*/pr-\([0-9]*\)-.*|\1|p')
+              if [ -n "$pr" ]; then
+                head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .head.sha)
+                git fetch --no-tags --depth=1 origin "$head"
+                concl=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head}/check-runs?check_name=workspace-test&per_page=20" --jq '[.check_runs[]|select(.status=="completed")]|sort_by(.completed_at)|last|.conclusion // "none"')
+                args+=(--pr-head "$head" --pr-head-conclusion "${concl:-none}")
+              fi
+              ;;
+          esac
+          bash scripts/ci_test_tier.sh "${args[@]}" | tee "$RUNNER_TEMP/tier.txt"
+          grep -E '^(tier|crates|targets|reason|cite)=' "$RUNNER_TEMP/tier.txt" >> "$GITHUB_OUTPUT"
       - name: Workspace lib tests (25,300+)
+        if: steps.tier.outputs.tier == 'full'
         # Excluded: aprender-gpu (cuBLAS), aprender-cuda-edge (CUDA), aprender-compute (SIMD SIGSEGV at exit)
         # Timeout: 75min (was 55, was 40).
         # 2026-05-15: bumped to 75min after the P0 per-run target-dir fix
@@ -358,6 +397,7 @@ jobs:
             "$IMAGE" \
             cargo nextest run --profile ci --workspace --lib --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
       - name: Compute tests (tolerate SIGSEGV at exit — all tests pass but harness crashes on cleanup)
+        if: steps.tier.outputs.tier == 'full'
         run: |
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
@@ -375,6 +415,7 @@ jobs:
             "$IMAGE" \
             bash -c 'cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q "test result: ok\." /tmp/compute-test.log && ! grep -q "test result: FAILED" /tmp/compute-test.log'
       - name: Integration tests
+        if: steps.tier.outputs.tier == 'full'
         # #2465: the four FALSIFY-AUTH targets were appended here because they
         # were DARK — `falsify_auth_002` appeared nowhere in .github/, scripts/
         # or Makefile, and neither did the contract loader
@@ -426,6 +467,90 @@ jobs:
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
             bash -c 'cargo test -p aprender-core --features setfit --lib setfit && cargo test -p aprender-core --features setfit,conformance-fixtures --test setfit_conformance && cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo test -p aprender-contracts-cli --test pv_surface_gate && cargo test -p aprender-contracts-cli --test cli_integration && cargo test -p aprender-contracts-cli --test ground_truth && cargo test -p aprender-contracts-cli --test version_identity && cargo build --examples --workspace --keep-going && cargo check --workspace --benches --locked'
+      # BSE-17 quick tier, part 1: the selected crates' unit and integration
+      # targets (default features) under the same image and mounts as the full
+      # tier. Empty selection (a scripts/docs PR) skips this step; part 2 still runs.
+      - name: "Quick tier: lib + integration tests of the selected crates (BSE-17)"
+        if: steps.tier.outputs.tier == 'quick' && steps.tier.outputs.crates != ''
+        timeout-minutes: 60
+        env:
+          CRATES: ${{ steps.tier.outputs.crates }}
+        run: |
+          set -euo pipefail
+          read -ra crates <<< "$CRATES"
+          pkgs=""; for c in "${crates[@]}"; do pkgs="$pkgs -p $c"; done
+          printf 'quick tier crates: %s\n' "$CRATES"
+          docker run --rm \
+          -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/home/noah/data/sccache:/sccache" \
+            -w /workspace \
+            -e CARGO_TARGET_DIR=/workspace/target \
+            -e RUSTC_WRAPPER=rustc-sccache \
+            -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
+            -e CARGO_INCREMENTAL=0 \
+            -e CARGO_BUILD_JOBS=8 \
+            -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
+            -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
+            -e CARGO_TERM_COLOR=never \
+            "$IMAGE" \
+            bash -c "cargo nextest run --profile ci --lib --tests $pkgs"
+      # BSE-17 quick tier, part 2: every test target that reads the tree, from
+      # scripts/tree_reader_tests.txt (derived; the guard has already proved the
+      # registry equals the sources in this run). Grouped per crate: one cargo
+      # invocation per crate, --lib and/or its --test targets.
+      - name: "Quick tier: every test target that reads the tree (BSE-17)"
+        if: steps.tier.outputs.tier == 'quick'
+        timeout-minutes: 60
+        env:
+          TARGETS: ${{ steps.tier.outputs.targets }}
+        run: |
+          set -euo pipefail
+          read -ra targets <<< "$TARGETS"
+          printf 'tree-reader targets: %s\n' "${#targets[@]}"
+          script=""
+          for crate in $(printf '%s\n' "${targets[@]}" | cut -d: -f1 | sort -u); do
+            flags=""
+            for t in "${targets[@]}"; do
+              case "$t" in
+                "$crate:--lib") flags="$flags --lib" ;;
+                "$crate:--test:"*) flags="$flags --test ${t#"$crate:--test:"}" ;;
+              esac
+            done
+            script="$script cargo test -p $crate$flags &&"
+          done
+          script="${script% &&}"
+          printf '%s\n' "$script" | tr '&' '\n' | grep -v '^$' | sed 's/^/  + /'
+          docker run --rm \
+          -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/home/noah/data/sccache:/sccache" \
+            -w /workspace \
+            -e CARGO_TARGET_DIR=/workspace/target \
+            -e RUSTC_WRAPPER=rustc-sccache \
+            -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
+            -e CARGO_INCREMENTAL=0 \
+            -e CARGO_BUILD_JOBS=8 \
+            -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
+            -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
+            -e CARGO_TERM_COLOR=never \
+            "$IMAGE" \
+            bash -c "set -e; $script"
+      # BSE-17 reuse: the queue ref's tree is byte-identical to a PR head whose
+      # workspace-test already succeeded; measuring it again is waste, not
+      # evidence. The tier step proved both facts (trees compared by hash, the
+      # check-run's conclusion read from GitHub); this step records the citation.
+      - name: "Reuse: this tree already passed workspace-test on the PR head (BSE-17)"
+        if: steps.tier.outputs.tier == 'reuse'
+        run: |
+          printf 'workspace-test REUSED: %s\n' "${{ steps.tier.outputs.reason }}"
+          printf 'cited PR head: %s\n' "${{ steps.tier.outputs.cite }}"
       - name: Build.rs crate-root escape check (v0.31.1 yank guard)
         # Static Poka-Yoke: flags build.rs files that panic on files outside
         # CARGO_MANIFEST_DIR, which break `cargo install` from crates.io.
@@ -996,6 +1121,12 @@ jobs:
       # parse shell. Ratcheted rather than fixed: turning the glob on outright
       # surfaces ~851 diagnostics, most of them bashrs false positives on
       # hand-written bash, and a gate that cannot go green gets disabled.
+      # BSE-17 (PMAT-1077): the tier decision's case table and the tree-reader
+      # registry guard's, both polarities; cargo metadata is needed, so here.
+      - name: "Test-tier decision case table (BSE-17): quick/full/reuse, drift is ENV"
+        run: bash scripts/ci_test_tier.sh --self-test
+      - name: "Tree-reader registry guard case table (BSE-17)"
+        run: bash scripts/check_tree_reader_tests.sh --self-test
       - name: bashrs must see every script in scripts/ (shrink-only)
         run: bash scripts/check_shell_lint_ratchet.sh
       # PMAT-746. The ONLY complexity gate in this repository was the LOCAL pmat

--- a/crates/aprender-train/src/prune/snapshot_tests.rs
+++ b/crates/aprender-train/src/prune/snapshot_tests.rs
@@ -7,6 +7,15 @@
 //! - Metrics computation consistency
 
 #[cfg(test)]
+// BSE-17 (PMAT-1077): every assertion below sorts map keys. The snapshots had
+// been recorded with maps in insertion order, an ordering this crate gets only
+// when a SIBLING enables serde_json/preserve_order and the build unifies
+// features workspace-wide (`cargo test --workspace`); built alone (`-p`) the
+// maps came out sorted and three snapshots failed. Declaring the feature here
+// was tried and reverted: aprender-core depends on this crate, so the flag
+// leaked into core and flipped the setfit artifact golden hash. Sorting at the
+// assertion makes the snapshot a function of the value, not of who else is
+// being built.
 mod tests {
     use crate::prune::{
         CalibrationConfig, PruneMethod, PruningConfig, PruningMetrics, PruningSchedule,
@@ -22,7 +31,7 @@ mod tests {
         // TEST_ID: SNAP-001
         // Snapshot test for OneShot schedule JSON serialization
         let schedule = PruningSchedule::OneShot { step: 1000 };
-        insta::assert_json_snapshot!("oneshot_schedule", schedule);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("oneshot_schedule", schedule); });
     }
 
     #[test]
@@ -36,7 +45,7 @@ mod tests {
             final_sparsity: 0.5,
             frequency: 100,
         };
-        insta::assert_json_snapshot!("gradual_schedule", schedule);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("gradual_schedule", schedule); });
     }
 
     #[test]
@@ -45,7 +54,7 @@ mod tests {
         // Snapshot test for Cubic schedule JSON serialization
         let schedule =
             PruningSchedule::Cubic { start_step: 0, end_step: 10000, final_sparsity: 0.7 };
-        insta::assert_json_snapshot!("cubic_schedule", schedule);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("cubic_schedule", schedule); });
     }
 
     #[test]
@@ -63,7 +72,7 @@ mod tests {
         let progression: Vec<(usize, f32)> =
             (0..=100).step_by(10).map(|step| (step, schedule.sparsity_at_step(step))).collect();
 
-        insta::assert_json_snapshot!("gradual_sparsity_progression", progression);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("gradual_sparsity_progression", progression); });
     }
 
     #[test]
@@ -75,7 +84,7 @@ mod tests {
         let progression: Vec<(usize, f32)> =
             (0..=100).step_by(10).map(|step| (step, schedule.sparsity_at_step(step))).collect();
 
-        insta::assert_json_snapshot!("cubic_sparsity_progression", progression);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("cubic_sparsity_progression", progression); });
     }
 
     // =========================================================================
@@ -87,7 +96,7 @@ mod tests {
         // TEST_ID: SNAP-010
         // Snapshot default PruningConfig to detect breaking changes
         let config = PruningConfig::default();
-        insta::assert_json_snapshot!("default_pruning_config", config);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("default_pruning_config", config); });
     }
 
     #[test]
@@ -105,7 +114,7 @@ mod tests {
                 final_sparsity: 0.5,
                 frequency: 100,
             });
-        insta::assert_json_snapshot!("wanda_config", config);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("wanda_config", config); });
     }
 
     #[test]
@@ -118,7 +127,7 @@ mod tests {
             .with_pattern(SparsityPatternConfig::Unstructured)
             .with_fine_tune(true)
             .with_fine_tune_steps(2000);
-        insta::assert_json_snapshot!("sparsegpt_config", config);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("sparsegpt_config", config); });
     }
 
     #[test]
@@ -133,7 +142,7 @@ mod tests {
             ("row", SparsityPatternConfig::Row),
             ("column", SparsityPatternConfig::Column),
         ];
-        insta::assert_json_snapshot!("all_sparsity_patterns", patterns);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("all_sparsity_patterns", patterns); });
     }
 
     #[test]
@@ -159,7 +168,7 @@ mod tests {
             })
             .collect();
 
-        insta::assert_json_snapshot!("all_prune_methods", method_info);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("all_prune_methods", method_info); });
     }
 
     // =========================================================================
@@ -193,7 +202,7 @@ mod tests {
             })
             .collect();
 
-        insta::assert_json_snapshot!("pipeline_stages", stage_info);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("pipeline_stages", stage_info); });
     }
 
     #[test]
@@ -201,7 +210,7 @@ mod tests {
         // TEST_ID: SNAP-021
         // Snapshot initial metrics state
         let metrics = PruningMetrics::new(0.5);
-        insta::assert_json_snapshot!("initial_metrics", metrics);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("initial_metrics", metrics); });
     }
 
     #[test]
@@ -215,7 +224,7 @@ mod tests {
         metrics.add_layer_sparsity("layer1", 0.25);
         metrics.add_layer_sparsity("layer2", 0.25);
         metrics.add_layer_sparsity("layer3", 0.30);
-        insta::assert_json_snapshot!("metrics_with_sparsity", metrics);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("metrics_with_sparsity", metrics); });
     }
 
     // =========================================================================
@@ -227,7 +236,7 @@ mod tests {
         // TEST_ID: SNAP-030
         // Snapshot default calibration configuration
         let config = CalibrationConfig::default();
-        insta::assert_json_snapshot!("calibration_config_default", config);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("calibration_config_default", config); });
     }
 
     #[test]
@@ -238,7 +247,7 @@ mod tests {
             .with_num_samples(1024)
             .with_batch_size(16)
             .with_sequence_length(4096);
-        insta::assert_json_snapshot!("calibration_config_custom", config);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("calibration_config_custom", config); });
     }
 
     // =========================================================================
@@ -300,7 +309,7 @@ mod tests {
             })
             .collect();
 
-        insta::assert_json_snapshot!("schedule_validation_errors", errors);
+        insta::with_settings!({ sort_maps => true }, { insta::assert_json_snapshot!("schedule_validation_errors", errors); });
     }
 
     // =========================================================================

--- a/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__all_prune_methods.snap
+++ b/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__all_prune_methods.snap
@@ -4,28 +4,28 @@ expression: method_info
 ---
 [
   {
-    "name": "magnitude",
     "display_name": "Magnitude",
+    "name": "magnitude",
     "requires_calibration": false
   },
   {
-    "name": "wanda",
     "display_name": "Wanda",
+    "name": "wanda",
     "requires_calibration": true
   },
   {
-    "name": "sparsegpt",
     "display_name": "SparseGPT",
+    "name": "sparsegpt",
     "requires_calibration": true
   },
   {
-    "name": "minitron_depth",
     "display_name": "Minitron (Depth)",
+    "name": "minitron_depth",
     "requires_calibration": true
   },
   {
-    "name": "minitron_width",
     "display_name": "Minitron (Width)",
+    "name": "minitron_width",
     "requires_calibration": true
   }
 ]

--- a/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__pipeline_stages.snap
+++ b/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__pipeline_stages.snap
@@ -4,48 +4,48 @@ expression: stage_info
 ---
 [
   {
-    "name": "Idle",
     "is_active": false,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Idle"
   },
   {
-    "name": "Calibrating",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Calibrating"
   },
   {
-    "name": "Computing Importance",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Computing Importance"
   },
   {
-    "name": "Pruning",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Pruning"
   },
   {
-    "name": "Fine-Tuning",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Fine-Tuning"
   },
   {
-    "name": "Evaluating",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Evaluating"
   },
   {
-    "name": "Exporting",
     "is_active": true,
-    "is_terminal": false
+    "is_terminal": false,
+    "name": "Exporting"
   },
   {
-    "name": "Complete",
     "is_active": false,
-    "is_terminal": true
+    "is_terminal": true,
+    "name": "Complete"
   },
   {
-    "name": "Failed",
     "is_active": false,
-    "is_terminal": true
+    "is_terminal": true,
+    "name": "Failed"
   }
 ]

--- a/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__schedule_validation_errors.snap
+++ b/crates/aprender-train/src/prune/snapshots/entrenar__prune__snapshot_tests__tests__schedule_validation_errors.snap
@@ -4,23 +4,23 @@ expression: errors
 ---
 [
   {
-    "name": "gradual_end_before_start",
-    "error": "end_step (50) must be greater than start_step (100)"
+    "error": "end_step (50) must be greater than start_step (100)",
+    "name": "gradual_end_before_start"
   },
   {
-    "name": "gradual_negative_initial",
-    "error": "initial_sparsity (-0.1) must be between 0.0 and 1.0"
+    "error": "initial_sparsity (-0.1) must be between 0.0 and 1.0",
+    "name": "gradual_negative_initial"
   },
   {
-    "name": "gradual_final_over_one",
-    "error": "final_sparsity (1.5) must be between 0.0 and 1.0"
+    "error": "final_sparsity (1.5) must be between 0.0 and 1.0",
+    "name": "gradual_final_over_one"
   },
   {
-    "name": "cubic_end_before_start",
-    "error": "end_step (50) must be greater than start_step (100)"
+    "error": "end_step (50) must be greater than start_step (100)",
+    "name": "cubic_end_before_start"
   },
   {
-    "name": "cubic_negative_sparsity",
-    "error": "final_sparsity (-0.1) must be between 0.0 and 1.0"
+    "error": "final_sparsity (-0.1) must be between 0.0 and 1.0",
+    "name": "cubic_negative_sparsity"
   }
 ]

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16599,3 +16599,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-1077
+  github_issue: null
+  item_type: task
+  title: 'BSE-17 two-tier tests: quick on pull_request (touched crates + reverse dependents + derived tree-reader targets), full on push-to-main/merge_group/nightly/pre-release; tree-identity reuse on the queue ref'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-07T15:00:58Z
+  updated: 2026-09-07T15:00:58Z
+  spec: null
+  acceptance_criteria:
+  - 'Ruling 2026-09-07 (Noah): ''quick test for aprender PR, then full test pre-release — implement ASAP''. Measured 2026-09-07: 22 workspace-test jobs in 33 CI runs, 8 green at 95 min avg, 6 cancelled by a newer push, 4 merge-queue rebuilds of a tree byte-identical to the PR head; both PR-B workspace-test reds came from tree-reader tests (contracts baseline reader, readme_contract.rs) that a crate selection alone would have skipped. Quick tier = gate_touched_crates.sh selection (cap -> full) + every test target that reads the tree, DERIVED by scripts/check_tree_reader_tests.sh from the test sources (include_str!, fs::read*, Path::new, project_root/workspace_root, CARGO_MANIFEST_DIR) into scripts/tree_reader_tests.txt and diffed on every run. Full tier unchanged on push to main, merge_group, workflow_dispatch, nightly, pre-release. Queue ref: when HEAD^{tree} equals the PR head''s tree and that head''s workspace-test check-run succeeded, the job cites it and skips the suite; any doubt runs it.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/scripts/check_baseline_ratchets.sh
+++ b/scripts/check_baseline_ratchets.sh
@@ -99,6 +99,11 @@ classify() { # classify <basename> -> "<kind>[<TAB>reason]", rc 1 if unclassifie
         # and the set grows whenever someone writes a test that reads the tree.
         # Freezing it against main would forbid adding such a test; the guard
         # that owns it already fails in both directions (BSE-17, PMAT-1077).
+        # The UNWIRED half: tree-reader targets no workflow runs. Same kind of
+        # file, same reason it is not a ratchet — it is an exact match against
+        # the sources, and drift FAILS in both directions in its own guard.
+        tree_reader_unwired_baseline.txt)
+            printf 'none\tderived ledger of tree-reader targets no lane runs (exact-match against the sources, scripts/check_tree_reader_tests.sh)\n' ;;
         tree_reader_tests.txt)
             printf 'none	derived registry, exact-match against the sources (drift FAILS both ways, scripts/check_tree_reader_tests.sh)
 ' ;;

--- a/scripts/check_baseline_ratchets.sh
+++ b/scripts/check_baseline_ratchets.sh
@@ -92,6 +92,16 @@ classify() { # classify <basename> -> "<kind>[<TAB>reason]", rc 1 if unclassifie
         test_fixture_path_baseline.txt)          printf 'count\n' ;;
         tracked_ignored_baseline.txt)            printf 'count\n' ;;
         unwired_guards_baseline.txt)             printf 'set\n' ;;
+        # NOT a ratchet either, and for the same reason one level along: this
+        # registry is DERIVED from the test sources on every run
+        # (scripts/check_tree_reader_tests.sh) and must equal that derivation
+        # EXACTLY — a stale line FAILS as drift, a missing one FAILS as drift,
+        # and the set grows whenever someone writes a test that reads the tree.
+        # Freezing it against main would forbid adding such a test; the guard
+        # that owns it already fails in both directions (BSE-17, PMAT-1077).
+        tree_reader_tests.txt)
+            printf 'none	derived registry, exact-match against the sources (drift FAILS both ways, scripts/check_tree_reader_tests.sh)
+' ;;
         # NOT a ratchet, and deliberately so. This file MODELS INTENT: its own
         # header says the declared set must match the OBSERVED set EXACTLY, an
         # entry whose duplicate no longer exists FAILS as stale, and adding a

--- a/scripts/check_tree_reader_tests.sh
+++ b/scripts/check_tree_reader_tests.sh
@@ -45,9 +45,72 @@ derive() { # derive <repo root> -> sorted "crate\t--test\tname" / "crate\t--lib"
             grep -q '#\[cfg(test)\]' "$f" || continue
             grep -qE "$ORACLE" "$f" || continue
             c=$(printf '%s' "$f" | sed "s|^$root/crates/||; s|/.*||")
-            printf '%s\t--lib\n' "$c"
+            # `--lib` on a crate with NO library target is a hard error, never a
+            # passable gate: `error: no library targets found in package X`.
+            # aprender-compute-xtask is bin-only and its src carries a cfg(test)
+            # reader, so the first quick-tier trial died on it (2026-09-07).
+            # cohete shipped this exact shape as a pre-push hook and every push
+            # then used --no-verify. The target follows the crate.
+            if [ -f "$root/crates/$c/src/lib.rs" ]; then
+                printf '%s\t--lib\n' "$c"
+            else
+                printf '%s\t--bins\n' "$c"
+            fi
         done
     ) | LC_ALL=C sort -u
+}
+
+
+# WIRED vs UNWIRED (BSE-17, measured 2026-09-07).
+#
+# A tree-reader target belongs in the QUICK TIER only if CI runs it somewhere.
+# The first run of this tier ran `apr-cli --test pixel_regression`, which NO
+# workflow runs and which fails on main (4 of 6 pixel tests red, golden
+# snapshots that no lane has compared in months). A quick tier stricter than
+# the full tier is a gate that cannot pass, and this repository has one of
+# those on the record already (cohete's pre-push).
+#
+# So the derived set is SPLIT by an oracle, never a hand list:
+#   * `--lib`  — wired: the full tier runs `cargo nextest run --workspace --lib`
+#                and the excluded crates have their own named steps.
+#   * `--test NAME` — wired iff some file under .github/workflows/ names
+#                `--test NAME`.
+# Unwired targets go to the ledger below and are NOT in the quick tier. The
+# ledger is shrink-only in the sense that matters: a new unwired reader FAILS
+# (write the test into a lane, or ledger it deliberately), and a ledger line
+# that has since been wired FAILS too (delete it). "Reads the tree and nothing
+# runs it" is itself a finding — 36 of 80 targets on the day this was written.
+UNWIRED_LEDGER_DEFAULT="scripts/tree_reader_unwired_baseline.txt"
+
+wired_targets() { # wired_targets <root> -- the derived set, wired half only
+    local root=$1 line c kind name
+    derive "$root" | while IFS=$'\t' read -r c kind name; do
+        if [ "$kind" = "--lib" ] || [ "$kind" = "--bins" ]; then
+            printf '%s\t%s\n' "$c" "$kind"
+        elif grep -rqF -- "--test $name" "$root"/.github/workflows/ 2>/dev/null; then
+            printf '%s\t--test\t%s\n' "$c" "$name"
+        fi
+    done
+}
+
+unwired_targets() { # unwired_targets <root> -- reads the tree, no lane runs it
+    local root=$1 c kind name
+    derive "$root" | while IFS=$'\t' read -r c kind name; do
+        [ "$kind" = "--test" ] || continue
+        grep -rqF -- "--test $name" "$root"/.github/workflows/ 2>/dev/null || printf '%s\t--test\t%s\n' "$c" "$name"
+    done
+}
+
+check_unwired() { # check_unwired <root> <ledger> -> 0 same, 1 drift, 2 env
+    local root=$1 ledger=$2 want have
+    [ -f "$ledger" ] || { printf 'ENV   %s missing — run --update to derive it\n' "$ledger"; return 2; }
+    want=$(unwired_targets "$root"); have=$(registry_body "$ledger")
+    if [ "$want" != "$have" ]; then
+        printf 'FAIL  %s drifted (<: ledgered but now wired — delete the line, >: new unwired tree-reader — wire it into a lane or ledger it):\n' "$ledger"
+        diff <(printf '%s\n' "$have") <(printf '%s\n' "$want") | grep '^[<>]' | sed 's/^/        /' | head -30
+        return 1
+    fi
+    printf 'PASS  %s: %s tree-reader target(s) that no workflow runs\n' "$ledger" "$(printf '%s\n' "$want" | grep -c .)"
 }
 
 registry_body() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | LC_ALL=C sort -u; }
@@ -55,7 +118,7 @@ registry_body() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | LC_ALL=C sort -
 check() { # check <root> <registry> -> 0 same, 1 drift, 2 env
     local root=$1 reg=$2 want have
     [ -f "$reg" ] || { printf 'ENV   %s missing — run --update to derive it; the quick tier refuses to run without it\n' "$reg"; return 2; }
-    want=$(derive "$root"); have=$(registry_body "$reg")
+    want=$(wired_targets "$root"); have=$(registry_body "$reg")
     [ -n "$want" ] || { printf 'FAIL  the oracle derived ZERO tree-reader targets under %s — a detector that finds nothing over a real tree is broken, not a pass\n' "$root"; return 1; }
     if [ "$want" != "$have" ]; then
         printf 'FAIL  %s drifted from the sources (<: registry only, >: derived only):\n' "$reg"
@@ -70,7 +133,7 @@ update() { # update <root> <registry>
     local root=$1 reg=$2
     { printf '# tool_version=none (derived by scripts/check_tree_reader_tests.sh from the test sources; regenerate with --update, never edit)\n'
       printf '# crate<TAB>--test<TAB>name | crate<TAB>--lib — every test target that reads the tree (BSE-17); the quick tier always runs these\n'
-      derive "$root"; } > "$reg"
+      wired_targets "$root"; } > "$reg"
     printf 'ok    wrote %s (%s target(s))\n' "$reg" "$(registry_body "$reg" | wc -l | tr -d ' ')"
 }
 
@@ -95,15 +158,39 @@ self_test() {
     row 0 "derive: alpha reads_readme (README path), beta --lib (cfg(test) + scripts/ path), gamma manifest_dir (CARGO_MANIFEST_DIR); NOT alpha pure, NOT gamma --lib (reader without cfg(test))" \
         '^alpha	--test	reads_readme$' bash -c "$(declare -f derive); derive '$td'"
     out=$(derive "$td") || true; printf '%s\n' "$out" | grep -q '^beta	--lib$' && printf '%s\n' "$out" | grep -q '^gamma	--test	manifest_dir$' && ! printf '%s\n' "$out" | grep -q 'pure' && ! printf '%s\n' "$out" | grep -q '^gamma	--lib$' && printf 'ok    row %-2s        derived set is exactly {alpha reads_readme, beta --lib, gamma manifest_dir}\n' "$((n + 1))" || { printf 'FAIL  row %-2s        derived set wrong:\n%s\n' "$((n + 1))" "$out"; red=1; }; n=$((n + 1))
+    # delta: a crate with a cfg(test) reader and NO src/lib.rs is bin-only, so
+    # the target is --bins. `--lib` there is `error: no library targets found`
+    # — a gate that cannot pass, which is how cohete's pre-push trained
+    # --no-verify on every push.
+    mkdir -p "$td/crates/delta/src"
+    printf 'fn main() {}\n#[cfg(test)]\nmod tests { #[test] fn t() { let _ = std::fs::read_to_string("scripts/d.txt"); } }\n' > "$td/crates/delta/src/main.rs"
+    n=$((n + 1))
+    if derive "$td" | grep -q '^delta	--bins$' && ! derive "$td" | grep -q '^delta	--lib$'; then
+        printf 'ok    row %-2s        a bin-only crate (cfg(test) reader, no src/lib.rs) is --bins, never --lib\n' "$n"
+    else
+        printf 'FAIL  row %-2s        bin-only crate mis-targeted: %s\n' "$n" "$(derive "$td" | grep '^delta' | tr '\n' ';')"; red=1
+    fi
+    # A workflow that names one target, so the wired/unwired split is exercised
+    # rather than assumed: alpha reads_readme is run by a lane, gamma manifest_dir
+    # is not, beta --lib is covered by the full tier's --workspace --lib.
+    mkdir -p "$td/.github/workflows"
+    printf 'jobs:\n  t:\n    steps:\n      - run: cargo test -p alpha --test reads_readme\n' > "$td/.github/workflows/ci.yml"
+    n=$((n + 1))
+    w=$(wired_targets "$td"); u=$(unwired_targets "$td")
+    if printf '%s\n' "$w" | grep -q '^alpha	test' 2>/dev/null || printf '%s\n' "$w" | grep -q '^alpha' && printf '%s\n' "$w" | grep -q '^beta	--lib$' && printf '%s\n' "$u" | grep -q '^gamma' && ! printf '%s\n' "$u" | grep -q '^alpha'; then
+        printf 'ok    row %-2s        WIRED/UNWIRED split: a lane names alpha reads_readme (quick tier), gamma manifest_dir is run by nothing (ledger), beta --lib is covered by --workspace --lib\n' "$n"
+    else
+        printf 'FAIL  row %-2s        split wrong. wired=[%s] unwired=[%s]\n' "$n" "$(printf '%s' "$w" | tr '\n' ';')" "$(printf '%s' "$u" | tr '\n' ';')"; red=1
+    fi
     update "$td" "$td/registry.txt" > /dev/null
-    row 0 "registry equals derived -> PASS" '^PASS' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
+    row 0 "registry equals derived -> PASS" '^PASS' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
     printf 'zeta\t--lib\n' >> "$td/registry.txt"
-    row 1 "a stale registry line -> RED (drift, registry only)" '^FAIL .*drifted' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
+    row 1 "a stale registry line -> RED (drift, registry only)" '^FAIL .*drifted' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
     update "$td" "$td/registry.txt" > /dev/null; sed -i '/^beta/d' "$td/registry.txt"
-    row 1 "a missing registry line -> RED (drift, derived only)" '> beta' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
-    row 2 "registry file absent -> ENV (exit 2), never a pass" '^ENV' bash -c "$(declare -f derive registry_body check); check '$td' '$td/absent.txt'"
+    row 1 "a missing registry line -> RED (drift, derived only)" '> beta' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
+    row 2 "registry file absent -> ENV (exit 2), never a pass" '^ENV' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/absent.txt'"
     mkdir -p "$td/empty/crates/x/tests"; printf '#[test] fn t() {}\n' > "$td/empty/crates/x/tests/t.rs"; printf '# h\n' > "$td/empty/reg.txt"
-    row 1 "a tree with ZERO readers -> RED (vacuity), never a pass" 'derived ZERO' bash -c "$(declare -f derive registry_body check); check '$td/empty' '$td/empty/reg.txt'"
+    row 1 "a tree with ZERO readers -> RED (vacuity), never a pass" 'derived ZERO' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td/empty' '$td/empty/reg.txt'"
     # MUTANT: drop the scripts/ pattern from the oracle -> beta --lib vanishes from the derived set (the falsifier discriminates)
     row 0 "mutant oracle without the scripts/ pattern loses beta --lib — this row proves the oracle is load-bearing" 'MUTANT-LOST-BETA' bash -c "ORACLE=$(printf %q "${ORACLE/\"scripts\/|/}"); $(declare -f derive); if derive '$td' | grep -q '^beta'; then echo MUTANT-KEPT-BETA; else echo MUTANT-LOST-BETA; fi"
     printf '\n%s checks, %s failed\n' "$n" "$red"
@@ -112,8 +199,9 @@ self_test() {
 
 case "${1:-}" in
     --self-test) self_test ;;
-    --print) derive "${2:-.}" ;;
-    --update) update "${2:-.}" "${3:-$REGISTRY_DEFAULT}" ;;
-    "") check . "$REGISTRY_DEFAULT" ;;
+    --print) wired_targets "${2:-.}" ;;
+    --print-unwired) unwired_targets "${2:-.}" ;;
+    --update) update "${2:-.}" "${3:-$REGISTRY_DEFAULT}"; { printf '# tool_version=none (derived by scripts/check_tree_reader_tests.sh --print-unwired; regenerate with --update, never edit)\n'; printf '# Test targets that READ THE TREE and that no workflow runs. Not in the quick\n# tier (it must never be stricter than the full tier), and each line is a\n# finding: a test nothing executes (BSE-17, PMAT-1077).\n'; unwired_targets "${2:-.}"; } > "${4:-$UNWIRED_LEDGER_DEFAULT}"; printf 'ok    wrote %s (%s unwired target(s))\n' "${4:-$UNWIRED_LEDGER_DEFAULT}" "$(unwired_targets "${2:-.}" | grep -c .)" ;;
+    "") check . "$REGISTRY_DEFAULT" && check_unwired . "$UNWIRED_LEDGER_DEFAULT" ;;
     *) printf 'usage: %s [--print [ROOT] | --update [ROOT [REGISTRY]] | --self-test]\n' "$0" >&2; exit 2 ;;
 esac

--- a/scripts/check_tree_reader_tests.sh
+++ b/scripts/check_tree_reader_tests.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# check_tree_reader_tests.sh — the test targets that READ THE TREE (BSE-17,
+# PMAT-1077): derived from the sources, never hand-listed.
+#
+# WHY. On 2026-09-07 both of PR #3039's workspace-test reds came from Rust
+# tests that read files outside any crate: aprender-contracts' baseline reader
+# (a lib unit test reading scripts/contract_test_binding_baseline.txt) and
+# aprender-core's readme_contract.rs (reading README.md). Neither PR touched
+# those crates. A quick test tier selected by touched crate alone would have
+# run nothing and passed. So the quick tier always runs these targets, and the
+# set is DERIVED here from an oracle over the test sources and diffed against
+# the committed registry on every run — a registry maintained by hand is the
+# two-lists defect (bashrs#266's root cause).
+#
+# ORACLE. A test target reads the tree when its source names a path INTO the
+# repository or resolves one from the manifest dir:
+#   "scripts/  "docs/  "README  "contracts/  "../../  "../..
+#   CARGO_MANIFEST_DIR  workspace_root(  project_root(
+# Integration targets: crates/<c>/tests/<t>.rs -> `<c> --test <t>`.
+# Lib targets: any crates/<c>/src/**/*.rs that contains `#[cfg(test)]` AND the
+# oracle -> `<c> --lib`. Fixture-only readers (tests/fixtures/...) are not
+# excluded: an extra target costs seconds, a missing one costs a red main.
+#
+# Usage:
+#   scripts/check_tree_reader_tests.sh            # derive, diff vs registry; exit 1 on drift
+#   scripts/check_tree_reader_tests.sh --print    # print the derived set
+#   scripts/check_tree_reader_tests.sh --update   # rewrite the registry
+#   scripts/check_tree_reader_tests.sh --self-test
+set -euo pipefail
+
+ORACLE='"scripts/|"docs/|"README|"contracts/|"\.\./\.\./|"\.\./\.\.|CARGO_MANIFEST_DIR|workspace_root\(|project_root\('
+REGISTRY_DEFAULT="scripts/tree_reader_tests.txt"
+export ORACLE
+
+derive() { # derive <repo root> -> sorted "crate\t--test\tname" / "crate\t--lib" lines
+    local root=$1 f c t
+    (
+        for f in "$root"/crates/*/tests/*.rs; do
+            [ -f "$f" ] || continue
+            grep -qE "$ORACLE" "$f" || continue
+            c=$(basename "$(dirname "$(dirname "$f")")"); t=$(basename "$f" .rs)
+            printf '%s\t--test\t%s\n' "$c" "$t"
+        done
+        for f in $(find "$root"/crates/*/src -name '*.rs' 2>/dev/null); do
+            grep -q '#\[cfg(test)\]' "$f" || continue
+            grep -qE "$ORACLE" "$f" || continue
+            c=$(printf '%s' "$f" | sed "s|^$root/crates/||; s|/.*||")
+            printf '%s\t--lib\n' "$c"
+        done
+    ) | LC_ALL=C sort -u
+}
+
+registry_body() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | LC_ALL=C sort -u; }
+
+check() { # check <root> <registry> -> 0 same, 1 drift, 2 env
+    local root=$1 reg=$2 want have
+    [ -f "$reg" ] || { printf 'ENV   %s missing — run --update to derive it; the quick tier refuses to run without it\n' "$reg"; return 2; }
+    want=$(derive "$root"); have=$(registry_body "$reg")
+    [ -n "$want" ] || { printf 'FAIL  the oracle derived ZERO tree-reader targets under %s — a detector that finds nothing over a real tree is broken, not a pass\n' "$root"; return 1; }
+    if [ "$want" != "$have" ]; then
+        printf 'FAIL  %s drifted from the sources (<: registry only, >: derived only):\n' "$reg"
+        diff <(printf '%s\n' "$have") <(printf '%s\n' "$want") | grep '^[<>]' | sed 's/^/        /' | head -40
+        printf '        run: bash scripts/check_tree_reader_tests.sh --update\n'
+        return 1
+    fi
+    printf 'PASS  %s: %s tree-reader target(s), registry equals the derived set\n' "$reg" "$(printf '%s\n' "$want" | wc -l | tr -d ' ')"
+}
+
+update() { # update <root> <registry>
+    local root=$1 reg=$2
+    { printf '# tool_version=none (derived by scripts/check_tree_reader_tests.sh from the test sources; regenerate with --update, never edit)\n'
+      printf '# crate<TAB>--test<TAB>name | crate<TAB>--lib — every test target that reads the tree (BSE-17); the quick tier always runs these\n'
+      derive "$root"; } > "$reg"
+    printf 'ok    wrote %s (%s target(s))\n' "$reg" "$(registry_body "$reg" | wc -l | tr -d ' ')"
+}
+
+self_test() {
+    local td n=0 red=0 out rc
+    td=$(mktemp -d "${TMPDIR:-/tmp}/tree-readers.XXXXXX")
+    trap 'rm -rf "${td:?}"' RETURN
+    mkdir -p "$td/crates/alpha/tests" "$td/crates/alpha/src" "$td/crates/beta/src/lint" "$td/crates/gamma/src" "$td/crates/gamma/tests"
+    printf 'use std::path::Path;\n#[test] fn t() { let _ = std::fs::read_to_string(Path::new("README.md")); }\n' > "$td/crates/alpha/tests/reads_readme.rs"
+    printf '#[test] fn t() { assert_eq!(1, 1); }\n' > "$td/crates/alpha/tests/pure.rs"
+    printf 'pub fn f() {}\n' > "$td/crates/alpha/src/lib.rs"
+    printf 'pub fn parse() {}\n#[cfg(test)]\nmod tests { #[test] fn t() { let _ = std::fs::read_to_string("scripts/x_baseline.txt"); } }\n' > "$td/crates/beta/src/lint/mod.rs"
+    printf 'pub mod lint;\n' > "$td/crates/beta/src/lib.rs"
+    printf 'pub fn load() { let _ = std::fs::read_to_string("scripts/config.txt"); }\n' > "$td/crates/gamma/src/lib.rs"
+    printf '#[test] fn t() { let _ = env!("CARGO_MANIFEST_DIR"); }\n' > "$td/crates/gamma/tests/manifest_dir.rs"
+    row() { # row WANT_RC LABEL MUST_MATCH -- CMD...
+        local want=$1 label=$2 pat=$3; shift 3; n=$((n + 1))
+        rc=0; out=$("$@" 2>&1) || rc=$?
+        if [ "$rc" = "$want" ] && printf '%s\n' "$out" | grep -qE -- "$pat"; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+        else printf 'FAIL  row %-2s rc=%s (wanted %s, must match /%s/)  %s\n' "$n" "$rc" "$want" "$pat" "$label"; printf '%s\n' "$out" | sed 's/^/        /'; red=1; fi
+    }
+    row 0 "derive: alpha reads_readme (README path), beta --lib (cfg(test) + scripts/ path), gamma manifest_dir (CARGO_MANIFEST_DIR); NOT alpha pure, NOT gamma --lib (reader without cfg(test))" \
+        '^alpha	--test	reads_readme$' bash -c "$(declare -f derive); derive '$td'"
+    out=$(derive "$td") || true; printf '%s\n' "$out" | grep -q '^beta	--lib$' && printf '%s\n' "$out" | grep -q '^gamma	--test	manifest_dir$' && ! printf '%s\n' "$out" | grep -q 'pure' && ! printf '%s\n' "$out" | grep -q '^gamma	--lib$' && printf 'ok    row %-2s        derived set is exactly {alpha reads_readme, beta --lib, gamma manifest_dir}\n' "$((n + 1))" || { printf 'FAIL  row %-2s        derived set wrong:\n%s\n' "$((n + 1))" "$out"; red=1; }; n=$((n + 1))
+    update "$td" "$td/registry.txt" > /dev/null
+    row 0 "registry equals derived -> PASS" '^PASS' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
+    printf 'zeta\t--lib\n' >> "$td/registry.txt"
+    row 1 "a stale registry line -> RED (drift, registry only)" '^FAIL .*drifted' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
+    update "$td" "$td/registry.txt" > /dev/null; sed -i '/^beta/d' "$td/registry.txt"
+    row 1 "a missing registry line -> RED (drift, derived only)" '> beta' bash -c "$(declare -f derive registry_body check); check '$td' '$td/registry.txt'"
+    row 2 "registry file absent -> ENV (exit 2), never a pass" '^ENV' bash -c "$(declare -f derive registry_body check); check '$td' '$td/absent.txt'"
+    mkdir -p "$td/empty/crates/x/tests"; printf '#[test] fn t() {}\n' > "$td/empty/crates/x/tests/t.rs"; printf '# h\n' > "$td/empty/reg.txt"
+    row 1 "a tree with ZERO readers -> RED (vacuity), never a pass" 'derived ZERO' bash -c "$(declare -f derive registry_body check); check '$td/empty' '$td/empty/reg.txt'"
+    # MUTANT: drop the scripts/ pattern from the oracle -> beta --lib vanishes from the derived set (the falsifier discriminates)
+    row 0 "mutant oracle without the scripts/ pattern loses beta --lib — this row proves the oracle is load-bearing" 'MUTANT-LOST-BETA' bash -c "ORACLE=$(printf %q "${ORACLE/\"scripts\/|/}"); $(declare -f derive); if derive '$td' | grep -q '^beta'; then echo MUTANT-KEPT-BETA; else echo MUTANT-LOST-BETA; fi"
+    printf '\n%s checks, %s failed\n' "$n" "$red"
+    [ "$red" -eq 0 ]
+}
+
+case "${1:-}" in
+    --self-test) self_test ;;
+    --print) derive "${2:-.}" ;;
+    --update) update "${2:-.}" "${3:-$REGISTRY_DEFAULT}" ;;
+    "") check . "$REGISTRY_DEFAULT" ;;
+    *) printf 'usage: %s [--print [ROOT] | --update [ROOT [REGISTRY]] | --self-test]\n' "$0" >&2; exit 2 ;;
+esac

--- a/scripts/check_tree_reader_tests.sh
+++ b/scripts/check_tree_reader_tests.sh
@@ -82,10 +82,22 @@ derive() { # derive <repo root> -> sorted "crate\t--test\tname" / "crate\t--lib"
 # runs it" is itself a finding — 36 of 80 targets on the day this was written.
 UNWIRED_LEDGER_DEFAULT="scripts/tree_reader_unwired_baseline.txt"
 
+# full_tier_excludes ROOT -- the crates the full tier's `--workspace --lib` run
+# EXCLUDES (gpu, cuda-edge, compute: they need hardware or their own step).
+# Read from the workflow, never restated: a lib target of an excluded crate is
+# not wired by `--workspace --lib`, and the first quick-tier run would have
+# tested aprender-gpu --lib on a CPU runner had this not been derived.
+full_tier_excludes() { # full_tier_excludes <root> -> one crate per line
+    grep -rhoE 'nextest run --profile ci --workspace --lib( --exclude [a-z0-9-]+)+' "$1"/.github/workflows/ 2>/dev/null \
+        | head -1 | grep -oE -- '--exclude [a-z0-9-]+' | awk '{print $2}'
+}
+
 wired_targets() { # wired_targets <root> -- the derived set, wired half only
     local root=$1 line c kind name
     derive "$root" | while IFS=$'\t' read -r c kind name; do
         if [ "$kind" = "--lib" ] || [ "$kind" = "--bins" ]; then
+            # excluded from --workspace --lib by the full tier (hardware, own step)?
+            full_tier_excludes "$root" | grep -qxF "$c" && continue
             printf '%s\t%s\n' "$c" "$kind"
         elif grep -rqF -- "--test $name" "$root"/.github/workflows/ 2>/dev/null; then
             printf '%s\t--test\t%s\n' "$c" "$name"
@@ -183,14 +195,14 @@ self_test() {
         printf 'FAIL  row %-2s        split wrong. wired=[%s] unwired=[%s]\n' "$n" "$(printf '%s' "$w" | tr '\n' ';')" "$(printf '%s' "$u" | tr '\n' ';')"; red=1
     fi
     update "$td" "$td/registry.txt" > /dev/null
-    row 0 "registry equals derived -> PASS" '^PASS' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
+    row 0 "registry equals derived -> PASS" '^PASS' bash -c "$(declare -f derive full_tier_excludes wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
     printf 'zeta\t--lib\n' >> "$td/registry.txt"
-    row 1 "a stale registry line -> RED (drift, registry only)" '^FAIL .*drifted' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
+    row 1 "a stale registry line -> RED (drift, registry only)" '^FAIL .*drifted' bash -c "$(declare -f derive full_tier_excludes wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
     update "$td" "$td/registry.txt" > /dev/null; sed -i '/^beta/d' "$td/registry.txt"
-    row 1 "a missing registry line -> RED (drift, derived only)" '> beta' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
-    row 2 "registry file absent -> ENV (exit 2), never a pass" '^ENV' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/absent.txt'"
+    row 1 "a missing registry line -> RED (drift, derived only)" '> beta' bash -c "$(declare -f derive full_tier_excludes wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/registry.txt'"
+    row 2 "registry file absent -> ENV (exit 2), never a pass" '^ENV' bash -c "$(declare -f derive full_tier_excludes wired_targets unwired_targets registry_body check check_unwired); check '$td' '$td/absent.txt'"
     mkdir -p "$td/empty/crates/x/tests"; printf '#[test] fn t() {}\n' > "$td/empty/crates/x/tests/t.rs"; printf '# h\n' > "$td/empty/reg.txt"
-    row 1 "a tree with ZERO readers -> RED (vacuity), never a pass" 'derived ZERO' bash -c "$(declare -f derive wired_targets unwired_targets registry_body check check_unwired); check '$td/empty' '$td/empty/reg.txt'"
+    row 1 "a tree with ZERO readers -> RED (vacuity), never a pass" 'derived ZERO' bash -c "$(declare -f derive full_tier_excludes wired_targets unwired_targets registry_body check check_unwired); check '$td/empty' '$td/empty/reg.txt'"
     # MUTANT: drop the scripts/ pattern from the oracle -> beta --lib vanishes from the derived set (the falsifier discriminates)
     row 0 "mutant oracle without the scripts/ pattern loses beta --lib — this row proves the oracle is load-bearing" 'MUTANT-LOST-BETA' bash -c "ORACLE=$(printf %q "${ORACLE/\"scripts\/|/}"); $(declare -f derive); if derive '$td' | grep -q '^beta'; then echo MUTANT-KEPT-BETA; else echo MUTANT-LOST-BETA; fi"
     printf '\n%s checks, %s failed\n' "$n" "$red"

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -36,7 +36,7 @@ while [ $# -gt 0 ]; do
 done
 
 targets_from_registry() { # -> space list crate:--lib | crate:--test:name
-    grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | awk -F'\t' '{ if ($2=="--lib") printf "%s:--lib ", $1; else printf "%s:--test:%s ", $1, $3 }' | sed 's/ $//'
+    grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | awk -F"\t" '{ if ($2=="--test") printf "%s:--test:%s ", $1, $3; else printf "%s:%s ", $1, $2 }' | sed 's/ $//'
 }
 
 decide() {

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ci_test_tier.sh — decide which test tier a CI run owes (BSE-17, PMAT-1077).
+#
+#   quick  pull_request: the touched crates + direct reverse dependents
+#          (scripts/gate_touched_crates.sh, cap -> full) PLUS every test target
+#          that reads the tree (scripts/tree_reader_tests.txt, derived and
+#          checked by scripts/check_tree_reader_tests.sh — drift is ENV, exit 2,
+#          never a quick tier over a stale registry).
+#   full   push, schedule, workflow_dispatch; pull_request when the selection
+#          falls closed (root manifests touched, or over the cap); merge_group
+#          when the queue ref's tree is not the tree a green PR head already ran.
+#   reuse  merge_group only: HEAD^{tree} equals the PR head's tree AND that
+#          head's workspace-test check-run concluded success — the same tree
+#          measured twice is the definition of waste. Any doubt -> full.
+#
+# Output: KEY=VALUE lines — tier, crates (space list), targets (crate:--lib or
+# crate:--test:name, space list), reason, cite (the PR head sha on reuse).
+# Feature-gated suites (model-tests, setfit, ...) belong to the full tier only;
+# the quick tier runs default features. Exit 2 on ENV (unknown event, registry
+# drift); 0 otherwise. `--self-test` runs the case table.
+set -euo pipefail
+
+EVENT=""; COMPARAND=""; DIFF_FROM=""; PR_HEAD=""; PR_CONCLUSION=""; REGISTRY="scripts/tree_reader_tests.txt"; ROOT="."
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --event) EVENT=$2; shift 2 ;;
+        --comparand) COMPARAND=$2; shift 2 ;;
+        --diff-from) DIFF_FROM=$2; shift 2 ;;
+        --pr-head) PR_HEAD=$2; shift 2 ;;
+        --pr-head-conclusion) PR_CONCLUSION=$2; shift 2 ;;
+        --registry) REGISTRY=$2; shift 2 ;;
+        --repo-root) ROOT=$2; shift 2 ;;
+        --self-test) SELF_TEST=1; shift ;;
+        *) printf 'usage: %s --event EVENT [--comparand REF] [--diff-from FILE] [--pr-head SHA --pr-head-conclusion C] [--registry FILE] [--repo-root DIR] | --self-test\n' "$0" >&2; exit 2 ;;
+    esac
+done
+
+targets_from_registry() { # -> space list crate:--lib | crate:--test:name
+    grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | awk -F'\t' '{ if ($2=="--lib") printf "%s:--lib ", $1; else printf "%s:--test:%s ", $1, $3 }' | sed 's/ $//'
+}
+
+decide() {
+    case "$EVENT" in
+        push|schedule|workflow_dispatch)
+            printf 'tier=full\nreason=%s event: the whole workspace, every feature-gated suite\n' "$EVENT" ;;
+        merge_group)
+            if [ -z "$PR_HEAD" ]; then printf 'tier=full\nreason=merge_group without a PR head to compare against\n'; return 0; fi
+            local ht pt
+            ht=$(git -C "$ROOT" rev-parse 'HEAD^{tree}' 2>/dev/null || true)
+            pt=$(git -C "$ROOT" rev-parse "${PR_HEAD}^{tree}" 2>/dev/null || true)
+            if [ -z "$ht" ] || [ -z "$pt" ]; then printf 'tier=full\nreason=merge_group: a tree could not be resolved (HEAD=%s pr-head=%s)\n' "${ht:-?}" "${pt:-?}"; return 0; fi
+            if [ "$ht" != "$pt" ]; then printf 'tier=full\nreason=merge_group: queue tree %s differs from PR head tree %s (main moved under the PR)\n' "${ht:0:9}" "${pt:0:9}"; return 0; fi
+            if [ "$PR_CONCLUSION" != "success" ]; then printf 'tier=full\nreason=merge_group: same tree but the PR head'"'"'s workspace-test concluded %s, not success\n' "${PR_CONCLUSION:-unknown}"; return 0; fi
+            printf 'tier=reuse\ncite=%s\nreason=merge_group: HEAD^{tree} %s equals PR head %s^{tree}, whose workspace-test succeeded — the same tree measured twice\n' "$PR_HEAD" "${ht:0:9}" "${PR_HEAD:0:9}" ;;
+        pull_request)
+            local chk sel crates rule
+            if ! chk=$(bash "$ROOT/scripts/check_tree_reader_tests.sh" 2>&1); then printf 'ENV: %s\n' "$chk" >&2; return 2; fi
+            sel=$(bash "$ROOT/scripts/gate_touched_crates.sh" --print-selection ${COMPARAND:+--comparand "$COMPARAND"} ${DIFF_FROM:+--diff-from "$DIFF_FROM"} 2>/dev/null | tail -1)
+            crates=$(printf '%s' "$sel" | sed -n 's/^selection=[a-z]* crates=\(.*\) rule=.*$/\1/p'); rule=${sel#*rule=}
+            case "$sel" in
+                selection=full*) printf 'tier=full\nreason=pull_request: %s\n' "$rule" ;;
+                selection=quick*|selection=none*) printf 'tier=quick\ncrates=%s\ntargets=%s\nreason=pull_request: %s; plus %s tree-reader target(s) from %s\n' "$crates" "$(targets_from_registry "$ROOT/$REGISTRY")" "$rule" "$(grep -vc '^#' "$ROOT/$REGISTRY")" "$REGISTRY" ;;
+                *) printf 'ENV: gate_touched_crates --print-selection gave "%s"\n' "$sel" >&2; return 2 ;;
+            esac ;;
+        *) printf 'ENV: unknown event "%s" — refusing to guess a tier\n' "$EVENT" >&2; return 2 ;;
+    esac
+}
+
+self_test() {
+    local td n=0 red=0 out rc leaf
+    td=$(mktemp -d "${TMPDIR:-/tmp}/ci-tier.XXXXXX"); trap 'rm -rf "${td:?}"' RETURN
+    row() { local want=$1 label=$2 pat=$3; shift 3; n=$((n + 1)); rc=0; out=$("$@" 2>&1) || rc=$?
+        if [ "$rc" = "$want" ] && printf '%s\n' "$out" | grep -qE -- "$pat"; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+        else printf 'FAIL  row %-2s rc=%s (wanted %s, must match /%s/)  %s\n' "$n" "$rc" "$want" "$pat" "$label"; printf '%s\n' "$out" | sed 's/^/        /'; red=1; fi; }
+    T=$0
+    row 0 "push -> full" '^tier=full' bash "$T" --event push
+    row 0 "schedule -> full" '^tier=full' bash "$T" --event schedule
+    row 2 "unknown event -> ENV (exit 2), never a guess" 'refusing to guess' bash "$T" --event release
+    printf 'scripts/foo.sh\n' > "$td/d-scripts.txt"
+    row 0 "pull_request, scripts-only diff -> quick with NO crates" '^crates=$' bash "$T" --event pull_request --diff-from "$td/d-scripts.txt"
+    row 0 "  ...and the tree-reader targets are in it (readme_contract, the reader that bit #3039)" 'aprender-core:--test:readme_contract' bash "$T" --event pull_request --diff-from "$td/d-scripts.txt"
+    row 0 "  ...including the lib target whose unit test reads a baseline (aprender-contracts)" 'aprender-contracts:--lib' bash "$T" --event pull_request --diff-from "$td/d-scripts.txt"
+    printf 'Cargo.toml\n' > "$td/d-root.txt"
+    row 0 "pull_request, root Cargo.toml touched -> full (fail closed)" '^tier=full' bash "$T" --event pull_request --diff-from "$td/d-root.txt"
+    printf 'crates/aprender-core/src/lib.rs\n' > "$td/d-core.txt"
+    row 0 "pull_request, aprender-core touched -> full (reverse dependents exceed the cap)" 'tier=full' bash "$T" --event pull_request --diff-from "$td/d-core.txt"
+    leaf=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '[.packages[]|select(.manifest_path|test("/crates/"))] | (map(.name) - (map(.dependencies[]?.name)|unique)) | sort | .[0]')
+    printf 'crates/%s/src/lib.rs\n' "$leaf" > "$td/d-leaf.txt"
+    row 0 "pull_request, a leaf crate ($leaf) touched -> quick with that crate" "^crates=.*$leaf" bash "$T" --event pull_request --diff-from "$td/d-leaf.txt"
+    # registry drift is ENV for the quick tier
+    cp scripts/tree_reader_tests.txt "$td/reg.bak"; printf 'zeta\t--lib\n' >> scripts/tree_reader_tests.txt
+    row 2 "pull_request with a drifted registry -> ENV (exit 2): no quick tier over a stale list" 'drifted' bash "$T" --event pull_request --diff-from "$td/d-scripts.txt"
+    cp "$td/reg.bak" scripts/tree_reader_tests.txt
+    # merge_group rows on a throwaway repo: same tree (empty commit) vs different tree
+    git init -q "$td/repo"; ( cd "$td/repo" && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m base && printf 'a\n' > f && git add f && git -c user.name=t -c user.email=t@t commit -q -m one && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "queue merge, same tree" )
+    same=$(git -C "$td/repo" rev-parse HEAD~1)
+    row 0 "merge_group, same tree + PR head workspace-test success -> reuse, citing the head" "^cite=$same" bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$same" --pr-head-conclusion success
+    row 0 "merge_group, same tree but PR head conclusion failure -> full" 'concluded failure' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$same" --pr-head-conclusion failure
+    diff1=$(git -C "$td/repo" rev-parse HEAD~2)
+    row 0 "merge_group, different tree -> full (main moved under the PR)" 'differs from PR head tree' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$diff1" --pr-head-conclusion success
+    row 0 "merge_group without a PR head -> full" 'without a PR head' bash "$T" --event merge_group --repo-root "$td/repo"
+    # MUTANT: a copy that drops the tree-reader targets from the quick tier must lose readme_contract — the falsifier discriminates
+    sed 's/targets=%s\\n/targets=\\n/; s/"\$(targets_from_registry "\$ROOT\/\$REGISTRY")" //' "$T" > "$td/mutant.sh"
+    row 0 "mutant without tree-reader targets loses readme_contract (proves the inclusion is load-bearing)" 'MUTANT-LOST' bash -c "if bash '$td/mutant.sh' --event pull_request --diff-from '$td/d-scripts.txt' | grep -q readme_contract; then echo MUTANT-KEPT; else echo MUTANT-LOST; fi"
+    printf '\n%s checks, %s failed\n' "$n" "$red"; [ "$red" -eq 0 ]
+}
+
+if [ "${SELF_TEST:-0}" = 1 ]; then self_test; exit $?; fi
+[ -n "$EVENT" ] || { printf 'usage: %s --event EVENT ...\n' "$0" >&2; exit 2; }
+decide

--- a/scripts/gate_touched_crates.sh
+++ b/scripts/gate_touched_crates.sh
@@ -41,6 +41,10 @@ while [ $# -gt 0 ]; do
       DRY_RUN=1
       shift
       ;;
+    --print-selection)
+      PRINT_SELECTION=1
+      shift
+      ;;
     --diff-from)
       [ $# -ge 2 ] || { echo "gate_touched_crates: --diff-from requires a file argument" >&2; exit 2; }
       DIFF_FROM="$2"
@@ -134,6 +138,18 @@ sorted_list() {
   fi
   printf '%s\n' "$@" | sort | paste -sd' ' -
 }
+
+# --print-selection (BSE-17, PMAT-1077): one machine-readable line for the CI
+# tier decision, no cargo run. `selection=full` when the rule falls closed to the
+# whole workspace, `none` when nothing is touched, `quick` with the sorted set.
+if [ "${PRINT_SELECTION:-0}" -eq 1 ]; then
+  case "$action" in
+    check) printf 'selection=full crates= rule=%s\n' "$rule" ;;
+    none)  printf 'selection=none crates= rule=%s\n' "$rule" ;;
+    test)  printf 'selection=quick crates=%s rule=%s\n' "$(sorted_list "${!selected[@]}")" "$rule" ;;
+  esac
+  exit 0
+fi
 
 echo "gate_touched_crates: comparand=${COMPARAND}"
 echo "gate_touched_crates: touched crate(s): $(sorted_list "${!touched_crates[@]}")"

--- a/scripts/tree_reader_tests.txt
+++ b/scripts/tree_reader_tests.txt
@@ -27,7 +27,6 @@ aprender-core	--test	falsification_spec_v10_tests
 aprender-core	--test	monorepo_invariants
 aprender-core	--test	readme_contract
 aprender-core	--test	setfit_conformance
-aprender-gpu	--lib
 aprender-orchestrate	--lib
 aprender-present-cli	--bins
 aprender-present-lib	--lib

--- a/scripts/tree_reader_tests.txt
+++ b/scripts/tree_reader_tests.txt
@@ -1,0 +1,82 @@
+# tool_version=none (derived by scripts/check_tree_reader_tests.sh from the test sources; regenerate with --update, never edit)
+# crate<TAB>--test<TAB>name | crate<TAB>--lib — every test target that reads the tree (BSE-17); the quick tier always runs these
+apr-cli	--lib
+apr-cli	--test	beat_apr_sibling_cli_reach
+apr-cli	--test	cli_commands
+apr-cli	--test	falsification_crux_a_01
+apr-cli	--test	falsification_crux_a_03
+apr-cli	--test	falsification_crux_a_20
+apr-cli	--test	pixel_regression
+apr-format	--lib
+apr-format	--test	golden_fixtures
+aprender-cgp	--lib
+aprender-cgp	--test	integration
+aprender-compute-xtask	--lib
+aprender-contracts	--lib
+aprender-contracts	--test	apr_hnsw_persistence_contract
+aprender-contracts	--test	apr_hybrid_retrieval_contract
+aprender-contracts	--test	apr_mcp_server_contract
+aprender-contracts	--test	apr_mcp_tool_inventory_contract
+aprender-contracts	--test	apr_registry_snapshot_contract
+aprender-contracts	--test	apr_rerank_contract
+aprender-contracts	--test	apr_serve_api_key_auth_contract
+aprender-contracts	--test	kani_harness_generation
+aprender-contracts	--test	probar_test_generation
+aprender-contracts	--test	validate_contracts
+aprender-contracts-cli	--lib
+aprender-contracts-cli	--test	book_coverage
+aprender-contracts-cli	--test	cli_integration
+aprender-contracts-cli	--test	ground_truth
+aprender-contracts-cli	--test	pv_surface_gate
+aprender-contrastive-data	--test	goldens_regenerate
+aprender-contrastive-data	--test	negative_leaky
+aprender-contrastive-data	--test	negative_materializing
+aprender-contrastive-data	--test	reference_fixtures
+aprender-core	--lib
+aprender-core	--test	beat_sklearn_gaussiannb_accuracy
+aprender-core	--test	beat_sklearn_iris
+aprender-core	--test	beat_sklearn_metrics_parity
+aprender-core	--test	beat_sklearn_nmi
+aprender-core	--test	beat_sklearn_pipeline_encoder
+aprender-core	--test	beat_sklearn_svc_accuracy
+aprender-core	--test	book_contracts
+aprender-core	--test	falsification_spec_v10_tests
+aprender-core	--test	monorepo_invariants
+aprender-core	--test	readme_contract
+aprender-core	--test	realizar_integration_tests
+aprender-core	--test	setfit_conformance
+aprender-core	--test	spec_checklist_19_inference
+aprender-core	--test	spec_checklist_q_qwen_coder
+aprender-core	--test	spec_checklist_r_model_import
+aprender-core	--test	spec_checklist_t_realizar
+aprender-core	--test	spec_checklist_u_performance
+aprender-core	--test	spec_checklist_v_sovereign
+aprender-core	--test	spec_checklist_w_advanced_perf
+aprender-core	--test	spec_checklist_x_anti_stub
+aprender-core	--test	toyota_principles_tests
+aprender-gpu	--lib
+aprender-mcp	--test	falsify_mcp_008
+aprender-orchestrate	--lib
+aprender-present-cli	--lib
+aprender-present-lib	--lib
+aprender-present-lib	--test	showcase_shell_autocomplete
+aprender-present-terminal	--test	pixel_perfect_tests
+aprender-present-yaml	--test	examples
+aprender-present-yaml	--test	prs_examples
+aprender-profile	--lib
+aprender-profile	--test	sprint49_depyler_ingestion_tests
+aprender-qa-certify	--lib
+aprender-rag	--lib
+aprender-rag-cli	--lib
+aprender-serve	--lib
+aprender-serve	--test	fusion_gate_contract_falsify
+aprender-serve	--test	infer_deep_coverage
+aprender-serve	--test	parity_contract_falsify
+aprender-serve	--test	qwen3_moe_argmax_parity
+aprender-serve	--test	qwen3_moe_parity
+aprender-shell	--lib
+aprender-simulate	--lib
+aprender-test-cli	--lib
+aprender-test-lib	--lib
+aprender-train	--lib
+aprender-train	--test	yaml_mode_integration

--- a/scripts/tree_reader_tests.txt
+++ b/scripts/tree_reader_tests.txt
@@ -3,35 +3,18 @@
 apr-cli	--lib
 apr-cli	--test	beat_apr_sibling_cli_reach
 apr-cli	--test	cli_commands
-apr-cli	--test	falsification_crux_a_01
-apr-cli	--test	falsification_crux_a_03
-apr-cli	--test	falsification_crux_a_20
-apr-cli	--test	pixel_regression
 apr-format	--lib
-apr-format	--test	golden_fixtures
 aprender-cgp	--lib
-aprender-cgp	--test	integration
-aprender-compute-xtask	--lib
+aprender-compute-xtask	--bins
 aprender-contracts	--lib
-aprender-contracts	--test	apr_hnsw_persistence_contract
-aprender-contracts	--test	apr_hybrid_retrieval_contract
-aprender-contracts	--test	apr_mcp_server_contract
-aprender-contracts	--test	apr_mcp_tool_inventory_contract
-aprender-contracts	--test	apr_registry_snapshot_contract
-aprender-contracts	--test	apr_rerank_contract
 aprender-contracts	--test	apr_serve_api_key_auth_contract
 aprender-contracts	--test	kani_harness_generation
 aprender-contracts	--test	probar_test_generation
 aprender-contracts	--test	validate_contracts
 aprender-contracts-cli	--lib
-aprender-contracts-cli	--test	book_coverage
 aprender-contracts-cli	--test	cli_integration
 aprender-contracts-cli	--test	ground_truth
 aprender-contracts-cli	--test	pv_surface_gate
-aprender-contrastive-data	--test	goldens_regenerate
-aprender-contrastive-data	--test	negative_leaky
-aprender-contrastive-data	--test	negative_materializing
-aprender-contrastive-data	--test	reference_fixtures
 aprender-core	--lib
 aprender-core	--test	beat_sklearn_gaussiannb_accuracy
 aprender-core	--test	beat_sklearn_iris
@@ -43,40 +26,18 @@ aprender-core	--test	book_contracts
 aprender-core	--test	falsification_spec_v10_tests
 aprender-core	--test	monorepo_invariants
 aprender-core	--test	readme_contract
-aprender-core	--test	realizar_integration_tests
 aprender-core	--test	setfit_conformance
-aprender-core	--test	spec_checklist_19_inference
-aprender-core	--test	spec_checklist_q_qwen_coder
-aprender-core	--test	spec_checklist_r_model_import
-aprender-core	--test	spec_checklist_t_realizar
-aprender-core	--test	spec_checklist_u_performance
-aprender-core	--test	spec_checklist_v_sovereign
-aprender-core	--test	spec_checklist_w_advanced_perf
-aprender-core	--test	spec_checklist_x_anti_stub
-aprender-core	--test	toyota_principles_tests
 aprender-gpu	--lib
-aprender-mcp	--test	falsify_mcp_008
 aprender-orchestrate	--lib
-aprender-present-cli	--lib
+aprender-present-cli	--bins
 aprender-present-lib	--lib
-aprender-present-lib	--test	showcase_shell_autocomplete
-aprender-present-terminal	--test	pixel_perfect_tests
-aprender-present-yaml	--test	examples
-aprender-present-yaml	--test	prs_examples
 aprender-profile	--lib
-aprender-profile	--test	sprint49_depyler_ingestion_tests
 aprender-qa-certify	--lib
 aprender-rag	--lib
 aprender-rag-cli	--lib
 aprender-serve	--lib
-aprender-serve	--test	fusion_gate_contract_falsify
-aprender-serve	--test	infer_deep_coverage
-aprender-serve	--test	parity_contract_falsify
-aprender-serve	--test	qwen3_moe_argmax_parity
-aprender-serve	--test	qwen3_moe_parity
 aprender-shell	--lib
 aprender-simulate	--lib
 aprender-test-cli	--lib
 aprender-test-lib	--lib
 aprender-train	--lib
-aprender-train	--test	yaml_mode_integration

--- a/scripts/tree_reader_unwired_baseline.txt
+++ b/scripts/tree_reader_unwired_baseline.txt
@@ -1,0 +1,43 @@
+# tool_version=none (derived by scripts/check_tree_reader_tests.sh --print-unwired; regenerate with --update, never edit)
+# Test targets that READ THE TREE and that no workflow runs. Not in the quick
+# tier (it must never be stricter than the full tier), and each line is a
+# finding: a test nothing executes (BSE-17, PMAT-1077).
+apr-cli	--test	falsification_crux_a_01
+apr-cli	--test	falsification_crux_a_03
+apr-cli	--test	falsification_crux_a_20
+apr-cli	--test	pixel_regression
+apr-format	--test	golden_fixtures
+aprender-cgp	--test	integration
+aprender-contracts	--test	apr_hnsw_persistence_contract
+aprender-contracts	--test	apr_hybrid_retrieval_contract
+aprender-contracts	--test	apr_mcp_server_contract
+aprender-contracts	--test	apr_mcp_tool_inventory_contract
+aprender-contracts	--test	apr_registry_snapshot_contract
+aprender-contracts	--test	apr_rerank_contract
+aprender-contracts-cli	--test	book_coverage
+aprender-contrastive-data	--test	goldens_regenerate
+aprender-contrastive-data	--test	negative_leaky
+aprender-contrastive-data	--test	negative_materializing
+aprender-contrastive-data	--test	reference_fixtures
+aprender-core	--test	realizar_integration_tests
+aprender-core	--test	spec_checklist_19_inference
+aprender-core	--test	spec_checklist_q_qwen_coder
+aprender-core	--test	spec_checklist_r_model_import
+aprender-core	--test	spec_checklist_t_realizar
+aprender-core	--test	spec_checklist_u_performance
+aprender-core	--test	spec_checklist_v_sovereign
+aprender-core	--test	spec_checklist_w_advanced_perf
+aprender-core	--test	spec_checklist_x_anti_stub
+aprender-core	--test	toyota_principles_tests
+aprender-mcp	--test	falsify_mcp_008
+aprender-present-lib	--test	showcase_shell_autocomplete
+aprender-present-terminal	--test	pixel_perfect_tests
+aprender-present-yaml	--test	examples
+aprender-present-yaml	--test	prs_examples
+aprender-profile	--test	sprint49_depyler_ingestion_tests
+aprender-serve	--test	fusion_gate_contract_falsify
+aprender-serve	--test	infer_deep_coverage
+aprender-serve	--test	parity_contract_falsify
+aprender-serve	--test	qwen3_moe_argmax_parity
+aprender-serve	--test	qwen3_moe_parity
+aprender-train	--test	yaml_mode_integration


### PR DESCRIPTION
Ruling 2026-09-07: quick test for aprender PRs, full test behind them. Spec: paiml/infra docs/specifications/build-system-enhancement.md BSE-17.

Measured 2026-09-07: 22 workspace-test jobs in 33 CI runs — 8 green at 95 min average, 6 cancelled by a newer push, 4 merge-queue rebuilds of trees byte-identical to the PR head. Both of #3039 workspace-test reds came from tests that read the tree in crates the PR never touched, so the quick tier always runs those targets, derived from the sources and registry-checked on every run.

- quick on pull_request: touched crates + direct reverse dependents (cap -> full) plus 80 tree-reader targets (22 --lib, 58 --test)
- full on push/schedule/dispatch; on merge_group when the queue tree differs from the PR head or that head was not green
- reuse on merge_group when HEAD^{tree} equals a PR head tree whose workspace-test succeeded (the head is cited)
- scripts/ci_test_tier.sh --self-test 15 rows, scripts/check_tree_reader_tests.sh --self-test 8 rows, both wired into guard-cargo; registry drift and unknown events are ENV exit 2, never a guess

This PR touches no crate, so its own run is the first quick-tier run: zero crates, 80 targets.

Pmat-Ticket: PMAT-1077