### PR TITLE
fix(guard): check_format_command_matrix.sh validates --out before mkdir (bashrs SEC010) — the 0.66.0 release dogfood's one red row (PMAT-1096)

### DIFF
--- a/scripts/check_format_command_matrix.sh
+++ b/scripts/check_format_command_matrix.sh
@@ -149,6 +149,7 @@ esac; done
 SINGLE="$MODELS_DIR/qwen2.5-coder-0.5b-instruct-safetensors/model.safetensors"
 [ -f "$SINGLE" ] || { printf '%s: ENV - %s not on this host\n' "$PROG" "$SINGLE" >&2; exit 2; }
 OUT=${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/fcm-live.XXXXXX")}
+case "$OUT" in *..*) printf '%s: refusing an --out with "..": %s\n' "$PROG" "$OUT" >&2; exit 2 ;; esac   # bashrs SEC010 (the 0.66.0 pre-publish dogfood, PMAT-1096)
 mkdir -p "$OUT"
 
 if [ -z "$FIXTURE" ]; then


### PR DESCRIPTION
The pre-publish dogfood on the release commit `7a33db8e0` (PMAT-1096 autopilot, R5 receipt) is NO-GO on exactly one row: `bashrs` — 1 SEC010 over 278 files, `scripts/check_format_command_matrix.sh:152` (`mkdir -p "$OUT"` with an unvalidated `--out`), a script #3050 (F-1) brought in. The tag waits on this.

Fix: refuse an `--out` carrying `..` before the `mkdir` (the pattern `predict_merge.sh` uses). Per-file and single-invocation bashrs gating count 0 over the tree; `--self-test` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjhtNUSensCYpQb3mCYLod