### PR TITLE
feat(gpu): O2 — arm the register_budget contract, vacuous since 2026-04-06

### DIFF
--- a/contracts/trueno/ptx-codegen-safety-v1.yaml
+++ b/contracts/trueno/ptx-codegen-safety-v1.yaml
@@ -2,15 +2,14 @@ metadata:
   version: 1.0.0
   created: '2026-04-06'
   author: PAIML Engineering
-  registry: true
   description: >
     PTX codegen safety contract — verifies that PTX assembly emitted by
     the kernel generator is well-formed, targets the correct SM version,
     stays within register limits, and uses no undefined instructions.
   references:
-  - 'NVIDIA PTX ISA 8.4 — .target directive, register usage'
-  - 'trueno/src/backends/gpu/ — kernel PTX generation'
-  - 'realizar/src/cuda/kernel_generator.rs — emit_ptx_for_target()'
+  - 'NVIDIA PTX ISA — .target directive, register usage'
+  - 'crates/aprender-gpu/src/ptx/ — kernel PTX generation'
+  - 'crates/aprender-serve/src/cuda/ — emit_ptx_for_target()'
   - 'paiml/aprender#613 — Jetson PTX CUDA_ERROR_INVALID_VALUE'
   depends_on:
   - ptx-target-parity-v1
@@ -21,7 +20,7 @@ equations:
       forall ptx in emit_ptx_for_target(sm):
         ptx.contains(".target sm_{sm}")
         AND ptx.contains(".address_size 64")
-    domain: SM target version (70, 75, 80, 86, 87, 89, 90)
+    domain: SM target version (70, 75, 80, 86, 87, 89, 90, 100, 120, 121)
     codomain: PTX string with correct .target directive
     invariants:
     - Every emitted PTX contains exactly one .target directive
@@ -41,13 +40,21 @@ equations:
     domain: Compiled PTX kernel
     codomain: Register and shared memory usage
     invariants:
-    - "sm_70: max 255 regs/thread, 96KB shared"
-    - "sm_80+: max 255 regs/thread, 163KB shared"
+    - "Limits are QUERIED from the device (cuDeviceGetAttribute), never tabulated per SM:
+       a per-arch table goes stale every GPU generation and this one did, at sm_90."
+    - "block_size <= CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK of the COMPILED kernel"
+    - "static_shared + dynamic_shared <= CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK"
+    - "num_regs * block_size <= CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK"
     - "Exceeding limits causes CUDA_ERROR_INVALID_VALUE (GH-613)"
     preconditions:
     - kernel compiled for target SM
     postconditions:
     - cuOccupancyMaxActiveBlocksPerMultiprocessor > 0
+    enforced_by:
+    - crates/aprender-gpu/src/launch_budget.rs::validate_launch (pure policy, runs
+      in the required check)
+    - crates/aprender-gpu/src/driver/budget_query.rs::enforce_register_budget (device
+      query + the postcondition above)
     lean_theorem: Theorems.RegisterBudget
 
   instruction_validity:
@@ -115,9 +122,25 @@ falsification_tests:
   if_fails: Hardcoded sm_70 path bypasses dynamic target
 - id: FALSIFY-PTX-003
   rule: Register budget
-  prediction: GEMM kernel uses <= 128 registers (leaves room for occupancy)
+  prediction: >
+    A launch whose block size exceeds the compiled kernel's own
+    CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK is REFUSED, and a legal launch reports
+    cuOccupancyMaxActiveBlocksPerMultiprocessor > 0.
   test: |
-    Parse ptxas output for register count, assert <= 128.
+    cargo test -p aprender-gpu --lib launch_budget
+    cargo test -p aprender-gpu --features cuda --lib launch_budget
+  red_witness: |
+    Each budget has its OWN mutation; one mutation does not falsify the others.
+    Deleting the block-size comparison in launch_budget.rs::validate_launch turns RED:
+      launch_budget::tests::rejects_block_above_kernel_max
+      launch_budget::tests::kernel_max_is_reported_before_device_max
+      launch_budget::tests::violations_name_both_sides_of_the_comparison
+      driver::cuda_tests::launch_budget_hw::budget_goes_red_on_an_oversized_block
+    The hardware test only witnesses this because it asserts the SPECIFIC violation
+    ("kernel's max_threads_per_block"). Asserting merely is_err() would have let the
+    mutation survive: the launch falls through to the device-wide check and still
+    errors. That was measured, not assumed — the first version of this test DID
+    survive the mutation.
   if_fails: Register spilling causes performance cliff or INVALID_VALUE
 
 kani_harnesses:

--- a/crates/aprender-gpu/src/driver/budget_query.rs
+++ b/crates/aprender-gpu/src/driver/budget_query.rs
@@ -1,0 +1,159 @@
+//! CUDA-backed queries that feed [`crate::launch_budget`].
+//!
+//! Split deliberately: the *policy* (`crate::launch_budget::validate_launch`) is pure and
+//! ungated so its case table runs in the required check; only these *queries* need a
+//! device. Putting the policy here would have made it untestable in CI, because the whole
+//! `driver` module is `#[cfg(feature = "cuda")]` — the same trap that leaves
+//! `driver::ptx_patch`'s GH-480 tests dark despite its comment claiming otherwise.
+
+use super::sys::{
+    CUdevice, CUfunction, CudaDriver, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+    CU_DEVICE_ATTRIBUTE_WARP_SIZE, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
+    CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, CU_FUNC_ATTRIBUTE_NUM_REGS,
+    CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+};
+use crate::error::GpuError;
+use crate::launch_budget::{DeviceLimits, KernelAttributes};
+use std::os::raw::c_int;
+
+fn driver() -> Result<&'static CudaDriver, GpuError> {
+    CudaDriver::load().ok_or_else(|| {
+        GpuError::CudaDriver("libcuda not loadable for budget query".to_string(), -1)
+    })
+}
+
+fn func_attr(d: &CudaDriver, attrib: c_int, func: CUfunction) -> Result<u32, GpuError> {
+    let mut v: c_int = 0;
+    // SAFETY: `func` is a live CUfunction from cuModuleGetFunction, `attrib` is one of the
+    // CU_FUNC_ATTRIBUTE_* constants, and `v` is a valid out-pointer for the call's lifetime.
+    CudaDriver::check(unsafe { (d.cuFuncGetAttribute)(&mut v, attrib, func) })?;
+    u32::try_from(v)
+        .map_err(|_| GpuError::CudaDriver(format!("negative function attribute {attrib}: {v}"), -1))
+}
+
+fn dev_attr(d: &CudaDriver, attrib: c_int, device: CUdevice) -> Result<u32, GpuError> {
+    let mut v: c_int = 0;
+    // SAFETY: `device` is a valid CUdevice ordinal handle and `v` is a valid out-pointer.
+    CudaDriver::check(unsafe { (d.cuDeviceGetAttribute)(&mut v, attrib, device) })?;
+    u32::try_from(v)
+        .map_err(|_| GpuError::CudaDriver(format!("negative device attribute {attrib}: {v}"), -1))
+}
+
+/// Read a compiled kernel's resource usage back from the driver.
+///
+/// These describe the **cubin the JIT actually produced**, not the PTX we emitted — which
+/// is the whole point: a codegen change that inflates register pressure is invisible in the
+/// PTX text and shows up here.
+///
+/// # Safety
+///
+/// `func` must be a live `CUfunction` obtained from `cuModuleGetFunction` on a module that
+/// is still loaded. The driver dereferences it.
+///
+/// # Errors
+///
+/// Returns [`GpuError::CudaDriver`] if libcuda is unavailable or any attribute query fails.
+pub unsafe fn kernel_attributes(func: CUfunction) -> Result<KernelAttributes, GpuError> {
+    let d = driver()?;
+    Ok(KernelAttributes {
+        max_threads_per_block: func_attr(d, CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK, func)?,
+        num_regs: func_attr(d, CU_FUNC_ATTRIBUTE_NUM_REGS, func)?,
+        static_shared_bytes: func_attr(d, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, func)?,
+        local_bytes: func_attr(d, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, func)?,
+    })
+}
+
+/// Query a device's limits instead of looking them up in a per-SM table.
+///
+/// The hand-written `CU_TARGET_COMPUTE_*` table stops at 90 and the contract's own `domain`
+/// stops at 90. Querying means sm_100 / sm_120 / sm_121 and whatever ships next need no
+/// edit here.
+///
+/// # Errors
+///
+/// Returns [`GpuError::CudaDriver`] if libcuda is unavailable or any attribute query fails.
+pub fn device_limits(device: CUdevice) -> Result<DeviceLimits, GpuError> {
+    let d = driver()?;
+    Ok(DeviceLimits {
+        max_threads_per_block: dev_attr(d, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, device)?,
+        max_shared_per_block: dev_attr(d, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, device)?,
+        max_regs_per_block: dev_attr(d, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK, device)?,
+        warp_size: dev_attr(d, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device)?,
+    })
+}
+
+/// The contract's own postcondition: `cuOccupancyMaxActiveBlocksPerMultiprocessor > 0`.
+///
+/// Zero means the configuration cannot be resident on any SM — the launch is impossible,
+/// not merely slow.
+///
+/// # Safety
+///
+/// `func` must be a live `CUfunction` from a still-loaded module.
+///
+/// # Errors
+///
+/// Returns [`GpuError::CudaDriver`] if libcuda is unavailable or the query fails.
+pub unsafe fn occupancy_max_active_blocks_per_sm(
+    func: CUfunction,
+    block_size: u32,
+    dynamic_shared_bytes: u32,
+) -> Result<u32, GpuError> {
+    let d = driver()?;
+    let mut blocks: c_int = 0;
+    let bs = c_int::try_from(block_size).map_err(|_| {
+        GpuError::InvalidParameter(format!("block_size {block_size} exceeds c_int"))
+    })?;
+    // SAFETY: `func` is a live CUfunction, `blocks` is a valid out-pointer, and the block
+    // size / dynamic shared size are plain scalars the driver validates itself.
+    CudaDriver::check(unsafe {
+        (d.cuOccupancyMaxActiveBlocksPerMultiprocessor)(
+            &mut blocks,
+            func,
+            bs,
+            dynamic_shared_bytes as usize,
+        )
+    })?;
+    u32::try_from(blocks)
+        .map_err(|_| GpuError::CudaDriver(format!("negative occupancy: {blocks}"), -1))
+}
+
+/// Full `register_budget` check for one kernel on one device.
+///
+/// Runs the pure policy, then asserts the contract's postcondition against the driver.
+/// This is the equation `contracts/trueno/ptx-codegen-safety-v1.yaml` has declared since
+/// 2026-04-06 and never enforced.
+///
+/// # Safety
+///
+/// `func` must be a live `CUfunction` from a still-loaded module, and `device` the ordinal
+/// of the device that module was loaded on.
+///
+/// # Errors
+///
+/// Returns [`GpuError::InvalidParameter`] naming the violated budget, or
+/// [`GpuError::CudaDriver`] if a query fails.
+pub unsafe fn enforce_register_budget(
+    func: CUfunction,
+    device: CUdevice,
+    block_size: u32,
+    dynamic_shared_bytes: u32,
+) -> Result<(), GpuError> {
+    // SAFETY: forwarded from this fn's own contract on `func` and `device`.
+    let attrs = unsafe { kernel_attributes(func) }?;
+    let limits = device_limits(device)?;
+    crate::launch_budget::validate_launch(&attrs, &limits, block_size, dynamic_shared_bytes)
+        .map_err(|v| GpuError::InvalidParameter(v.to_string()))?;
+    // SAFETY: same contract as above.
+    let blocks =
+        unsafe { occupancy_max_active_blocks_per_sm(func, block_size, dynamic_shared_bytes) }?;
+    if blocks == 0 {
+        return Err(GpuError::InvalidParameter(format!(
+            "cuOccupancyMaxActiveBlocksPerMultiprocessor == 0 for block_size={block_size}, \
+             dynamic_shared={dynamic_shared_bytes}: the launch cannot be resident on any SM \
+             (contract ptx-codegen-safety-v1 register_budget postcondition)"
+        )));
+    }
+    Ok(())
+}

--- a/crates/aprender-gpu/src/driver/cuda_tests/launch_budget_hw.rs
+++ b/crates/aprender-gpu/src/driver/cuda_tests/launch_budget_hw.rs
@@ -1,0 +1,153 @@
+//! Hardware half of O2 — `register_budget` enforced against a real compiled kernel.
+//!
+//! `crate::launch_budget`'s case table proves the POLICY on any host. These prove the
+//! MECHANISM engages: that the driver actually reports a kernel's registers and shared
+//! memory back to us, and that the gate can go RED on real hardware. A policy that is
+//! never fed by a real query is theater — which is exactly what
+//! `contracts/trueno/ptx-codegen-safety-v1.yaml` `register_budget` has been since
+//! 2026-04-06.
+
+use super::*;
+use crate::driver::budget_query::{
+    device_limits, enforce_register_budget, kernel_attributes, occupancy_max_active_blocks_per_sm,
+};
+
+/// A kernel with a real body, so the JIT allocates registers it can report back.
+/// A bare `ret;` can legitimately compile to zero registers and would prove nothing.
+const PTX: &str = r#".version 8.0
+.target sm_80
+.address_size 64
+
+.visible .entry budget_probe(
+    .param .u64 p_out,
+    .param .u32 p_n
+) {
+    .reg .pred  %p<2>;
+    .reg .f32   %f<3>;
+    .reg .b32   %r<6>;
+    .reg .b64   %rd<4>;
+    ld.param.u64 %rd1, [p_out];
+    ld.param.u32 %r2, [p_n];
+    cvta.to.global.u64 %rd2, %rd1;
+    mov.u32 %r3, %ctaid.x;
+    mov.u32 %r4, %ntid.x;
+    mov.u32 %r5, %tid.x;
+    mad.lo.s32 %r1, %r3, %r4, %r5;
+    setp.ge.s32 %p1, %r1, %r2;
+    @%p1 bra DONE;
+    mul.wide.s32 %rd3, %r1, 4;
+    add.s64 %rd3, %rd2, %rd3;
+    cvt.rn.f32.s32 %f1, %r1;
+    add.f32 %f2, %f1, %f1;
+    st.global.f32 [%rd3], %f2;
+DONE:
+    ret;
+}
+"#;
+
+fn probe_function() -> (CudaContext, CudaModule, crate::driver::sys::CUfunction) {
+    let ctx = CudaContext::new(0).expect("Context creation MUST succeed");
+    let mut module = CudaModule::from_ptx(&ctx, PTX).expect("Module from_ptx MUST succeed");
+    let func = module
+        .get_function("budget_probe")
+        .expect("entry budget_probe MUST resolve");
+    (ctx, module, func)
+}
+
+#[test]
+fn kernel_attributes_are_read_back_from_the_driver() {
+    let (_ctx, _module, func) = probe_function();
+    let attrs = unsafe { kernel_attributes(func) }.expect("cuFuncGetAttribute MUST succeed");
+
+    // Prove the MECHANISM engaged: these are properties of the cubin the JIT produced,
+    // not of the PTX text. A stub returning zeros would pass a weaker assertion.
+    assert!(
+        attrs.max_threads_per_block > 0,
+        "max_threads_per_block must be positive, got {}",
+        attrs.max_threads_per_block
+    );
+    assert!(
+        attrs.num_regs > 0,
+        "a kernel with a real body must use registers, got {}",
+        attrs.num_regs
+    );
+    assert!(
+        attrs.num_regs <= 255,
+        "registers per thread cannot exceed 255, got {}",
+        attrs.num_regs
+    );
+}
+
+#[test]
+fn device_limits_are_queried_not_tabulated() {
+    let ctx = CudaContext::new(0).expect("Context creation MUST succeed");
+    let limits = device_limits(ctx.device()).expect("cuDeviceGetAttribute MUST succeed");
+
+    // The point of querying: this passes on sm_121 (GB10) with no entry in any per-SM
+    // table, where the hand-written CU_TARGET_COMPUTE_* list stops at 90.
+    assert!(limits.max_threads_per_block >= 1024);
+    assert!(limits.max_shared_per_block >= 16 * 1024);
+    assert!(limits.max_regs_per_block >= 32 * 1024);
+    assert_eq!(limits.warp_size, 32, "warp size is 32 on every CUDA arch");
+}
+
+#[test]
+fn occupancy_is_positive_for_a_legal_launch() {
+    let (_ctx, _module, func) = probe_function();
+    let blocks = unsafe { occupancy_max_active_blocks_per_sm(func, 256, 0) }
+        .expect("cuOccupancyMaxActiveBlocksPerMultiprocessor MUST succeed");
+    // This IS the contract's postcondition, executed for the first time.
+    assert!(
+        blocks > 0,
+        "occupancy must be positive for a 256-thread block"
+    );
+}
+
+#[test]
+fn legal_launch_passes_the_budget() {
+    let (ctx, _module, func) = probe_function();
+    unsafe { enforce_register_budget(func, ctx.device(), 256, 0) }
+        .expect("a 256-thread launch of a tiny kernel MUST satisfy the budget");
+}
+
+#[test]
+fn budget_goes_red_on_an_oversized_block() {
+    // THE FALSIFIER. Without this the gate is unfalsifiable: a check that has never been
+    // observed to fail is indistinguishable from one that cannot.
+    let (ctx, _module, func) = probe_function();
+    let attrs = unsafe { kernel_attributes(func) }.expect("attributes MUST be readable");
+    let over = attrs.max_threads_per_block + 1;
+
+    let err = unsafe { enforce_register_budget(func, ctx.device(), over, 0) }
+        .expect_err("a block above the kernel's own maximum MUST be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&over.to_string()),
+        "the error must name the requested block size {over}: {msg}"
+    );
+    // Assert the SPECIFIC violation, not merely that something failed. Checking only
+    // `is_err()` here would let this test pass with the kernel-max comparison deleted —
+    // the launch would fall through to the device-wide check and still error, so the
+    // test would witness nothing. Measured: with that comparison removed this assertion
+    // is what turns the hardware test RED.
+    assert!(
+        msg.contains("kernel's max_threads_per_block"),
+        "must be refused by the KERNEL's ceiling, not the device's: {msg}"
+    );
+}
+
+#[test]
+fn budget_goes_red_on_impossible_shared_memory() {
+    // Second, independent RED path: shared memory rather than block size, so the gate is
+    // not merely one comparison that happens to work.
+    let (ctx, _module, func) = probe_function();
+    let limits = device_limits(ctx.device()).expect("limits MUST be readable");
+    let err = unsafe {
+        enforce_register_budget(func, ctx.device(), 128, limits.max_shared_per_block + 1)
+    }
+    .expect_err("dynamic shared memory above the device limit MUST be refused");
+    assert!(
+        err.to_string().contains("shared memory"),
+        "error must identify the shared-memory budget: {err}"
+    );
+}

--- a/crates/aprender-gpu/src/driver/cuda_tests/mod.rs
+++ b/crates/aprender-gpu/src/driver/cuda_tests/mod.rs
@@ -50,6 +50,7 @@ pub(super) fn capture_vs_ctx_sync() -> std::sync::MutexGuard<'static, ()> {
 mod cuda_graph_tests;
 mod driver_and_context;
 mod gpu_buffer;
+mod launch_budget_hw;
 mod module_tests;
 mod streams;
 mod stress_and_advanced;

--- a/crates/aprender-gpu/src/driver/mod.rs
+++ b/crates/aprender-gpu/src/driver/mod.rs
@@ -103,6 +103,11 @@ mod cublaslt;
 pub mod cublaslt_sys;
 
 // GH-480: PTX backward branch patcher (not feature-gated — pure string transform)
+// CUDA-backed queries that FEED launch_budget (the policy itself is ungated at
+// crate::launch_budget so its case table runs in the required check).
+#[cfg(feature = "cuda")]
+pub mod budget_query;
+
 pub(crate) mod ptx_patch;
 
 // PTX disk cache utilities (not feature-gated — SHA-256, cache I/O testable without CUDA)
@@ -125,7 +130,6 @@ pub use graph::{CaptureMode, CudaGraph, CudaGraphExec};
 pub use memory::{
     device_bytes_outstanding, device_memory_exclusive, DeviceMemoryExclusive, GpuBuffer,
 };
-#[cfg(feature = "cuda")]
 pub use module::CudaModule;
 #[cfg(feature = "cuda")]
 pub use stream::{CudaEvent, CudaStream, DEFAULT_STREAM};

--- a/crates/aprender-gpu/src/driver/sys/mod.rs
+++ b/crates/aprender-gpu/src/driver/sys/mod.rs
@@ -173,6 +173,31 @@ pub const CU_TARGET_COMPUTE_89: c_uint = 89;
 /// SM 9.0 (Hopper)
 pub const CU_TARGET_COMPUTE_90: c_uint = 90;
 
+// CUfunction_attribute — read back a COMPILED kernel's resource usage. Unlike the
+// CU_TARGET_COMPUTE_* table above (which stops at 90 and needs an edit per GPU
+// generation), these are architecture-independent: they do not change when a new SM
+// ships, which is why the launch-budget check is built on them.
+/// Max threads per block this kernel can be launched with.
+pub const CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK: c_int = 0;
+/// Statically declared shared memory, bytes.
+pub const CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES: c_int = 1;
+/// User-declared constant memory, bytes.
+pub const CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES: c_int = 2;
+/// Per-thread local memory, bytes. Non-zero means registers spilled.
+pub const CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES: c_int = 3;
+/// Registers used per thread.
+pub const CU_FUNC_ATTRIBUTE_NUM_REGS: c_int = 4;
+
+// CUdevice_attribute — queried, never tabulated, so a new architecture needs no edit here.
+/// Max threads per block the device supports.
+pub const CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK: c_int = 1;
+/// Max shared memory per block, bytes.
+pub const CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK: c_int = 8;
+/// Warp size in threads.
+pub const CU_DEVICE_ATTRIBUTE_WARP_SIZE: c_int = 10;
+/// Max 32-bit registers available per block.
+pub const CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK: c_int = 12;
+
 // ============================================================================
 // CUDA Stream Flags
 // ============================================================================
@@ -414,6 +439,19 @@ pub struct CudaDriver {
     pub cuLinkDestroy: unsafe extern "C" fn(state: CUlinkState) -> CUresult,
 
     // Driver Version Query (PTX disk cache key component)
+    // Launch budget / occupancy (O2 — enforces contracts/trueno/ptx-codegen-safety-v1.yaml
+    // `register_budget`, whose generated macro was invoked nowhere in the tree)
+    /// cuFuncGetAttribute - Read a compiled kernel's resource usage (regs, shared, local)
+    pub cuFuncGetAttribute:
+        unsafe extern "C" fn(pi: *mut c_int, attrib: c_int, func: CUfunction) -> CUresult,
+    /// cuOccupancyMaxActiveBlocksPerMultiprocessor - the contract's own postcondition
+    pub cuOccupancyMaxActiveBlocksPerMultiprocessor: unsafe extern "C" fn(
+        num_blocks: *mut c_int,
+        func: CUfunction,
+        block_size: c_int,
+        dynamic_smem_bytes: usize,
+    ) -> CUresult,
+
     /// cuDriverGetVersion - Get CUDA driver version
     pub cuDriverGetVersion: unsafe extern "C" fn(version: *mut c_int) -> CUresult,
 }
@@ -494,6 +532,10 @@ mod loading {
                 type FnDeviceTotalMem = unsafe extern "C" fn(*mut usize, CUdevice) -> CUresult;
                 type FnDeviceGetAttribute =
                     unsafe extern "C" fn(*mut c_int, c_int, CUdevice) -> CUresult;
+                type FnFuncGetAttribute =
+                    unsafe extern "C" fn(*mut c_int, c_int, CUfunction) -> CUresult;
+                type FnOccupancyMaxActiveBlocks =
+                    unsafe extern "C" fn(*mut c_int, CUfunction, c_int, usize) -> CUresult;
                 type FnPrimaryCtxRetain =
                     unsafe extern "C" fn(*mut CUcontext, CUdevice) -> CUresult;
                 type FnPrimaryCtxRelease = unsafe extern "C" fn(CUdevice) -> CUresult;
@@ -670,6 +712,12 @@ mod loading {
                     cuLinkAddData: load_sym!(cuLinkAddData_v2, FnLinkAddData),
                     cuLinkComplete: load_sym!(cuLinkComplete, FnLinkComplete),
                     cuLinkDestroy: load_sym!(cuLinkDestroy, FnLinkDestroy),
+                    // Launch budget / occupancy (O2)
+                    cuFuncGetAttribute: load_sym!(cuFuncGetAttribute, FnFuncGetAttribute),
+                    cuOccupancyMaxActiveBlocksPerMultiprocessor: load_sym!(
+                        cuOccupancyMaxActiveBlocksPerMultiprocessor,
+                        FnOccupancyMaxActiveBlocks
+                    ),
                     // Driver version
                     cuDriverGetVersion: load_sym!(cuDriverGetVersion, FnDriverGetVersion),
                 })

--- a/crates/aprender-gpu/src/launch_budget.rs
+++ b/crates/aprender-gpu/src/launch_budget.rs
@@ -1,0 +1,368 @@
+//! Launch budget validation — the enforcement `ptx-codegen-safety-v1` has always declared.
+//!
+//! `contracts/trueno/ptx-codegen-safety-v1.yaml` equation `register_budget` states
+//!
+//! ```text
+//! forall kernel K:
+//!   reg_count(K)  <= max_regs_per_thread(sm)
+//!   shared_mem(K) <= max_shared_per_block(sm)
+//! postcondition: cuOccupancyMaxActiveBlocksPerMultiprocessor > 0
+//! ```
+//!
+//! and nothing enforced it: the generated `contract_register_budget!` macro is invoked
+//! nowhere in the tree, and its postcondition names an unbound identifier that would not
+//! compile if it ever were. This module is that missing enforcement.
+//!
+//! **Arch-agnostic by construction.** The contract's own `domain` stops at sm_90, and so
+//! does the hand-written arch table in `driver/sys/mod.rs` (`CU_TARGET_COMPUTE_90` is the
+//! last constant). A per-SM limit table is a thing that goes stale every GPU generation —
+//! this one has, twice. So the limits here are **queried from the device**
+//! (`cuDeviceGetAttribute`) rather than looked up, and adding a new architecture requires
+//! no change to this file.
+//!
+//! The policy — [`validate_launch`] — is pure and needs no GPU, so its case table runs in
+//! the required check. Only [`DeviceLimits::query`] and [`KernelAttributes::query`] need
+//! CUDA.
+
+/// Per-kernel resource usage, as reported by the JIT for a *compiled* kernel.
+///
+/// These are properties of the cubin the driver actually produced — not of the PTX we
+/// emitted — which is why they can only be read back after a module load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KernelAttributes {
+    /// Largest block size this kernel can be launched with (`CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`).
+    pub max_threads_per_block: u32,
+    /// Registers used per thread (`CU_FUNC_ATTRIBUTE_NUM_REGS`).
+    pub num_regs: u32,
+    /// Statically declared shared memory, bytes (`CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`).
+    pub static_shared_bytes: u32,
+    /// Per-thread local memory, bytes (`CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`). Non-zero means
+    /// the kernel spilled registers to local memory — legal, but a performance cliff.
+    pub local_bytes: u32,
+}
+
+/// Device-side limits, queried rather than tabulated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceLimits {
+    /// `CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK`.
+    pub max_threads_per_block: u32,
+    /// `CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`.
+    pub max_shared_per_block: u32,
+    /// `CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK`.
+    pub max_regs_per_block: u32,
+    /// `CU_DEVICE_ATTRIBUTE_WARP_SIZE`.
+    pub warp_size: u32,
+}
+
+/// A way a launch violates the kernel's or the device's budget.
+///
+/// Every variant names both sides of the comparison: a violation you cannot act on is a
+/// log line, not a gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum LaunchBudgetViolation {
+    /// Block size exceeds what the compiled kernel supports (usually register pressure).
+    #[error("block size {requested} exceeds the kernel's max_threads_per_block {kernel_max} (register pressure); launch would fail with CUDA_ERROR_INVALID_VALUE")]
+    BlockExceedsKernelMax {
+        /// Threads per block the launch site asked for.
+        requested: u32,
+        /// What the compiled kernel supports.
+        kernel_max: u32,
+    },
+    /// Block size exceeds the device maximum.
+    #[error("block size {requested} exceeds the device's max_threads_per_block {device_max}")]
+    BlockExceedsDeviceMax {
+        /// Threads per block the launch site asked for.
+        requested: u32,
+        /// What the device supports.
+        device_max: u32,
+    },
+    /// Static + dynamic shared memory exceeds the per-block limit.
+    #[error("shared memory {static_bytes}+{dynamic_bytes}={total} bytes exceeds the device's max_shared_per_block {device_max}")]
+    SharedMemoryExceeded {
+        /// Statically declared bytes.
+        static_bytes: u32,
+        /// Dynamically requested bytes.
+        dynamic_bytes: u32,
+        /// Their sum.
+        total: u32,
+        /// Device per-block limit.
+        device_max: u32,
+    },
+    /// Registers for the whole block exceed the per-block register file.
+    #[error("register budget {num_regs}regs x {block_size}threads = {total} exceeds the device's max_regs_per_block {device_max}")]
+    RegisterBudgetExceeded {
+        /// Registers per thread.
+        num_regs: u32,
+        /// Threads per block.
+        block_size: u32,
+        /// Their product.
+        total: u32,
+        /// Device per-block limit.
+        device_max: u32,
+    },
+    /// A zero-sized launch. Always a bug at the call site, never a legal request.
+    #[error("block size is zero")]
+    ZeroBlockSize,
+}
+
+/// Validate one launch configuration against a compiled kernel and its device.
+///
+/// This is the `register_budget` equation, executable. It is **pure** — no CUDA, no global
+/// state — so the case table below runs anywhere, including the CPU-only required check.
+///
+/// # Errors
+///
+/// Returns the first [`LaunchBudgetViolation`] found. Checks are ordered cheapest-first and
+/// most-specific-first, so `BlockExceedsKernelMax` (the actionable one, naming the kernel's
+/// own ceiling) is reported ahead of the device-wide limit.
+pub fn validate_launch(
+    attrs: &KernelAttributes,
+    limits: &DeviceLimits,
+    block_size: u32,
+    dynamic_shared_bytes: u32,
+) -> Result<(), LaunchBudgetViolation> {
+    if block_size == 0 {
+        return Err(LaunchBudgetViolation::ZeroBlockSize);
+    }
+    if block_size > attrs.max_threads_per_block {
+        return Err(LaunchBudgetViolation::BlockExceedsKernelMax {
+            requested: block_size,
+            kernel_max: attrs.max_threads_per_block,
+        });
+    }
+    if block_size > limits.max_threads_per_block {
+        return Err(LaunchBudgetViolation::BlockExceedsDeviceMax {
+            requested: block_size,
+            device_max: limits.max_threads_per_block,
+        });
+    }
+    let total_shared = attrs
+        .static_shared_bytes
+        .saturating_add(dynamic_shared_bytes);
+    if total_shared > limits.max_shared_per_block {
+        return Err(LaunchBudgetViolation::SharedMemoryExceeded {
+            static_bytes: attrs.static_shared_bytes,
+            dynamic_bytes: dynamic_shared_bytes,
+            total: total_shared,
+            device_max: limits.max_shared_per_block,
+        });
+    }
+    let total_regs = attrs.num_regs.saturating_mul(block_size);
+    if total_regs > limits.max_regs_per_block {
+        return Err(LaunchBudgetViolation::RegisterBudgetExceeded {
+            num_regs: attrs.num_regs,
+            block_size,
+            total: total_regs,
+            device_max: limits.max_regs_per_block,
+        });
+    }
+    Ok(())
+}
+
+/// Whether a kernel spilled registers to local memory.
+///
+/// Not a violation — a spilled kernel is correct, just slow — so this is reported
+/// separately from [`validate_launch`] rather than failing it. FALSIFY-PTX-003's
+/// "register spilling causes performance cliff" half.
+#[must_use]
+pub fn spills_to_local(attrs: &KernelAttributes) -> bool {
+    attrs.local_bytes > 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A kernel that comfortably fits: the shape `probe.ptx` reported on GB10.
+    fn ok_kernel() -> KernelAttributes {
+        KernelAttributes {
+            max_threads_per_block: 1024,
+            num_regs: 10,
+            static_shared_bytes: 0,
+            local_bytes: 0,
+        }
+    }
+
+    /// Limits as an sm_89/sm_121-class device reports them.
+    fn limits() -> DeviceLimits {
+        DeviceLimits {
+            max_threads_per_block: 1024,
+            max_shared_per_block: 49152,
+            max_regs_per_block: 65536,
+            warp_size: 32,
+        }
+    }
+
+    #[test]
+    fn accepts_a_legal_launch() {
+        assert!(validate_launch(&ok_kernel(), &limits(), 256, 0).is_ok());
+    }
+
+    #[test]
+    fn accepts_the_kernel_max_exactly() {
+        // Boundary: block_size == max_threads_per_block is legal, not off-by-one.
+        assert!(validate_launch(&ok_kernel(), &limits(), 1024, 0).is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_block_size() {
+        assert_eq!(
+            validate_launch(&ok_kernel(), &limits(), 0, 0),
+            Err(LaunchBudgetViolation::ZeroBlockSize)
+        );
+    }
+
+    #[test]
+    fn rejects_block_above_kernel_max() {
+        // The real GH-613 shape: a register-heavy kernel caps below the device max, and a
+        // hardcoded block=256 launch site walks straight into CUDA_ERROR_INVALID_VALUE.
+        let heavy = KernelAttributes {
+            max_threads_per_block: 128,
+            num_regs: 200,
+            static_shared_bytes: 0,
+            local_bytes: 0,
+        };
+        assert_eq!(
+            validate_launch(&heavy, &limits(), 256, 0),
+            Err(LaunchBudgetViolation::BlockExceedsKernelMax {
+                requested: 256,
+                kernel_max: 128,
+            })
+        );
+    }
+
+    #[test]
+    fn kernel_max_is_reported_before_device_max() {
+        // Both are violated; the kernel's own ceiling is the actionable one.
+        let heavy = KernelAttributes {
+            max_threads_per_block: 128,
+            ..ok_kernel()
+        };
+        let tight = DeviceLimits {
+            max_threads_per_block: 512,
+            ..limits()
+        };
+        assert!(matches!(
+            validate_launch(&heavy, &tight, 2048, 0),
+            Err(LaunchBudgetViolation::BlockExceedsKernelMax { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_block_above_device_max() {
+        let permissive = KernelAttributes {
+            max_threads_per_block: 4096,
+            ..ok_kernel()
+        };
+        assert_eq!(
+            validate_launch(&permissive, &limits(), 2048, 0),
+            Err(LaunchBudgetViolation::BlockExceedsDeviceMax {
+                requested: 2048,
+                device_max: 1024,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_shared_memory_overflow_counting_both_halves() {
+        // static alone fits and dynamic alone fits; only the SUM violates.
+        let k = KernelAttributes {
+            static_shared_bytes: 32768,
+            ..ok_kernel()
+        };
+        assert_eq!(
+            validate_launch(&k, &limits(), 256, 32768),
+            Err(LaunchBudgetViolation::SharedMemoryExceeded {
+                static_bytes: 32768,
+                dynamic_bytes: 32768,
+                total: 65536,
+                device_max: 49152,
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_shared_memory_exactly_at_the_limit() {
+        let k = KernelAttributes {
+            static_shared_bytes: 49152,
+            ..ok_kernel()
+        };
+        assert!(validate_launch(&k, &limits(), 256, 0).is_ok());
+    }
+
+    #[test]
+    fn rejects_register_budget_overflow() {
+        // 255 regs x 1024 threads = 261_120 > 65_536.
+        let k = KernelAttributes {
+            max_threads_per_block: 1024,
+            num_regs: 255,
+            ..ok_kernel()
+        };
+        assert_eq!(
+            validate_launch(&k, &limits(), 1024, 0),
+            Err(LaunchBudgetViolation::RegisterBudgetExceeded {
+                num_regs: 255,
+                block_size: 1024,
+                total: 261_120,
+                device_max: 65536,
+            })
+        );
+    }
+
+    #[test]
+    fn register_product_saturates_instead_of_overflowing() {
+        // u32 multiply of two large values must not wrap into a FALSE PASS.
+        let k = KernelAttributes {
+            max_threads_per_block: u32::MAX,
+            num_regs: u32::MAX,
+            ..ok_kernel()
+        };
+        let wide = DeviceLimits {
+            max_threads_per_block: u32::MAX,
+            ..limits()
+        };
+        assert!(matches!(
+            validate_launch(&k, &wide, u32::MAX, 0),
+            Err(LaunchBudgetViolation::RegisterBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn shared_memory_sum_saturates_instead_of_overflowing() {
+        let k = KernelAttributes {
+            static_shared_bytes: u32::MAX,
+            ..ok_kernel()
+        };
+        assert!(matches!(
+            validate_launch(&k, &limits(), 256, u32::MAX),
+            Err(LaunchBudgetViolation::SharedMemoryExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn spill_detection_is_separate_from_validity() {
+        let spilled = KernelAttributes {
+            local_bytes: 128,
+            ..ok_kernel()
+        };
+        // Spilling is a performance cliff, not an illegal launch.
+        assert!(validate_launch(&spilled, &limits(), 256, 0).is_ok());
+        assert!(spills_to_local(&spilled));
+        assert!(!spills_to_local(&ok_kernel()));
+    }
+
+    #[test]
+    fn violations_name_both_sides_of_the_comparison() {
+        // A violation you cannot act on is a log line, not a gate.
+        let heavy = KernelAttributes {
+            max_threads_per_block: 128,
+            ..ok_kernel()
+        };
+        let Err(v) = validate_launch(&heavy, &limits(), 256, 0) else {
+            panic!("expected a violation");
+        };
+        let msg = v.to_string();
+        assert!(msg.contains("256"), "message must name the request: {msg}");
+        assert!(msg.contains("128"), "message must name the limit: {msg}");
+    }
+}

--- a/crates/aprender-gpu/src/lib.rs
+++ b/crates/aprender-gpu/src/lib.rs
@@ -150,8 +150,13 @@ pub mod monitor;
 #[cfg(feature = "cuda")]
 pub mod ptx;
 
-/// Error types for trueno-gpu operations
 pub mod error;
+/// Error types for trueno-gpu operations
+/// Launch budget validation — the executable form of
+/// `contracts/trueno/ptx-codegen-safety-v1.yaml` `register_budget`.
+/// Deliberately NOT under `driver` (which is `#[cfg(feature = "cuda")]` in its
+/// entirety): the policy is pure, so its case table runs in the required check.
+pub mod launch_budget;
 
 /// E2E visual testing framework for GPU kernels
 pub mod testing;


### PR DESCRIPTION
**O2** of the 0.67 CUDA Rust spec (#3062). Developed and validated on **gx10 (GB10 Blackwell sm_121)**, the only host where the interesting arch lives.

## The defect

`contracts/trueno/ptx-codegen-safety-v1.yaml` equation `register_budget` declares a register/shared-memory budget with postcondition `cuOccupancyMaxActiveBlocksPerMultiprocessor > 0`. **Nothing enforced it:**

- the generated macro `contract_register_budget!` is invoked **nowhere in the tree**
- its postcondition names `cuOccupancyMaxActiveBlocksPerMultiprocessor`, an unbound identifier that would not compile if the macro ever were invoked
- `FALSIFY-PTX-003`'s `test:` is prose — *"Parse ptxas output for register count, assert <= 128"* — and prose never runs
- it carries `registry: true`, the exemption class retired 2026-08-21

Meanwhile `aprender-gpu` launches hand-emitted PTX with hardcoded block sizes (128/256) and validates **nothing** about the kernel the JIT actually produced.

## Two deliberate design splits

**1. The policy is ungated.** `crate::launch_budget::validate_launch` is pure and lives at the crate root, *not* under `driver`. The whole `driver` module is `#[cfg(feature = "cuda")]` (`lib.rs:138`), so anything placed there runs only with `--features cuda` and would never reach the required check.

> Measured while building this: that is exactly why `driver::ptx_patch`'s GH-480 tests are dark today — despite its module comment claiming *"NOT feature-gated so that its tests run without CUDA hardware."* Putting the policy there would have made O2 theater.

`aprender-gpu --lib` goes **444 → 457** tests, all in the CPU-only path #3063 un-darks.

**2. Limits are queried, not tabulated.** A per-SM table goes stale every GPU generation and this one did — the hand-written `CU_TARGET_COMPUTE_*` list stops at 90, and so did the contract's own `domain`. `driver/budget_query.rs` reads limits from `cuDeviceGetAttribute`, so sm_100/120/121 and whatever ships next need **no edit here**.

## Mechanism engaged, on Blackwell

Not "it compiled" — the actual values read back on GB10 sm_121 under ptxas 13.3:

```
cc=(12,1)  kernel{max_thr=1024 regs=8 smem=0 local=0}
           device{max_thr=1024 smem=49152 regs=65536 warp=32}
           occupancy@256=6
```

`19/19` with `--features cuda` on sm_121, and `13/13` pure on the default build. Also 19/19 on RTX 4090 sm_89.

## Mutation proof — and the test that failed it

Deleting the block-size comparison in `validate_launch` turns **4 tests RED**, restoring turns them GREEN:

```
launch_budget::tests::rejects_block_above_kernel_max
launch_budget::tests::kernel_max_is_reported_before_device_max
launch_budget::tests::violations_name_both_sides_of_the_comparison
driver::cuda_tests::launch_budget_hw::budget_goes_red_on_an_oversized_block
```

**The hardware test's first version SURVIVED the mutation.** It asserted only that an error occurred — but with the kernel-max check deleted the oversized launch falls through to the device-wide check and *still* errors, so the test witnessed nothing. It now asserts the **specific** violation. That was found by running the mutation, not by reading the test, and the contract's `red_witness` records it.

## Contract repaired in the same commit

- `registry: true` dropped
- `FALSIFY-PTX-003` prose replaced with two executable `cargo test` commands
- `domain` extended past sm_90 to 100/120/121
- two pre-monorepo paths fixed (`trueno/src/…`, `realizar/src/…` — neither exists since APR-MONO)
- `enforced_by:` names the two files that now implement it
- `pv validate` → **0 errors, 0 warnings**

## Verification

`cargo fmt` clean · `clippy -D warnings` clean on **both** default and `--features cuda` — the raw-pointer entry points are `unsafe fn` with `# Safety` docs rather than an `#[allow]` · 457/457 default · 19/19 cuda on sm_89 **and** sm_121.

Refs #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9cSQynVPYeUkQ2i7ccvrs