### PR TITLE
fix(tests): mutation_testing_tests MUT-05/06/07 read ci.yml from the crate dir — dark on every box (#3126)

### DIFF
--- a/crates/aprender-core/tests/includes/mut0.rs
+++ b/crates/aprender-core/tests/includes/mut0.rs
@@ -153,13 +153,18 @@ fn mut04_return_value_mutation_detection() {
 /// MUT-05: CI mutation testing workflow exists
 #[test]
 fn mut05_ci_mutation_workflow_exists() {
-    let ci_path = Path::new(".github/workflows/ci.yml");
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root must resolve from crates/aprender-core");
+    let ci_path = workspace_root.join(".github/workflows/ci.yml");
     assert!(
         ci_path.exists(),
-        "MUT-05 FALSIFIED: No CI configuration found"
+        "MUT-05 FALSIFIED: No CI configuration found at {}",
+        ci_path.display()
     );
 
-    let ci_content = std::fs::read_to_string(ci_path).expect("read ci.yml");
+    let ci_content = std::fs::read_to_string(&ci_path).unwrap_or_else(|e| panic!("read {}: {}", ci_path.display(), e));
 
     let has_mutants_job = ci_content.contains("mutants:");
     assert!(has_mutants_job, "MUT-05 FALSIFIED: No mutants job in CI");
@@ -180,8 +185,12 @@ fn mut05_ci_mutation_workflow_exists() {
 /// MUT-06: Mutation results are captured as artifacts
 #[test]
 fn mut06_mutation_artifacts_captured() {
-    let ci_path = Path::new(".github/workflows/ci.yml");
-    let ci_content = std::fs::read_to_string(ci_path).expect("read ci.yml");
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root must resolve from crates/aprender-core");
+    let ci_path = workspace_root.join(".github/workflows/ci.yml");
+    let ci_content = std::fs::read_to_string(&ci_path).unwrap_or_else(|e| panic!("read {}: {}", ci_path.display(), e));
 
     let has_upload = ci_content.contains("upload-artifact");
     let has_mutants_results =
@@ -196,8 +205,12 @@ fn mut06_mutation_artifacts_captured() {
 /// MUT-07: Mutation timeout configured appropriately
 #[test]
 fn mut07_mutation_timeout_configured() {
-    let ci_path = Path::new(".github/workflows/ci.yml");
-    let ci_content = std::fs::read_to_string(ci_path).expect("read ci.yml");
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root must resolve from crates/aprender-core");
+    let ci_path = workspace_root.join(".github/workflows/ci.yml");
+    let ci_content = std::fs::read_to_string(&ci_path).unwrap_or_else(|e| panic!("read {}: {}", ci_path.display(), e));
 
     let has_timeout = ci_content.contains("--timeout");
 


### PR DESCRIPTION
Closes #3126.

`crates/aprender-core/tests/includes/mut0.rs` resolved `.github/workflows/ci.yml` with a repo-relative `Path::new(...)`, but cargo and nextest run every test binary with cwd = the crate dir (`crates/aprender-core`), so MUT-05/06/07 could not pass on any box — the target was dark until the quick tier ran it (measured 2026-09-11 15:47Z, `cargo nextest run -p aprender-core --tests`: 3 failed). Every repo path in the file now anchors on `CARGO_MANIFEST_DIR/../..` (the `monorepo_invariants.rs` pattern; same class as the #3112 fixes for `falsification_model_oracle_tests`, `realizar_integration_tests`, `toyota_principles_tests`), and each panic prints the path it tried.

Written by an agy goal lane (PMAT-1098 phase 3, conversation in the receipt); re-verified by the orchestrator:

```
cargo nextest run -p aprender-core --test mutation_testing_tests --no-fail-fast
     Summary [   0.025s] 16 tests run: 16 passed, 0 skipped
bash scripts/check_tree_reader_tests.sh   -> exit 0 (registry unchanged)
cargo fmt -p aprender-core -- --check     -> exit 0
```

No roadmap change on purpose: this PR stays mergeable after the 0.67 train (#3127) squashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
