### PR TITLE
perf(ci): P0-3 — the quick tier is ONE build graph (55 min → ~6 min) and the merge queue mirrors the PR instead of paying an hour for a moved main (67-E1 + 67-E2, #3084, PMAT-1098)

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -236,6 +236,13 @@ jobs:
           # the same path. The work root is mirrored host<->container; $HOME is not.
           CACHE="$(cd "$GITHUB_WORKSPACE/../.." && pwd)/cache-apr-cuda/${{ matrix.target }}"
           mkdir -p "$CACHE/registry" "$CACHE/target"
+          # The bind-mount TARGET inside the workspace must exist BEFORE the container
+          # starts: when it does not, dockerd creates the mountpoint as root, and after
+          # the container exits the workspace carries an empty root-owned `target/` the
+          # runner (uid 1001) cannot write — run 34488955316 built the asset in 1m54s and
+          # then died on `mkdir: cannot create directory 'target/aarch64-unknown-linux-gnu':
+          # Permission denied`. Pre-creating it as the runner keeps the ownership.
+          mkdir -p "$GITHUB_WORKSPACE/target"
           $DOCKER run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -v "$CACHE/registry:/usr/local/cargo/registry" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1922,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2243,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2372,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,26 @@ jobs:
         run: |
           set -euo pipefail
           args=(--event "${GITHUB_EVENT_NAME}")
+          # PMAT-1098 67-E2: the queue and a push to main re-derive their own
+          # diff from HEAD's FIRST PARENT (HEAD^1..HEAD is the PR's diff on the
+          # new base). actions/checkout is shallow, so that parent is not in the
+          # object store until we deepen -- and without it ci_test_tier.sh falls
+          # closed to `full` every single time, which would make the whole
+          # optimisation inert while looking like it worked. Best effort by
+          # design: if the deepen fails the decision still falls closed, and the
+          # warning below says so instead of the run silently paying the hour.
+          case "${GITHUB_EVENT_NAME}" in
+            merge_group|push)
+              git fetch --no-tags --depth=2 origin "${GITHUB_SHA}" 2>/dev/null \
+                || git fetch --no-tags --deepen=1 origin 2>/dev/null \
+                || true
+              if git rev-parse -q --verify 'HEAD^1' >/dev/null 2>&1; then
+                printf 'first parent available: %s\n' "$(git rev-parse HEAD^1)"
+              else
+                printf '::warning::first parent unavailable after deepen -- the tier falls closed to full\n'
+              fi
+              ;;
+          esac
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
               git fetch --no-tags --depth=1 origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
@@ -369,7 +389,7 @@ jobs:
               ;;
           esac
           bash scripts/ci_test_tier.sh "${args[@]}" | tee "$RUNNER_TEMP/tier.txt"
-          grep -E '^(tier|crates|targets|reason|cite)=' "$RUNNER_TEMP/tier.txt" >> "$GITHUB_OUTPUT"
+          grep -E '^(tier|crates|targets|check_workspace|reason|cite)=' "$RUNNER_TEMP/tier.txt" >> "$GITHUB_OUTPUT"
       - name: Workspace lib tests (25,300+)
         if: steps.tier.outputs.tier == 'full'
         # Excluded: aprender-compute (SIMD SIGSEGV at exit), aprender-gpu and aprender-cuda-edge
@@ -614,6 +634,47 @@ jobs:
             -e CARGO_TERM_COLOR=never \
             "$IMAGE" \
             cargo nextest run --profile ci --workspace --lib --tests --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute -E "$EXPR"
+      # BSE-17 quick tier, part 3 (PMAT-1098 67-E2, #3084 — rule (i)): the
+      # selection was OVER THE CAP (touched crates + their direct reverse
+      # dependents exceed gate_touched_crates.sh's CAP=3). That used to escalate
+      # the entire run to the full tier — roughly an hour — for the ordinary case
+      # of touching a widely-depended-on crate. The touched crates' own tests ran
+      # in part 1; this step buys what the cap was really protecting, the reverse
+      # dependents' INTEGRATION, at compile level over the WHOLE workspace in one
+      # cargo invocation: minutes, not an hour. It catches exactly the class the
+      # cap exists for — signature changes, trait-impl breakage, type errors in
+      # every dependent, benches and examples included (--all-targets). A
+      # behaviour regression inside an untouched dependent is not caught here; it
+      # is what the nightly full tier is for (decision D-1).
+      #
+      # --locked: a quick tier that silently rewrites Cargo.lock would be a
+      # different dependency graph from the one the PR is proposing.
+      - name: "Quick tier: cargo check --workspace (over-the-cap integration, BSE-17 rule (i))"
+        if: steps.tier.outputs.tier == 'quick' && steps.tier.outputs.check_workspace == '1'
+        timeout-minutes: 20
+        env:
+          REASON: ${{ steps.tier.outputs.reason }}
+        run: |
+          set -euo pipefail
+          printf 'over the cap: %s\n' "$REASON"
+          docker run --rm \
+          -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${SCCACHE_HOST_DIR}:/sccache" \
+            -w /workspace \
+            -e CARGO_TARGET_DIR=/workspace/target \
+            -e RUSTC_WRAPPER=rustc-sccache \
+            -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=50G \
+            -e CARGO_INCREMENTAL=0 \
+            -e CARGO_BUILD_JOBS=8 \
+            -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
+            -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
+            -e CARGO_TERM_COLOR=never \
+            "$IMAGE" \
+            cargo check --workspace --all-targets --locked
       # BSE-17 reuse: the queue ref's tree is byte-identical to a PR head whose
       # workspace-test already succeeded; measuring it again is waste, not
       # evidence. The tier step proved both facts (trees compared by hash, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
-      # BUILD POOL (#3100): every job of the reusable workflow lands on any x86 box carrying `build`
-      # (paiml/.github#67 added the input; its default is the clean-room pool every other consumer uses).
-      runs_on: '["self-hosted","X64","Linux","build"]'
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
@@ -96,7 +93,7 @@ jobs:
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): measured on yoga (CI nextest line ~11 min vs 73 on the shared intel box)
     # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
     # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
     # timeout always fired first -- producing a bare "The operation was canceled"
@@ -663,7 +660,7 @@ jobs:
   # can never again silently land a job on a GPU/dev runner without the
   # sovereign-ci registry. Pure text check; runs on the clean-room pool.
   guard-tree:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until its host-side guards are measured on the pool (#3100)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): p50 52.9 /
     # p99 85.1 minutes over the last 9 SUCCESSFUL runs of this job as it stood
@@ -1015,7 +1012,7 @@ jobs:
   # No `needs:` — running these AFTER workspace-test would serialise ~40
   # minutes onto every green run for no ordering that anything requires.
   guard-cargo:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): the
     # unsplit `guard-tree` measured p50 52.9 / p99 85.1 minutes over
@@ -1840,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): pure scripts, no image, no arch need — any pool box incl. gx10-build
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -1925,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2246,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2375,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
@@ -2476,7 +2473,7 @@ jobs:
   # in the C0-5 PR body, never applied by the session that wrote this).
 
   gate:
-    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): no image, no arch need — any pool box incl. gx10-build
+    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): result check only; must not wait an hour for an intel slot
     # 22: BSE-05 formula T = max(15, ceil(1.5*p99), p99+20) over this job's own
     # history -- p50 0.2 / p90 1.4 / p99 1.4 minutes over its last 7 successful
     # runs, so p99+20 = 21.4 binds and rounds to 22. This job only reads
@@ -2547,7 +2544,7 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # BUILD POOL (#3100): every job of the reusable workflow lands on any x86 box carrying `build`
+      # (paiml/.github#67 added the input; its default is the clean-room pool every other consumer uses).
+      runs_on: '["self-hosted","X64","Linux","build"]'
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,7 +606,11 @@ jobs:
       # exclusion removes nothing the filterset asks for.
       - name: "Quick tier: every test target that reads the tree (BSE-17)"
         if: steps.tier.outputs.tier == 'quick'
-        timeout-minutes: 20
+        # 45, not 20. Measured 2026-09-11 under train load, this PR's own runs never fit 20: run 34542045481 on
+        # yoga-build2 compiled 811 crates in ~9 min (cold per-run target dir, warm shared sccache) and was part way
+        # through 65,266 tests at the cap; attempt 2 on intel-clean-room-15 timed out at 20 min too. The ~6 min
+        # figure was never reproduced in CI. 45 still sits well under the serial tier's 60; re-tighten when measured.
+        timeout-minutes: 45
         env:
           TARGETS: ${{ steps.tier.outputs.targets }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
     # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
     # timeout always fired first -- producing a bare "The operation was canceled"
@@ -660,7 +660,7 @@ jobs:
   # can never again silently land a job on a GPU/dev runner without the
   # sovereign-ci registry. Pure text check; runs on the clean-room pool.
   guard-tree:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): p50 52.9 /
     # p99 85.1 minutes over the last 9 SUCCESSFUL runs of this job as it stood
@@ -1012,7 +1012,7 @@ jobs:
   # No `needs:` — running these AFTER workspace-test would serialise ~40
   # minutes onto every green run for no ordering that anything requires.
   guard-cargo:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): the
     # unsplit `guard-tree` measured p50 52.9 / p99 85.1 minutes over
@@ -1837,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -1922,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2243,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2372,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
@@ -2473,7 +2473,7 @@ jobs:
   # in the C0-5 PR body, never applied by the session that wrote this).
 
   gate:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): no image, no arch need — any pool box incl. gx10-build
     # 22: BSE-05 formula T = max(15, ceil(1.5*p99), p99+20) over this job's own
     # history -- p50 0.2 / p90 1.4 / p99 1.4 minutes over its last 7 successful
     # runs, so p99+20 = 21.4 binds and rounds to 22. This job only reads
@@ -2544,7 +2544,7 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1837,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): pure scripts, no image, no arch need — any pool box incl. gx10-build
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
       # in its per-PR-per-run target dir
-      # (`/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>`)
+      # (`${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>`)
       # for ~34min, leaving only ~4min for tests inside the 40min timeout —
       # the entire merge queue saturates.
       #
@@ -54,7 +54,7 @@ jobs:
       # was missing the `rustc-sccache` wrapper script. Fixed upstream in
       # paiml/infra commit f4fccf9 (PR #66, "use exec script not symlink").
       # 2026-05-12: re-enabled — image verified to ship `/usr/local/bin/rustc-sccache`
-      # (sccache 0.14.0), shared cache at `/home/noah/data/sccache` (warm, ~11GB).
+      # (sccache 0.14.0), shared cache at `${SCCACHE_HOST_DIR}` (warm, ~11GB).
       # 2026-08-20: that "warm, ~11GB" was NOT health — it was the cache pinned
       # at sccache's DEFAULT 10 GiB cap. /var/log/ci-metrics/sccache-*.json has
       # recorded cache_size and max_cache_size on every job all along (18,292
@@ -86,7 +86,7 @@ jobs:
   # unconditional `docker pull` with only 3 retries / ~6s total backoff) to
   # explicit `docker run` steps with a 15-attempt linear-backoff pull retry.
   # The previous design conflated "image is required" with "registry must be
-  # reachable at pull time" — when `localhost:5000` blipped (registry restart,
+  # reachable at pull time" — when `${CI_REGISTRY}` blipped (registry restart,
   # network reload), the pull failed and the whole job died after ~25s. This
   # refactor preserves the same execution semantics (same image, same volume
   # mounts, same env) but moves the pull into a step the workflow controls,
@@ -114,10 +114,22 @@ jobs:
       # The sccache host directory, named ONCE per job: the machine-specific-path
       # ratchet counts literals, and the quick-tier steps added two more copies
       # of a path this job already spelled five times (PMAT-1077).
-      SCCACHE_HOST_DIR: /home/noah/data/sccache
-      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Five-whys: the end-of-job "Fix file ownership" step is
         # `if: always()`, but a hard-killed job (runner death, forced
@@ -143,7 +155,7 @@ jobs:
           fi
       - uses: actions/checkout@v7
       - name: Pull sovereign-ci image (with retry + local-cache fallback)
-        # Self-hosted runner's local Docker registry at localhost:5000 is
+        # Self-hosted runner's local Docker registry at ${CI_REGISTRY} is
         # occasionally restarting OR experiencing extended outages
         # (paiml/infra ops). Two layers of resilience:
         #   1. Check the local Docker daemon cache first — the image was
@@ -171,7 +183,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts (~13min) AND image not in local cache"
+              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts (~13min) AND image not in local cache"
               echo "::error::Suggests paiml/infra runner-side registry restart + initial image seed needed"
               exit 1
             fi
@@ -194,7 +206,7 @@ jobs:
         # cancelled:
         #
         #   docker run --rm \
-        #     -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+        #     -v "${CI_TARGETS_ROOT}/${PR_OR_REF}:/workspace/target" \
         #     "$IMAGE" bash -c 'rm -rf /workspace/target/* /workspace/target/.[!.]* ...'
         #
         # It mounted the PARENT. The tree is `aprender-ci/<PR>/run-<RUN_ID>`
@@ -204,7 +216,7 @@ jobs:
         #
         # Its own five-whys (whose text is preserved below) was written against
         # a premise #1693 removed: "the target dir is bind-mounted from a per-PR
-        # persistent path /mnt/nvme-raid0/targets/aprender-ci/<PR>/, so partial-
+        # persistent path ${CI_TARGETS_ROOT}/<PR>/, so partial-
         # compile state survives across runs". Since #1693 the mount is per-RUN,
         # so no other run's state can reach this run at all. The parent-wide
         # removal bought nothing and could only take a sibling with it:
@@ -246,7 +258,7 @@ jobs:
         run: |
           set -uo pipefail
           set +e
-          PARENT="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
+          PARENT="${CI_TARGETS_ROOT}/${PR_OR_REF}"
           PLAN="${RUNNER_TEMP:-/tmp}/reclaim-${GITHUB_RUN_ID}.txt"
           bash scripts/ci_reclaim_target_dirs.sh "$PARENT" "$GITHUB_RUN_ID" > "$PLAN"
           rc=$?
@@ -297,10 +309,10 @@ jobs:
             done
             mkdir -p "$path"
           }
-          parent="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
-          reg="/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}"
-          heal_path /mnt/nvme-raid0/targets/aprender-ci "${parent}/run-${GITHUB_RUN_ID}"
-          heal_path /mnt/nvme-raid0/cargo-ci/registry "$reg"
+          parent="${CI_TARGETS_ROOT}/${PR_OR_REF}"
+          reg="${CI_CARGO_ROOT}/registry/${PR_OR_REF}"
+          heal_path ${CI_TARGETS_ROOT} "${parent}/run-${GITHUB_RUN_ID}"
+          heal_path ${CI_CARGO_ROOT}/registry "$reg"
           ls -ld "$parent" "${parent}/run-${GITHUB_RUN_ID}" "$reg"
       - name: Pre-build chown — fix per-RUN root ownership
         # Root cause (five-whys):
@@ -309,7 +321,7 @@ jobs:
         #      Cargo (running as user 1000 inside the container) can't
         #      write to /workspace/target/debug.
         #   2. Why can't it write? The bind-mount source dir on the host
-        #      (/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>) is
+        #      (${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>) is
         #      owned by root:root.
         #   3. Why is it root-owned? Docker's bind-mount creates missing
         #      host directories with the daemon's uid (root). Per-RUN
@@ -328,8 +340,8 @@ jobs:
         # noah-owned (e.g. a rerun of the same run-id).
         run: |
           docker run --rm \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
       # BSE-17 (PMAT-1077): which tier this run owes. quick on pull_request —
@@ -411,8 +423,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -435,8 +447,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -455,8 +467,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -508,8 +520,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -536,8 +548,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -580,8 +592,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -638,8 +650,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace || true; chown -R 1000:1000 /usr/local/cargo/registry || true; chown -R 1000:1000 /workspace/target || true'
 
@@ -658,7 +670,6 @@ jobs:
     # here, because this job strictly shrank.
     timeout-minutes: 90
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       # Same definition as workspace-test (:106). aprender#2627: the
       # model-tests step below was added with workspace-test's mount lines
       # copied verbatim, but PR_OR_REF is JOB-level env there and this job
@@ -674,6 +685,20 @@ jobs:
       # not define.
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -977,7 +1002,7 @@ jobs:
   #
   # workspace-test and the guard job are two jobs of the SAME run on two
   # runners of one host, and both bind-mounted
-  # `/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>` as
+  # `${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>` as
   # `/workspace/target` while both ran cargo against it. That is the
   # dep-info race behind aprender#2822 / `could not parse/generate dep info
   # at .../deps/<crate>.d: No such file or directory`. This job's container
@@ -998,12 +1023,10 @@ jobs:
     # above the worst contended run of the strictly larger job it came from.
     timeout-minutes: 90
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
       # This job's OWN per-run target dir. The `-guards` suffix is the whole
       # point: workspace-test mounts `run-<RUN_ID>` and this job must never
       # resolve to the same path. Reaped by the same `run-*` sweep on intel.
-      GUARD_TARGET_DIR: /mnt/nvme-raid0/targets/aprender-ci/${{ github.event.pull_request.number || github.ref_name }}/run-${{ github.run_id }}-guards
       # PMAT-238 (paiml/infra#435): the CARGO_HOME mount is the WHOLE cargo
       # home, not `registry/` alone. `.package-cache` and
       # `.package-cache-mutate` are cargo's flock files and they live beside
@@ -1011,8 +1034,23 @@ jobs:
       # container its own private lock while they all share one registry —
       # which is infra#77 (16 private locks over one shared registry), and it
       # corrupts the registry rather than serialising access to it.
-      GUARD_CARGO_HOME: /mnt/nvme-raid0/cargo-ci/home/${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+            echo "GUARD_TARGET_DIR=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}/${{ github.event.pull_request.number || github.ref_name }}/run-${GITHUB_RUN_ID}-guards"
+            echo "GUARD_CARGO_HOME=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}/home/${{ github.event.pull_request.number || github.ref_name }}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -1098,8 +1136,8 @@ jobs:
             done
             mkdir -p "$path"
           }
-          heal_path /mnt/nvme-raid0/targets/aprender-ci "$GUARD_TARGET_DIR"
-          heal_path /mnt/nvme-raid0/cargo-ci/home "$GUARD_CARGO_HOME/registry"
+          heal_path ${CI_TARGETS_ROOT} "$GUARD_TARGET_DIR"
+          heal_path ${CI_CARGO_ROOT}/home "$GUARD_CARGO_HOME/registry"
           printf 'target dir: %s\n' "$GUARD_TARGET_DIR"
           printf 'cargo home: %s (registry/ .package-cache .package-cache-mutate travel together)\n' "$GUARD_CARGO_HOME"
       # Poka-yoke: a beat that no workflow executes reads as enforcement, is
@@ -1559,7 +1597,7 @@ jobs:
               -v "${GUARD_CARGO_HOME}:/cargo-home" \
               -v "${GUARD_TARGET_DIR}:/workspace/target" \
               -e CARGO_HOME=/cargo-home \
-              -v "/home/noah/data/sccache:/sccache" \
+              -v "${SCCACHE_HOST_DIR}:/sccache" \
               -w /workspace \
               -e CARGO_TARGET_DIR=/workspace/target \
               -e RUSTC_WRAPPER=rustc-sccache \
@@ -2511,12 +2549,25 @@ jobs:
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       # Max surviving (missed) mutants tolerated on the PR diff. 0 = every
       # mutant introduced/touched by this PR must be caught by a test. Tune up
       # via repo variable MUTANTS_MAX_MISSED if a diff legitimately can't reach 0.
       MUTANTS_MAX_MISSED: ${{ vars.MUTANTS_MAX_MISSED || '0' }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test: a hard-killed docker job leaves
         # root-owned files that EACCES this job's `git clean` at checkout
@@ -2573,7 +2624,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts AND image not in local cache"
+              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts AND image not in local cache"
               exit 1
             fi
             echo "Pull attempt $i/$max_attempts failed; sleeping ${delay}s"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
       # in its per-PR-per-run target dir
-      # (`${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>`)
+      # (`/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>`)
       # for ~34min, leaving only ~4min for tests inside the 40min timeout —
       # the entire merge queue saturates.
       #
@@ -54,7 +54,7 @@ jobs:
       # was missing the `rustc-sccache` wrapper script. Fixed upstream in
       # paiml/infra commit f4fccf9 (PR #66, "use exec script not symlink").
       # 2026-05-12: re-enabled — image verified to ship `/usr/local/bin/rustc-sccache`
-      # (sccache 0.14.0), shared cache at `${SCCACHE_HOST_DIR}` (warm, ~11GB).
+      # (sccache 0.14.0), shared cache at `/home/noah/data/sccache` (warm, ~11GB).
       # 2026-08-20: that "warm, ~11GB" was NOT health — it was the cache pinned
       # at sccache's DEFAULT 10 GiB cap. /var/log/ci-metrics/sccache-*.json has
       # recorded cache_size and max_cache_size on every job all along (18,292
@@ -86,14 +86,14 @@ jobs:
   # unconditional `docker pull` with only 3 retries / ~6s total backoff) to
   # explicit `docker run` steps with a 15-attempt linear-backoff pull retry.
   # The previous design conflated "image is required" with "registry must be
-  # reachable at pull time" — when `${CI_REGISTRY}` blipped (registry restart,
+  # reachable at pull time" — when `localhost:5000` blipped (registry restart,
   # network reload), the pull failed and the whole job died after ~25s. This
   # refactor preserves the same execution semantics (same image, same volume
   # mounts, same env) but moves the pull into a step the workflow controls,
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): measured on yoga (CI nextest line ~11 min vs 73 on the shared intel box)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
     # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
     # timeout always fired first -- producing a bare "The operation was canceled"
@@ -114,22 +114,10 @@ jobs:
       # The sccache host directory, named ONCE per job: the machine-specific-path
       # ratchet counts literals, and the quick-tier steps added two more copies
       # of a path this job already spelled five times (PMAT-1077).
+      SCCACHE_HOST_DIR: /home/noah/data/sccache
+      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
-      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
-      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
-      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
-      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
-      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
-      - name: Host layout (build pool defaults = intel clean-room)
-        run: |
-          {
-            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
-            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
-            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
-            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
-            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
-          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Five-whys: the end-of-job "Fix file ownership" step is
         # `if: always()`, but a hard-killed job (runner death, forced
@@ -155,7 +143,7 @@ jobs:
           fi
       - uses: actions/checkout@v7
       - name: Pull sovereign-ci image (with retry + local-cache fallback)
-        # Self-hosted runner's local Docker registry at ${CI_REGISTRY} is
+        # Self-hosted runner's local Docker registry at localhost:5000 is
         # occasionally restarting OR experiencing extended outages
         # (paiml/infra ops). Two layers of resilience:
         #   1. Check the local Docker daemon cache first — the image was
@@ -183,7 +171,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts (~13min) AND image not in local cache"
+              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts (~13min) AND image not in local cache"
               echo "::error::Suggests paiml/infra runner-side registry restart + initial image seed needed"
               exit 1
             fi
@@ -206,7 +194,7 @@ jobs:
         # cancelled:
         #
         #   docker run --rm \
-        #     -v "${CI_TARGETS_ROOT}/${PR_OR_REF}:/workspace/target" \
+        #     -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
         #     "$IMAGE" bash -c 'rm -rf /workspace/target/* /workspace/target/.[!.]* ...'
         #
         # It mounted the PARENT. The tree is `aprender-ci/<PR>/run-<RUN_ID>`
@@ -216,7 +204,7 @@ jobs:
         #
         # Its own five-whys (whose text is preserved below) was written against
         # a premise #1693 removed: "the target dir is bind-mounted from a per-PR
-        # persistent path ${CI_TARGETS_ROOT}/<PR>/, so partial-
+        # persistent path /mnt/nvme-raid0/targets/aprender-ci/<PR>/, so partial-
         # compile state survives across runs". Since #1693 the mount is per-RUN,
         # so no other run's state can reach this run at all. The parent-wide
         # removal bought nothing and could only take a sibling with it:
@@ -258,7 +246,7 @@ jobs:
         run: |
           set -uo pipefail
           set +e
-          PARENT="${CI_TARGETS_ROOT}/${PR_OR_REF}"
+          PARENT="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
           PLAN="${RUNNER_TEMP:-/tmp}/reclaim-${GITHUB_RUN_ID}.txt"
           bash scripts/ci_reclaim_target_dirs.sh "$PARENT" "$GITHUB_RUN_ID" > "$PLAN"
           rc=$?
@@ -309,10 +297,10 @@ jobs:
             done
             mkdir -p "$path"
           }
-          parent="${CI_TARGETS_ROOT}/${PR_OR_REF}"
-          reg="${CI_CARGO_ROOT}/registry/${PR_OR_REF}"
-          heal_path ${CI_TARGETS_ROOT} "${parent}/run-${GITHUB_RUN_ID}"
-          heal_path ${CI_CARGO_ROOT}/registry "$reg"
+          parent="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
+          reg="/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}"
+          heal_path /mnt/nvme-raid0/targets/aprender-ci "${parent}/run-${GITHUB_RUN_ID}"
+          heal_path /mnt/nvme-raid0/cargo-ci/registry "$reg"
           ls -ld "$parent" "${parent}/run-${GITHUB_RUN_ID}" "$reg"
       - name: Pre-build chown — fix per-RUN root ownership
         # Root cause (five-whys):
@@ -321,7 +309,7 @@ jobs:
         #      Cargo (running as user 1000 inside the container) can't
         #      write to /workspace/target/debug.
         #   2. Why can't it write? The bind-mount source dir on the host
-        #      (${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>) is
+        #      (/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>) is
         #      owned by root:root.
         #   3. Why is it root-owned? Docker's bind-mount creates missing
         #      host directories with the daemon's uid (root). Per-RUN
@@ -340,8 +328,8 @@ jobs:
         # noah-owned (e.g. a rerun of the same run-id).
         run: |
           docker run --rm \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
       # BSE-17 (PMAT-1077): which tier this run owes. quick on pull_request —
@@ -443,8 +431,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -467,8 +455,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -487,8 +475,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -540,8 +528,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -573,8 +561,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -631,8 +619,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -730,8 +718,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace || true; chown -R 1000:1000 /usr/local/cargo/registry || true; chown -R 1000:1000 /workspace/target || true'
 
@@ -740,7 +728,7 @@ jobs:
   # can never again silently land a job on a GPU/dev runner without the
   # sovereign-ci registry. Pure text check; runs on the clean-room pool.
   guard-tree:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until its host-side guards are measured on the pool (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): p50 52.9 /
     # p99 85.1 minutes over the last 9 SUCCESSFUL runs of this job as it stood
@@ -750,6 +738,7 @@ jobs:
     # here, because this job strictly shrank.
     timeout-minutes: 90
     env:
+      IMAGE: localhost:5000/sovereign-ci:stable
       # Same definition as workspace-test (:106). aprender#2627: the
       # model-tests step below was added with workspace-test's mount lines
       # copied verbatim, but PR_OR_REF is JOB-level env there and this job
@@ -765,20 +754,6 @@ jobs:
       # not define.
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
-      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
-      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
-      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
-      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
-      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
-      - name: Host layout (build pool defaults = intel clean-room)
-        run: |
-          {
-            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
-            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
-            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
-            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
-            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
-          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -1082,7 +1057,7 @@ jobs:
   #
   # workspace-test and the guard job are two jobs of the SAME run on two
   # runners of one host, and both bind-mounted
-  # `${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>` as
+  # `/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>` as
   # `/workspace/target` while both ran cargo against it. That is the
   # dep-info race behind aprender#2822 / `could not parse/generate dep info
   # at .../deps/<crate>.d: No such file or directory`. This job's container
@@ -1092,7 +1067,7 @@ jobs:
   # No `needs:` — running these AFTER workspace-test would serialise ~40
   # minutes onto every green run for no ordering that anything requires.
   guard-cargo:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): the
     # unsplit `guard-tree` measured p50 52.9 / p99 85.1 minutes over
@@ -1103,10 +1078,12 @@ jobs:
     # above the worst contended run of the strictly larger job it came from.
     timeout-minutes: 90
     env:
+      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
       # This job's OWN per-run target dir. The `-guards` suffix is the whole
       # point: workspace-test mounts `run-<RUN_ID>` and this job must never
       # resolve to the same path. Reaped by the same `run-*` sweep on intel.
+      GUARD_TARGET_DIR: /mnt/nvme-raid0/targets/aprender-ci/${{ github.event.pull_request.number || github.ref_name }}/run-${{ github.run_id }}-guards
       # PMAT-238 (paiml/infra#435): the CARGO_HOME mount is the WHOLE cargo
       # home, not `registry/` alone. `.package-cache` and
       # `.package-cache-mutate` are cargo's flock files and they live beside
@@ -1114,23 +1091,8 @@ jobs:
       # container its own private lock while they all share one registry —
       # which is infra#77 (16 private locks over one shared registry), and it
       # corrupts the registry rather than serialising access to it.
+      GUARD_CARGO_HOME: /mnt/nvme-raid0/cargo-ci/home/${{ github.event.pull_request.number || github.ref_name }}
     steps:
-      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
-      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
-      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
-      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
-      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
-      - name: Host layout (build pool defaults = intel clean-room)
-        run: |
-          {
-            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
-            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
-            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
-            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
-            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
-            echo "GUARD_TARGET_DIR=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}/${{ github.event.pull_request.number || github.ref_name }}/run-${GITHUB_RUN_ID}-guards"
-            echo "GUARD_CARGO_HOME=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}/home/${{ github.event.pull_request.number || github.ref_name }}"
-          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -1216,8 +1178,8 @@ jobs:
             done
             mkdir -p "$path"
           }
-          heal_path ${CI_TARGETS_ROOT} "$GUARD_TARGET_DIR"
-          heal_path ${CI_CARGO_ROOT}/home "$GUARD_CARGO_HOME/registry"
+          heal_path /mnt/nvme-raid0/targets/aprender-ci "$GUARD_TARGET_DIR"
+          heal_path /mnt/nvme-raid0/cargo-ci/home "$GUARD_CARGO_HOME/registry"
           printf 'target dir: %s\n' "$GUARD_TARGET_DIR"
           printf 'cargo home: %s (registry/ .package-cache .package-cache-mutate travel together)\n' "$GUARD_CARGO_HOME"
       # Poka-yoke: a beat that no workflow executes reads as enforcement, is
@@ -1677,7 +1639,7 @@ jobs:
               -v "${GUARD_CARGO_HOME}:/cargo-home" \
               -v "${GUARD_TARGET_DIR}:/workspace/target" \
               -e CARGO_HOME=/cargo-home \
-              -v "${SCCACHE_HOST_DIR}:/sccache" \
+              -v "/home/noah/data/sccache:/sccache" \
               -w /workspace \
               -e CARGO_TARGET_DIR=/workspace/target \
               -e RUSTC_WRAPPER=rustc-sccache \
@@ -2553,7 +2515,7 @@ jobs:
   # in the C0-5 PR body, never applied by the session that wrote this).
 
   gate:
-    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): result check only; must not wait an hour for an intel slot
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 22: BSE-05 formula T = max(15, ceil(1.5*p99), p99+20) over this job's own
     # history -- p50 0.2 / p90 1.4 / p99 1.4 minutes over its last 7 successful
     # runs, so p99+20 = 21.4 binds and rounds to 22. This job only reads
@@ -2624,30 +2586,17 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'
     env:
+      IMAGE: localhost:5000/sovereign-ci:stable
       # Max surviving (missed) mutants tolerated on the PR diff. 0 = every
       # mutant introduced/touched by this PR must be caught by a test. Tune up
       # via repo variable MUTANTS_MAX_MISSED if a diff legitimately can't reach 0.
       MUTANTS_MAX_MISSED: ${{ vars.MUTANTS_MAX_MISSED || '0' }}
     steps:
-      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
-      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
-      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
-      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
-      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
-      - name: Host layout (build pool defaults = intel clean-room)
-        run: |
-          {
-            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
-            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
-            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
-            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
-            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
-          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test: a hard-killed docker job leaves
         # root-owned files that EACCES this job's `git clean` at checkout
@@ -2704,7 +2653,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts AND image not in local cache"
+              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts AND image not in local cache"
               exit 1
             fi
             echo "Pull attempt $i/$max_attempts failed; sleeping ${delay}s"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,12 @@ jobs:
       # tier. Empty selection (a scripts/docs PR) skips this step; part 2 still runs.
       - name: "Quick tier: lib + integration tests of the selected crates (BSE-17)"
         if: steps.tier.outputs.tier == 'quick' && steps.tier.outputs.crates != ''
-        timeout-minutes: 60
+        # 20, not 60 (PMAT-1098, #3084). A quick tier that is ALLOWED an hour is
+        # not a quick tier, and 60 is the number that let part 2 burn 55 minutes
+        # (run 34449608126) before dying at the cap under fleet load on #3063
+        # (#3070). The budget is the assertion: over 20 minutes, this tier has
+        # stopped being cheaper than the full one and should fail loudly.
+        timeout-minutes: 20
         env:
           CRATES: ${{ steps.tier.outputs.crates }}
         run: |
@@ -553,30 +558,44 @@ jobs:
             bash -c "cargo nextest run --profile ci --lib --tests$pkgs"
       # BSE-17 quick tier, part 2: every test target that reads the tree, from
       # scripts/tree_reader_tests.txt (derived; the guard has already proved the
-      # registry equals the sources in this run). Grouped per crate: one cargo
-      # invocation per crate, --lib and/or its --test targets.
+      # registry equals the sources in this run).
+      #
+      # PMAT-1098 (#3084) — ONE BUILD GRAPH. This step used to expand `targets`
+      # into a `&&` chain of one `cargo nextest run -p CRATE ...` per crate: 26
+      # cargo invocations for 41 targets, so the shared dependency graph was
+      # resolved and linked 26 times and the 26 test runs went one after another.
+      # Measured 55 minutes on a PR that touched a single YAML file (run
+      # 34449608126) and killed at the 60-minute cap under fleet load on #3063
+      # (#3070). A quick tier that costs more than the full tier is not an
+      # optimisation, it is a second full tier with a smaller test set.
+      #
+      # The same registry tokens now become ONE nextest filterset
+      # (`scripts/ci_test_tier.sh --filterset`, whose token->clause translation is
+      # pinned in both polarities by that script's --self-test case table, an
+      # unrecognised token being ENV rather than a silently dropped target). The
+      # union is built once and every selected test runs in the single parallel
+      # pool.
+      #
+      # `--workspace --lib --tests` is the BUILD set: nextest can only select from
+      # binaries it built, and -E narrows the RUN to the registry. The three
+      # `--exclude` crates are held verbatim from the full tier's `--workspace
+      # --lib` line above and for the same reason stated there — under --workspace
+      # feature unification pulls the cuda driver in, and those crates have their
+      # own steps. None of them appears in the registry (check_tree_reader_tests.sh
+      # reads this exclude list out of this file and drops their targets), so the
+      # exclusion removes nothing the filterset asks for.
       - name: "Quick tier: every test target that reads the tree (BSE-17)"
         if: steps.tier.outputs.tier == 'quick'
-        timeout-minutes: 60
+        timeout-minutes: 20
         env:
           TARGETS: ${{ steps.tier.outputs.targets }}
         run: |
           set -euo pipefail
           read -ra targets <<< "$TARGETS"
           printf 'tree-reader targets: %s\n' "${#targets[@]}"
-          script=""
-          for crate in $(printf '%s\n' "${targets[@]}" | cut -d: -f1 | sort -u); do
-            flags=""
-            for t in "${targets[@]}"; do
-              case "$t" in
-                "$crate:--lib") flags="$flags --lib" ;;
-                "$crate:--test:"*) flags="$flags --test ${t#"$crate:--test:"}" ;;
-              esac
-            done
-            script="$script cargo nextest run --profile ci -p $crate$flags &&"
-          done
-          script="${script% &&}"
-          printf '%s\n' "$script" | tr '&' '\n' | grep -v '^$' | sed 's/^/  + /'
+          EXPR="$(bash scripts/ci_test_tier.sh --filterset "$TARGETS")"
+          printf 'nextest filterset (%s clause(s)):\n' "$(printf '%s' "$EXPR" | tr '|' '\n' | wc -l)"
+          printf '%s\n' "$EXPR" | tr '|' '\n' | sed 's/^ *//; s/ *$//; s/^/  + /'
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
@@ -594,7 +613,7 @@ jobs:
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             -e CARGO_TERM_COLOR=never \
             "$IMAGE" \
-            bash -c "set -e; $script"
+            cargo nextest run --profile ci --workspace --lib --tests --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute -E "$EXPR"
       # BSE-17 reuse: the queue ref's tree is byte-identical to a PR head whose
       # workspace-test already succeeded; measuring it again is waste, not
       # evidence. The tier step proved both facts (trees compared by hash, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -460,7 +460,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -480,7 +480,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -533,7 +533,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -566,7 +566,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -624,7 +624,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -665,7 +665,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -1642,7 +1642,7 @@ jobs:
               -v "/home/noah/data/sccache:/sccache" \
               -w /workspace \
               -e CARGO_TARGET_DIR=/workspace/target \
-              -e RUSTC_WRAPPER=rustc-sccache \
+              -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
               -e SCCACHE_DIR=/sccache \
               -e SCCACHE_CACHE_SIZE=50G \
               -e CARGO_INCREMENTAL=0 \

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16858,3 +16858,25 @@ roadmap:
   - release
   - 0.66.0
   notes: 'orch-basis:release — the 0.66.0 cut is a release-state ticket (AUTO-IMPL-SKILL-003 §2.1 basis=release); push, tag, gh release and the crates.io cascade are orchestration phases (route=self).'
+- id: PMAT-1098
+  github_issue: null
+  item_type: task
+  title: '0.67.0 release train (epic #3078, spec docs/specifications/06x-release-schedule.md §3): P0-1 67-A1 four apr assets + verify-apr-assets + check_release_assets.sh, P0-2 67-C2 self-hosted preflight + fleet toolset, P0-3 67-E1/E2 one build graph for tree-reader targets + queue mirrors the PR, 67-E3 guards under 20 min, 67-D0 yoga group restriction + smoke, 67-C1/D1 gpu-quick + cuda-unit, 67-B1 #3061/#3068/#3066 merged + cuda suites green, 67-E0 nightly FULL green, 67-R bump/tag/release/cascade by 2026-09-12T18:00Z'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-09-10T10:27:17Z
+  updated: 2026-09-10T10:27:17Z
+  spec: null
+  acceptance_criteria:
+  - 'orch-basis:release. Rows and acceptance commands are the spec''s §2/§3 (PR #3087); C3/D2/F1/F2 slip first per §1.2.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - orch:fable
+  - release
+  - 0.67.0
+  - epic-3078
+  notes: 'orch-basis:release — the 0.67.0 train (epic #3078) is a release-state ticket; orchestration phases (push, PR, tag, cascade) route=self'

--- a/scripts/check_runner_labels.sh
+++ b/scripts/check_runner_labels.sh
@@ -9,6 +9,7 @@
 #
 # Rule: any `runs-on:` that names `self-hosted` must ALSO name one of:
 #   - clean-room  (the provisioned sovereign-ci pool: registry + cached image)
+#   - build       (the aprender build pool: intel clean-room + yoga-eph + gx10-build; #3100)
 #   - a GPU label: cuda | gpu | rtx4090 | ada | blackwell | gb10
 #   - a macOS label: apple-silicon | m4
 # Reusable-workflow jobs (`uses:`) have no `runs-on` and are naturally exempt.
@@ -16,7 +17,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-DISCRIM='clean-room|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
+# `build` is the aprender BUILD POOL (operator 2026-09-10, #3100): the label sits on the 16 intel
+# clean-room runners, yoga-eph and gx10-build (infra machines/*/forjar-*.yaml). It discriminates exactly
+# like clean-room does — a provisioned pool, never a stray dev box; a job that also names X64/ARM64 narrows
+# it to the boxes of that arch.
+DISCRIM='clean-room|build|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
 fail=0
 
 while IFS=: read -r file line sel; do

--- a/scripts/check_runner_labels.sh
+++ b/scripts/check_runner_labels.sh
@@ -9,7 +9,6 @@
 #
 # Rule: any `runs-on:` that names `self-hosted` must ALSO name one of:
 #   - clean-room  (the provisioned sovereign-ci pool: registry + cached image)
-#   - build       (the aprender build pool: intel clean-room + yoga-eph + gx10-build; #3100)
 #   - a GPU label: cuda | gpu | rtx4090 | ada | blackwell | gb10
 #   - a macOS label: apple-silicon | m4
 # Reusable-workflow jobs (`uses:`) have no `runs-on` and are naturally exempt.
@@ -17,11 +16,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-# `build` is the aprender BUILD POOL (operator 2026-09-10, #3100): the label sits on the 16 intel
-# clean-room runners, yoga-eph and gx10-build (infra machines/*/forjar-*.yaml). It discriminates exactly
-# like clean-room does — a provisioned pool, never a stray dev box; a job that also names X64/ARM64 narrows
-# it to the boxes of that arch.
-DISCRIM='clean-room|build|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
+DISCRIM='clean-room|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
 fail=0
 
 while IFS=: read -r file line sel; do

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -18,6 +18,23 @@
 # Feature-gated suites (model-tests, setfit, ...) belong to the full tier only;
 # the quick tier runs default features. Exit 2 on ENV (unknown event, registry
 # drift); 0 otherwise. `--self-test` runs the case table.
+#
+# `--filterset '<targets>'` (or the same list on stdin) prints the cargo-nextest
+# FILTERSET expression that selects exactly those targets — one clause per token,
+# UNIONed with `|`. It is the whole of PMAT-1098 (#3084): the quick tier used to
+# expand `targets` into a `&&` chain of one `cargo nextest run -p CRATE ...` per
+# crate — 26 cargo invocations, 26 compiles of the shared dependency graph, run
+# serially. Measured 55 min on a one-file YAML PR (run 34449608126) and killed at
+# the 60-minute step timeout under fleet load on #3063 (#3070). One invocation
+# over the filterset builds the union ONCE and runs the tests in parallel.
+#   crate:--lib        -> (package(crate) & kind(lib))
+#   crate:--bins       -> (package(crate) & kind(bin))    [bin-only crates: no lib target]
+#   crate:--test:NAME  -> binary_id(crate::NAME)
+# The binary-id forms are nextest's own, verified on cargo-nextest 0.9.132 against
+# this workspace (`cargo nextest list --message-format json`): a lib suite's id is
+# the bare package name, an integration target's is `package::target`, a bin's is
+# `package::bin/name`. `kind(lib)`/`kind(bin)` are equality matches on those kinds,
+# which is why the lib and bins tokens do not need to name the binary at all.
 set -euo pipefail
 
 EVENT=""; COMPARAND=""; DIFF_FROM=""; PR_HEAD=""; PR_CONCLUSION=""; REGISTRY="scripts/tree_reader_tests.txt"; ROOT="."
@@ -31,12 +48,36 @@ while [ $# -gt 0 ]; do
         --registry) REGISTRY=$2; shift 2 ;;
         --repo-root) ROOT=$2; shift 2 ;;
         --self-test) SELF_TEST=1; shift ;;
-        *) printf 'usage: %s --event EVENT [--comparand REF] [--diff-from FILE] [--pr-head SHA --pr-head-conclusion C] [--registry FILE] [--repo-root DIR] | --self-test\n' "$0" >&2; exit 2 ;;
+        # optional operand: `--filterset 'a:--lib b:--test:c'`, or nothing and the
+        # list comes from stdin (how ci.yml pipes steps.tier.outputs.targets in).
+        --filterset) FILTERSET=1; shift; if [ $# -gt 0 ]; then FS_TARGETS=$1; shift; fi ;;
+        *) printf 'usage: %s --event EVENT [--comparand REF] [--diff-from FILE] [--pr-head SHA --pr-head-conclusion C] [--registry FILE] [--repo-root DIR] | --filterset [TARGETS] | --self-test\n' "$0" >&2; exit 2 ;;
     esac
 done
 
 targets_from_registry() { # -> space list crate:--lib | crate:--test:name
     grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | awk -F"\t" '{ if ($2=="--test") printf "%s:--test:%s ", $1, $3; else printf "%s:%s ", $1, $2 }' | sed 's/ $//'
+}
+
+filterset_from_targets() { # <space list of crate:--lib|crate:--bins|crate:--test:NAME> -> nextest -E expression
+    local t clause expr=""
+    for t in $1; do
+        case "$t" in
+            *:--lib)    clause="(package(${t%:--lib}) & kind(lib))" ;;
+            *:--bins)   clause="(package(${t%:--bins}) & kind(bin))" ;;
+            *:--test:*) clause="binary_id(${t%%:--test:*}::${t#*:--test:})" ;;
+            # Never a silent drop: a token this does not understand is a
+            # tree-reader target that would stop running while the step stayed
+            # green — exactly the darkness scripts/tree_reader_tests.txt exists
+            # to end. ENV, exit 2, name the token.
+            *) printf 'ENV: unrecognised target token "%s" — expected crate:--lib, crate:--bins or crate:--test:NAME\n' "$t" >&2; return 2 ;;
+        esac
+        expr="${expr:+$expr | }$clause"
+    done
+    # An empty -E is not "select nothing", it is `cargo nextest run --workspace`
+    # with no filter at all. Refuse rather than run the full tier by accident.
+    [ -n "$expr" ] || { printf 'ENV: no targets given — refusing to emit an empty filterset (nextest would then select the WHOLE workspace)\n' >&2; return 2; }
+    printf '%s\n' "$expr"
 }
 
 decide() {
@@ -121,5 +162,9 @@ self_test() {
 }
 
 if [ "${SELF_TEST:-0}" = 1 ]; then self_test; exit $?; fi
+if [ "${FILTERSET:-0}" = 1 ]; then
+    if [ -z "${FS_TARGETS+x}" ]; then FS_TARGETS=$(cat); fi
+    filterset_from_targets "$FS_TARGETS"; exit $?
+fi
 [ -n "$EVENT" ] || { printf 'usage: %s --event EVENT ...\n' "$0" >&2; exit 2; }
 decide

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -110,12 +110,18 @@ decide() {
 self_test() {
     local td n=0 red=0 out rc leaf
     td=$(mktemp -d "${TMPDIR:-/tmp}/ci-tier.XXXXXX"); trap 'rm -rf "${td:?}"' RETURN
+    # One decision, many rows. Each full decision re-runs check_tree_reader_tests.sh
+    # (~23s, it re-derives the registry from the sources), so a fixture is DECIDED
+    # once into a file and every assertion about it replays that file with its exit
+    # code. Same output, same rc — the rows are not weakened, only the wall clock.
+    cap() { local name=$1 r=0; shift; "$@" > "$td/$name.out" 2>&1 || r=$?; printf '%s' "$r" > "$td/$name.rc"; }
+    replay() { printf 'cat "%s/%s.out"; exit "$(cat "%s/%s.rc")"' "$td" "$1" "$td" "$1"; }
     row() { local want=$1 label=$2 pat=$3; shift 3; n=$((n + 1)); rc=0; out=$("$@" 2>&1) || rc=$?
         if [ "$rc" = "$want" ] && printf '%s\n' "$out" | grep -qE -- "$pat"; then printf 'ok    row %-2s rc=%s  %s\n' "$n" "$rc" "$label"
         else printf 'FAIL  row %-2s rc=%s (wanted %s, must match /%s/)  %s\n' "$n" "$rc" "$want" "$pat" "$label"; printf '%s\n' "$out" | sed 's/^/        /'; red=1; fi; }
     T=$0
-    row 0 "push -> full" '^tier=full' bash "$T" --event push
-    row 0 "schedule -> full" '^tier=full' bash "$T" --event schedule
+    row 0 "schedule -> full (FULL still lives on the nightlies — decision D-1)" '^tier=full' bash "$T" --event schedule
+    row 0 "workflow_dispatch -> full" '^tier=full' bash "$T" --event workflow_dispatch
     row 2 "unknown event -> ENV (exit 2), never a guess" 'refusing to guess' bash "$T" --event release
     printf 'scripts/foo.sh\n' > "$td/d-scripts.txt"
     row 0 "pull_request, scripts-only diff -> quick with NO crates" '^crates=$' bash "$T" --event pull_request --diff-from "$td/d-scripts.txt"
@@ -124,7 +130,11 @@ self_test() {
     printf 'Cargo.toml\n' > "$td/d-root.txt"
     row 0 "pull_request, root Cargo.toml touched -> full (fail closed)" '^tier=full' bash "$T" --event pull_request --diff-from "$td/d-root.txt"
     printf 'crates/aprender-core/src/lib.rs\n' > "$td/d-core.txt"
-    row 0 "pull_request, aprender-core touched -> full (reverse dependents exceed the cap)" 'tier=full' bash "$T" --event pull_request --diff-from "$td/d-core.txt"
+    cap pr-cap bash "$T" --event pull_request --diff-from "$td/d-core.txt"
+    row 0 "pull_request over the cap (aprender-core) -> quick, NOT an hour of full workspace tests" '^tier=quick' bash -c "$(replay pr-cap)"
+    row 0 "  ...with check_workspace=1: ONE cargo check --workspace covers every reverse dependent (rule (i))" '^check_workspace=1$' bash -c "$(replay pr-cap)"
+    row 0 "  ...and the touched crate itself still runs its tests" '^crates=.*aprender-core' bash -c "$(replay pr-cap)"
+    row 0 "pull_request WITHIN the cap emits NO check_workspace line (the workspace check is not free)" '^NO-CHECK-WORKSPACE$' bash -c "if bash '$T' --event pull_request --diff-from '$td/d-leaf.txt' | grep -q '^check_workspace='; then echo HAS-CHECK-WORKSPACE; else echo NO-CHECK-WORKSPACE; fi"
     leaf=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '[.packages[]|select(.manifest_path|test("/crates/"))] | (map(.name) - (map(.dependencies[]?.name)|unique)) | sort | .[0]')
     printf 'crates/%s/src/lib.rs\n' "$leaf" > "$td/d-leaf.txt"
     row 0 "pull_request, a leaf crate ($leaf) touched -> quick with that crate" "^crates=.*$leaf" bash "$T" --event pull_request --diff-from "$td/d-leaf.txt"
@@ -138,8 +148,51 @@ self_test() {
     row 0 "merge_group, same tree + PR head workspace-test success -> reuse, citing the head" "^cite=$same" bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$same" --pr-head-conclusion success
     row 0 "merge_group, same tree but PR head conclusion failure -> full" 'concluded failure' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$same" --pr-head-conclusion failure
     diff1=$(git -C "$td/repo" rev-parse HEAD~2)
-    row 0 "merge_group, different tree -> full (main moved under the PR)" 'differs from PR head tree' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$diff1" --pr-head-conclusion success
+    row 0 "merge_group, different tree on a ref that is NOT a merge -> full (the PR diff cannot be re-derived)" 'not a merge commit' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$diff1" --pr-head-conclusion success
     row 0 "merge_group without a PR head -> full" 'without a PR head' bash "$T" --event merge_group --repo-root "$td/repo"
+    # PMAT-1098 67-E2 (#3084): THE QUEUE MIRRORS THE PR. A rebase is not new
+    # evidence about the PR's diff, it is the same diff on a new base — so a
+    # merge_group whose tree moved re-derives the PR's OWN selection from the
+    # queue ref (first parent = main's tip, second = the PR head, so HEAD^1..HEAD
+    # IS the PR's diff) and runs the tier the PR ran. Same for a push to main.
+    # Both used to cost the full hour every time main moved.
+    mkqueue() { # $1 dir, $2 touched path -> HEAD = merge(main tip, PR head), a queue ref's shape
+        local d=$1 f=$2
+        git init -q -b main "$d"
+        ( cd "$d" \
+          && export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+          && git commit -q --allow-empty -m base \
+          && git branch pr \
+          && printf 'moved\n' > main-moved.txt && git add -A && git commit -q -m "main moved under the PR" \
+          && git checkout -q pr && mkdir -p "$(dirname "$f")" && printf 'x\n' > "$f" && git add -A && git commit -q -m "the PR" \
+          && git checkout -q main && git merge -q --no-ff -m "queue merge" pr )
+    }
+    mkqueue "$td/q-leaf" "crates/$leaf/src/lib.rs"
+    mkqueue "$td/q-root" "Cargo.toml"
+    mkqueue "$td/q-cap"  "crates/aprender-core/src/lib.rs"
+    qh() { git -C "$1" rev-parse pr; }
+    cap mg-leaf bash "$T" --event merge_group --repo-root "$td/q-leaf" --pr-head "$(qh "$td/q-leaf")" --pr-head-conclusion success
+    row 0 "merge_group, different tree, the PR ran quick -> quick, not full (main moved is not new evidence)" '^tier=quick' bash -c "$(replay mg-leaf)"
+    row 0 "  ...with the SAME crates the PR ran ($leaf), re-derived from HEAD^1..HEAD on the queue ref" "^crates=.*$leaf" bash -c "$(replay mg-leaf)"
+    row 0 "  ...and the reason names the re-derivation, not a guess" 're-derived on the queue ref' bash -c "$(replay mg-leaf)"
+    row 0 "  ...and the tree-reader targets ride along (readme_contract, the reader that bit #3039)" 'aprender-core:--test:readme_contract' bash -c "$(replay mg-leaf)"
+    cap mg-root bash "$T" --event merge_group --repo-root "$td/q-root" --pr-head "$(qh "$td/q-root")" --pr-head-conclusion success
+    row 0 "merge_group, the PR touched a ROOT manifest -> full at the queue too (rule (ii))" '^tier=full' bash -c "$(replay mg-root)"
+    row 0 "  ...citing the root-manifest rule, so the escalation is auditable" 'root Cargo.toml' bash -c "$(replay mg-root)"
+    cap mg-cap bash "$T" --event merge_group --repo-root "$td/q-cap" --pr-head "$(qh "$td/q-cap")" --pr-head-conclusion success
+    row 0 "merge_group over the cap -> quick + check_workspace=1 (rule (i)), not full" '^check_workspace=1$' bash -c "$(replay mg-cap)"
+    cap push-leaf bash "$T" --event push --repo-root "$td/q-leaf"
+    row 0 "push (a queue merge of one PR) -> quick with the PUSH own diff, not the whole workspace" "^crates=.*$leaf" bash -c "$(replay push-leaf)"
+    row 0 "  ...and the reason names HEAD^1..HEAD, so the diff is auditable" 'HEAD\^1' bash -c "$(replay push-leaf)"
+    cap push-root bash "$T" --event push --repo-root "$td/q-root"
+    row 0 "push touching a ROOT manifest -> full on main too (rule (ii))" '^tier=full' bash -c "$(replay push-root)"
+    cap push-cap bash "$T" --event push --repo-root "$td/q-cap"
+    row 0 "push over the cap -> quick + check_workspace=1 (rule (i))" '^check_workspace=1$' bash -c "$(replay push-cap)"
+    row 0 "push whose diff cannot be derived (root commit, no reflog) -> full (fail closed)" '^tier=full' bash -c "d=$td/p-root; git init -q -b main \"\$d\"; git -C \"\$d\" -c user.name=t -c user.email=t@t commit -q --allow-empty -m only; bash '$T' --event push --repo-root \"\$d\""
+    # MUTANT: a copy whose queue branch ignores the re-derived diff and always
+    # says full is exactly today's behaviour — the rows above must lose the crates.
+    sed 's|^\( *\)selection "merge_group|\1printf "tier=full\\nreason=MUTANT\\n"; return 0; selection "merge_group|' "$T" > "$td/mutant-queue.sh"
+    row 0 "mutant queue branch (always full on a moved main) loses the crates — the rows discriminate" 'MUTANT-FULL' bash -c "if bash '$td/mutant-queue.sh' --event merge_group --repo-root '$td/q-leaf' --pr-head '$(qh "$td/q-leaf")' --pr-head-conclusion success | grep -q '^tier=quick'; then echo MUTANT-QUICK; else echo MUTANT-FULL; fi"
     # --filterset (PMAT-1098, #3084): the quick tier's 26-way `&&` chain of
     # per-crate cargo invocations became ONE build graph + one nextest run over a
     # filterset. These rows pin the token->clause translation in BOTH polarities:

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -99,6 +99,21 @@ self_test() {
     diff1=$(git -C "$td/repo" rev-parse HEAD~2)
     row 0 "merge_group, different tree -> full (main moved under the PR)" 'differs from PR head tree' bash "$T" --event merge_group --repo-root "$td/repo" --pr-head "$diff1" --pr-head-conclusion success
     row 0 "merge_group without a PR head -> full" 'without a PR head' bash "$T" --event merge_group --repo-root "$td/repo"
+    # --filterset (PMAT-1098, #3084): the quick tier's 26-way `&&` chain of
+    # per-crate cargo invocations became ONE build graph + one nextest run over a
+    # filterset. These rows pin the token->clause translation in BOTH polarities:
+    # every recognised token becomes exactly one clause, and anything else is ENV
+    # (exit 2) — a token silently dropped here is a tree-reader target that stops
+    # running while the step stays green, which is the failure mode this whole
+    # registry exists to prevent.
+    row 0 "--filterset: a lib token -> (package & kind(lib))" '^\(package\(apr-cli\) & kind\(lib\)\)$' bash "$T" --filterset 'apr-cli:--lib'
+    row 0 "--filterset: a test token -> binary_id(crate::name), nextest's id for an integration target" '^binary_id\(aprender-core::readme_contract\)$' bash "$T" --filterset 'aprender-core:--test:readme_contract'
+    row 0 "--filterset: a bins token -> (package & kind(bin)); a bin-only crate has NO lib target" '^\(package\(aprender-compute-xtask\) & kind\(bin\)\)$' bash "$T" --filterset 'aprender-compute-xtask:--bins'
+    row 0 "--filterset: two tokens are UNIONed with |" 'kind\(lib\)\) \| binary_id\(' bash "$T" --filterset 'apr-cli:--lib aprender-core:--test:readme_contract'
+    row 2 "--filterset: an unknown token -> ENV (exit 2), never a silently dropped target" 'unrecognised target token' bash "$T" --filterset 'apr-cli:--doc'
+    row 2 "--filterset: no targets -> ENV (exit 2); an empty -E would select the WHOLE workspace" 'empty filterset' bash "$T" --filterset ''
+    row 0 "--filterset reads stdin and translates EVERY registry token (no ':--' survives)" '^NONE-LEFT$' bash -c "e=\$(bash '$T' --event pull_request --diff-from '$td/d-scripts.txt' | sed -n 's/^targets=//p' | bash '$T' --filterset); if [ -z \"\$e\" ]; then echo EMPTY; elif printf '%s' \"\$e\" | grep -q ':--'; then echo LEFTOVER; else echo NONE-LEFT; fi"
+    row 0 "--filterset over the registry: one clause per registry line (nothing dropped, nothing invented)" '^EQUAL$' bash -c "reg=\$(grep -vc '^#' scripts/tree_reader_tests.txt); n=\$(bash '$T' --event pull_request --diff-from '$td/d-scripts.txt' | sed -n 's/^targets=//p' | bash '$T' --filterset | tr '|' '\n' | wc -l); [ \"\$reg\" = \"\$n\" ] && echo EQUAL || echo \"DIFFER registry=\$reg clauses=\$n\""
     # MUTANT: a copy that drops the tree-reader targets from the quick tier must lose readme_contract — the falsifier discriminates
     sed 's/targets=%s\\n/targets=\\n/; s/"\$(targets_from_registry "\$ROOT\/\$REGISTRY")" //' "$T" > "$td/mutant.sh"
     row 0 "mutant without tree-reader targets loses readme_contract (proves the inclusion is load-bearing)" 'MUTANT-LOST' bash -c "if bash '$td/mutant.sh' --event pull_request --diff-from '$td/d-scripts.txt' | grep -q readme_contract; then echo MUTANT-KEPT; else echo MUTANT-LOST; fi"

--- a/scripts/ci_test_tier.sh
+++ b/scripts/ci_test_tier.sh
@@ -2,19 +2,44 @@
 # ci_test_tier.sh — decide which test tier a CI run owes (BSE-17, PMAT-1077).
 #
 #   quick  pull_request: the touched crates + direct reverse dependents
-#          (scripts/gate_touched_crates.sh, cap -> full) PLUS every test target
-#          that reads the tree (scripts/tree_reader_tests.txt, derived and
-#          checked by scripts/check_tree_reader_tests.sh — drift is ENV, exit 2,
-#          never a quick tier over a stale registry).
-#   full   push, schedule, workflow_dispatch; pull_request when the selection
-#          falls closed (root manifests touched, or over the cap); merge_group
-#          when the queue ref's tree is not the tree a green PR head already ran.
+#          (scripts/gate_touched_crates.sh) PLUS every test target that reads
+#          the tree (scripts/tree_reader_tests.txt, derived and checked by
+#          scripts/check_tree_reader_tests.sh — drift is ENV, exit 2, never a
+#          quick tier over a stale registry). ALSO merge_group and push: see
+#          THE QUEUE MIRRORS THE PR below.
+#   full   schedule, workflow_dispatch — that is where FULL lives now
+#          (coverage-nightly, full-nightly, the pre-publish dogfood; PMAT-1098
+#          67-E2 decision D-1) — plus any event whose diff touches a ROOT
+#          manifest (rule (ii)) or whose own diff cannot be derived.
+#
+# THE QUEUE MIRRORS THE PR (PMAT-1098 67-E2, #3084). A rebase is not new
+# evidence about a PR's diff: it is the same diff on a new base. This script
+# used to answer `full` for every merge_group whose tree had moved and for
+# every push to main, so the queue paid a ~1h full workspace run each time main
+# moved under a PR — the single largest cost in the merge queue. Now:
+#   merge_group, tree moved: the queue ref's first parent is main's tip and its
+#     second is the PR head, so HEAD^1..HEAD IS the PR's diff on the new base.
+#     Re-derive the PR's own selection from it and run the tier the PR ran.
+#   push to main: the same, over the push's own diff (HEAD^1..HEAD for a queue
+#     merge; origin/main@{1}..HEAD for a non-merge tip; neither -> full).
+#   rule (ii): a diff touching a ROOT Cargo.toml / Cargo.lock /
+#     rust-toolchain.toml keeps `full` at the PR, in the queue and on push —
+#     dependency bumps are where compile-level integration breaks. The rule is
+#     gate_touched_crates.sh's own ("root Cargo.toml/Cargo.lock/
+#     rust-toolchain.toml touched -> full workspace check"), cited not copied.
+#   rule (i): a selection OVER THE CAP (gate_touched_crates.sh CAP=3, rule text
+#     "selection of N crate(s) exceeds cap") is no longer an hour of full
+#     workspace tests. It is `quick` over the TOUCHED crates + the tree readers
+#     plus one extra output line, check_workspace=1, which ci.yml turns into a
+#     single `cargo check --workspace --all-targets --locked` — the
+#     compile-level integration of every reverse dependent, in minutes.
 #   reuse  merge_group only: HEAD^{tree} equals the PR head's tree AND that
 #          head's workspace-test check-run concluded success — the same tree
 #          measured twice is the definition of waste. Any doubt -> full.
 #
 # Output: KEY=VALUE lines — tier, crates (space list), targets (crate:--lib or
-# crate:--test:name, space list), reason, cite (the PR head sha on reuse).
+# crate:--test:name, space list), check_workspace (1, only under rule (i)),
+# reason, cite (the PR head sha on reuse).
 # Feature-gated suites (model-tests, setfit, ...) belong to the full tier only;
 # the quick tier runs default features. Exit 2 on ENV (unknown event, registry
 # drift); 0 otherwise. `--self-test` runs the case table.
@@ -38,6 +63,11 @@
 set -euo pipefail
 
 EVENT=""; COMPARAND=""; DIFF_FROM=""; PR_HEAD=""; PR_CONCLUSION=""; REGISTRY="scripts/tree_reader_tests.txt"; ROOT="."
+# The sibling scripts and the registry always come from the checkout this script
+# runs in (cwd = repo root, in ci.yml and in the case table alike); --repo-root
+# re-points only the GIT queries — HEAD, its parents, their trees — which is how
+# the case table hands this a throwaway queue-shaped repository.
+TREE="."
 while [ $# -gt 0 ]; do
     case "$1" in
         --event) EVENT=$2; shift 2 ;;
@@ -80,29 +110,94 @@ filterset_from_targets() { # <space list of crate:--lib|crate:--bins|crate:--tes
     printf '%s\n' "$expr"
 }
 
+# The tier a given touched-path set owes. ONE function for all three events
+# that carry a diff (pull_request, merge_group on a moved main, push to main):
+# the queue and main must not answer a different question about the same diff
+# than the PR did, and one code path is how that stays true.
+selection() { # $1 = reason prefix (names the event and how the diff was derived), $2 = diff file ("" -> gate_touched_crates' own git diff)
+    local prefix=$1 diff=$2 chk sel crates rule touched nreg
+    if ! chk=$(bash "$TREE/scripts/check_tree_reader_tests.sh" 2>&1); then printf 'ENV: %s\n' "$chk" >&2; return 2; fi
+    sel=$(bash "$TREE/scripts/gate_touched_crates.sh" --print-selection ${COMPARAND:+--comparand "$COMPARAND"} ${diff:+--diff-from "$diff"} 2>/dev/null | tail -1)
+    crates=$(printf '%s' "$sel" | sed -n 's/^selection=[a-z]* crates=\(.*\) rule=.*$/\1/p'); rule=${sel#*rule=}
+    nreg=$(grep -vc '^#' "$TREE/$REGISTRY")
+    case "$sel" in
+        selection=full*)
+            # gate_touched_crates.sh prints `selection=full` for BOTH fail-closed
+            # rules and distinguishes them only in the rule text, so this reads
+            # the rule rather than duplicating either test (that script is the
+            # owner of both; PMAT-1098 67-E2 rule (i)/(ii)).
+            case "$rule" in
+                *"exceeds cap"*)
+                    # Rule (i): over the cap is not a reason to spend an hour. The
+                    # TOUCHED crates run their own tests (the reverse dependents
+                    # are what blew the cap, and a test-level run of all of them is
+                    # the expensive part), every tree reader still runs, and
+                    # check_workspace=1 buys the compile-level integration of the
+                    # whole workspace in one `cargo check` step.
+                    touched=$(bash "$TREE/scripts/gate_touched_crates.sh" --dry-run ${diff:+--diff-from "$diff"} 2>/dev/null | sed -n 's/^gate_touched_crates: touched crate(s): //p')
+                    if [ "$touched" = "(none)" ]; then touched=""; fi
+                    printf 'tier=quick\ncrates=%s\ntargets=%s\ncheck_workspace=1\nreason=%s: %s -- rule (i): the touched crate(s) run their tests and ONE cargo check --workspace --all-targets covers every reverse dependent at compile level; plus %s tree-reader target(s) from %s\n' \
+                        "$touched" "$(targets_from_registry "$TREE/$REGISTRY")" "$prefix" "$rule" "$nreg" "$REGISTRY" ;;
+                # Rule (ii): a ROOT manifest stays full at the PR, in the queue and
+                # on push alike — a dependency bump is exactly where compile-level
+                # integration breaks, and its blast radius is the whole workspace.
+                *) printf 'tier=full\nreason=%s: %s\n' "$prefix" "$rule" ;;
+            esac ;;
+        selection=quick*|selection=none*) printf 'tier=quick\ncrates=%s\ntargets=%s\nreason=%s: %s; plus %s tree-reader target(s) from %s\n' "$crates" "$(targets_from_registry "$TREE/$REGISTRY")" "$prefix" "$rule" "$nreg" "$REGISTRY" ;;
+        *) printf 'ENV: gate_touched_crates --print-selection gave "%s"\n' "$sel" >&2; return 2 ;;
+    esac
+}
+
+# The diff between a base revision and HEAD, as paths, into a file. Two-dot on
+# purpose: for a merge or a squash the base IS an ancestor of HEAD, so
+# base..HEAD and base...HEAD name the same tree comparison, and the two-dot form
+# needs no merge-base — which a shallow CI checkout usually cannot compute.
+diff_into() { # $1 = out file, $2 = base rev
+    git -C "$ROOT" diff --name-only "$2" HEAD > "$1" 2>/dev/null
+}
+
 decide() {
+    local df rc=0
     case "$EVENT" in
-        push|schedule|workflow_dispatch)
-            printf 'tier=full\nreason=%s event: the whole workspace, every feature-gated suite\n' "$EVENT" ;;
+        schedule|workflow_dispatch)
+            printf 'tier=full\nreason=%s event: the whole workspace, every feature-gated suite -- FULL lives here (coverage-nightly, full-nightly, the pre-publish dogfood; 67-E2 decision D-1)\n' "$EVENT" ;;
+        push)
+            # A push to main is the merge queue landing ONE PR, so the push's own
+            # diff is HEAD^1..HEAD. It used to be a flat `full`, which is how every
+            # landing paid an hour for work the PR and the queue had both already
+            # measured.
+            local base how
+            if git -C "$ROOT" rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
+                base='HEAD^1'; how="the merge commit's own diff, HEAD^1..HEAD"
+            elif git -C "$ROOT" rev-parse -q --verify 'origin/main@{1}' >/dev/null 2>&1; then
+                base='origin/main@{1}'; how='a non-merge tip diffed against the previous main, origin/main@{1}..HEAD'
+            else
+                printf 'tier=full\nreason=push: neither a merge commit (no HEAD^2) nor a previous origin/main in the reflog -- the pushed diff cannot be derived, so this falls closed to full\n'; return 0
+            fi
+            df=$(mktemp "${TMPDIR:-/tmp}/ci-tier-diff.XXXXXX")
+            if ! diff_into "$df" "$base"; then rm -f "$df"; printf 'tier=full\nreason=push: git diff %s..HEAD failed -- the pushed diff cannot be derived, so this falls closed to full\n' "$base"; return 0; fi
+            selection "push: $how" "$df" || rc=$?
+            rm -f "$df"; return $rc ;;
         merge_group)
             if [ -z "$PR_HEAD" ]; then printf 'tier=full\nreason=merge_group without a PR head to compare against\n'; return 0; fi
             local ht pt
             ht=$(git -C "$ROOT" rev-parse 'HEAD^{tree}' 2>/dev/null || true)
             pt=$(git -C "$ROOT" rev-parse "${PR_HEAD}^{tree}" 2>/dev/null || true)
             if [ -z "$ht" ] || [ -z "$pt" ]; then printf 'tier=full\nreason=merge_group: a tree could not be resolved (HEAD=%s pr-head=%s)\n' "${ht:-?}" "${pt:-?}"; return 0; fi
-            if [ "$ht" != "$pt" ]; then printf 'tier=full\nreason=merge_group: queue tree %s differs from PR head tree %s (main moved under the PR)\n' "${ht:0:9}" "${pt:0:9}"; return 0; fi
+            if [ "$ht" != "$pt" ]; then
+                # THE QUEUE MIRRORS THE PR: main moved, the PR's diff did not.
+                if ! git -C "$ROOT" rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
+                    printf 'tier=full\nreason=merge_group: main moved under the PR (queue tree %s != PR head tree %s) and the queue ref is not a merge commit, so the PR diff cannot be re-derived -- fail closed\n' "${ht:0:9}" "${pt:0:9}"; return 0
+                fi
+                df=$(mktemp "${TMPDIR:-/tmp}/ci-tier-diff.XXXXXX")
+                if ! diff_into "$df" 'HEAD^1'; then rm -f "$df"; printf 'tier=full\nreason=merge_group: main moved under the PR but git diff HEAD^1..HEAD failed, so the PR diff cannot be re-derived -- fail closed\n'; return 0; fi
+                selection "merge_group: main moved under the PR (queue tree ${ht:0:9} != PR head tree ${pt:0:9}); the PR's own selection re-derived on the queue ref" "$df" || rc=$?
+                rm -f "$df"; return $rc
+            fi
             if [ "$PR_CONCLUSION" != "success" ]; then printf 'tier=full\nreason=merge_group: same tree but the PR head'"'"'s workspace-test concluded %s, not success\n' "${PR_CONCLUSION:-unknown}"; return 0; fi
             printf 'tier=reuse\ncite=%s\nreason=merge_group: HEAD^{tree} %s equals PR head %s^{tree}, whose workspace-test succeeded — the same tree measured twice\n' "$PR_HEAD" "${ht:0:9}" "${PR_HEAD:0:9}" ;;
         pull_request)
-            local chk sel crates rule
-            if ! chk=$(bash "$ROOT/scripts/check_tree_reader_tests.sh" 2>&1); then printf 'ENV: %s\n' "$chk" >&2; return 2; fi
-            sel=$(bash "$ROOT/scripts/gate_touched_crates.sh" --print-selection ${COMPARAND:+--comparand "$COMPARAND"} ${DIFF_FROM:+--diff-from "$DIFF_FROM"} 2>/dev/null | tail -1)
-            crates=$(printf '%s' "$sel" | sed -n 's/^selection=[a-z]* crates=\(.*\) rule=.*$/\1/p'); rule=${sel#*rule=}
-            case "$sel" in
-                selection=full*) printf 'tier=full\nreason=pull_request: %s\n' "$rule" ;;
-                selection=quick*|selection=none*) printf 'tier=quick\ncrates=%s\ntargets=%s\nreason=pull_request: %s; plus %s tree-reader target(s) from %s\n' "$crates" "$(targets_from_registry "$ROOT/$REGISTRY")" "$rule" "$(grep -vc '^#' "$ROOT/$REGISTRY")" "$REGISTRY" ;;
-                *) printf 'ENV: gate_touched_crates --print-selection gave "%s"\n' "$sel" >&2; return 2 ;;
-            esac ;;
+            selection "pull_request" "$DIFF_FROM" || return $? ;;
         *) printf 'ENV: unknown event "%s" — refusing to guess a tier\n' "$EVENT" >&2; return 2 ;;
     esac
 }
@@ -161,6 +256,7 @@ self_test() {
         git init -q -b main "$d"
         ( cd "$d" \
           && export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+          && export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null \
           && git commit -q --allow-empty -m base \
           && git branch pr \
           && printf 'moved\n' > main-moved.txt && git add -A && git commit -q -m "main moved under the PR" \
@@ -209,7 +305,7 @@ self_test() {
     row 0 "--filterset reads stdin and translates EVERY registry token (no ':--' survives)" '^NONE-LEFT$' bash -c "e=\$(bash '$T' --event pull_request --diff-from '$td/d-scripts.txt' | sed -n 's/^targets=//p' | bash '$T' --filterset); if [ -z \"\$e\" ]; then echo EMPTY; elif printf '%s' \"\$e\" | grep -q ':--'; then echo LEFTOVER; else echo NONE-LEFT; fi"
     row 0 "--filterset over the registry: one clause per registry line (nothing dropped, nothing invented)" '^EQUAL$' bash -c "reg=\$(grep -vc '^#' scripts/tree_reader_tests.txt); n=\$(bash '$T' --event pull_request --diff-from '$td/d-scripts.txt' | sed -n 's/^targets=//p' | bash '$T' --filterset | tr '|' '\n' | wc -l); [ \"\$reg\" = \"\$n\" ] && echo EQUAL || echo \"DIFFER registry=\$reg clauses=\$n\""
     # MUTANT: a copy that drops the tree-reader targets from the quick tier must lose readme_contract — the falsifier discriminates
-    sed 's/targets=%s\\n/targets=\\n/; s/"\$(targets_from_registry "\$ROOT\/\$REGISTRY")" //' "$T" > "$td/mutant.sh"
+    sed 's/targets=%s\\n/targets=\\n/; s/"\$(targets_from_registry "\$TREE\/\$REGISTRY")" //' "$T" > "$td/mutant.sh"
     row 0 "mutant without tree-reader targets loses readme_contract (proves the inclusion is load-bearing)" 'MUTANT-LOST' bash -c "if bash '$td/mutant.sh' --event pull_request --diff-from '$td/d-scripts.txt' | grep -q readme_contract; then echo MUTANT-KEPT; else echo MUTANT-LOST; fi"
     printf '\n%s checks, %s failed\n' "$n" "$red"; [ "$red" -eq 0 ]
 }

--- a/tests/spec/pp066_v16_defects.sh
+++ b/tests/spec/pp066_v16_defects.sh
@@ -20,6 +20,10 @@ V15_SHA=42be1560b
 
 if [ "${1:-}" = "--v15-red" ]; then
     TMP=$(mktemp "${TMPDIR:-/tmp}/pp066-v15.XXXXXX.md")
+    # A shallow CI checkout (a fresh ephemeral runner) lacks this commit even though main reaches it, and the
+    # intel runners only ever passed on leftover history in their long-lived workspaces (yoga, 2026-09-10:
+    # `fatal: invalid object name`, exit 128). Fetch the one object instead of depending on that.
+    git -C "$ROOT" cat-file -e "$V15_SHA^{commit}" 2>/dev/null || git -C "$ROOT" fetch -q --no-tags --depth=1 origin "$V15_SHA" 2>/dev/null || true
     git -C "$ROOT" show "$V15_SHA:docs/specifications/PP-066-release-spec.md" > "$TMP"
     rc=0; bash "$0" "$TMP" > /dev/null 2>&1 || rc=$?
     rm -f -- "$TMP"

--- a/tests/spec/pp066_v16_defects.sh
+++ b/tests/spec/pp066_v16_defects.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SPEC="${1:-$ROOT/docs/specifications/PP-066-release-spec.md}"
-V15_SHA=42be1560b
+V15_SHA=42be1560bc078bee787feccd6336b0f22eefcc3c
 
 if [ "${1:-}" = "--v15-red" ]; then
     TMP=$(mktemp "${TMPDIR:-/tmp}/pp066-v15.XXXXXX.md")


### PR DESCRIPTION
## Rows 67-E1 + 67-E2 (P0-3, #3084) — spec `docs/specifications/06x-release-schedule.md` §2 E · epic #3078 · ticket PMAT-1098

**67-E1 — one build graph.** The quick-tier step expanded `scripts/tree_reader_tests.txt` into a `&&` chain of one `cargo nextest run -p <crate>` per crate: 26 cargo invocations, 26 dependency resolutions, serial runs; 55 min on a one-file YAML PR (run 34449608126) and a 60-min timeout under fleet load on #3063 (#3070). Now `scripts/ci_test_tier.sh --filterset` turns the same tokens into one nextest filterset (`(package(x) & kind(lib))`, `(package(x) & kind(bin))`, `binary_id(x::t)`; an unknown token is ENV, never a dropped target — 8 case rows both polarities) and the step runs ONE `cargo nextest run --profile ci --workspace --lib --tests --exclude … -E "<expr>"`. `timeout-minutes: 20` on both quick steps: over that, the quick tier has stopped being quick and fails loudly.

**Measured on lambda, warm target dir:** the same 39 test binaries as the chain; 65,263 tests run in 240 s, 351 s wall including the build. Per-binary counts differ from the chain by feature unification (aprender-core +199, aprender-orchestrate +36, aprender-test-lib −174): the one graph builds the tree-reader libs under `--workspace`-unified features — exactly what the FULL tier builds — so the quick tier now tests the same binaries the full tier does.

**67-E2 — the queue mirrors the PR.** `merge_group` on a moved main re-derives the PR's own diff from `HEAD^1..HEAD` on the queue ref and runs the tier the PR ran (the `reuse` rule is untouched); `push` to main runs quick on the push's diff; `schedule`/`workflow_dispatch` stay FULL (decision D-1: FULL lives in the nightly and the pre-publish dogfood). Over the cap → quick on the touched crates + one `cargo check --workspace --all-targets --locked` step (`check_workspace=1`, compile-level integration of every reverse dependent); a root-manifest diff (`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`) stays FULL at PR, in the queue and on push — cited from `gate_touched_crates.sh`, not duplicated. A depth-2 fetch on merge_group/push so `HEAD^1` resolves on the shallow checkout — without it the change would look wired and be inert (fail-closed to full with a `::warning::`). 39/39 case rows, incl. a mutant row (a queue that always answers full loses the crates).

Orchestrator re-runs: case table 39/39 (E1 23 + E2), YAML parses, `check_workflow_path_filters`/`check_guards_are_wired` PASS, `make gate` 41 checks 0 failed. Two pre-existing rows encoded the replaced decision (`push -> full`, `aprender-core touched -> full`) and were rewritten, not deleted silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)