### PR TITLE
fix(test): pp066 --v15-red fetches its v1.5 commit on a shallow checkout — every fresh yoga guard-tree died exit 128

### DIFF
--- a/tests/spec/pp066_v16_defects.sh
+++ b/tests/spec/pp066_v16_defects.sh
@@ -20,6 +20,10 @@ V15_SHA=42be1560b
 
 if [ "${1:-}" = "--v15-red" ]; then
     TMP=$(mktemp "${TMPDIR:-/tmp}/pp066-v15.XXXXXX.md")
+    # A shallow CI checkout (a fresh ephemeral runner) lacks this commit even though main reaches it, and the
+    # intel runners only ever passed on leftover history in their long-lived workspaces (yoga, 2026-09-10:
+    # `fatal: invalid object name`, exit 128). Fetch the one object instead of depending on that.
+    git -C "$ROOT" cat-file -e "$V15_SHA^{commit}" 2>/dev/null || git -C "$ROOT" fetch -q --no-tags --depth=1 origin "$V15_SHA" 2>/dev/null || true
     git -C "$ROOT" show "$V15_SHA:docs/specifications/PP-066-release-spec.md" > "$TMP"
     rc=0; bash "$0" "$TMP" > /dev/null 2>&1 || rc=$?
     rm -f -- "$TMP"

--- a/tests/spec/pp066_v16_defects.sh
+++ b/tests/spec/pp066_v16_defects.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SPEC="${1:-$ROOT/docs/specifications/PP-066-release-spec.md}"
-V15_SHA=42be1560b
+V15_SHA=42be1560bc078bee787feccd6336b0f22eefcc3c
 
 if [ "${1:-}" = "--v15-red" ]; then
     TMP=$(mktemp "${TMPDIR:-/tmp}/pp066-v15.XXXXXX.md")


### PR DESCRIPTION
In a fresh shallow checkout, which every yoga ephemeral runner does, `tests/spec/pp066_v16_defects.sh --v15-red` died with `fatal: invalid object name '42be1560b'` (exit 128) and turned guard-tree red (#3097 on yoga-build3).

`42be1560b` is on main, the v1.5 spec's squash-merge from 2026-09-05, but it is deeper than CI's checkout. Intel's long-lived workspaces passed only on leftover history. The test now fetches that one commit by its full SHA when it's missing; a remote can't resolve an abbreviated one.

Proof: a fresh depth-1 clone of this branch passes the `--v15-red` arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
