### PR TITLE
fix(compute): nine GPU tests panicked without an adapter — the nightly coverage run was RED six days on an environment fact (PMAT-1106)

### DIFF
--- a/crates/aprender-compute/src/backends/gpu/device/backward.rs
+++ b/crates/aprender-compute/src/backends/gpu/device/backward.rs
@@ -1059,6 +1059,20 @@ fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
 mod tests {
     use super::*;
 
+    /// A GPU test on a box without an adapter is not a failure of the kernel under test; it is an
+    /// environment fact. `expect("GPU device")` turned that fact into a panic and kept the nightly
+    /// coverage run RED for six days (runs 34451014241, 34575134766 — PMAT-1106). Skip, say so on
+    /// stdout so the skip is visible in the log, and let the box that HAS an adapter be the gate.
+    fn device_or_skip() -> Option<GpuDevice> {
+        match GpuDevice::new() {
+            Ok(device) => Some(device),
+            Err(err) => {
+                println!("SKIP: no GPU adapter on this host ({err}); nothing here is asserted");
+                None
+            }
+        }
+    }
+
     /// CPU reference: SiLU backward
     fn silu_backward_cpu(input: &[f32], grad_output: &[f32]) -> Vec<f32> {
         input
@@ -1076,7 +1090,7 @@ mod tests {
     /// FALSIFY-WGPU-001: SiLU backward matches CPU within ε < 1e-4
     #[test]
     fn test_falsify_wgpu_001_silu_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let input: Vec<f32> = (-50..50).map(|i| i as f32 * 0.1).collect();
         let grad_output: Vec<f32> = (0..100).map(|i| (i as f32 - 50.0) * 0.01).collect();
@@ -1100,7 +1114,7 @@ mod tests {
     /// SiLU backward at x=0 (sigmoid=0.5, silu'=0.5)
     #[test]
     fn test_silu_backward_at_zero() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let input = vec![0.0f32; 4];
         let grad_output = vec![1.0f32; 4];
@@ -1117,7 +1131,7 @@ mod tests {
     /// SiLU backward length mismatch error
     #[test]
     fn test_silu_backward_length_mismatch() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let input = vec![1.0f32; 10];
         let grad_output = vec![1.0f32; 5]; // wrong length
@@ -1148,7 +1162,7 @@ mod tests {
     /// Which is matmul(grad_c, B^T, M, N, K) but our shader handles the transpose internally.
     #[test]
     fn test_falsify_wgpu_001_gemm_backward_a_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let (m, k, n) = (4, 8, 6);
 
@@ -1185,7 +1199,7 @@ mod tests {
     /// grad_b[K,N] = A^T[K,M] @ grad_c[M,N]
     #[test]
     fn test_falsify_wgpu_001_gemm_backward_b_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let (m, k, n) = (4, 8, 6);
 
@@ -1218,7 +1232,7 @@ mod tests {
     /// FALSIFY-WGPU-001: RoPE backward matches CPU
     #[test]
     fn test_falsify_wgpu_001_rope_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let (num_heads, head_dim, seq_len) = (2, 4, 3);
         let theta = 10000.0f32;
@@ -1278,7 +1292,7 @@ mod tests {
     /// FALSIFY-WGPU-001: AdamW step matches CPU
     #[test]
     fn test_falsify_wgpu_001_adamw_step_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let n = 16;
         let mut params: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
@@ -1334,7 +1348,7 @@ mod tests {
     /// FALSIFY-WGPU-001: RMSNorm backward matches CPU
     #[test]
     fn test_falsify_wgpu_001_rmsnorm_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         let (num_rows, hidden_dim) = (3, 8);
         let eps: f32 = 1e-5;
@@ -1417,7 +1431,7 @@ mod tests {
     /// FALSIFY-WGPU-003: NF4 dequant matches CPU
     #[test]
     fn test_falsify_wgpu_003_nf4_dequant_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip() else { return };
 
         // NF4 codebook
         let nf4_lut: [f32; 16] = [

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16858,3 +16858,22 @@ roadmap:
   - release
   - 0.66.0
   notes: 'orch-basis:release — the 0.66.0 cut is a release-state ticket (AUTO-IMPL-SKILL-003 §2.1 basis=release); push, tag, gh release and the crates.io cascade are orchestration phases (route=self).'
+- id: PMAT-1106
+  github_issue: null
+  item_type: task
+  title: 'coverage nightly RED 6 days: GPU-conditional tests panic without an adapter (compute backward.rs x9, cgp x2) — skip, never expect'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T09:00:10Z
+  updated: 2026-09-11T09:00:10Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - orch:fable
+  - ci
+  notes: null


### PR DESCRIPTION
## What
`backends::gpu::device::backward::tests` called `GpuDevice::new().expect("GPU device")` nine times. Under `cargo llvm-cov` on yoga-build2 (docker runner, no GPU passthrough) two of them panicked and the whole nightly coverage run exited 2 — run 34575134766, and the run is RED six days running (the other half of that redness is the same class in aprender-cgp, #2848, pulled into 0.67.0).

A missing adapter is an environment fact, not a kernel defect. `device_or_skip()` prints `SKIP: no GPU adapter on this host (<err>)` and the test returns; the box that has an adapter stays the gate.

## Proven both ways (lambda-vector, `cargo test -p aprender-compute --lib --features gpu -- backends::gpu::device::backward --nocapture`)
| polarity | result |
|---|---|
| `VK_ICD_FILENAMES=/nonexistent` (no adapter) | 9 `SKIP:` lines, 9 passed in 0.00 s |
| real adapter | 0 `SKIP:` lines, 9 passed in 1.42 s |
| `cargo fmt --check`; `cargo clippy -p aprender-compute --all-targets -- -D warnings -A unused-variables` (CI's chain, default features) | clean, 0 errors |
| `cargo clippy -p aprender-compute --lib --tests --features gpu -- -D warnings` | 1 error, **pre-existing and not in this diff**: `len() == 0` at `backends/gpu/pool.rs:169`, a gpu-feature-only test target no gate lints today (same class as the aprender-gpu dark targets noted in memory) |

Falsifier of record: the next `coverage-nightly.yml` run (03:00 UTC) — with this and #2848 on main it must reach the report step and print a line-coverage figure instead of exiting 2 in `cargo test`.

Refs PMAT-1106, #2848, operator rule 2026-09-11 ("nightly we should have a low priority code coverage run with goal of eventually getting to 95% coverage").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
