### PR TITLE
fix(ci): RUSTC_WRAPPER names sccache itself — the dash wrapper drops CARGO_BIN_EXE_aprender-explain, so every quick-tier PR fails workspace-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -440,7 +440,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -460,7 +460,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -513,7 +513,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -541,7 +541,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -585,7 +585,7 @@ jobs:
             -v "${SCCACHE_HOST_DIR}:/sccache" \
             -w /workspace \
             -e CARGO_TARGET_DIR=/workspace/target \
-            -e RUSTC_WRAPPER=rustc-sccache \
+            -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
             -e SCCACHE_DIR=/sccache \
             -e SCCACHE_CACHE_SIZE=50G \
             -e CARGO_INCREMENTAL=0 \
@@ -1562,7 +1562,7 @@ jobs:
               -v "/home/noah/data/sccache:/sccache" \
               -w /workspace \
               -e CARGO_TARGET_DIR=/workspace/target \
-              -e RUSTC_WRAPPER=rustc-sccache \
+              -e RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
               -e SCCACHE_DIR=/sccache \
               -e SCCACHE_CACHE_SIZE=50G \
               -e CARGO_INCREMENTAL=0 \


### PR DESCRIPTION
Fixes the quick-tier `CARGO_BIN_EXE_aprender-explain not defined at compile time` failure that turns every CI- or docs-only PR's required `workspace-test` red.

**Cause.** `RUSTC_WRAPPER=rustc-sccache` is `#!/bin/sh` plus `exec sccache "$@"` in the sovereign-ci image, and `/bin/sh` there is dash. dash does not pass environment variables whose names are not shell identifiers to its children. Cargo's `CARGO_BIN_EXE_aprender-explain` has a hyphen, so it never reaches rustc. `CARGO_BIN_EXE_apr` survives, which is why the apr-cli integration tests never showed it.

**Proof.**

| Check | Result |
|---|---|
| Env vars through the image's `/bin/sh` | `CARGO_BIN_EXE_apr` kept, `CARGO_BIN_EXE_aprender-explain` dropped |
| Env vars through bash | both kept |
| The quick tier's exact build on yoga, without the wrapper | compiled clean in 12m42s |

**Change.** All 7 settings in `ci.yml` now name `/usr/local/cargo/bin/sccache`, the same binary without the shell. The infra image's wrapper moves to `#!/bin/bash` separately. #3089 carries the identical edit.

**Gates.** `guard_tree_test.sh` passes all 23 checks, and `check_workflow_env_defined.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
