### PR TITLE
fix(ptx): emitter was non-deterministic — the cubin cache has NEVER hit (42,880 stale cubins / 498 MB)

### DIFF
--- a/crates/aprender-gpu/src/ptx/registers/mod.rs
+++ b/crates/aprender-gpu/src/ptx/registers/mod.rs
@@ -3,7 +3,7 @@
 //! Provides register allocation with liveness analysis to prevent spills (Muda).
 
 use super::types::PtxType;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 /// Special PTX registers (read-only hardware registers)
@@ -264,7 +264,16 @@ impl RegisterAllocator {
         // BUG FIX: previously grouped by PtxType → duplicate .reg lines for
         // types sharing a prefix (U64+B64→%rd, U8+B8→%rs, etc.).
         // Now groups by prefix; declaration type is taken from first type in group.
-        let mut by_prefix: HashMap<&'static str, (PtxType, Vec<&VirtualReg>)> = HashMap::new();
+        // BTreeMap, NOT HashMap: this map is ITERATED to emit `.reg` declarations, and
+        // Rust's HashMap iteration order is randomised per process. With a HashMap the
+        // SAME kernel emitted twice produced two different PTX strings (measured: 5
+        // emissions in one process -> 5 distinct outputs), and since the cubin disk cache
+        // is keyed on sha256(patched_ptx ‖ target ‖ driver), every emission minted a fresh
+        // key and the cache could never hit. Measured fallout before this fix: 42,880
+        // distinct cubins / 498 MB on one dev box, 25,216 / 274 MB on gx10, for a few dozen
+        // real kernels. Ordering by prefix is arbitrary but STABLE, which is all the
+        // declarations need.
+        let mut by_prefix: BTreeMap<&'static str, (PtxType, Vec<&VirtualReg>)> = BTreeMap::new();
         for vreg in &self.allocated {
             let prefix = vreg.ty().register_prefix();
             by_prefix
@@ -278,7 +287,7 @@ impl RegisterAllocator {
         // NOTE: PTX only supports register declarations of 16-bit or wider types.
         // 8-bit types (.u8, .s8, .b8) must be widened to their 16-bit equivalent.
         // Values are automatically zero/sign-extended to 16 bits by the hardware.
-        for (prefix, (ty, regs)) in by_prefix {
+        for (prefix, (ty, regs)) in &by_prefix {
             if !regs.is_empty() {
                 let count = regs.len();
                 let decl_type = ty.register_declaration_type();

--- a/crates/aprender-gpu/src/ptx/registers/tests.rs
+++ b/crates/aprender-gpu/src/ptx/registers/tests.rs
@@ -226,3 +226,79 @@ fn test_live_range_fields() {
     assert_eq!(range.start, 5);
     assert_eq!(range.end, 15);
 }
+
+/// PTX emission must be a PURE FUNCTION of its inputs.
+///
+/// `emit_declarations` iterates a map to produce `.reg` lines. With the `HashMap` this
+/// used to be, iteration order was randomised per map instance, so the SAME kernel emitted
+/// twice produced two different PTX strings — measured as 5 distinct outputs from 5
+/// emissions in one process.
+///
+/// That is not cosmetic. The cubin disk cache is keyed on
+/// `sha256(patched_ptx ‖ jit_target ‖ driver_version)` (`driver/ptx_cache.rs`), so a
+/// non-deterministic emitter mints a fresh key every time and the cache can never hit.
+/// Measured fallout before the fix: **42,880 distinct cubins / 498 MB** in
+/// `~/.cache/trueno/ptx/` on one dev box and **25,216 / 274 MB** on gx10, for a few dozen
+/// real kernels.
+#[cfg(test)]
+mod determinism {
+    use super::super::RegisterAllocator;
+    use crate::ptx::types::PtxType;
+
+    /// Allocate a fixed, prefix-colliding set: several types share a `.reg` prefix
+    /// (`U64`/`B64` → `%rd`, `U8`/`B8` → `%rs`), which is what the grouping map exists for.
+    fn allocate_fixed() -> RegisterAllocator {
+        let mut a = RegisterAllocator::new();
+        for ty in [
+            PtxType::Pred,
+            PtxType::F32,
+            PtxType::U32,
+            PtxType::U64,
+            PtxType::S32,
+            PtxType::U16,
+            PtxType::F32,
+            PtxType::U64,
+        ] {
+            let _ = a.allocate_virtual(ty);
+        }
+        a
+    }
+
+    #[test]
+    fn emit_declarations_is_stable_across_allocator_instances() {
+        // Two independent allocators, identical allocation sequence. Under a HashMap these
+        // are two different map instances with two different iteration orders, so this is
+        // the assertion that turns RED if the BTreeMap is reverted.
+        let first = allocate_fixed().emit_declarations();
+        for i in 0..32 {
+            let again = allocate_fixed().emit_declarations();
+            assert_eq!(
+                first, again,
+                "emit_declarations must be a pure function of its inputs (iteration {i}); \
+                 a non-deterministic emitter mints a fresh cubin cache key every call"
+            );
+        }
+    }
+
+    #[test]
+    fn emit_declarations_is_stable_within_one_allocator() {
+        let a = allocate_fixed();
+        let first = a.emit_declarations();
+        assert_eq!(first, a.emit_declarations());
+    }
+
+    #[test]
+    fn declarations_are_sorted_by_register_prefix() {
+        // Order is arbitrary but must be STABLE. Asserting the actual order pins it, so a
+        // future refactor back to an unordered container is caught rather than absorbed.
+        let out = allocate_fixed().emit_declarations();
+        let prefixes: Vec<&str> = out
+            .lines()
+            .filter_map(|l| l.split_whitespace().nth(2))
+            .map(|d| d.split('<').next().unwrap_or(d))
+            .collect();
+        let mut sorted = prefixes.clone();
+        sorted.sort_unstable();
+        assert_eq!(prefixes, sorted, "`.reg` declarations must be emitted in a stable (sorted) prefix order, got {prefixes:?}");
+    }
+}


### PR DESCRIPTION
Found while building T3 (#3065). `RegisterAllocator::emit_declarations` iterated a **`HashMap`** to emit `.reg` lines, and Rust randomises HashMap iteration order per map instance — so PTX emission was **not a pure function of its inputs**.

## Measured before the fix (gx10)

```
same kernel (VectorizedRmsNormKernel h=4096), 5 emissions in ONE process
  -> 5 DISTINCT PTX strings
same kernel, 3 separate processes
  -> 3 distinct sha256
reg order across h=2048 / 4096 / 8192
  -> [.pred .f32 .u64 .u32] / [.u64 .u32 .f32 .pred] / [.u64 .pred .u32 .f32]
```

## Why it isn't cosmetic

`driver/ptx_cache.rs` keys the cubin disk cache on `sha256(patched_ptx ‖ jit_target ‖ driver_version)`, and `generate_ptx` is called **per launch path** (`layer_cuda_executor.rs:71`, `incremental_attention.rs:94`, …). A fresh key every call means **the cache can never hit** — every kernel is JIT-compiled from scratch, every time, and the cache grows without bound.

I checked the predicted consequence on disk rather than assuming it:

| host | `~/.cache/trueno/ptx/` |
|---|---|
| lambda-vector | **42,880 cubins / 498 MB** |
| gx10 | **25,216 cubins / 274 MB** |

42,880 distinct sha256 keys for a few dozen distinct kernels.

## Fix

`HashMap` → `BTreeMap` for the prefix-grouping map. Declaration order becomes sorted-by-prefix — arbitrary, but **stable**, which is all `.reg` declarations require. One line, plus a comment on why it must not go back.

After, same script and host: 5 emissions → **1** distinct output; 3 processes → identical sha256; all three hidden sizes → identical order.

## Mutation proof

Reverting `BTreeMap` → `HashMap` turns all three new tests RED; restoring turns them GREEN. Worth noting the second one: **two calls on one allocator** disagreed, because the map is rebuilt per call.

## Verification

fmt clean · clippy `-D warnings` clean on default **and** `--features cuda` · `cargo test -p aprender-gpu --features cuda --lib` → **2604 passed, 0 failed**.

## Caveat that limits this guard

`pub mod ptx` is `#[cfg(feature = "cuda")]` (`lib.rs:150`), so these tests run **only** with `--features cuda` — today that means the gx10 nightly, not the required check. Filed separately.

Refs #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9cSQynVPYeUkQ2i7ccvrs