### PR TITLE
fix(serve,x86): AVX2 Q4_K×Q8_K kernels paired each block with the wrong scale — no CI box ever ran them

### DIFF
--- a/contracts/aprender/quantized-dot-product-v1.yaml
+++ b/contracts/aprender/quantized-dot-product-v1.yaml
@@ -162,6 +162,8 @@ simd_dispatch:
     avx512_vnni: fused_q4k_dot_avx512_vnni
     q8k_scalar: fused_q4k_q8k_dot
     q8k_avx2: fused_q4k_q8k_dot_simd
+    q8k_avx2_kernel: fused_q4k_q8k_dot_avx2
+    q8k_bsums_avx2: fused_q4k_q8k_dot_with_bsums_avx2
     q8k_avx512_vnni: fused_q4k_q8k_dot_avx512vnni_v2
     q8k_4row_avx512_vnni: fused_q4k_q8k_dot_4rows_avx512vnni
   Q5_K:
@@ -235,6 +237,18 @@ falsification_tests:
   test: For each format in YAML, verify simd_dispatch has an entry with at least 'scalar'
     key
   if_fails: Format was added to registry but dispatch table not updated
+- id: FALSIFY-QDOT-006
+  rule: Every x86 Q4_K x Q8_K kernel matches scalar on every box that can run it, not only
+    on the box whose best CPU feature makes the dispatcher select it
+  prediction: fused_q4k_q8k_dot_avx2 and fused_q4k_q8k_dot_with_bsums_avx2 equal fused_q4k_q8k_dot
+    within 1e-3 relative on super-blocks whose 8 scales and 8 mins all differ, on any AVX2 box;
+    fused_q4k_q8k_dot_avx512vnni_v2 likewise on any AVX-512 VNNI box
+  test: cargo test -p aprender-serve --lib -- test_fused_q4k_q8k_dot_avx2_path_matches_scalar_on_every_avx2_box
+    test_fused_q4k_q8k_dot_with_bsums_matches_scalar_on_every_avx2_box test_fused_q4k_q8k_dot_avx512vnni_path_matches_scalar
+  if_fails: A kernel pairs a nibble half with the wrong block scale or drops part of a block's Q8 sum.
+    The dispatcher hid both AVX2 defects for as long as every x86 CI box had AVX-512 VNNI
+    (found 2026-09-10 when yoga, a Core Ultra 9 185H, joined the pool; reverting the fix gives
+    -3650.1 against scalar -25161.5)
 qa_gate:
   id: F-QDOT-001
   name: Quantized Dot Product Contract
@@ -244,7 +258,7 @@ qa_gate:
   - Format registry matches trait implementations
   - Dispatch table covers all formats
   - Cross-format isolation holds
-  pass_criteria: All 5 FALSIFY tests pass
+  pass_criteria: All 6 FALSIFY tests pass
   falsification: Introduce a sign error in nibble extraction — gate must catch it
 equations:
   identity:

--- a/contracts/quantized-dot-product-v1.yaml
+++ b/contracts/quantized-dot-product-v1.yaml
@@ -162,6 +162,8 @@ simd_dispatch:
     avx512_vnni: fused_q4k_dot_avx512_vnni
     q8k_scalar: fused_q4k_q8k_dot
     q8k_avx2: fused_q4k_q8k_dot_simd
+    q8k_avx2_kernel: fused_q4k_q8k_dot_avx2
+    q8k_bsums_avx2: fused_q4k_q8k_dot_with_bsums_avx2
     q8k_avx512_vnni: fused_q4k_q8k_dot_avx512vnni_v2
     q8k_4row_avx512_vnni: fused_q4k_q8k_dot_4rows_avx512vnni
   Q5_K:
@@ -235,6 +237,18 @@ falsification_tests:
   test: For each format in YAML, verify simd_dispatch has an entry with at least 'scalar'
     key
   if_fails: Format was added to registry but dispatch table not updated
+- id: FALSIFY-QDOT-006
+  rule: Every x86 Q4_K x Q8_K kernel matches scalar on every box that can run it, not only
+    on the box whose best CPU feature makes the dispatcher select it
+  prediction: fused_q4k_q8k_dot_avx2 and fused_q4k_q8k_dot_with_bsums_avx2 equal fused_q4k_q8k_dot
+    within 1e-3 relative on super-blocks whose 8 scales and 8 mins all differ, on any AVX2 box;
+    fused_q4k_q8k_dot_avx512vnni_v2 likewise on any AVX-512 VNNI box
+  test: cargo test -p aprender-serve --lib -- test_fused_q4k_q8k_dot_avx2_path_matches_scalar_on_every_avx2_box
+    test_fused_q4k_q8k_dot_with_bsums_matches_scalar_on_every_avx2_box test_fused_q4k_q8k_dot_avx512vnni_path_matches_scalar
+  if_fails: A kernel pairs a nibble half with the wrong block scale or drops part of a block's Q8 sum.
+    The dispatcher hid both AVX2 defects for as long as every x86 CI box had AVX-512 VNNI
+    (found 2026-09-10 when yoga, a Core Ultra 9 185H, joined the pool; reverting the fix gives
+    -3650.1 against scalar -25161.5)
 qa_gate:
   id: F-QDOT-001
   name: Quantized Dot Product Contract
@@ -244,7 +258,7 @@ qa_gate:
   - Format registry matches trait implementations
   - Dispatch table covers all formats
   - Cross-format isolation holds
-  pass_criteria: All 5 FALSIFY tests pass
+  pass_criteria: All 6 FALSIFY tests pass
   falsification: Introduce a sign error in nibble extraction — gate must catch it
 equations:
   identity:

--- a/crates/aprender-serve/src/quantize/bsum_precompute.rs
+++ b/crates/aprender-serve/src/quantize/bsum_precompute.rs
@@ -182,8 +182,12 @@ unsafe fn fused_q4k_q8k_dot_with_bsums_avx2(
             let sum_hi_1 = _mm_madd_epi16(prod_hi_128, _mm_set1_epi16(1));
             let sum_hi_2 = _mm_madd_epi16(prod_hi_hi128, _mm_set1_epi16(1));
 
-            let sum_1 = _mm_add_epi32(sum_lo_1, sum_hi_1);
-            let sum_2 = _mm_add_epi32(sum_lo_2, sum_hi_2);
+            // One block per nibble half: low nibbles = block `is` (sc1), high nibbles = block
+            // `is + 1` (sc2). Pairing sum_lo_1 with sum_hi_1 (the pre-layout-fix order) put each
+            // scale on half of EACH block, the same defect as `fused_q4k_q8k_dot_avx2`; this
+            // dispatcher takes AVX2 on every x86 box, so only data with sc1 == sc2 ever passed.
+            let sum_1 = _mm_add_epi32(sum_lo_1, sum_lo_2);
+            let sum_2 = _mm_add_epi32(sum_hi_1, sum_hi_2);
 
             let sum_1_f = _mm_cvtepi32_ps(sum_1);
             let sum_2_f = _mm_cvtepi32_ps(sum_2);

--- a/crates/aprender-serve/src/quantize/fused_k_tests_q4k.rs
+++ b/crates/aprender-serve/src/quantize/fused_k_tests_q4k.rs
@@ -443,3 +443,95 @@ fn test_fused_q4k_dot_activation_error_message() {
         msg
     );
 }
+
+// ---- every x86 path against scalar, on every box that can run it -------------------------------
+// `fused_q4k_q8k_dot_simd` takes the BEST path the box has. Every x86 CI box had AVX-512 VNNI
+// (intel Xeon W-3245, lambda Threadripper 7960X) until yoga (Core Ultra 9 185H, AVX2 + AVX-VNNI
+// only) joined on 2026-09-10, so the parity tests above only ever judged the VNNI kernel and the
+// AVX2 kernel shipped two defects: nibble halves paired with the wrong block scale, and half of
+// one block's Q8 sum dropped from the min term. Each path is now called directly.
+
+#[cfg(target_arch = "x86_64")]
+fn q4k_q8k_every_scale_distinct(n_sb: usize) -> (Vec<u8>, Vec<f32>, Vec<i8>) {
+    let mut data = vec![0u8; 144 * n_sb];
+    for (sb, b) in data.chunks_exact_mut(144).enumerate() {
+        b[0..2].copy_from_slice(&0x3C00u16.to_le_bytes()); // d = 1.0
+        b[2..4].copy_from_slice(&0x3800u16.to_le_bytes()); // dmin = 0.5
+        // all 12 packed bytes vary (top bits included): the 8 scales and the 8 mins all differ
+        for (i, v) in b[4..16].iter_mut().enumerate() {
+            *v = ((i * 37 + sb * 11 + 5) % 251) as u8;
+        }
+        for (i, v) in b[16..144].iter_mut().enumerate() {
+            *v = ((i * 7 + 11 + sb * 3) % 256) as u8;
+        }
+    }
+    let scales = (0..n_sb).map(|sb| 0.25 + 0.125 * sb as f32).collect();
+    // Q8 differs between the two 16-value halves of every 32-value block
+    let quants = (0..256 * n_sb)
+        .map(|i| (((i * 29 + (i / 16) * 13) % 255) as i32 - 127) as i8)
+        .collect();
+    (data, scales, quants)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn assert_path_matches_scalar(path: &str, got: f32, want: f32) {
+    let tol = 1e-3 * want.abs().max(1.0);
+    assert!(
+        (got - want).abs() <= tol,
+        "{path}: {got} vs scalar {want} (|diff| {} > tol {tol})",
+        (got - want).abs()
+    );
+}
+
+#[test]
+#[cfg(target_arch = "x86_64")]
+fn test_fused_q4k_q8k_dot_avx2_path_matches_scalar_on_every_avx2_box() {
+    assert!(
+        is_x86_feature_detected!("avx2"),
+        "every x86 CI box has AVX2; a box without it must not read this test as passed"
+    );
+    for n_sb in [1usize, 2, 5] {
+        let (data, scales, quants) = q4k_q8k_every_scale_distinct(n_sb);
+        let want = fused_q4k_q8k_dot(&data, &scales, &quants).expect("scalar");
+        // SAFETY: AVX2 asserted above; the buffers hold exactly n_sb super-blocks.
+        let got = unsafe { fused_q4k_q8k_dot_avx2(&data, &scales, &quants) }.expect("avx2");
+        assert_path_matches_scalar(&format!("avx2 n_sb={n_sb}"), got, want);
+    }
+}
+
+#[test]
+#[cfg(target_arch = "x86_64")]
+fn test_fused_q4k_q8k_dot_with_bsums_matches_scalar_on_every_avx2_box() {
+    use crate::quantize::bsum_precompute::{fused_q4k_q8k_dot_with_bsums_simd, precompute_q8k_bsums};
+    assert!(
+        is_x86_feature_detected!("avx2"),
+        "every x86 CI box has AVX2; a box without it must not read this test as passed"
+    );
+    for n_sb in [1usize, 2, 5] {
+        let (data, scales, quants) = q4k_q8k_every_scale_distinct(n_sb);
+        let want = fused_q4k_q8k_dot(&data, &scales, &quants).expect("scalar");
+        let bsums = precompute_q8k_bsums(&quants, n_sb).expect("bsums");
+        // this dispatcher has no AVX-512 branch: it takes its AVX2 kernel on every AVX2 box
+        let got = fused_q4k_q8k_dot_with_bsums_simd(&data, &scales, &quants, &bsums).expect("bsums dot");
+        assert_path_matches_scalar(&format!("avx2+bsums n_sb={n_sb}"), got, want);
+    }
+}
+
+#[test]
+#[cfg(target_arch = "x86_64")]
+fn test_fused_q4k_q8k_dot_avx512vnni_path_matches_scalar() {
+    if !(is_x86_feature_detected!("avx512f")
+        && is_x86_feature_detected!("avx512vnni")
+        && is_x86_feature_detected!("avx512bw"))
+    {
+        eprintln!("SKIP avx512vnni path: no AVX-512 VNNI on this box (the AVX2 tests cover it)");
+        return;
+    }
+    for n_sb in [1usize, 2, 5] {
+        let (data, scales, quants) = q4k_q8k_every_scale_distinct(n_sb);
+        let want = fused_q4k_q8k_dot(&data, &scales, &quants).expect("scalar");
+        // SAFETY: avx512f + avx512vnni + avx512bw detected above
+        let got = unsafe { fused_q4k_q8k_dot_avx512vnni_v2(&data, &scales, &quants) }.expect("vnni");
+        assert_path_matches_scalar(&format!("avx512vnni_v2 n_sb={n_sb}"), got, want);
+    }
+}

--- a/crates/aprender-serve/src/quantize/requires.rs
+++ b/crates/aprender-serve/src/quantize/requires.rs
@@ -127,9 +127,14 @@ unsafe fn fused_q4k_q8k_dot_avx2(
             let sum_hi_1 = _mm_madd_epi16(prod_hi_128, _mm_set1_epi16(1));
             let sum_hi_2 = _mm_madd_epi16(prod_hi_hi128, _mm_set1_epi16(1));
 
-            // Add low and high nibble products
-            let sum_1 = _mm_add_epi32(sum_lo_1, sum_hi_1);
-            let sum_2 = _mm_add_epi32(sum_lo_2, sum_hi_2);
+            // One block per nibble half: the low nibbles are block `is` (sc1/m1), the high
+            // nibbles block `is + 1` (sc2/m2), so each block's sum is its OWN two 128-bit halves.
+            // This used to pair sum_lo_1 with sum_hi_1 and sum_lo_2 with sum_hi_2 (the layout
+            // before the Q8 load fix), so each scale covered half of EACH block: rel_err 2.6% vs
+            // scalar on yoga's Core Ultra 9 185H, the first CI box without AVX-512 VNNI and so the
+            // first to reach this path at all (2026-09-10).
+            let sum_1 = _mm_add_epi32(sum_lo_1, sum_lo_2);
+            let sum_2 = _mm_add_epi32(sum_hi_1, sum_hi_2);
 
             // Apply scales (as f32 to avoid overflow)
             let sum_1_f = _mm_cvtepi32_ps(sum_1);
@@ -151,13 +156,18 @@ unsafe fn fused_q4k_q8k_dot_avx2(
                 _mm256_castsi256_si128(q8_sum_lo),
                 _mm256_extracti128_si256(q8_sum_lo, 1),
             );
-            let _hsum_hi = _mm_add_epi32(
+            let hsum_hi = _mm_add_epi32(
                 _mm256_castsi256_si128(q8_sum_hi),
                 _mm256_extracti128_si256(q8_sum_hi, 1),
             );
 
-            // Include both halves in block sum
-            let q8_block1_sum = _mm_add_epi32(hsum_lo, _mm_shuffle_epi32(hsum_lo, 0b10_11_00_01));
+            // Include both halves in the block sum: q8[j..j+16] AND q8[j+16..j+32]. The second
+            // half was computed as `_hsum_hi` and dropped, so block `is`'s min term missed 16 values.
+            let q8_block1_sum = _mm_add_epi32(hsum_lo, hsum_hi);
+            let q8_block1_sum = _mm_add_epi32(
+                q8_block1_sum,
+                _mm_shuffle_epi32(q8_block1_sum, 0b10_11_00_01),
+            );
             let q8_block1_sum = _mm_add_epi32(
                 q8_block1_sum,
                 _mm_shuffle_epi32(q8_block1_sum, 0b00_00_10_10),

--- a/crates/aprender-serve/src/quantize/tests/tests_28.rs
+++ b/crates/aprender-serve/src/quantize/tests/tests_28.rs
@@ -154,37 +154,37 @@ fn test_simd_performance_speedup() {
     );
 }
 
-/// Verify SIMD dispatch is happening by checking runtime feature detection
+/// Runtime feature detection obeys the ISA hierarchy, and realizar's backend choice follows what
+/// the CPU reports. This test used to assert AVX-512 because it was written on a Threadripper
+/// 7960X: on yoga's Core Ultra 9 185H (AVX2 + AVX-VNNI, no AVX-512, in the build pool since
+/// 2026-09-10) it failed by construction, and it asserted nothing about realizar's own dispatch.
 #[test]
 fn test_simd_feature_detection() {
-    // This test verifies that the CPU features are detected correctly
-    // On AMD Threadripper 7960X, we expect AVX-512 and AVX-512 VNNI
+    use crate::quantize::{detect_simd_backend, SimdBackend};
 
     #[cfg(target_arch = "x86_64")]
     {
+        let has_sse2 = std::is_x86_feature_detected!("sse2");
         let has_avx2 = std::is_x86_feature_detected!("avx2");
         let has_avx512f = std::is_x86_feature_detected!("avx512f");
         let has_avx512vnni = std::is_x86_feature_detected!("avx512vnni");
-
-        println!("CPU Feature Detection:");
-        println!("  AVX2:        {}", has_avx2);
-        println!("  AVX512F:     {}", has_avx512f);
-        println!("  AVX512VNNI:  {}", has_avx512vnni);
-
-        // Threadripper 7960X should have all these features
-        assert!(has_avx2, "AVX2 not detected on Threadripper 7960X");
-        assert!(has_avx512f, "AVX512F not detected on Threadripper 7960X");
-        assert!(
-            has_avx512vnni,
-            "AVX512VNNI not detected on Threadripper 7960X"
+        println!(
+            "CPU features: sse2={has_sse2} avx2={has_avx2} avx512f={has_avx512f} avx512vnni={has_avx512vnni}"
         );
+
+        // x86_64 guarantees SSE2; every AVX-512F CPU has AVX2; AVX-512 VNNI needs AVX-512F.
+        assert!(has_sse2, "an x86_64 CPU without SSE2 is not an x86_64 CPU");
+        assert!(!has_avx512f || has_avx2, "AVX-512F reported without AVX2");
+        assert!(!has_avx512vnni || has_avx512f, "AVX-512 VNNI reported without AVX-512F");
+
+        // The dispatch follows the CPU: AVX2 when present, else SSE2 — never a backend the CPU
+        // lacks, never a slower one than it has.
+        let expected = if has_avx2 { SimdBackend::Avx2 } else { SimdBackend::Sse2 };
+        assert_eq!(detect_simd_backend(), expected, "the backend must follow the detected features");
     }
 
-    #[cfg(not(target_arch = "x86_64"))]
-    {
-        // On non-x86 platforms, just verify the function runs
-        println!("Non-x86 platform - SIMD features not checked");
-    }
+    #[cfg(target_arch = "aarch64")]
+    assert_eq!(detect_simd_backend(), SimdBackend::Neon, "aarch64 always has NEON");
 }
 
 /// Test SIMD path with various data sizes to verify vectorization


### PR DESCRIPTION
Fixes #3105.

## The defects

Two AVX2 Q4_K x Q8_K kernels have been wrong since the Q8 load-layout fix. No CI box could see it, because every x86 CI box took the AVX-512 VNNI path.

- **Scale pairing.** This affects both `fused_q4k_q8k_dot_avx2` and `fused_q4k_q8k_dot_with_bsums_avx2`. Each block's product sum is now its own two 128-bit halves: `sum_lo_1 + sum_lo_2` for block `is` (sc1), and `sum_hi_1 + sum_hi_2` for block `is+1` (sc2). The kernels used to pair `sum_lo_1` with `sum_hi_1`.
- **Dropped Q8 half.** This affects `fused_q4k_q8k_dot_avx2` only. Block `is`'s Q8 sum now includes `q8[j+16..j+32]`, which the kernel computed as `_hsum_hi` and discarded.

The bsums dispatcher has no AVX-512 branch. The Q8K FFN up/gate projection, `fused_q4k_q8k_ffn_up_gate_into`, calls it for every row. So the pairing defect reached that path on every x86 CPU. The effect on real-model outputs is not measured, and this PR claims no number.

## The falsifier (FALSIFY-QDOT-006, `contracts/quantized-dot-product-v1.yaml` plus its `aprender/` copy)

Three tests call each kernel directly, not through a dispatcher. The fixture has super-blocks whose 8 scales and 8 mins all differ, and Q8 values that differ between the two halves of each block. Tolerance is 1e-3 relative.

| Test | Runs on |
|---|---|
| `test_fused_q4k_q8k_dot_avx2_path_matches_scalar_on_every_avx2_box` | every AVX2 box; asserts AVX2 is present rather than skipping |
| `test_fused_q4k_q8k_dot_with_bsums_matches_scalar_on_every_avx2_box` | every AVX2 box |
| `test_fused_q4k_q8k_dot_avx512vnni_path_matches_scalar` | AVX-512 VNNI boxes; prints SKIP elsewhere |

Measured on lambda (Threadripper 7960X):

| Tree | Result |
|---|---|
| Both fixes | 145 Q4K x Q8K and bsums tests pass, and the VNNI test ran (not skipped) |
| `requires.rs` fix reverted | avx2 n_sb=1: -3650.1 vs scalar -25161.5, RED |
| `bsum_precompute.rs` fix reverted | avx2+bsums n_sb=1: -3329.5 vs scalar -25161.5, RED |

The pre-commit gates pass: format, complexity, SATD and docs.

## Why now

This is the last code blocker for yoga in the build pool (operator P0, 2026-09-10: aprender jobs on intel, gx10 and yoga). yoga's CPU takes the AVX2 path, so every workspace-test there failed the existing parity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
