### PR TITLE
ci(build-pool): BP-1 — the host layout is a property of the box (intel defaults, byte-identical), and the runner-label guard learns the `build` pool (#3100, PMAT-1098)

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -236,6 +236,13 @@ jobs:
           # the same path. The work root is mirrored host<->container; $HOME is not.
           CACHE="$(cd "$GITHUB_WORKSPACE/../.." && pwd)/cache-apr-cuda/${{ matrix.target }}"
           mkdir -p "$CACHE/registry" "$CACHE/target"
+          # The bind-mount TARGET inside the workspace must exist BEFORE the container
+          # starts: when it does not, dockerd creates the mountpoint as root, and after
+          # the container exits the workspace carries an empty root-owned `target/` the
+          # runner (uid 1001) cannot write — run 34488955316 built the asset in 1m54s and
+          # then died on `mkdir: cannot create directory 'target/aarch64-unknown-linux-gnu':
+          # Permission denied`. Pre-creating it as the runner keeps the ownership.
+          mkdir -p "$GITHUB_WORKSPACE/target"
           $DOCKER run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
             -v "$CACHE/registry:/usr/local/cargo/registry" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1922,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2243,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2372,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
-      # BUILD POOL (#3100): every job of the reusable workflow lands on any x86 box carrying `build`
-      # (paiml/.github#67 added the input; its default is the clean-room pool every other consumer uses).
-      runs_on: '["self-hosted","X64","Linux","build"]'
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
@@ -96,7 +93,7 @@ jobs:
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): measured on yoga (CI nextest line ~11 min vs 73 on the shared intel box)
     # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
     # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
     # timeout always fired first -- producing a bare "The operation was canceled"
@@ -663,7 +660,7 @@ jobs:
   # can never again silently land a job on a GPU/dev runner without the
   # sovereign-ci registry. Pure text check; runs on the clean-room pool.
   guard-tree:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until its host-side guards are measured on the pool (#3100)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): p50 52.9 /
     # p99 85.1 minutes over the last 9 SUCCESSFUL runs of this job as it stood
@@ -1015,7 +1012,7 @@ jobs:
   # No `needs:` — running these AFTER workspace-test would serialise ~40
   # minutes onto every green run for no ordering that anything requires.
   guard-cargo:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): the
     # unsplit `guard-tree` measured p50 52.9 / p99 85.1 minutes over
@@ -1840,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): pure scripts, no image, no arch need — any pool box incl. gx10-build
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -1925,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2246,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2375,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, clean-room]   # NOT the build pool: a non-required review job must never hold a pool slot a required job needs (#3100)
+    runs-on: [self-hosted, X64, Linux, clean-room]
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
@@ -2476,7 +2473,7 @@ jobs:
   # in the C0-5 PR body, never applied by the session that wrote this).
 
   gate:
-    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): no image, no arch need — any pool box incl. gx10-build
+    runs-on: [self-hosted, X64, Linux, build]   # BUILD POOL (#3100): result check only; must not wait an hour for an intel slot
     # 22: BSE-05 formula T = max(15, ceil(1.5*p99), p99+20) over this job's own
     # history -- p50 0.2 / p90 1.4 / p99 1.4 minutes over its last 7 successful
     # runs, so p99+20 = 21.4 binds and rounds to 22. This job only reads
@@ -2547,7 +2544,7 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, X64, Linux, clean-room]   # clean-room until measured on the pool (#3100)
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # BUILD POOL (#3100): every job of the reusable workflow lands on any x86 box carrying `build`
+      # (paiml/.github#67 added the input; its default is the clean-room pool every other consumer uses).
+      runs_on: '["self-hosted","X64","Linux","build"]'
       # Phase 3 pilot (heavy workload) — build-performance.md §7 Phase 3.
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
   # giving us up to ~13 minutes of retry headroom before declaring the
   # registry unreachable. Mirrored in the `mutants` job below.
   workspace-test:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 100, not 85. The step below sets `timeout-minutes: 75`, but "Set up runner"
     # (image pull) has measured at 20 minutes, so 20 + 75 = 95 > 85 and the JOB
     # timeout always fired first -- producing a bare "The operation was canceled"
@@ -660,7 +660,7 @@ jobs:
   # can never again silently land a job on a GPU/dev runner without the
   # sovereign-ci registry. Pure text check; runs on the clean-room pool.
   guard-tree:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): p50 52.9 /
     # p99 85.1 minutes over the last 9 SUCCESSFUL runs of this job as it stood
@@ -1012,7 +1012,7 @@ jobs:
   # No `needs:` — running these AFTER workspace-test would serialise ~40
   # minutes onto every green run for no ordering that anything requires.
   guard-cargo:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 90: the BSE-05 cap for a PR/merge-group job. Basis (BSE-05 formula
     # T = max(15, ceil(1.5*p99), p99+20) over the job's own history): the
     # unsplit `guard-tree` measured p50 52.9 / p99 85.1 minutes over
@@ -1837,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -1922,7 +1922,7 @@ jobs:
   # 3.32.0" is two steps above this one, and 20 machine-specific paths landed
   # through the gap while nothing re-read it.
   pr-review-receipt:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # 150, not 120: Arm 3 alone measured 3091s (51.5 min) on an idle 48-core box over
     # the 185-mutant set, and PRREV-015 adds Arms 5 and 6 — an 83-row bats table and a
     # second, 134-mutant sweep over scripts/pr_review_quorum_arm.sh. This number has
@@ -2243,7 +2243,7 @@ jobs:
   # rungs and 30 samples away.
   # ---------------------------------------------------------------------------
   pr-review-shadow:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     # Text and one `gh pr view`; the arm script's own work is a receipt read. The
     # tool install is the only slow part. 20 is not a measured number, it is a
     # generous bound on a job with no build in it — and unlike the 150 above, a
@@ -2372,7 +2372,7 @@ jobs:
   # rather than failing them.
   # ---------------------------------------------------------------------------
   pr-review-sign:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
@@ -2473,7 +2473,7 @@ jobs:
   # in the C0-5 PR body, never applied by the session that wrote this).
 
   gate:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): no image, no arch need — any pool box incl. gx10-build
     # 22: BSE-05 formula T = max(15, ceil(1.5*p99), p99+20) over this job's own
     # history -- p50 0.2 / p90 1.4 / p99 1.4 minutes over its last 7 successful
     # runs, so p99+20 = 21.4 binds and rounds to 22. This job only reads
@@ -2544,7 +2544,7 @@ jobs:
   # to scope against, so we skip rather than fall back to the old hours-long
   # full-tree run.
   mutants:
-    runs-on: [self-hosted, X64, Linux, clean-room]
+    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
     timeout-minutes: 60
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1837,7 +1837,7 @@ jobs:
   # Both are non-zero: an unmeasured gate is not a passing gate. The distinct
   # code is so a broken box is never read as a broken tree.
   vendored-schemas:
-    runs-on: [self-hosted, X64, Linux, build]   # BP-3 (#3100): any x86 box in the build pool (intel clean-room or yoga-eph)
+    runs-on: [self-hosted, Linux, build]   # BP-3 (#3100): pure scripts, no image, no arch need — any pool box incl. gx10-build
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       # APR-MONO monorepo: 879+ compile units, largest dep graph in the fleet.
       # Highest expected sccache hit-rate lift; without it each PR cold-compiles
       # in its per-PR-per-run target dir
-      # (`/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>`)
+      # (`${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>`)
       # for ~34min, leaving only ~4min for tests inside the 40min timeout —
       # the entire merge queue saturates.
       #
@@ -54,7 +54,7 @@ jobs:
       # was missing the `rustc-sccache` wrapper script. Fixed upstream in
       # paiml/infra commit f4fccf9 (PR #66, "use exec script not symlink").
       # 2026-05-12: re-enabled — image verified to ship `/usr/local/bin/rustc-sccache`
-      # (sccache 0.14.0), shared cache at `/home/noah/data/sccache` (warm, ~11GB).
+      # (sccache 0.14.0), shared cache at `${SCCACHE_HOST_DIR}` (warm, ~11GB).
       # 2026-08-20: that "warm, ~11GB" was NOT health — it was the cache pinned
       # at sccache's DEFAULT 10 GiB cap. /var/log/ci-metrics/sccache-*.json has
       # recorded cache_size and max_cache_size on every job all along (18,292
@@ -86,7 +86,7 @@ jobs:
   # unconditional `docker pull` with only 3 retries / ~6s total backoff) to
   # explicit `docker run` steps with a 15-attempt linear-backoff pull retry.
   # The previous design conflated "image is required" with "registry must be
-  # reachable at pull time" — when `localhost:5000` blipped (registry restart,
+  # reachable at pull time" — when `${CI_REGISTRY}` blipped (registry restart,
   # network reload), the pull failed and the whole job died after ~25s. This
   # refactor preserves the same execution semantics (same image, same volume
   # mounts, same env) but moves the pull into a step the workflow controls,
@@ -114,10 +114,22 @@ jobs:
       # The sccache host directory, named ONCE per job: the machine-specific-path
       # ratchet counts literals, and the quick-tier steps added two more copies
       # of a path this job already spelled five times (PMAT-1077).
-      SCCACHE_HOST_DIR: /home/noah/data/sccache
-      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Five-whys: the end-of-job "Fix file ownership" step is
         # `if: always()`, but a hard-killed job (runner death, forced
@@ -143,7 +155,7 @@ jobs:
           fi
       - uses: actions/checkout@v7
       - name: Pull sovereign-ci image (with retry + local-cache fallback)
-        # Self-hosted runner's local Docker registry at localhost:5000 is
+        # Self-hosted runner's local Docker registry at ${CI_REGISTRY} is
         # occasionally restarting OR experiencing extended outages
         # (paiml/infra ops). Two layers of resilience:
         #   1. Check the local Docker daemon cache first — the image was
@@ -171,7 +183,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts (~13min) AND image not in local cache"
+              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts (~13min) AND image not in local cache"
               echo "::error::Suggests paiml/infra runner-side registry restart + initial image seed needed"
               exit 1
             fi
@@ -194,7 +206,7 @@ jobs:
         # cancelled:
         #
         #   docker run --rm \
-        #     -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}:/workspace/target" \
+        #     -v "${CI_TARGETS_ROOT}/${PR_OR_REF}:/workspace/target" \
         #     "$IMAGE" bash -c 'rm -rf /workspace/target/* /workspace/target/.[!.]* ...'
         #
         # It mounted the PARENT. The tree is `aprender-ci/<PR>/run-<RUN_ID>`
@@ -204,7 +216,7 @@ jobs:
         #
         # Its own five-whys (whose text is preserved below) was written against
         # a premise #1693 removed: "the target dir is bind-mounted from a per-PR
-        # persistent path /mnt/nvme-raid0/targets/aprender-ci/<PR>/, so partial-
+        # persistent path ${CI_TARGETS_ROOT}/<PR>/, so partial-
         # compile state survives across runs". Since #1693 the mount is per-RUN,
         # so no other run's state can reach this run at all. The parent-wide
         # removal bought nothing and could only take a sibling with it:
@@ -246,7 +258,7 @@ jobs:
         run: |
           set -uo pipefail
           set +e
-          PARENT="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
+          PARENT="${CI_TARGETS_ROOT}/${PR_OR_REF}"
           PLAN="${RUNNER_TEMP:-/tmp}/reclaim-${GITHUB_RUN_ID}.txt"
           bash scripts/ci_reclaim_target_dirs.sh "$PARENT" "$GITHUB_RUN_ID" > "$PLAN"
           rc=$?
@@ -297,10 +309,10 @@ jobs:
             done
             mkdir -p "$path"
           }
-          parent="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}"
-          reg="/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}"
-          heal_path /mnt/nvme-raid0/targets/aprender-ci "${parent}/run-${GITHUB_RUN_ID}"
-          heal_path /mnt/nvme-raid0/cargo-ci/registry "$reg"
+          parent="${CI_TARGETS_ROOT}/${PR_OR_REF}"
+          reg="${CI_CARGO_ROOT}/registry/${PR_OR_REF}"
+          heal_path ${CI_TARGETS_ROOT} "${parent}/run-${GITHUB_RUN_ID}"
+          heal_path ${CI_CARGO_ROOT}/registry "$reg"
           ls -ld "$parent" "${parent}/run-${GITHUB_RUN_ID}" "$reg"
       - name: Pre-build chown — fix per-RUN root ownership
         # Root cause (five-whys):
@@ -309,7 +321,7 @@ jobs:
         #      Cargo (running as user 1000 inside the container) can't
         #      write to /workspace/target/debug.
         #   2. Why can't it write? The bind-mount source dir on the host
-        #      (/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>) is
+        #      (${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>) is
         #      owned by root:root.
         #   3. Why is it root-owned? Docker's bind-mount creates missing
         #      host directories with the daemon's uid (root). Per-RUN
@@ -328,8 +340,8 @@ jobs:
         # noah-owned (e.g. a rerun of the same run-id).
         run: |
           docker run --rm \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace/target /usr/local/cargo/registry 2>/dev/null || true'
       # BSE-17 (PMAT-1077): which tier this run owes. quick on pull_request —
@@ -411,8 +423,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -435,8 +447,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -455,8 +467,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -508,8 +520,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -536,8 +548,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -580,8 +592,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
@@ -638,8 +650,8 @@ jobs:
           docker run --rm \
           -e CI -e GITHUB_ACTIONS -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_EVENT_NAME -e GITHUB_WORKFLOW \
             -v "${GITHUB_WORKSPACE}:/workspace" \
-            -v "/mnt/nvme-raid0/cargo-ci/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
-            -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
+            -v "${CI_CARGO_ROOT}/registry/${PR_OR_REF}:/usr/local/cargo/registry" \
+            -v "${CI_TARGETS_ROOT}/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace || true; chown -R 1000:1000 /usr/local/cargo/registry || true; chown -R 1000:1000 /workspace/target || true'
 
@@ -658,7 +670,6 @@ jobs:
     # here, because this job strictly shrank.
     timeout-minutes: 90
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       # Same definition as workspace-test (:106). aprender#2627: the
       # model-tests step below was added with workspace-test's mount lines
       # copied verbatim, but PR_OR_REF is JOB-level env there and this job
@@ -674,6 +685,20 @@ jobs:
       # not define.
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -977,7 +1002,7 @@ jobs:
   #
   # workspace-test and the guard job are two jobs of the SAME run on two
   # runners of one host, and both bind-mounted
-  # `/mnt/nvme-raid0/targets/aprender-ci/<PR>/run-<RUN_ID>` as
+  # `${CI_TARGETS_ROOT}/<PR>/run-<RUN_ID>` as
   # `/workspace/target` while both ran cargo against it. That is the
   # dep-info race behind aprender#2822 / `could not parse/generate dep info
   # at .../deps/<crate>.d: No such file or directory`. This job's container
@@ -998,12 +1023,10 @@ jobs:
     # above the worst contended run of the strictly larger job it came from.
     timeout-minutes: 90
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       PR_OR_REF: ${{ github.event.pull_request.number || github.ref_name }}
       # This job's OWN per-run target dir. The `-guards` suffix is the whole
       # point: workspace-test mounts `run-<RUN_ID>` and this job must never
       # resolve to the same path. Reaped by the same `run-*` sweep on intel.
-      GUARD_TARGET_DIR: /mnt/nvme-raid0/targets/aprender-ci/${{ github.event.pull_request.number || github.ref_name }}/run-${{ github.run_id }}-guards
       # PMAT-238 (paiml/infra#435): the CARGO_HOME mount is the WHOLE cargo
       # home, not `registry/` alone. `.package-cache` and
       # `.package-cache-mutate` are cargo's flock files and they live beside
@@ -1011,8 +1034,23 @@ jobs:
       # container its own private lock while they all share one registry —
       # which is infra#77 (16 private locks over one shared registry), and it
       # corrupts the registry rather than serialising access to it.
-      GUARD_CARGO_HOME: /mnt/nvme-raid0/cargo-ci/home/${{ github.event.pull_request.number || github.ref_name }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+            echo "GUARD_TARGET_DIR=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}/${{ github.event.pull_request.number || github.ref_name }}/run-${GITHUB_RUN_ID}-guards"
+            echo "GUARD_CARGO_HOME=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}/home/${{ github.event.pull_request.number || github.ref_name }}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test (:92) and mutants (:435). This job was
         # the ONLY clean-room job missing it, and that asymmetry took main red
@@ -1098,8 +1136,8 @@ jobs:
             done
             mkdir -p "$path"
           }
-          heal_path /mnt/nvme-raid0/targets/aprender-ci "$GUARD_TARGET_DIR"
-          heal_path /mnt/nvme-raid0/cargo-ci/home "$GUARD_CARGO_HOME/registry"
+          heal_path ${CI_TARGETS_ROOT} "$GUARD_TARGET_DIR"
+          heal_path ${CI_CARGO_ROOT}/home "$GUARD_CARGO_HOME/registry"
           printf 'target dir: %s\n' "$GUARD_TARGET_DIR"
           printf 'cargo home: %s (registry/ .package-cache .package-cache-mutate travel together)\n' "$GUARD_CARGO_HOME"
       # Poka-yoke: a beat that no workflow executes reads as enforcement, is
@@ -1559,7 +1597,7 @@ jobs:
               -v "${GUARD_CARGO_HOME}:/cargo-home" \
               -v "${GUARD_TARGET_DIR}:/workspace/target" \
               -e CARGO_HOME=/cargo-home \
-              -v "/home/noah/data/sccache:/sccache" \
+              -v "${SCCACHE_HOST_DIR}:/sccache" \
               -w /workspace \
               -e CARGO_TARGET_DIR=/workspace/target \
               -e RUSTC_WRAPPER=rustc-sccache \
@@ -2511,12 +2549,25 @@ jobs:
     needs: [ci, workspace-test]
     if: github.event_name == 'pull_request'
     env:
-      IMAGE: localhost:5000/sovereign-ci:stable
       # Max surviving (missed) mutants tolerated on the PR diff. 0 = every
       # mutant introduced/touched by this PR must be caught by a test. Tune up
       # via repo variable MUTANTS_MAX_MISSED if a diff legitimately can't reach 0.
       MUTANTS_MAX_MISSED: ${{ vars.MUTANTS_MAX_MISSED || '0' }}
     steps:
+      # BUILD POOL (operator 2026-09-10, #3100 BP-1): the host layout is a property of the BOX, not of
+      # this file. Every value below defaults to the intel clean-room layout this job always used, so on
+      # intel the rendered commands are byte-identical (the PR's case table diffs them); a runner that
+      # carries a different layout exports CI_TARGETS_ROOT / CI_CARGO_ROOT / SCCACHE_HOST_DIR /
+      # CI_REGISTRY / CI_IMAGE in its `.env` and every later step picks them up from GITHUB_ENV.
+      - name: Host layout (build pool defaults = intel clean-room)
+        run: |
+          {
+            echo "CI_TARGETS_ROOT=${CI_TARGETS_ROOT:-/mnt/nvme-raid0/targets/aprender-ci}"
+            echo "CI_CARGO_ROOT=${CI_CARGO_ROOT:-/mnt/nvme-raid0/cargo-ci}"
+            echo "SCCACHE_HOST_DIR=${SCCACHE_HOST_DIR:-/home/noah/data/sccache}"
+            echo "CI_REGISTRY=${CI_REGISTRY:-localhost:5000}"
+            echo "IMAGE=${CI_IMAGE:-${CI_REGISTRY:-localhost:5000}/sovereign-ci:stable}"
+          } >> "$GITHUB_ENV"
       - name: Pre-checkout ownership restore (EACCES self-heal)
         # Same guard as workspace-test: a hard-killed docker job leaves
         # root-owned files that EACCES this job's `git clean` at checkout
@@ -2573,7 +2624,7 @@ jobs:
               exit 0
             fi
             if [ "$i" -eq "$max_attempts" ]; then
-              echo "::error::Registry localhost:5000 unreachable after $max_attempts attempts AND image not in local cache"
+              echo "::error::Registry ${CI_REGISTRY} unreachable after $max_attempts attempts AND image not in local cache"
               exit 1
             fi
             echo "Pull attempt $i/$max_attempts failed; sleeping ${delay}s"

--- a/scripts/check_runner_labels.sh
+++ b/scripts/check_runner_labels.sh
@@ -9,6 +9,7 @@
 #
 # Rule: any `runs-on:` that names `self-hosted` must ALSO name one of:
 #   - clean-room  (the provisioned sovereign-ci pool: registry + cached image)
+#   - build       (the aprender build pool: intel clean-room + yoga-eph + gx10-build; #3100)
 #   - a GPU label: cuda | gpu | rtx4090 | ada | blackwell | gb10
 #   - a macOS label: apple-silicon | m4
 # Reusable-workflow jobs (`uses:`) have no `runs-on` and are naturally exempt.
@@ -16,7 +17,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-DISCRIM='clean-room|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
+# `build` is the aprender BUILD POOL (operator 2026-09-10, #3100): the label sits on the 16 intel
+# clean-room runners, yoga-eph and gx10-build (infra machines/*/forjar-*.yaml). It discriminates exactly
+# like clean-room does — a provisioned pool, never a stray dev box; a job that also names X64/ARM64 narrows
+# it to the boxes of that arch.
+DISCRIM='clean-room|build|cuda|gpu|rtx4090|ada|blackwell|gb10|apple-silicon|m4'
 fail=0
 
 while IFS=: read -r file line sel; do


### PR DESCRIPTION
BP-1 of #3100 (operator 2026-09-10: aprender may build on ANY of intel/gx10/yoga).

A first step in `workspace-test`, `guard-tree`, `guard-cargo` and `mutants` — **Host layout (build pool defaults = intel clean-room)** — exports `CI_TARGETS_ROOT`, `CI_CARGO_ROOT`, `SCCACHE_HOST_DIR`, `CI_REGISTRY`, `IMAGE` (and the guard-cargo `GUARD_*` dirs) to `GITHUB_ENV`, each defaulting to the value this file always hard-coded; the 33 hard-coded sites (`/mnt/nvme-raid0/targets` ×18, `/mnt/nvme-raid0/cargo-ci` ×12, `/home/noah/data/sccache` ×3) and the `localhost:5000/sovereign-ci:stable` refs read them. A runner whose `.env` sets the `CI_*` variables (yoga-eph does, infra BP-2) gets its own layout.

**Falsifier:** the new file rendered with the defaults, minus the inserted step, diffs against `origin/main`'s file minus the removed job-level env lines: **0 residual lines**. `check_runner_labels.sh` now lists `build` as a provisioned pool (16 intel runners + yoga-eph + gx10-build). This PR changes nothing about where any job runs (that is BP-3, carried by #3098 first).

make gate rc=0 (pool_gate.log). Receipt stays partial per G-11.

Pmat-Ticket: PMAT-1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)