### PR TITLE
dogfood(examples): G3.EX learns needs-data — 173 examples that need a model or tokenizer the repo does not ship were reading as defects

### DIFF
--- a/.claude/skills/apr-dogfood/SKILL.md
+++ b/.claude/skills/apr-dogfood/SKILL.md
@@ -1300,7 +1300,7 @@ Universe: every `kind == ["example"]` target from `cargo metadata --no-deps`, wi
 its owning package and `required-features` — never a directory listing. Evidence:
 `evidence/dogfood/<version>/examples.tsv`, one
 `pkg<TAB>example<TAB>class<TAB>rc<TAB>secs<TAB>cite` row per target plus a
-`# summary pass=… fail=… timeout=… needs-args=… needs-hardware=…` trailer.
+`# summary pass=… fail=… timeout=… needs-args=… needs-hardware=… needs-data=…` trailer.
 
 | class | meaning |
 |---|---|
@@ -1309,6 +1309,7 @@ its owning package and `required-features` — never a directory listing. Eviden
 | `timeout` | killed by `timeout --signal=KILL` (rc 124/137); a defect |
 | `needs-args` | rc ≠ 0 and stderr opens a clap usage line, cited — not runnable bare, not broken |
 | `needs-hardware` | stderr names a missing CUDA/wgpu device, cited — a SKIP, never a pass |
+| `needs-data` | rc ≠ 0 and stderr names a file/model/tokenizer the repository does not ship, cited — a SKIP, never a pass; re-run with the data present before a release verdict |
 
 Exit contract: **1** if any row is `fail` or `timeout`, **2** if the enumeration is
 empty (vacuity: a run with nothing to run is not a pass), 0 otherwise. No row is

--- a/scripts/dogfood_examples.sh
+++ b/scripts/dogfood_examples.sh
@@ -38,6 +38,10 @@
 #                   a driver-less host must not be readable as "the CUDA example
 #                   works". These rows are re-run on the CUDA host before the
 #                   release verdict (G3.EX).
+#   needs-data      (Added 2026-09-12): 173 rows on the 0.67 train head (981
+#                   example targets) were classified `fail` whose stderr says
+#                   the example needs a FILE the repository does not ship.
+#                   Those are not runnable bare, but are not broken.
 #
 # Exit 1 if any row is `fail` or `timeout`. Exit 2 if the enumeration is EMPTY —
 # a gate that finds nothing to run and exits 0 is the vacuity defect this repo
@@ -71,6 +75,7 @@ SELFTEST=0
 # table first.
 NEEDS_ARGS_RE='^(Usage|error: the following required arguments)'
 NEEDS_HW_RE='(CUDA_ERROR_[A-Z_]+|no CUDA-capable device|CUDA driver version is insufficient|cuInit|libcuda\.so|libnvidia-ml|[Nn]o (suitable )?(graphics )?adapter|RequestAdapterError|NoAdapter|wgpu.*(device|adapter) (not|un)|Metal device (not|un))'
+NEEDS_DATA_RE='No such file or directory|[Mm]odel not found|not found at |Failed to open |[Nn]o tokenizer|Download with:|does not exist|hf://|apr pull '
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -183,6 +188,11 @@ classify() {
         printf 'needs-hardware\t%s\n' "$(oneline "${line}")"
         return 0
     fi
+    line=$(grep -m1 -E "${NEEDS_DATA_RE}" "${log}" 2> /dev/null) || line=''
+    if [ -n "${line}" ]; then
+        printf 'needs-data\t%s\n' "$(oneline "${line}")"
+        return 0
+    fi
     line=$(grep -m1 -E '[^[:space:]]' "${log}" 2> /dev/null) || line=''
     printf 'fail\t%s: %s\n' "${stage}" "$(oneline "${line:-no output}")"
 }
@@ -230,7 +240,7 @@ build_then_run() {
 main_run() {
     local meta_file rows count out ver ws_root
     local td pkg name feats stage rc secs t0 class cite row note
-    local n_pass=0 n_fail=0 n_timeout=0 n_args=0 n_hw=0
+    local n_pass=0 n_fail=0 n_timeout=0 n_args=0 n_hw=0 n_data=0
 
     require_tools
     td=$(mktemp -d)
@@ -291,14 +301,15 @@ main_run() {
             timeout) n_timeout=$((n_timeout + 1)) ;;
             needs-args) n_args=$((n_args + 1)) ;;
             needs-hardware) n_hw=$((n_hw + 1)) ;;
+            needs-data) n_data=$((n_data + 1)) ;;
         esac
     done < <(printf '%s\n' "${rows}")
 
-    printf '# summary pass=%s fail=%s timeout=%s needs-args=%s needs-hardware=%s\n' \
-        "${n_pass}" "${n_fail}" "${n_timeout}" "${n_args}" "${n_hw}" >> "${out}"
+    printf '# summary pass=%s fail=%s timeout=%s needs-args=%s needs-hardware=%s needs-data=%s\n' \
+        "${n_pass}" "${n_fail}" "${n_timeout}" "${n_args}" "${n_hw}" "${n_data}" >> "${out}"
     printf 'wrote %s\n' "${out}"
-    printf 'summary pass=%s fail=%s timeout=%s needs-args=%s needs-hardware=%s\n' \
-        "${n_pass}" "${n_fail}" "${n_timeout}" "${n_args}" "${n_hw}"
+    printf 'summary pass=%s fail=%s timeout=%s needs-args=%s needs-hardware=%s needs-data=%s\n' \
+        "${n_pass}" "${n_fail}" "${n_timeout}" "${n_args}" "${n_hw}" "${n_data}"
 
     if [ "${n_fail}" -gt 0 ] || [ "${n_timeout}" -gt 0 ]; then
         printf 'FAIL: %s example(s) failed, %s timed out.\n' "${n_fail}" "${n_timeout}"
@@ -387,6 +398,7 @@ selftest() {
     st_expect 'class: hang -> timeout' "${out}" "${p}" hang timeout
     st_expect 'class: needs_arg -> needs-args' "${out}" "${p}" needs_arg needs-args
     st_expect 'class: nohw -> needs-hardware' "${out}" "${p}" nohw needs-hardware
+    st_expect 'class: nodata -> needs-data' "${out}" "${p}" nodata needs-data
 
     # rc of the failing example is recorded, not flattened to 1.
     if awk -F'\t' '$2 == "bad" && $4 == 3 { f = 1 } END { exit !f }' "${out}"; then
@@ -397,15 +409,15 @@ selftest() {
     fi
 
     # Every citing class cites a LINE, not an empty cell.
-    if awk -F'\t' '$3 == "needs-args" || $3 == "needs-hardware" { if ($6 == "") bad = 1 } END { exit bad }' \
+    if awk -F'\t' '$3 == "needs-args" || $3 == "needs-hardware" || $3 == "needs-data" { if ($6 == "") bad = 1 } END { exit bad }' \
             "${out}"; then
-        st_row PASS 'cite: needs-args and needs-hardware rows cite a line'
+        st_row PASS 'cite: the three skip classes cite a line'
     else
-        st_row FAIL 'cite: needs-args and needs-hardware rows cite a line'
+        st_row FAIL 'cite: the three skip classes cite a line'
     fi
 
     # Trailer counts.
-    if grep -qxF '# summary pass=1 fail=1 timeout=1 needs-args=1 needs-hardware=1' "${out}"; then
+    if grep -qxF '# summary pass=1 fail=1 timeout=1 needs-args=1 needs-hardware=1 needs-data=1' "${out}"; then
         st_row PASS 'trailer: summary counts'
     else
         st_row FAIL 'trailer: summary counts' "$(oneline "$(grep '^# summary' "${out}" || true)")"
@@ -419,11 +431,11 @@ selftest() {
     fi
 
     # No unclassified row.
-    if awk -F'\t' '/^#/ { next } { if ($3 !~ /^(pass|fail|timeout|needs-args|needs-hardware)$/) bad = 1 } END { exit bad }' \
+    if awk -F'\t' '/^#/ { next } { if ($3 !~ /^(pass|fail|timeout|needs-args|needs-hardware|needs-data)$/) bad = 1 } END { exit bad }' \
             "${out}"; then
-        st_row PASS 'rows: every row carries one of the five classes'
+        st_row PASS 'rows: every row carries one of the six classes'
     else
-        st_row FAIL 'rows: every row carries one of the five classes'
+        st_row FAIL 'rows: every row carries one of the six classes'
     fi
 
     st_mutation_row "${td}" "${ws}" "${p}"

--- a/tests/fixtures/dogfood_examples/README.md
+++ b/tests/fixtures/dogfood_examples/README.md
@@ -11,6 +11,7 @@ classification the script is allowed to emit:
 | `hang` | sleeps forever | `timeout` (only the `timeout(1)` wrapper can decide this) |
 | `needs_arg` | prints a `Usage:` line to stderr, exits 2 | `needs-args`, citing that line |
 | `nohw` | prints a CUDA driver error to stderr, exits 1 | `needs-hardware`, citing that line |
+| `nodata` | prints `Model not found at …` and `Download with: apr pull hf://…` to stderr, exits 1 | `needs-data`, citing that line |
 
 The manifest is `Cargo.toml.in`, not `Cargo.toml`, on purpose: a nested real
 manifest inside the repo tree is a second package that `cargo metadata`,

--- a/tests/fixtures/dogfood_examples/examples/nodata.rs
+++ b/tests/fixtures/dogfood_examples/examples/nodata.rs
@@ -1,0 +1,6 @@
+//! Classification witness: `needs-data`.
+fn main() {
+    eprintln!("Model not found at ../tiny-model-ground-truth/models/qwen2-0.5b-int8.apr");
+    eprintln!("Download with: apr pull hf://Qwen/Qwen2-0.5B-Instruct");
+    std::process::exit(1);
+}


### PR DESCRIPTION
## What

`scripts/dogfood_examples.sh` (the G3.EX row of the apr-dogfood skill) gains a sixth class, `needs-data`: rc ≠ 0 and stderr names a model, tokenizer or fixture the repository does not ship. Checked after `needs-args` and `needs-hardware`, before `fail`; a SKIP, never a pass; the row cites the matched line.

## Why (measured)

The 0.67 pre-release sweep on lambda (981 example targets, `scripts/dogfood_examples.sh --out …`, 2026-09-12) classified **173 rows `fail`** whose stderr, re-run with output kept, reads like:

```
Model not found at ../tiny-model-ground-truth/models/qwen2-0.5b-int8.apr
Download with: apr pull hf://Qwen/Qwen2-0.5B-Instruct
Error: UnsupportedOperation { operation: "open_model_file", reason: "Failed to open /home/noah/models/TinyLlama-1.1B-Chat-v1.0-Q4_K_M.gguf: No such file or directory (os error 2)" }
(no tokenizer at 'tokenizer.json'; the repository ships none)
```

The class table already says `needs-args` is "not runnable bare, not broken"; a missing file is the same kind of row, but nothing classified it, so the release gate read 173 defects. PR #3136 said the sweep had classified three rows outside pass/args/hw over 981 targets; that was a reading of the first rows of a sweep still running. The full picture is in the PMAT-1098 receipt.

## Proof

- `bash scripts/dogfood_examples.sh --selftest`: 18/18 PASS, including `class: nodata -> needs-data`, `cite: the three skip classes cite a line`, `trailer: summary counts` (`needs-data=1`), `rows: every row carries one of the six classes`.
- Mutation: `NEEDS_DATA_RE='zzz-never-matches'` → selftest rc=1, `FAIL class: nodata -> needs-data`, `FAIL trailer: summary counts`; restored → rc=0.
- `bashrs lint scripts/dogfood_examples.sh`: 0 errors, 16 warnings on both origin/main and this branch (infos 60→63, no new warning class).
- Exit contract unchanged: 1 only for `fail`/`timeout`.

Implemented by an agy goal lane (conversation `5aa7d8b2-11d6-4ad6-802a-8630b43abd45`); the lane failed isolation (it also wrote the SKILL.md hunk into the shared checkout), so its detached commit was cherry-picked and every claim re-run by the orchestrator. Receipt: `docs/audits/impl-PMAT-1098-receipt.md` (PR to follow).

Refs #3121, PMAT-1098. Not part of the 0.67.0 cut: the release train is frozen; auto-merge is armed after the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
