### PR TITLE
ci(R2a): junit + sccache-metrics + llvm-cov artifacts for Arbiter, and fix the DEAD Coverage Nightly (#3133)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
             -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             "$IMAGE" \
-            cargo nextest run --profile ci --workspace --lib --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
+            bash scripts/ci_measured.sh lib cargo nextest run --profile ci --workspace --lib --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute
       - name: "GPU crates on their default features (per-package resolve, no device needed)"
         if: steps.tier.outputs.tier == 'full'
         # aprender-gpu + aprender-cuda-edge, un-darked from the required check (T0 of the
@@ -468,7 +468,7 @@ jobs:
             -e CARGO_PROFILE_TEST_DEBUG=line-tables-only \
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             "$IMAGE" \
-            cargo nextest run --profile ci -p aprender-gpu -p aprender-cuda-edge --lib
+            bash scripts/ci_measured.sh gpu cargo nextest run --profile ci -p aprender-gpu -p aprender-cuda-edge --lib
       - name: Compute tests (tolerate SIGSEGV at exit — all tests pass but harness crashes on cleanup)
         if: steps.tier.outputs.tier == 'full'
         run: |
@@ -486,7 +486,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q "test result: ok\." /tmp/compute-test.log && ! grep -q "test result: FAILED" /tmp/compute-test.log'
+            bash scripts/ci_measured.sh compute bash -c 'cargo test -p aprender-compute --lib 2>&1 | tee /tmp/compute-test.log; grep -q "test result: ok\." /tmp/compute-test.log && ! grep -q "test result: FAILED" /tmp/compute-test.log'
       - name: Integration tests
         if: steps.tier.outputs.tier == 'full'
         # #2465: the four FALSIFY-AUTH targets were appended here because they
@@ -539,7 +539,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_JOBS=8 \
             "$IMAGE" \
-            bash -c 'cargo test -p aprender-core --features setfit --lib setfit && cargo test -p aprender-core --features setfit,conformance-fixtures --test setfit_conformance && cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p apr-cli --test reg15_admission && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo test -p aprender-contracts-cli --test pv_surface_gate && cargo test -p aprender-contracts-cli --test cli_integration && cargo test -p aprender-contracts-cli --test ground_truth && cargo test -p aprender-contracts-cli --test version_identity && cargo test -p apr-cli --test pixel_regression && cargo build --examples --workspace --keep-going && cargo check --workspace --benches --locked'
+            bash scripts/ci_measured.sh integration bash -c 'cargo test -p aprender-core --features setfit --lib setfit && cargo test -p aprender-core --features setfit,conformance-fixtures --test setfit_conformance && cargo test -p aprender-core --test monorepo_invariants && cargo test -p aprender-core --test readme_contract && cargo test -p apr-cli --test cli_commands && cargo test -p apr-cli --test reg15_admission && cargo test -p aprender-train-inspect --test falsify_no_fabricated_metadata_2519 && cargo test -p aprender-train-bench --test falsify_no_fabricated_benchmarks_2519 && cargo test -p aprender-train-shell --test falsify_no_fabricated_fetch_2519 && cargo test -p aprender-core --test beat_sklearn_iris && cargo test -p aprender-core --test beat_sklearn_nmi && cargo test -p aprender-core --test beat_sklearn_metrics_parity && cargo test -p aprender-core --test beat_sklearn_gaussiannb_accuracy && cargo test -p aprender-core --test beat_sklearn_svc_accuracy && cargo test -p aprender-core --test beat_sklearn_pipeline_encoder && cargo test -p aprender-serve --test beat_fail_closed_garbage && cargo test -p aprender-compute --lib beat_nf4_bitsandbytes_equivalence && cargo test -p aprender-core --test beat_pytorch_autograd_grad && cargo test -p aprender-train-lora --lib beat_lora_merge_forward_equivalence && cargo test -p apr-cli --release --test beat_pytorch_deploy_footprint && cargo test -p aprender-serve --test beat_fail_closed_structural && cargo test -p aprender-serve --test ollama_http_compat && cargo test -p apr-cli --test ollama_ndjson_streaming && cargo test -p apr-cli --test falsification_chat_http_cli && cargo test -p aprender-contracts --test apr_serve_api_key_auth_contract && cargo test -p apr-cli --test falsify_auth_001 --test falsify_auth_002 --test falsify_auth_003 --no-fail-fast && cargo test -p apr-cli --test beat_apr_data_alimentar_reach && cargo test -p apr-cli --test beat_apr_sibling_cli_reach && cargo test -p aprender-contracts-cli --test pv_surface_gate && cargo test -p aprender-contracts-cli --test cli_integration && cargo test -p aprender-contracts-cli --test ground_truth && cargo test -p aprender-contracts-cli --test version_identity && cargo test -p apr-cli --test pixel_regression && cargo build --examples --workspace --keep-going && cargo check --workspace --benches --locked'
       # BSE-17 quick tier, part 1: the selected crates' unit and integration
       # targets (default features) under the same image and mounts as the full
       # tier. Empty selection (a scripts/docs PR) skips this step; part 2 still runs.
@@ -575,7 +575,7 @@ jobs:
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             -e CARGO_TERM_COLOR=never \
             "$IMAGE" \
-            bash -c "cargo nextest run --profile ci --lib --tests$pkgs"
+            bash scripts/ci_measured.sh quicklib bash -c "cargo nextest run --profile ci --lib --tests$pkgs"
       # BSE-17 quick tier, part 2: every test target that reads the tree, from
       # scripts/tree_reader_tests.txt (derived; the guard has already proved the
       # registry equals the sources in this run).
@@ -637,7 +637,7 @@ jobs:
             -e CARGO_PROFILE_DEV_DEBUG=line-tables-only \
             -e CARGO_TERM_COLOR=never \
             "$IMAGE" \
-            cargo nextest run --profile ci --workspace --lib --tests --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute -E "$EXPR"
+            bash scripts/ci_measured.sh treeread cargo nextest run --profile ci --workspace --lib --tests --exclude aprender-gpu --exclude aprender-cuda-edge --exclude aprender-compute -E "$EXPR"
       # BSE-17 quick tier, part 3 (PMAT-1098 67-E2, #3084 — rule (i)): the
       # selection was OVER THE CAP (touched crates + their direct reverse
       # dependents exceed gate_touched_crates.sh's CAP=3). That used to escalate
@@ -726,6 +726,39 @@ jobs:
             -v "/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}:/workspace/target" \
             "$IMAGE" \
             bash -c 'chown -R 1000:1000 /workspace || true; chown -R 1000:1000 /usr/local/cargo/registry || true; chown -R 1000:1000 /workspace/target || true'
+      # ARBITER-001 R2a (#3133, infra#532): the sccache stats and per-invocation
+      # junit that scripts/ci_measured.sh dropped into the container's
+      # /workspace/target/ci-artifacts (host path below) become named artifacts
+      # so Arbiter's s-practice sensor can see 'this main run measured its
+      # tests and its cache'. Ownership was just restored to noah:1000 above,
+      # so these read cleanly. `if-no-files-found: ignore` because the reuse
+      # tier runs no tests (the reused run already carries them).
+      - name: Stamp the test tier into the artifact dir (Arbiter R2a, #3133)
+        if: '!cancelled()'
+        run: |
+          d="/mnt/nvme-raid0/targets/aprender-ci/${PR_OR_REF}/run-${GITHUB_RUN_ID}/ci-artifacts"
+          mkdir -p "$d"
+          printf '%s\n' "${{ steps.tier.outputs.tier }}" > "$d/tier"
+      - name: Upload junit (Arbiter R2a, #3133)
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit
+          path: |
+            /mnt/nvme-raid0/targets/aprender-ci/${{ env.PR_OR_REF }}/run-${{ github.run_id }}/ci-artifacts/junit-*.xml
+            /mnt/nvme-raid0/targets/aprender-ci/${{ env.PR_OR_REF }}/run-${{ github.run_id }}/ci-artifacts/tier
+          if-no-files-found: ignore
+          retention-days: 90
+      - name: Upload sccache-metrics (Arbiter R2a, #3133)
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sccache-metrics
+          path: |
+            /mnt/nvme-raid0/targets/aprender-ci/${{ env.PR_OR_REF }}/run-${{ github.run_id }}/ci-artifacts/sccache-*.json
+            /mnt/nvme-raid0/targets/aprender-ci/${{ env.PR_OR_REF }}/run-${{ github.run_id }}/ci-artifacts/tier
+          if-no-files-found: ignore
+          retention-days: 90
 
   # Poka-yoke (aprender#2269): fail fast if ANY self-hosted job omits a
   # discriminating runner label, so a bare [self-hosted, X64, Linux] selector

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -201,6 +201,28 @@ jobs:
           # ARMED, it just reports a value first.
           exit "$cov_rc"
 
+      # ARBITER-001 R2a (#3133, infra#532): re-emit the coverage the step above
+      # just measured as a machine-readable JSON summary and upload it under the
+      # name `llvm-cov`, so Arbiter's s-practice sensor sees that aprender's main
+      # carries a coverage artifact (and R7 can later pair it by sha with the
+      # push run's junit). `report` re-reads the profdata `make coverage` already
+      # produced — it runs no tests. It only runs when the coverage step passed,
+      # so a coverage regression still fails first and this never masks it.
+      - name: llvm-cov JSON summary for Arbiter (R2a, #3133)
+        run: |
+          export PATH="$COV_TOOLS/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+          mkdir -p target/coverage
+          cargo llvm-cov report --json --summary-only --output-path target/coverage/llvm-cov.json
+          test -s target/coverage/llvm-cov.json
+      - name: Upload llvm-cov (Arbiter R2a, #3133)
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v7
+        with:
+          name: llvm-cov
+          path: target/coverage/llvm-cov.json
+          if-no-files-found: warn
+          retention-days: 90
+
       # pmat (crates.io) for the dogfooded gap analysis — BEST-EFFORT. cargo isn't
       # on PATH for raw run: steps on these runners, so source the cargo env; and
       # `|| true` keeps a pmat failure from aborting the job (the coverage % below

--- a/crates/aprender-compute/src/backends/gpu/device/backward.rs
+++ b/crates/aprender-compute/src/backends/gpu/device/backward.rs
@@ -1059,6 +1059,35 @@ fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
 mod tests {
     use super::*;
 
+    /// The crate's convention for a GPU test, applied here: ASK whether an
+    /// adapter exists, and skip with a printed reason when it does not
+    /// (`backends/gpu/batch/tests.rs` does the same).
+    ///
+    /// Why this module needed it (aprender#3133). Every test below opened with
+    /// `GpuDevice::new().expect("GPU device")`. `Coverage Nightly` runs
+    /// bare-metal on the clean-room runner, where there is no Vulkan adapter,
+    /// so `test_silu_backward_at_zero` and `test_silu_backward_length_mismatch`
+    /// panicked and the lane has been RED every day since 2026-08-29 --
+    /// long enough for the fleet dead-man's switch to call it DEAD. Their seven
+    /// siblings survived only because their names contain `wgpu_` and the
+    /// coverage recipe passes `--skip gpu_`: a NAME filter, which the two newer
+    /// tests happened not to match. A name is not a capability, so all nine go
+    /// through this function and none of them depends on the skip list.
+    ///
+    /// This is not a way to make the tests disappear. Where an adapter exists
+    /// they run exactly as before; measured on this box's RTX 4090, all nine
+    /// still run and pass. Only a host without an adapter sees a SKIP, and it
+    /// sees it on stdout with the reason.
+    fn device_or_skip(test: &str) -> Option<GpuDevice> {
+        if !GpuDevice::is_available() {
+            eprintln!(
+                "SKIP {test}: no GPU adapter (GpuDevice::is_available() == false) -- bare-metal clean-room runner, aprender#3133"
+            );
+            return None;
+        }
+        Some(GpuDevice::new().expect("GPU device: is_available() said yes"))
+    }
+
     /// CPU reference: SiLU backward
     fn silu_backward_cpu(input: &[f32], grad_output: &[f32]) -> Vec<f32> {
         input
@@ -1076,7 +1105,9 @@ mod tests {
     /// FALSIFY-WGPU-001: SiLU backward matches CPU within ε < 1e-4
     #[test]
     fn test_falsify_wgpu_001_silu_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_silu_backward_parity") else {
+            return;
+        };
 
         let input: Vec<f32> = (-50..50).map(|i| i as f32 * 0.1).collect();
         let grad_output: Vec<f32> = (0..100).map(|i| (i as f32 - 50.0) * 0.01).collect();
@@ -1100,7 +1131,9 @@ mod tests {
     /// SiLU backward at x=0 (sigmoid=0.5, silu'=0.5)
     #[test]
     fn test_silu_backward_at_zero() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_silu_backward_at_zero") else {
+            return;
+        };
 
         let input = vec![0.0f32; 4];
         let grad_output = vec![1.0f32; 4];
@@ -1117,7 +1150,9 @@ mod tests {
     /// SiLU backward length mismatch error
     #[test]
     fn test_silu_backward_length_mismatch() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_silu_backward_length_mismatch") else {
+            return;
+        };
 
         let input = vec![1.0f32; 10];
         let grad_output = vec![1.0f32; 5]; // wrong length
@@ -1148,7 +1183,9 @@ mod tests {
     /// Which is matmul(grad_c, B^T, M, N, K) but our shader handles the transpose internally.
     #[test]
     fn test_falsify_wgpu_001_gemm_backward_a_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_gemm_backward_a_parity") else {
+            return;
+        };
 
         let (m, k, n) = (4, 8, 6);
 
@@ -1185,7 +1222,9 @@ mod tests {
     /// grad_b[K,N] = A^T[K,M] @ grad_c[M,N]
     #[test]
     fn test_falsify_wgpu_001_gemm_backward_b_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_gemm_backward_b_parity") else {
+            return;
+        };
 
         let (m, k, n) = (4, 8, 6);
 
@@ -1218,7 +1257,9 @@ mod tests {
     /// FALSIFY-WGPU-001: RoPE backward matches CPU
     #[test]
     fn test_falsify_wgpu_001_rope_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_rope_backward_parity") else {
+            return;
+        };
 
         let (num_heads, head_dim, seq_len) = (2, 4, 3);
         let theta = 10000.0f32;
@@ -1278,7 +1319,9 @@ mod tests {
     /// FALSIFY-WGPU-001: AdamW step matches CPU
     #[test]
     fn test_falsify_wgpu_001_adamw_step_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_adamw_step_parity") else {
+            return;
+        };
 
         let n = 16;
         let mut params: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
@@ -1334,7 +1377,9 @@ mod tests {
     /// FALSIFY-WGPU-001: RMSNorm backward matches CPU
     #[test]
     fn test_falsify_wgpu_001_rmsnorm_backward_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_001_rmsnorm_backward_parity") else {
+            return;
+        };
 
         let (num_rows, hidden_dim) = (3, 8);
         let eps: f32 = 1e-5;
@@ -1417,7 +1462,9 @@ mod tests {
     /// FALSIFY-WGPU-003: NF4 dequant matches CPU
     #[test]
     fn test_falsify_wgpu_003_nf4_dequant_parity() {
-        let device = GpuDevice::new().expect("GPU device");
+        let Some(device) = device_or_skip("test_falsify_wgpu_003_nf4_dequant_parity") else {
+            return;
+        };
 
         // NF4 codebook
         let nf4_lut: [f32; 16] = [

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16858,6 +16858,27 @@ roadmap:
   - release
   - 0.66.0
   notes: 'orch-basis:release — the 0.66.0 cut is a release-state ticket (AUTO-IMPL-SKILL-003 §2.1 basis=release); push, tag, gh release and the crates.io cascade are orchestration phases (route=self).'
+- id: PMAT-1097
+  github_issue: null
+  item_type: task
+  title: '06x release schedule spec: 0.67.0/0.68.0/0.69.0/0.70.0 at a 2-3 day 24/7 cadence, one GitHub epic per release, priorities A-G (four binaries per tag, NVIDIA CUDA Rust default, gx10 never idle, yoga CUDA tests, 20-minute PR gate, Qwen2.5-Coder-7B parity, declarative fine-tune) + release-schedule contract + docs drift gate'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-10T09:12:19Z
+  updated: 2026-09-10T09:12:19Z
+  spec: docs/specifications/06x-release-schedule.md
+  acceptance_criteria:
+  - 'orch-basis:release — a release-schedule spec is a release-state ticket (AUTO-IMPL-SKILL-003 §2.1 basis=release). Operator 2026-09-10 verbatim: ''override "kind:docs" block if needed'' — kind:code because the ticket ships contracts/release-schedule-06x-v1.yaml (pv-validated) and extends FALSIFY-DOCS-CLAUDE-001 to the spec (mutation-verified), alongside the spec and four epics.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - orch:fable
+  - release
+  - 06x-schedule
+  notes: 'orch-basis:release — a release-schedule spec is a release-state ticket (AUTO-IMPL-SKILL-003 §2.1 basis=release); the spec, its contract, the drift-gate extension and the four epics are one PR; epic creation, push and PR are orchestration phases (route=self).'
 - id: PMAT-1098
   github_issue: null
   item_type: task
@@ -16880,6 +16901,81 @@ roadmap:
   - 0.67.0
   - epic-3078
   notes: 'orch-basis:release — the 0.67.0 train (epic #3078) is a release-state ticket; orchestration phases (push, PR, tag, cascade) route=self'
+- id: PMAT-1100
+  github_issue: null
+  item_type: task
+  title: 'Triage: file every open issue and PR without a milestone into a release train, link duplicates, Alfredo first'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-10T14:03:43Z
+  updated: 2026-09-10T14:03:43Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:triage
+  - orch:fable
+  notes: null
+- id: PMAT-1101
+  github_issue: null
+  item_type: task
+  title: Q5_K dequant + fused dot read a non-ggml bit layout — every Q5_K tensor on the CPU path (realizar) and in apr import (aprender-quant) is wrong
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-09-11T03:40:49Z
+  updated: 2026-09-11T03:40:49Z
+  spec: null
+  acceptance_criteria:
+  - 'Measured on Qwen3.5-0.8B-Q4_K_M blk.0.attn_qkv (Q5_K, 6144x1024): realizar dequantize_q5_k mismatches gguf-py on 5,959,751/6,291,456 values; matvec sum +26.64 vs llama.cpp -17.06. A literal transcription of ggml dequantize_row_q5_K is bit-exact vs gguf-py. Blocks #3091 CPU parity.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - 0.67.0
+  notes: null
+- id: PMAT-1102
+  github_issue: null
+  item_type: task
+  title: 'gx10 cannot run ci / lint: 14 aarch64-only clippy errors in aprender-compute + present-terminal, and #2567''s aarch64 parallel Q4_K path was never called'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T04:06:14Z
+  updated: 2026-09-11T04:06:14Z
+  spec: null
+  acceptance_criteria:
+  - 'gx10-pool1 canary: ci / lint failed on #3089 (job 103137079500). x86 lint is clean; aarch64 has unreachable tails after unconditional NEON returns, x86-only helpers compiled dead on arm, and matmul_q4k_f32_parallel (non-x86, #2567) whose only caller is inside the x86_64 block.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - 0.67.0
+  notes: null
+- id: PMAT-1104
+  github_issue: null
+  item_type: task
+  title: CUDA Q5_K GEMV reads the fifth bit from a sequential bitmask instead of ggml's qh[l] bit s (#3111)
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-09-11T04:56:39Z
+  updated: 2026-09-11T04:56:39Z
+  spec: null
+  acceptance_criteria:
+  - 'Q5KGemvKernel: qh byte val_idx/8, bit val_idx%8; ggml: byte val_idx%32, bit val_idx/32. Golden GPU test from the FALSIFY-QDOT-009 fixture; Q5KKernel (gemm) is unreachable from inference and tracked separately in #3111.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - 0.67.0
+  notes: null
 - id: PMAT-1105
   github_issue: null
   item_type: task
@@ -16889,6 +16985,25 @@ roadmap:
   assigned_to: null
   created: 2026-09-11T06:31:20Z
   updated: 2026-09-11T06:31:20Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - orch:fable
+  - ci
+  notes: null
+- id: PMAT-1106
+  github_issue: null
+  item_type: task
+  title: 'coverage nightly RED 6 days: GPU-conditional tests panic without an adapter (compute backward.rs x9, cgp x2) — skip, never expect'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T09:00:10Z
+  updated: 2026-09-11T09:00:10Z
   spec: null
   acceptance_criteria: []
   phases: []
@@ -16949,6 +17064,40 @@ roadmap:
   estimated_effort: null
   labels:
   - kind:code
+  notes: null
+- id: PMAT-3121
+  github_issue: 3121
+  item_type: task
+  title: 'pre-release dogfood: every workspace example builds AND runs, apr-cookbook updated, release notes written — three rows on every tagged release (operator 2026-09-11)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T12:32:25Z
+  updated: 2026-09-11T12:32:25Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: null
+- id: PMAT-3124
+  github_issue: 3124
+  item_type: task
+  title: 'Triage pass: label the 72 open issues that carry no label'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T15:07:05Z
+  updated: 2026-09-11T15:07:05Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:triage
   notes: null
 - id: PMAT-3133
   github_issue: 3133

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -16950,3 +16950,23 @@ roadmap:
   labels:
   - kind:code
   notes: null
+- id: PMAT-3133
+  github_issue: 3133
+  item_type: task
+  title: 'CI artifact rows for Arbiter R2a: junit + sccache-metrics from workspace-test, llvm-cov JSON from Coverage Nightly; Coverage Nightly red since 2026-08-29 (two GPU tests panic bare-metal)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-12T04:52:57Z
+  updated: 2026-09-12T04:52:57Z
+  spec: null
+  acceptance_criteria:
+  - paiml/aprender#3133, infra#532 (PMAT-532). See the issue for the measured baseline and the deliverable.
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - ci
+  - arbiter
+  notes: null

--- a/scripts/ci_measured.sh
+++ b/scripts/ci_measured.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# ci_measured.sh - run a CI command and collect its MEASUREMENT ARTIFACTS,
+# whatever that command's outcome (ARBITER-001 row R2a, PMAT-532, aprender#3133).
+#
+#   bash scripts/ci_measured.sh <name> <cmd> [args...]
+#   bash scripts/ci_measured.sh --self-test
+#
+# WHY THIS EXISTS
+# ---------------
+# Measured 2026-09-12 by `gh api`: the newest completed `main` push run of `CI`
+# in EVERY roster repo carries ZERO artifacts. aprender already WRITES a junit
+# file - `.config/nextest.toml` `[profile.ci.junit] path = "junit.xml"` puts it
+# at <target>/nextest/ci/junit.xml - but nothing uploads it, and `workspace-test`
+# runs nextest more than once per job, so the second run OVERWRITES the first
+# one's junit before anybody could. sccache's stats live in the sccache SERVER,
+# which lives inside each `docker run --rm` and dies with it, so the capture has
+# to happen in the SAME invocation as cargo, not in a host-side step afterwards.
+#
+# So: one wrapper, called at each test step. It runs the command it is given,
+# and then - whatever happened - MOVES the junit to a per-step name and writes
+# the sccache stats beside it under <target>/ci-artifacts/, which the host-side
+# `upload-artifact` step reads.
+#
+# WHY MOVE THE JUNIT AND NOT COPY IT
+# ----------------------------------
+# A copy leaves <target>/nextest/ci/junit.xml in place, so the NEXT step in the
+# same job starts with a stale file it did not write. If that step's nextest
+# never gets to write its own (a compile error, a signal, a timeout), the
+# collector would pick the previous step's results up and upload them under the
+# new step's name: a measurement attributed to a run that never produced it,
+# which is this fleet's signature defect. Moving makes that impossible - the
+# absence of a junit is then reported as `junit=none`.
+#
+# WHAT IT CANNOT DO, STATED RATHER THAN HIDDEN
+# --------------------------------------------
+# It cannot save a junit nextest never wrote. If the wrapped command dies before
+# nextest finishes (signal, timeout, compile failure), there is no junit and the
+# summary says `junit=none`. The sccache stats are still collected, because the
+# sccache server answers whether or not the build finished.
+#
+# EXIT CODE
+# ---------
+# The child's exit code, unchanged, AFTER the collectors have run - or 128+N
+# when the child died of signal N. There is no `set -e` here and the collectors
+# never overwrite the code: a wrapper that turned a red step green, or a green
+# step red, would be worse than no measurement at all.
+#
+# SIGNALS
+# -------
+# TERM, INT and HUP are trapped and FORWARDED to the child, then the wrapper
+# waits for the child and runs the collectors anyway. GitHub cancels a job with
+# a signal, and a cancelled job is exactly when the sccache stats are most worth
+# having. Self-test case 6 kills a wrapped `sleep 30` after one second and
+# asserts the sccache file exists and the wrapper exits 143 in about a second.
+set -u -o pipefail
+
+ART_SUBDIR="ci-artifacts"
+CHILD=0
+
+usage() {
+    printf 'usage: %s <name> <cmd> [args...]\n' "$0" >&2
+    printf '       %s --self-test\n' "$0" >&2
+    printf 'name must match ^[A-Za-z0-9._-]+$ and is used in the artifact file names\n' >&2
+}
+
+target_dir() { # where cargo writes, and where ci-artifacts/ is created
+    printf '%s' "${CI_MEASURED_TARGET_DIR:-${CARGO_TARGET_DIR:-target}}"
+}
+
+forward() { # send the signal we caught on to the child, never to ourselves
+    if [ "$CHILD" -ne 0 ]; then
+        kill -s "$1" "$CHILD" 2>/dev/null || true
+    fi
+}
+
+collect() { # $1 name, $2 art dir, $3 junit source -> prints the summary fields
+    local name=$1 art=$2 junit_src=$3 junit_dst=none sccache_dst=none part
+    if [ -f "$junit_src" ]; then
+        if mv -f "$junit_src" "$art/junit-$name.xml"; then
+            junit_dst="$art/junit-$name.xml"
+        else
+            printf 'ci_measured: could not move %s; no junit artifact for %s\n' "$junit_src" "$name"
+        fi
+    fi
+    if command -v sccache >/dev/null 2>&1; then
+        part="$art/.sccache-$name.json.part"
+        if sccache --show-stats --stats-format json > "$part" 2>/dev/null; then
+            mv -f "$part" "$art/sccache-$name.json"
+            sccache_dst="$art/sccache-$name.json"
+        else
+            rm -f "$part"
+            printf 'ci_measured: sccache --show-stats failed; no sccache artifact for %s, exit code unchanged\n' "$name"
+        fi
+    fi
+    printf 'ci_measured: name=%s rc=%s junit=%s sccache=%s\n' "$name" "$RC" "$junit_dst" "$sccache_dst"
+}
+
+run_measured() { # $1 name, rest: the command, passed through UNPARSED
+    local name=$1
+    shift
+    # STUB. The collectors are not wired yet; the self-test below is the RED.
+    "$@"
+    return $?
+}
+
+self_test() {
+    local td n=0 red=0 rc out T
+    T=$(cd "$(dirname "$0")" && pwd)/$(basename "$0")
+    td=$(mktemp -d "${TMPDIR:-/tmp}/ci-measured.XXXXXX") || return 1
+    trap 'rm -rf "${td:?}"' RETURN
+
+    # A fake sccache on a PRIVATE path, so the case table measures the wrapper
+    # and not whether this box happens to have a build cache daemon.
+    mkdir -p "$td/good" "$td/bad"
+    cat > "$td/good/sccache" <<'SCCACHE_OK'
+#!/usr/bin/env bash
+printf '{"stats":{"compile_requests":1}}\n'
+SCCACHE_OK
+    cat > "$td/bad/sccache" <<'SCCACHE_BAD'
+#!/usr/bin/env bash
+printf 'sccache: error: failed to connect to server\n' >&2
+exit 1
+SCCACHE_BAD
+    chmod +x "$td/good/sccache" "$td/bad/sccache"
+
+    sanitized_path() { # PATH with every directory that holds an sccache removed
+        local d out=""
+        while IFS= read -r d; do
+            if [ -z "$d" ]; then continue; fi
+            if [ -x "$d/sccache" ]; then continue; fi
+            out="${out:+$out:}$d"
+        done < <(printf '%s' "$PATH" | tr ':' '\n')
+        printf '%s' "$out"
+    }
+    NO_SCCACHE_PATH=$(sanitized_path)
+
+    mkcase() { # $1 a fresh fake target dir, $2 = junit to seed nextest's output
+        rm -rf "${1:?}"
+        mkdir -p "$1/nextest/ci"
+        if [ "${2:-}" = junit ]; then printf '<testsuites/>\n' > "$1/nextest/ci/junit.xml"; fi
+    }
+    # One invocation, many assertions: capture the run once, replay its stdout
+    # and its exit code for every row that asks a question about it.
+    cap() { local name=$1 r=0; shift; "$@" > "$td/$name.out" 2>&1 || r=$?; printf '%s' "$r" > "$td/$name.rc"; }
+    replay() { printf 'cat "%s/%s.out"; exit "$(cat "%s/%s.rc")"' "$td" "$1" "$td" "$1"; }
+    row() { local want=$1 label=$2 pat=$3; shift 3; n=$((n + 1)); rc=0; out=$("$@" 2>&1) || rc=$?
+        if [ "$rc" = "$want" ] && printf '%s\n' "$out" | grep -qE -- "$pat"; then
+            printf 'ok    case %-2s rc=%s  %s\n' "$n" "$rc" "$label"
+        else
+            printf 'FAIL  case %-2s rc=%s (wanted %s, must match /%s/)  %s\n' "$n" "$rc" "$want" "$pat" "$label"
+            printf '%s\n' "$out" | sed 's/^/        /'
+            red=$((red + 1))
+        fi
+    }
+    exists() { if [ -e "$1" ]; then printf 'PRESENT %s\n' "$1"; else printf 'ABSENT %s\n' "$1"; return 1; fi; }
+    absent() { if [ -e "$1" ]; then printf 'PRESENT %s\n' "$1"; return 1; else printf 'ABSENT %s\n' "$1"; fi; }
+
+    # --- case 1: the happy path. Both artifacts, exit 0, and the junit MOVED.
+    mkcase "$td/c1" junit
+    cap c1 env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c1" bash "$T" c1 true
+    row 0 "rc 0 with a junit present: exit 0 and the summary names both artifacts" \
+        'name=c1 rc=0 junit=.*/ci-artifacts/junit-c1\.xml sccache=.*/ci-artifacts/sccache-c1\.json' bash -c "$(replay c1)"
+    row 0 "  ...the junit was MOVED, so nextest's own path is now empty" '^ABSENT' absent "$td/c1/nextest/ci/junit.xml"
+    row 0 "  ...and the per-step copy exists" '^PRESENT' exists "$td/c1/ci-artifacts/junit-c1.xml"
+    row 0 "  ...and the sccache file holds the server's JSON, not an empty file" 'compile_requests' cat "$td/c1/ci-artifacts/sccache-c1.json"
+
+    # --- case 2: a FAILING child still gets measured, and keeps its code.
+    mkcase "$td/c2" junit
+    cap c2 env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c2" bash "$T" c2 bash -c 'exit 7'
+    row 7 "child exits 7: the collectors still run and rc 7 is returned unchanged" 'name=c2 rc=7' bash -c "$(replay c2)"
+    row 0 "  ...junit collected despite the failure" '^PRESENT' exists "$td/c2/ci-artifacts/junit-c2.xml"
+    row 0 "  ...sccache collected despite the failure" '^PRESENT' exists "$td/c2/ci-artifacts/sccache-c2.json"
+
+    # --- case 3: no junit is reported as none, never invented.
+    mkcase "$td/c3"
+    cap c3 env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c3" bash "$T" c3 true
+    row 0 "no junit produced: junit=none and exit 0" 'name=c3 rc=0 junit=none' bash -c "$(replay c3)"
+    row 0 "  ...and no junit file was written" '^ABSENT' absent "$td/c3/ci-artifacts/junit-c3.xml"
+
+    # --- case 4: no sccache on PATH is not an error and not a file.
+    mkcase "$td/c4" junit
+    cap c4 env PATH="$NO_SCCACHE_PATH" CI_MEASURED_TARGET_DIR="$td/c4" bash "$T" c4 bash -c 'exit 5'
+    row 5 "sccache absent from PATH: sccache=none and the child's rc 5 survives" 'name=c4 rc=5 .*sccache=none' bash -c "$(replay c4)"
+    row 0 "  ...no sccache file was invented" '^ABSENT' absent "$td/c4/ci-artifacts/sccache-c4.json"
+    row 0 "  ...and the junit was collected anyway" '^PRESENT' exists "$td/c4/ci-artifacts/junit-c4.xml"
+
+    # --- case 5: the command is passed through UNPARSED. `false && true` is a
+    # bash -c STRING; a wrapper that re-split or re-quoted it would not exit 1.
+    mkcase "$td/c5"
+    cap c5 env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c5" bash "$T" c5 bash -c 'false && true'
+    row 1 "a bash -c string is run as given: 'false && true' exits 1 and the 1 survives" 'name=c5 rc=1' bash -c "$(replay c5)"
+
+    # --- case 5b: an argument holding a space stays ONE argument.
+    mkcase "$td/c5b"
+    cap c5b env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c5b" bash "$T" c5b printf '[%s]' 'a b'
+    row 0 "an argument with a space arrives as one argument, not two" '^\[a b\]' bash -c "$(replay c5b)"
+
+    # --- case 6: a cancelled job. TERM to the WRAPPER must reach the child,
+    # the collectors must still run, and the wrapper must not sit out the sleep.
+    term_case() {
+        local start end pid r=0
+        mkcase "$td/c6"
+        start=$SECONDS
+        env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c6" bash "$T" c6 sleep 30 > "$td/c6-wrapper.out" 2>&1 &
+        pid=$!
+        sleep 1
+        kill -TERM "$pid" 2>/dev/null || true
+        wait "$pid" || r=$?
+        end=$SECONDS
+        printf 'rc=%s elapsed=%s\n' "$r" "$((end - start))"
+        cat "$td/c6-wrapper.out"
+    }
+    cap c6 term_case
+    row 0 "a wrapped sleep 30 TERMed after 1s: exit 143 within 3s, not 30" '^rc=143 elapsed=[0-3]$' bash -c "$(replay c6)"
+    row 0 "  ...and the summary was still printed, naming rc=143" 'name=c6 rc=143' bash -c "$(replay c6)"
+    row 0 "  ...and the sccache stats were collected after the signal" '^PRESENT' exists "$td/c6/ci-artifacts/sccache-c6.json"
+    row 0 "  ...while junit is honestly none: nextest never ran, so there is nothing to save" 'junit=none' bash -c "$(replay c6)"
+
+    # --- case 7: a bad name is refused BEFORE anything is run or created.
+    mkcase "$td/c7"
+    cap c7 env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c7" bash "$T" a/b true
+    row 2 "a name outside ^[A-Za-z0-9._-]+\$ exits 2 with usage" 'usage:' bash -c "$(replay c7)"
+    row 0 "  ...and nothing was created: no ci-artifacts directory" '^ABSENT' absent "$td/c7/ci-artifacts"
+    mkcase "$td/c7b"
+    cap c7b env PATH="$td/good:$PATH" CI_MEASURED_TARGET_DIR="$td/c7b" bash "$T" c7b
+    row 2 "a name with no command exits 2 with usage" 'usage:' bash -c "$(replay c7b)"
+
+    # --- case 8: a BROKEN sccache writes nothing and changes no exit code.
+    mkcase "$td/c8" junit
+    cap c8 env PATH="$td/bad:$PATH" CI_MEASURED_TARGET_DIR="$td/c8" bash "$T" c8 bash -c 'exit 3'
+    row 3 "sccache --show-stats fails: sccache=none and the child's rc 3 survives" 'name=c8 rc=3 .*sccache=none' bash -c "$(replay c8)"
+    row 3 "  ...and it says so on stdout rather than failing silently" 'sccache --show-stats failed' bash -c "$(replay c8)"
+    row 0 "  ...no sccache file, not even an empty one" '^ABSENT' absent "$td/c8/ci-artifacts/sccache-c8.json"
+    row 0 "  ...and the junit was still collected" '^PRESENT' exists "$td/c8/ci-artifacts/junit-c8.xml"
+
+    # --- case 9: CARGO_TARGET_DIR is the fallback, which is what the six call
+    # sites in ci.yml actually set inside the container.
+    mkcase "$td/c9" junit
+    cap c9 env PATH="$td/good:$PATH" CARGO_TARGET_DIR="$td/c9" bash "$T" c9 true
+    row 0 "CARGO_TARGET_DIR is honoured when CI_MEASURED_TARGET_DIR is unset" 'junit=.*/c9/ci-artifacts/junit-c9\.xml' bash -c "$(replay c9)"
+
+    printf '\nci_measured --self-test: %s cases, %s failed\n' "$n" "$red"
+    [ "$red" -eq 0 ]
+}
+
+if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
+if [ $# -lt 2 ]; then usage; exit 2; fi
+NAME=$1
+shift
+case "$NAME" in
+    *[!A-Za-z0-9._-]*) printf 'ci_measured: bad name "%s"\n' "$NAME" >&2; usage; exit 2 ;;
+esac
+run_measured "$NAME" "$@"
+exit $?

--- a/scripts/ci_measured.sh
+++ b/scripts/ci_measured.sh
@@ -96,11 +96,36 @@ collect() { # $1 name, $2 art dir, $3 junit source -> prints the summary fields
 }
 
 run_measured() { # $1 name, rest: the command, passed through UNPARSED
-    local name=$1
+    local name=$1 td art junit_src
     shift
-    # STUB. The collectors are not wired yet; the self-test below is the RED.
-    "$@"
-    return $?
+    td=$(target_dir)
+    art="$td/$ART_SUBDIR"
+    junit_src="$td/nextest/ci/junit.xml"
+    mkdir -p "$art" || return 2
+
+    trap 'forward TERM' TERM
+    trap 'forward INT' INT
+    trap 'forward HUP' HUP
+
+    # The child runs in the BACKGROUND so that a signal arriving at this shell
+    # interrupts `wait` and runs the trap. A foreground child would make this
+    # shell die of the signal with the collectors never reached.
+    "$@" &
+    CHILD=$!
+    RC=0
+    while : ; do
+        wait "$CHILD"
+        RC=$?
+        # A status above 128 from `wait` means either the child died of a signal
+        # or a trapped signal interrupted the wait. Only the second leaves the
+        # child alive, and only then is there anything left to wait for.
+        if [ "$RC" -gt 128 ] && kill -0 "$CHILD" 2>/dev/null; then continue; fi
+        break
+    done
+    trap - TERM INT HUP
+
+    collect "$name" "$art" "$junit_src"
+    return "$RC"
 }
 
 self_test() {


### PR DESCRIPTION
Row R2a of ARBITER-001 (paiml/infra `docs/specifications/arbiter.md` §9.4, infra#532). Makes aprender's `main` CI upload the three artifacts Arbiter's `s-practice` sensor reads, and fixes the coverage lane that has been DEAD for two weeks.

## What changed
- **`scripts/ci_measured.sh`** — a bashrs-clean wrapper: `ci_measured.sh <name> <cmd…>` runs the command, then (whatever its exit code, and forwarding TERM/INT/HUP so a step-timeout kill still collects) moves `target/nextest/ci/junit.xml` to `target/ci-artifacts/junit-<name>.xml` and writes `sccache --show-stats --stats-format json` to `target/ci-artifacts/sccache-<name>.json`. A 26-case `--self-test` covers rc 0, rc 7, no-junit, no-sccache, `bash -c` chains, a TERM'd child (exit 143, files still written), a bad name, and a failing sccache. `bashrs lint`: 0 errors; the shell-lint ratchet improved 8→6.
- **`workspace-test`** — the six nextest/`cargo test` invocations are wrapped, and two `upload-artifact@v7` steps publish `junit` (per-invocation xml + a `tier` marker) and `sccache-metrics`. Every push run to `main` now carries both.
- **`coverage-nightly.yml`** — after `make coverage` a `cargo llvm-cov report --json --summary-only` re-emits the coverage it just measured (no second test run) and uploads it as `llvm-cov`.
- **The DEAD Coverage Nightly, fixed at the root.** It has failed every night since 2026-08-29: `test_silu_backward_at_zero` and `test_silu_backward_length_mismatch` in `crates/aprender-compute/src/backends/gpu/device/backward.rs` called `GpuDevice::new().expect(..)` on the bare-metal clean-room runner (no Vulkan adapter). All nine tests in that module now obtain their device through a `device_or_skip()` helper gated on `GpuDevice::is_available()` — the crate's own convention (`backends/gpu/batch/tests.rs`) — so they RUN where a device exists (the CI container, and this workstation's 4090) and SKIP where none does, instead of the seven that only survived by the recipe's brittle `--skip gpu_` name filter. The infra Nightly Audit's dead-man's switch reported `aprender/Coverage Nightly is DEAD (no-healthy 12d)`.

## Verification
- `bash scripts/ci_measured.sh --self-test`: 26 cases, 0 failed.
- `bashrs lint scripts/ci_measured.sh`: 0 errors. `check_shell_lint_ratchet.sh`, `check_cargo_install_private_root.sh`, `check_workflow_env_defined.sh`: PASS.
- RED proven by the implementing agent: all nine backward tests panic `Failed to find GPU adapter` with the adapter hidden, before the gate. GREEN by inspection: 1 helper + 9 gated call sites, no bare `expect` outside the guarded helper. The authoritative gate is this PR's own `workspace-test` run (adapter present → the tests run) and a `Coverage Nightly` dispatch after merge (bare-metal → they skip, lane green). Cargo.lock is unchanged.

Once merged, this repo's newest `main` push run carries `junit` + `sccache-metrics` and the next `Coverage Nightly` carries `llvm-cov`, flipping aprender from `UNMEASURED` to a row in Arbiter's `s-practice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)