### PR TITLE
feat(crux): linfa and burn become CRUX competitors — category N, 17 contracts, registry edit + mutation proof

### DIFF
--- a/contracts/crux-N-01-v1.yaml
+++ b/contracts/crux-N-01-v1.yaml
@@ -1,0 +1,89 @@
+# CRUX-N-01 — SVD substrate (Golub-Reinsch + randomized)
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3147, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-01
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 5  # 1..5, critical priority in pmat work
+  intake_status: missing
+  github_issue: 3147
+  description: >
+    Singular value decomposition as a reusable primitive. burn ships burn-linalg ("Linear algebra operations for Burn tensors"). aprender has NO SVD anywhere: only SymmetricEigen at crates/aprender-compute/src/eigen/mod.rs:72. Five downstream capabilities are blocked or degraded by its absence.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3147'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  thin_svd_reconstruction:
+    formula: |
+      svd(A) -> (U, S, V) with A ∈ R^{m×n}
+        ‖A − U·diag(S)·Vᵀ‖_F / ‖A‖_F ≤ 1e-10   (f64)
+        shapes: U ∈ R^{m×k}, S ∈ R^k, V ∈ R^{n×k}, k = min(m,n)
+    domain: "A ∈ R^{m×n}, f64, m<n ∨ m=n ∨ m>n, cond(A) ≤ 1e8"
+    codomain: "(U, S, V) with reconstruction error ≤ 1e-10"
+    invariants:
+    - "handles m<n and m>n without caller transposition"
+    - "S is non-negative and sorted descending"
+    - "sign convention: max-|·| component of each u_i is positive => deterministic output"
+
+  randomized_svd_topk:
+    formula: |
+      rsvd(A, k, p, q) -> (U_k, S_k, V_k)
+        ∀ i ≤ k: |S_k[i] − S_exact[i]| / S_exact[i] ≤ 0.01   for p=10, q=2
+    domain: "A with a rank-k spectrum plus noise"
+    codomain: "top-k singular triplets within 1% of exact"
+    invariants:
+    - "oversampling p and power iterations q are explicit parameters"
+    - "never forms AᵀA"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-01-001
+  rule: "reconstruction holds across shape and conditioning classes"
+  prediction: "200 random f64 matrices spanning m<n, m=n, m>n, rank-deficient and cond>=1e8 all reconstruct within 1e-10"
+  test: >-
+    LIVE-PENDING - reconstruction holds across shape and conditioning classes. No test surface exists today because the capability is unimplemented: SVD substrate (Golub-Reinsch + randomized) (aprender#3147, CRUX-N-01). PROMOTE by authoring a test named reconstruction_across_shape_classes in module `svd/tests` of crate `aprender-compute`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'reconstruction holds across shape and conditioning classes' is violated — the burn parity claim for CRUX-N-01 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-01-002
+  rule: "U and V are orthonormal"
+  prediction: "proptest over generated shapes asserts ‖UᵀU − I‖_inf <= 1e-10 and likewise for V"
+  test: >-
+    LIVE-PENDING - U and V are orthonormal. No test surface exists today because the capability is unimplemented: SVD substrate (Golub-Reinsch + randomized) (aprender#3147, CRUX-N-01). PROMOTE by authoring a test named prop_orthonormal_factors in module `svd/tests` of crate `aprender-compute`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'U and V are orthonormal' is violated — the burn parity claim for CRUX-N-01 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-01-003
+  rule: "singular values match the scipy oracle"
+  prediction: "singular VALUES match scipy.linalg.svd within 1e-9 relative on pinned fixtures"
+  test: >-
+    LIVE-PENDING - singular values match the scipy oracle. No test surface exists today because the capability is unimplemented: SVD substrate (Golub-Reinsch + randomized) (aprender#3147, CRUX-N-01). PROMOTE by authoring a test named oracle_parity_scipy in module `svd/tests` of crate `aprender-compute`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'singular values match the scipy oracle' is violated — the burn parity claim for CRUX-N-01 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "reconstruction holds across shape and conditioning classes"
+- type: invariant
+  property: "U and V are orthonormal"
+- type: invariant
+  property: "singular values match the scipy oracle"
+
+kani_harnesses:
+- id: KH-CRUX-N-01-001
+  obligation: thin_svd_reconstruction
+  property: thin_svd_reconstruction_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-01-002
+  obligation: randomized_svd_topk
+  property: randomized_svd_topk_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-02-v1.yaml
+++ b/contracts/crux-N-02-v1.yaml
@@ -1,0 +1,91 @@
+# CRUX-N-02 — PCA on SVD + TruncatedSVD
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3148, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-02
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 5  # 1..5, critical priority in pmat work
+  intake_status: partial
+  github_issue: 3148
+  description: >
+    PCA computed via SVD on centered data rather than eigendecomposition of the covariance matrix. crates/aprender-core/src/preprocessing/pca.rs:334 currently forms the covariance matrix and calls SymmetricEigen, which squares the condition number and is O(d^3) in FEATURES. docs/BEATS.md records the resulting 18.6x loss vs sklearn -- the only measured sklearn loss in the scoreboard.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3148'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  pca_via_svd_not_covariance:
+    formula: |
+      fit(X) :  X_c = X − mean(X)
+                (U, S, V) = svd(X_c)
+                components_ = Vᵀ[:k] ;  explained_variance_ = S² / (n−1)
+        FORBIDDEN: any construction of Xᵀ·X (d×d covariance)
+    domain: "X ∈ R^{n×d}"
+    codomain: "components_ ∈ R^{k×d}, explained_variance_ratio_ ∈ [0,1]^k"
+    invariants:
+    - "covariance matrix is never materialized"
+    - "Σ explained_variance_ratio_ = 1.0 ± 1e-12 when k = min(n,d)"
+    - "deterministic sign convention => two fits give byte-identical components"
+
+  conditioning_advantage_is_real:
+    formula: |
+      for X with singular values spanning 1e0..1e-9:
+        ‖components_svd − components_exact‖_inf ≤ 1e-7
+        AND ‖components_covariance − components_exact‖_inf > 1e-7
+    domain: "ill-conditioned X"
+    codomain: "bool (both halves must hold)"
+    invariants:
+    - "the covariance path is asserted to FAIL the tolerance the SVD path passes"
+    - "a test showing only the success half does not discharge this obligation"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-02-001
+  rule: "the covariance path is gone"
+  prediction: "preprocessing/pca.rs constructs no d×d covariance matrix; anchored guard with a must-match/must-not-match case table"
+  test: >-
+    LIVE-PENDING - the covariance path is gone. No test surface exists today because the capability is unimplemented: PCA on SVD + TruncatedSVD (aprender#3148, CRUX-N-02). PROMOTE by authoring a test named the test named in the ticket in crate `the owning crate`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the covariance path is gone' is violated — the linfa parity claim for CRUX-N-02 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-02-002
+  rule: "ill-conditioned input separates the two paths"
+  prediction: "on singular values spanning 1e0..1e-9 the SVD path is within 1e-7 of exact and the covariance path is asserted to exceed it"
+  test: >-
+    LIVE-PENDING - ill-conditioned input separates the two paths. No test surface exists today because the capability is unimplemented: PCA on SVD + TruncatedSVD (aprender#3148, CRUX-N-02). PROMOTE by authoring a test named ill_conditioned_separates_paths in module `preprocessing/pca/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'ill-conditioned input separates the two paths' is violated — the linfa parity claim for CRUX-N-02 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-02-003
+  rule: "the BEATS.md loss row is re-measured, not deleted"
+  prediction: "beat-sklearn-pca-speed-v1.yaml exists with a measured ratio; a still-losing number is a PASS for this gate, a missing row is a FAIL"
+  test: >-
+    LIVE-PENDING - the BEATS.md loss row is re-measured, not deleted. No test surface exists today because the capability is unimplemented: PCA on SVD + TruncatedSVD (aprender#3148, CRUX-N-02). PROMOTE by authoring a test named readme_contract in crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the BEATS.md loss row is re-measured, not deleted' is violated — the linfa parity claim for CRUX-N-02 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "the covariance path is gone"
+- type: invariant
+  property: "ill-conditioned input separates the two paths"
+- type: invariant
+  property: "the BEATS.md loss row is re-measured, not deleted"
+
+kani_harnesses:
+- id: KH-CRUX-N-02-001
+  obligation: pca_via_svd_not_covariance
+  property: pca_via_svd_not_covariance_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-02-002
+  obligation: conditioning_advantage_is_real
+  property: conditioning_advantage_is_real_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-03-v1.yaml
+++ b/contracts/crux-N-03-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-03 — Spatial neighbour index (kd-tree + ball-tree + brute)
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3149, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-03
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 5  # 1..5, critical priority in pmat work
+  intake_status: missing
+  github_issue: 3149
+  description: >
+    Exact nearest-neighbour search backed by a spatial index. linfa ships linfa-nn ("A collection of nearest neighbour algorithms") marked Tested/Benchmarked. aprender has no index at all: KdTree and BallTree are absent repo-wide and KNearestNeighbors performs a linear scan. Six existing consumers pay O(n) per query.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3149'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  index_exactness:
+    formula: |
+      ∀ query q, ∀ k:  k_nearest_index(q, k) ≡ k_nearest_bruteforce(q, k)
+        as SETS, including tie handling
+    domain: "point clouds n ∈ [10, 2000], d ∈ [1, 30], any supported metric"
+    codomain: "identical neighbour set"
+    invariants:
+    - "an index returning different neighbours is a DEFECT, not an optimization"
+    - "radius queries agree with brute force on the same data"
+
+  sublinear_query_growth:
+    formula: |
+      visits(n) counted as node expansions, NOT wall-clock:
+        visits(1e4)/visits(1e3) < 10  AND  visits(1e5)/visits(1e4) < 10
+    domain: "n ∈ {1e3, 1e4, 1e5}"
+    codomain: "node-visit counts"
+    invariants:
+    - "counted, never timed -- the repo forbids wall-clock in required checks"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-03-001
+  rule: "index returns the identical neighbour set as brute force"
+  prediction: "proptest over n in 10..2000 and d in 1..30 asserts set equality with brute force including ties"
+  test: >-
+    LIVE-PENDING - index returns the identical neighbour set as brute force. No test surface exists today because the capability is unimplemented: Spatial neighbour index (kd-tree + ball-tree + brute) (aprender#3149, CRUX-N-03). PROMOTE by authoring a test named prop_exact_vs_bruteforce in module `neighbors/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'index returns the identical neighbour set as brute force' is violated — the linfa parity claim for CRUX-N-03 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-03-002
+  rule: "query cost grows sub-linearly"
+  prediction: "node-visit counts across n=1e3,1e4,1e5 grow sub-linearly; measured by counter, not clock"
+  test: >-
+    LIVE-PENDING - query cost grows sub-linearly. No test surface exists today because the capability is unimplemented: Spatial neighbour index (kd-tree + ball-tree + brute) (aprender#3149, CRUX-N-03). PROMOTE by authoring a test named visits_sublinear_in_n in module `neighbors/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'query cost grows sub-linearly' is violated — the linfa parity claim for CRUX-N-03 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-03-003
+  rule: "rewired consumers are unchanged"
+  prediction: "DBSCAN, LOF and KNearestNeighbors produce identical labels/scores before and after the rewire on pinned fixtures"
+  test: >-
+    LIVE-PENDING - rewired consumers are unchanged. No test surface exists today because the capability is unimplemented: Spatial neighbour index (kd-tree + ball-tree + brute) (aprender#3149, CRUX-N-03). PROMOTE by authoring a test named consumers_unchanged_after_rewire in module `neighbors/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'rewired consumers are unchanged' is violated — the linfa parity claim for CRUX-N-03 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "index returns the identical neighbour set as brute force"
+- type: invariant
+  property: "query cost grows sub-linearly"
+- type: invariant
+  property: "rewired consumers are unchanged"
+
+kani_harnesses:
+- id: KH-CRUX-N-03-001
+  obligation: index_exactness
+  property: index_exactness_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-03-002
+  obligation: sublinear_query_growth
+  property: sublinear_query_growth_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-04-v1.yaml
+++ b/contracts/crux-N-04-v1.yaml
@@ -1,0 +1,76 @@
+# CRUX-N-04 — Const-generic rank-checked tensor
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3150, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-04
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 5  # 1..5, critical priority in pmat work
+  intake_status: missing
+  github_issue: 3150
+  description: >
+    Tensor rank carried in the type system. burn's core type is Tensor<B, const D: usize, K>, so a rank mismatch fails to compile. aprender's crates/aprender-tensor/src/tensor.rs:10 carries shape: Vec<usize>, making rank a runtime property. CLAUDE.md records LAYOUT-001 as having occurred 100+ times, defended only by runtime contracts and a hand-maintained FORBIDDEN IMPORTS list.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3150'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  rank_is_static:
+    formula: |
+      Tensor<const D: usize, L: Layout>
+        matmul : Tensor<2,L> × Tensor<2,L> -> Tensor<2,L>     (only D=2)
+        reshape::<D2> : Tensor<D,L> -> Tensor<D2,L>
+        add : Tensor<D,L> × Tensor<D,L> -> Tensor<D,L>        (same D required)
+    domain: "Rust type level"
+    codomain: "compile success or compile ERROR"
+    invariants:
+    - "a rank mismatch is a compile error, not a runtime Result::Err"
+    - "Layout ∈ {RowMajor, ColMajor} is a type parameter wired to tensor-layout-v1.yaml"
+    - "the wrapper is zero-cost: same codegen as the untyped path"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-04-001
+  rule: "rank mismatch fails to COMPILE"
+  prediction: ">=8 trybuild compile-fail cases (2D matmul on 3D, incompatible reshape, mismatched-rank add, ColMajor where RowMajor required) each fail with committed expected stderr"
+  test: >-
+    LIVE-PENDING - rank mismatch fails to COMPILE. No test surface exists today because the capability is unimplemented: Const-generic rank-checked tensor (aprender#3150, CRUX-N-04). PROMOTE by authoring a test named trybuild_rank in crate `aprender-tensor`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'rank mismatch fails to COMPILE' is violated — the burn parity claim for CRUX-N-04 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-04-002
+  rule: "the type is not merely rejecting everything"
+  prediction: "a trybuild PASS suite compiles the legal forms of every operation above"
+  test: >-
+    LIVE-PENDING - the type is not merely rejecting everything. No test surface exists today because the capability is unimplemented: Const-generic rank-checked tensor (aprender#3150, CRUX-N-04). PROMOTE by authoring a test named trybuild_rank_pass in crate `aprender-tensor`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the type is not merely rejecting everything' is violated — the burn parity claim for CRUX-N-04 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-04-003
+  rule: "the migrated path is unchanged and zero-cost"
+  prediction: "the one migrated hot path produces byte-identical output before and after, and shows no added runtime cost"
+  test: >-
+    LIVE-PENDING - the migrated path is unchanged and zero-cost. No test surface exists today because the capability is unimplemented: Const-generic rank-checked tensor (aprender#3150, CRUX-N-04). PROMOTE by authoring a test named byte_identical_after_typing in module `migration/tests` of crate `aprender-tensor`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the migrated path is unchanged and zero-cost' is violated — the burn parity claim for CRUX-N-04 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "rank mismatch fails to COMPILE"
+- type: invariant
+  property: "the type is not merely rejecting everything"
+- type: invariant
+  property: "the migrated path is unchanged and zero-cost"
+
+kani_harnesses:
+- id: KH-CRUX-N-04-001
+  obligation: rank_is_static
+  property: rank_is_static_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-05-v1.yaml
+++ b/contracts/crux-N-05-v1.yaml
@@ -1,0 +1,75 @@
+# CRUX-N-05 — Autodiff op coverage: conv, pooling, embedding, gather
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3151, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-05
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 4  # 1..5, high priority in pmat work
+  intake_status: partial
+  github_issue: 3151
+  description: >
+    Differentiable operator coverage beyond the transformer path. burn-autodiff differentiates any graph expressible in its tensor API. aprender's autograd has 21 ops, all transformer-path (add, matmul, gelu, layer_norm, attention, softmax, ...). conv1d, conv2d, max_pool, avg_pool, gather and scatter are absent; embedding exists only inside wgpu_block.rs. aprender cannot train a CNN.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3151'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  gradcheck:
+    formula: |
+      ∀ op ∈ {conv1d, conv2d, max_pool2d, avg_pool2d, embedding, gather, scatter_add,
+              mean, max, min, prod, batch_norm}:
+        |∂f/∂x_analytic − (f(x+h) − f(x−h)) / 2h| / |∂f/∂x_analytic| ≤ 1e-6   at h = 1e-5, f64
+    domain: "randomized shapes × stride × padding × dilation × groups"
+    codomain: "relative gradient error"
+    invariants:
+    - "central differences, f64, over parameter combinations -- not a single shape"
+    - "embedding backward ACCUMULATES for repeated indices; the test asserts the summed gradient"
+    - "max/max_pool tie subgradient convention is documented AND tested"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-05-001
+  rule: "every new op passes finite-difference gradcheck"
+  prediction: "central-difference gradcheck at h=1e-5 on f64 with relative error <=1e-6 across stride/padding/dilation/groups"
+  test: >-
+    LIVE-PENDING - every new op passes finite-difference gradcheck. No test surface exists today because the capability is unimplemented: Autodiff op coverage: conv, pooling, embedding, gather (aprender#3151, CRUX-N-05). PROMOTE by authoring a test named gradcheck_all_new_ops in module `autograd/ops/correctness_tests` of crate `aprender-train`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'every new op passes finite-difference gradcheck' is violated — the burn parity claim for CRUX-N-05 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-05-002
+  rule: "embedding backward accumulates on repeated indices"
+  prediction: "a batch containing the same index twice yields the SUMMED gradient, asserted by value, not merely non-zero"
+  test: >-
+    LIVE-PENDING - embedding backward accumulates on repeated indices. No test surface exists today because the capability is unimplemented: Autodiff op coverage: conv, pooling, embedding, gather (aprender#3151, CRUX-N-05). PROMOTE by authoring a test named embedding_repeated_index_accumulates in module `autograd/ops/correctness_tests` of crate `aprender-train`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'embedding backward accumulates on repeated indices' is violated — the burn parity claim for CRUX-N-05 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-05-003
+  rule: "a CNN actually trains end to end"
+  prediction: "a small CNN reaches an asserted loss floor on an MNIST-like fixture"
+  test: >-
+    LIVE-PENDING - a CNN actually trains end to end. No test surface exists today because the capability is unimplemented: Autodiff op coverage: conv, pooling, embedding, gather (aprender#3151, CRUX-N-05). PROMOTE by authoring a test named cnn_trains_to_loss_floor in module `autograd/tests` of crate `aprender-train`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'a CNN actually trains end to end' is violated — the burn parity claim for CRUX-N-05 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "every new op passes finite-difference gradcheck"
+- type: invariant
+  property: "embedding backward accumulates on repeated indices"
+- type: invariant
+  property: "a CNN actually trains end to end"
+
+kani_harnesses:
+- id: KH-CRUX-N-05-001
+  obligation: gradcheck
+  property: gradcheck_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-06-v1.yaml
+++ b/contracts/crux-N-06-v1.yaml
@@ -1,0 +1,89 @@
+# CRUX-N-06 — ONNX import
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3152, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-06
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 4  # 1..5, high priority in pmat work
+  intake_status: missing
+  github_issue: 3152
+  description: >
+    Import an ONNX graph into a runnable aprender model. burn ships burn-onnx, converting ONNX into Rust against burn's native API. aprender has no import path, and its ONNX EXPORT is a reachable stub: crates/apr-cli/src/commands/export.rs:7 marks it "(planned)" while the CLI still offers onnx as a valid format -- the advertised-but-absent defect class from the 0.63.0 dogfood audit.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3152'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  supported_op_set_is_closed:
+    formula: |
+      import(model) :
+        ∀ node ∈ graph.nodes:
+          node.op_type ∈ SUPPORTED  =>  lowered
+          node.op_type ∉ SUPPORTED  =>  Err(msg) where node.op_type ⊆ msg
+        SUPPORTED is declared in this contract, never only in a doc comment
+    domain: "ONNX protobuf + opset version"
+    codomain: "runnable .apr model, or an error naming the unsupported op"
+    invariants:
+    - "FAIL-CLOSED: silent partial import is the defect this excludes"
+    - "a blacklist that fails open on its complement is not a gate"
+    - "unsupported opset is refused with the version in the message"
+
+  numerical_parity_with_onnxruntime:
+    formula: |
+      ∀ op ∈ SUPPORTED: ‖apr(x) − onnxruntime(x)‖_inf ≤ 1e-5
+    domain: "pinned fixture models under tests/fixtures/onnx/"
+    codomain: "per-op max abs deviation"
+    invariants:
+    - "end-to-end: a real model matches onnxruntime top-1 on 20 pinned inputs"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-06-001
+  rule: "unsupported operators fail loudly and by name"
+  prediction: "a model containing an op outside SUPPORTED is refused with that op's name in the error; import never partially succeeds"
+  test: >-
+    LIVE-PENDING - unsupported operators fail loudly and by name. No test surface exists today because the capability is unimplemented: ONNX import (aprender#3152, CRUX-N-06). PROMOTE by authoring a test named unsupported_op_fails_closed in module `onnx_import` of crate `apr-cli`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'unsupported operators fail loudly and by name' is violated — the burn parity claim for CRUX-N-06 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-06-002
+  rule: "per-op parity against onnxruntime"
+  prediction: "each supported op matches onnxruntime within 1e-5 on pinned fixtures"
+  test: >-
+    LIVE-PENDING - per-op parity against onnxruntime. No test surface exists today because the capability is unimplemented: ONNX import (aprender#3152, CRUX-N-06). PROMOTE by authoring a test named per_op_parity_onnxruntime in module `onnx_import` of crate `apr-cli`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'per-op parity against onnxruntime' is violated — the burn parity claim for CRUX-N-06 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-06-003
+  rule: "the advertised export stub is resolved"
+  prediction: "apr export --format onnx either works or onnx is no longer offered in the CLI format list; a test asserts whichever was chosen"
+  test: >-
+    LIVE-PENDING - the advertised export stub is resolved. No test surface exists today because the capability is unimplemented: ONNX import (aprender#3152, CRUX-N-06). PROMOTE by authoring a test named onnx_export_not_advertised_unless_implemented in module `cli_commands` of crate `apr-cli`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the advertised export stub is resolved' is violated — the burn parity claim for CRUX-N-06 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "unsupported operators fail loudly and by name"
+- type: invariant
+  property: "per-op parity against onnxruntime"
+- type: invariant
+  property: "the advertised export stub is resolved"
+
+kani_harnesses:
+- id: KH-CRUX-N-06-001
+  obligation: supported_op_set_is_closed
+  property: supported_op_set_is_closed_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-06-002
+  obligation: numerical_parity_with_onnxruntime
+  property: numerical_parity_with_onnxruntime_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-07-v1.yaml
+++ b/contracts/crux-N-07-v1.yaml
@@ -1,0 +1,87 @@
+# CRUX-N-07 — AdaBoost + generic Bagging/Voting meta-estimators
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3153, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-07
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 4  # 1..5, high priority in pmat work
+  intake_status: missing
+  github_issue: 3153
+  description: >
+    Ensemble meta-estimators over an arbitrary base estimator. linfa-ensemble ships bagging, random forest and AdaBoost. aprender's ensembles (RandomForestClassifier/Regressor, GradientBoostingClassifier) are concrete and hard-wired; AdaBoost is absent and there is no generic wrapper. The missing piece is the WRAPPER: BaggingClassifier<E: Estimator> makes all ~55 fittable types ensembleable in one change.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3153'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  boosting_improves_a_weak_learner:
+    formula: |
+      acc(AdaBoost(base, n=50)) > τ  AND  acc(base) < 0.70
+        on a fixture chosen so the weak learner provably underperforms
+    domain: "fixture where a depth-1 tree scores below 0.70"
+    codomain: "accuracy of both, asserted separately"
+    invariants:
+    - "a test asserting only fit().is_ok() LOCKS THE DEFECT IN and does not discharge this"
+    - "sample weights are asserted to CHANGE between rounds, with misclassified samples gaining weight"
+
+  bagging_is_genuinely_generic:
+    formula: |
+      BaggingClassifier<E> instantiated over E ∈ {DecisionTreeClassifier,
+        KNearestNeighbors, GaussianNB} -- at least three distinct base types
+    domain: "any E: Estimator"
+    codomain: "fitted ensemble per base type"
+    invariants:
+    - "genericity proven by instantiation over >=3 bases, not by the signature alone"
+    - "soft voting fails at CONSTRUCTION for bases lacking predict_proba"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-07-001
+  rule: "AdaBoost beats its own weak learner"
+  prediction: "on a fixture where a depth-1 tree scores <0.70, the 50-estimator ensemble exceeds an asserted threshold; both halves checked"
+  test: >-
+    LIVE-PENDING - AdaBoost beats its own weak learner. No test surface exists today because the capability is unimplemented: AdaBoost + generic Bagging/Voting meta-estimators (aprender#3153, CRUX-N-07). PROMOTE by authoring a test named boosts_a_weak_learner in module `ensemble/adaboost/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'AdaBoost beats its own weak learner' is violated — the linfa parity claim for CRUX-N-07 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-07-002
+  rule: "sample weights are updated between rounds"
+  prediction: "the weight vector changes across rounds and misclassified samples gain weight"
+  test: >-
+    LIVE-PENDING - sample weights are updated between rounds. No test surface exists today because the capability is unimplemented: AdaBoost + generic Bagging/Voting meta-estimators (aprender#3153, CRUX-N-07). PROMOTE by authoring a test named weights_update_toward_errors in module `ensemble/adaboost/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'sample weights are updated between rounds' is violated — the linfa parity claim for CRUX-N-07 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-07-003
+  rule: "bagging works over three different base estimators"
+  prediction: "BaggingClassifier is instantiated and fitted over tree, KNN and GaussianNB in the test suite"
+  test: >-
+    LIVE-PENDING - bagging works over three different base estimators. No test surface exists today because the capability is unimplemented: AdaBoost + generic Bagging/Voting meta-estimators (aprender#3153, CRUX-N-07). PROMOTE by authoring a test named generic_over_three_bases in module `ensemble/bagging/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'bagging works over three different base estimators' is violated — the linfa parity claim for CRUX-N-07 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "AdaBoost beats its own weak learner"
+- type: invariant
+  property: "sample weights are updated between rounds"
+- type: invariant
+  property: "bagging works over three different base estimators"
+
+kani_harnesses:
+- id: KH-CRUX-N-07-001
+  obligation: boosting_improves_a_weak_learner
+  property: boosting_improves_a_weak_learner_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-07-002
+  obligation: bagging_is_genuinely_generic
+  property: bagging_is_genuinely_generic_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-08-v1.yaml
+++ b/contracts/crux-N-08-v1.yaml
@@ -1,0 +1,87 @@
+# CRUX-N-08 — FTRL-Proximal + SGDClassifier/SGDRegressor
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3154, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-08
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 4  # 1..5, high priority in pmat work
+  intake_status: missing
+  github_issue: 3154
+  description: >
+    Classical streaming linear learners. linfa-ftrl ships Follow The Regularized Leader, marked Tested/Benchmarked. aprender has neither FTRL nor a classical SGD linear learner, though the seam exists: crates/aprender-core/src/online/mod.rs:61 already declares partial_fit with two implementors. aprender's online/ is otherwise aimed at LLM post-training (DPO, RLVR), a different use case the directory name over-promises.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3154'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  ftrl_produces_sparse_solutions:
+    formula: |
+      with λ₁ > 0 on d = 10000 features of which 50 are informative:
+        |{ j : w_j = 0 exactly }| / d  ≥  0.90
+    domain: "high-dimensional sparse-signal stream"
+    codomain: "fraction of exactly-zero weights"
+    invariants:
+    - "EXACT zeros, not small magnitudes -- L1 proximal truncation is the mechanism"
+    - "sparsity is FTRL's entire reason to exist; a test that omits it tests the wrong thing"
+
+  streaming_convergence:
+    formula: |
+      windowed mean loss L_w is non-increasing over a separable stream,
+        and final accuracy > τ
+    domain: "linearly separable stream"
+    codomain: "(loss trajectory, final accuracy)"
+    invariants:
+    - "two different shuffles converge within a documented tolerance"
+    - "chunked partial_fit ≈ one batch fit within a documented tolerance"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-08-001
+  rule: "FTRL yields exactly-zero weights under L1"
+  prediction: "with lambda1>0 on 10,000 features where 50 are informative, >=90% of weights are exactly zero"
+  test: >-
+    LIVE-PENDING - FTRL yields exactly-zero weights under L1. No test surface exists today because the capability is unimplemented: FTRL-Proximal + SGDClassifier/SGDRegressor (aprender#3154, CRUX-N-08). PROMOTE by authoring a test named l1_yields_exact_zeros in module `online/ftrl/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'FTRL yields exactly-zero weights under L1' is violated — the linfa parity claim for CRUX-N-08 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-08-002
+  rule: "running loss decreases on a separable stream"
+  prediction: "the windowed mean loss is non-increasing and final accuracy exceeds an asserted threshold"
+  test: >-
+    LIVE-PENDING - running loss decreases on a separable stream. No test surface exists today because the capability is unimplemented: FTRL-Proximal + SGDClassifier/SGDRegressor (aprender#3154, CRUX-N-08). PROMOTE by authoring a test named windowed_loss_decreases in module `online/ftrl/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'running loss decreases on a separable stream' is violated — the linfa parity claim for CRUX-N-08 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-08-003
+  rule: "both learners compose inside Pipeline"
+  prediction: "a Pipeline containing SGDClassifier fits and predicts"
+  test: >-
+    LIVE-PENDING - both learners compose inside Pipeline. No test surface exists today because the capability is unimplemented: FTRL-Proximal + SGDClassifier/SGDRegressor (aprender#3154, CRUX-N-08). PROMOTE by authoring a test named composes_in_pipeline in module `online/sgd/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'both learners compose inside Pipeline' is violated — the linfa parity claim for CRUX-N-08 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "FTRL yields exactly-zero weights under L1"
+- type: monotonicity
+  property: "running loss decreases on a separable stream"
+- type: invariant
+  property: "both learners compose inside Pipeline"
+
+kani_harnesses:
+- id: KH-CRUX-N-08-001
+  obligation: ftrl_produces_sparse_solutions
+  property: ftrl_produces_sparse_solutions_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-08-002
+  obligation: streaming_convergence
+  property: streaming_convergence_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-09-v1.yaml
+++ b/contracts/crux-N-09-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-09 — OPTICS clustering
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3155, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-09
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 3  # 1..5, medium priority in pmat work
+  intake_status: missing
+  github_issue: 3155
+  description: >
+    Density-based clustering with a reachability ordering. linfa-clustering ships OPTICS alongside K-Means, GMM and DBSCAN. aprender has DBSCAN but not OPTICS, so it cannot separate clusters of differing density -- DBSCAN's single global eps cannot do it at any value. Depends on the neighbour index (CRUX-N-03); started before it, OPTICS grows its own O(n^2) scan.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3155'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  dbscan_equivalence:
+    formula: |
+      ∀ eps: OPTICS(X).extract_dbscan(eps)  ≡  DBSCAN(X, eps)   as labelings
+    domain: "eps over >=5 values, >=3 fixtures"
+    codomain: "identical cluster labels"
+    invariants:
+    - "this is what proves the reachability ordering correct"
+    - "noise points receive reachability ∞ and label −1"
+
+  varying_density_separation:
+    formula: |
+      on a fixture with two clusters of different density:
+        (∀ eps: DBSCAN(X, eps) is wrong)  AND  extract_xi(ξ) is correct
+    domain: "varying-density fixture"
+    codomain: "bool (both halves)"
+    invariants:
+    - "the DBSCAN-fails half is asserted by SWEEPING eps, not assumed"
+    - "without both halves the ticket has not demonstrated why OPTICS exists"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-09-001
+  rule: "extract_dbscan reproduces DBSCAN exactly"
+  prediction: "for >=5 eps values on 3 fixtures, extract_dbscan(eps) labels are identical to DBSCAN(eps)"
+  test: >-
+    LIVE-PENDING - extract_dbscan reproduces DBSCAN exactly. No test surface exists today because the capability is unimplemented: OPTICS clustering (aprender#3155, CRUX-N-09). PROMOTE by authoring a test named extract_dbscan_equivalence in module `cluster/optics/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'extract_dbscan reproduces DBSCAN exactly' is violated — the linfa parity claim for CRUX-N-09 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-09-002
+  rule: "varying density is separated where DBSCAN provably cannot be"
+  prediction: "an eps sweep shows every DBSCAN result wrong on the fixture, and extract_xi is correct"
+  test: >-
+    LIVE-PENDING - varying density is separated where DBSCAN provably cannot be. No test surface exists today because the capability is unimplemented: OPTICS clustering (aprender#3155, CRUX-N-09). PROMOTE by authoring a test named varying_density_where_dbscan_fails in module `cluster/optics/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'varying density is separated where DBSCAN provably cannot be' is violated — the linfa parity claim for CRUX-N-09 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-09-003
+  rule: "the neighbour index is actually used"
+  prediction: "above the auto-select threshold the brute-force path is asserted NOT taken"
+  test: >-
+    LIVE-PENDING - the neighbour index is actually used. No test surface exists today because the capability is unimplemented: OPTICS clustering (aprender#3155, CRUX-N-09). PROMOTE by authoring a test named uses_spatial_index in module `cluster/optics/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the neighbour index is actually used' is violated — the linfa parity claim for CRUX-N-09 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "extract_dbscan reproduces DBSCAN exactly"
+- type: invariant
+  property: "varying density is separated where DBSCAN provably cannot be"
+- type: invariant
+  property: "the neighbour index is actually used"
+
+kani_harnesses:
+- id: KH-CRUX-N-09-001
+  obligation: dbscan_equivalence
+  property: dbscan_equivalence_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-09-002
+  obligation: varying_density_separation
+  property: varying_density_separation_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-10-v1.yaml
+++ b/contracts/crux-N-10-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-10 — PLSRegression / PLSCanonical
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3156, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-10
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 3  # 1..5, medium priority in pmat work
+  intake_status: missing
+  github_issue: 3156
+  description: >
+    Partial Least Squares. linfa-pls ships the PLS family, marked Tested. aprender has none. PLS is the default method wherever predictors are many, collinear and fewer than samples (chemometrics, spectroscopy, genomics); its absence is a hard no for that audience. PCA cannot substitute -- PCA maximizes variance in X, PLS maximizes covariance with y.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3156'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  pls_beats_pca_on_low_variance_signal:
+    formula: |
+      on X whose predictive direction has LOW variance:
+        score(PCA -> regression) < τ_low  AND  score(PLS) > τ_high
+    domain: "synthetic X with signal in a low-variance direction"
+    codomain: "both scores, asserted separately"
+    invariants:
+    - "if BOTH pass the fixture is wrong and does not demonstrate PLS"
+    - "successive components are orthogonal within 1e-10"
+
+  degenerates_to_ols_at_full_rank:
+    formula: |
+      n_components = rank(X)  =>  ‖coef_PLS − coef_OLS‖_inf ≤ 1e-8
+    domain: "well-conditioned X"
+    codomain: "coefficient deviation"
+    invariants:
+    - "duplicated columns fit where a naive OLS is asserted to fail"
+    - "multi-output y (PLS2) is supported and tested with a 3-column y"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-10-001
+  rule: "PLS succeeds where PCA-regression fails"
+  prediction: "on a low-variance-signal fixture, PCA-then-regression is asserted below a threshold and PLS above it"
+  test: >-
+    LIVE-PENDING - PLS succeeds where PCA-regression fails. No test surface exists today because the capability is unimplemented: PLSRegression / PLSCanonical (aprender#3156, CRUX-N-10). PROMOTE by authoring a test named beats_pca_on_low_variance_signal in module `cross_decomposition/pls/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'PLS succeeds where PCA-regression fails' is violated — the linfa parity claim for CRUX-N-10 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-10-002
+  rule: "full-rank PLS reproduces OLS"
+  prediction: "with n_components = rank(X), coefficients match OLS within 1e-8"
+  test: >-
+    LIVE-PENDING - full-rank PLS reproduces OLS. No test surface exists today because the capability is unimplemented: PLSRegression / PLSCanonical (aprender#3156, CRUX-N-10). PROMOTE by authoring a test named degenerates_to_ols in module `cross_decomposition/pls/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'full-rank PLS reproduces OLS' is violated — the linfa parity claim for CRUX-N-10 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-10-003
+  rule: "collinear input fits where naive OLS fails"
+  prediction: "on duplicated columns PLS fits and OLS is asserted to fail"
+  test: >-
+    LIVE-PENDING - collinear input fits where naive OLS fails. No test surface exists today because the capability is unimplemented: PLSRegression / PLSCanonical (aprender#3156, CRUX-N-10). PROMOTE by authoring a test named handles_collinearity in module `cross_decomposition/pls/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'collinear input fits where naive OLS fails' is violated — the linfa parity claim for CRUX-N-10 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "PLS succeeds where PCA-regression fails"
+- type: invariant
+  property: "full-rank PLS reproduces OLS"
+- type: invariant
+  property: "collinear input fits where naive OLS fails"
+
+kani_harnesses:
+- id: KH-CRUX-N-10-001
+  obligation: pls_beats_pca_on_low_variance_signal
+  property: pls_beats_pca_on_low_variance_signal_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-10-002
+  obligation: degenerates_to_ols_at_full_rank
+  property: degenerates_to_ols_at_full_rank_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-11-v1.yaml
+++ b/contracts/crux-N-11-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-11 — LARS / LassoLars / lars_path
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3157, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-11
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 3  # 1..5, medium priority in pmat work
+  intake_status: missing
+  github_issue: 3157
+  description: >
+    Least Angle Regression and the full regularization path. linfa-lars ships LARS, marked Tested. aprender has Lasso and ElasticNet fitted by coordinate descent at a SINGLE alpha. The value here is the PATH: lars_path computes every Lasso solution for all alphas in roughly one OLS fit, where alpha selection today means refitting per candidate (crates/aprender-core/src/model_selection/alpha.rs suggests that cost is already being paid).
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3157'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  path_agrees_with_coordinate_descent:
+    formula: |
+      ∀ α ∈ path (>=20 sampled):
+        ‖coef_LassoLars(α) − coef_Lasso_cd(α)‖_inf ≤ 1e-8
+    domain: "alpha sweep over the path"
+    codomain: "coefficient deviation"
+    invariants:
+    - "two INDEPENDENT implementations cross-checking each other is the load-bearing test"
+    - "coefficients are piecewise linear in the path parameter between knots"
+    - "variables enter the active set in order of decreasing |corr(x_j, residual)|"
+
+  path_is_cheaper_than_refitting:
+    formula: |
+      flops(lars_path) < flops(Σ_α coordinate_descent(α))   -- COUNTED, not timed
+    domain: "same number of alphas"
+    codomain: "flop counts"
+    invariants:
+    - "counted via an instrumented counter; the repo forbids wall-clock in required checks"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-11-001
+  rule: "LassoLars agrees with coordinate-descent Lasso along the path"
+  prediction: "at >=20 alphas spanning the path, coefficients from the two independent implementations match within 1e-8"
+  test: >-
+    LIVE-PENDING - LassoLars agrees with coordinate-descent Lasso along the path. No test surface exists today because the capability is unimplemented: LARS / LassoLars / lars_path (aprender#3157, CRUX-N-11). PROMOTE by authoring a test named path_matches_coordinate_descent in module `linear_model/lars/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'LassoLars agrees with coordinate-descent Lasso along the path' is violated — the linfa parity claim for CRUX-N-11 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-11-002
+  rule: "the active set enters in correlation order"
+  prediction: "at each knot the entering variable has the largest absolute residual correlation"
+  test: >-
+    LIVE-PENDING - the active set enters in correlation order. No test surface exists today because the capability is unimplemented: LARS / LassoLars / lars_path (aprender#3157, CRUX-N-11). PROMOTE by authoring a test named active_set_enters_in_correlation_order in module `linear_model/lars/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the active set enters in correlation order' is violated — the linfa parity claim for CRUX-N-11 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-11-003
+  rule: "the path costs fewer flops than refitting"
+  prediction: "an instrumented flop counter shows the full path below the sum of per-alpha coordinate-descent fits"
+  test: >-
+    LIVE-PENDING - the path costs fewer flops than refitting. No test surface exists today because the capability is unimplemented: LARS / LassoLars / lars_path (aprender#3157, CRUX-N-11). PROMOTE by authoring a test named path_flops_below_refit in module `linear_model/lars/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the path costs fewer flops than refitting' is violated — the linfa parity claim for CRUX-N-11 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "LassoLars agrees with coordinate-descent Lasso along the path"
+- type: invariant
+  property: "the active set enters in correlation order"
+- type: invariant
+  property: "the path costs fewer flops than refitting"
+
+kani_harnesses:
+- id: KH-CRUX-N-11-001
+  obligation: path_agrees_with_coordinate_descent
+  property: path_agrees_with_coordinate_descent_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-11-002
+  obligation: path_is_cheaper_than_refitting
+  property: path_is_cheaper_than_refitting_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-12-v1.yaml
+++ b/contracts/crux-N-12-v1.yaml
@@ -1,0 +1,88 @@
+# CRUX-N-12 — KernelPCA + Nystroem + RBFSampler
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3158, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-12
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 3  # 1..5, medium priority in pmat work
+  intake_status: missing
+  github_issue: 3158
+  description: >
+    Reusable kernel methods. linfa-kernel ships "Kernel methods for non-linear algorithms", marked Tested. aprender evaluates kernels inside SVCRbf/MultiClassSVC but never exposes them as a transform; KernelPCA, Nystroem and RBFSampler are all absent. Two wins: nonlinear reduction, and letting the fast LinearSVM do the accurate SVCRbf's job at linear cost.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3158'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  kernel_pca_unfolds_what_linear_pca_cannot:
+    formula: |
+      on concentric circles:
+        acc(linear PCA -> linear clf) ≤ 0.60  AND  acc(RBF KernelPCA -> same clf) ≥ 0.95
+    domain: "concentric-circles fixture"
+    codomain: "both accuracies, asserted separately"
+    invariants:
+    - "showing only the success half demonstrates nothing"
+    - "the centered Gram matrix has zero row and column means within 1e-10"
+
+  nystroem_approximation_converges:
+    formula: |
+      ‖K − K_approx(m)‖_F / ‖K‖_F is non-increasing in m, over >=5 values of m
+      AND acc(Nystroem + LinearSVM) ≥ acc(SVCRbf) − 0.03
+           where acc(LinearSVM alone) < acc(SVCRbf) − 0.03
+    domain: "m = n_components"
+    codomain: "relative Frobenius error; accuracies"
+    invariants:
+    - "the LinearSVM-alone half is asserted, so the gain is attributable to the kernel map"
+    - "SVCRbf and KernelPCA produce IDENTICAL kernel matrix values at the same gamma"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-12-001
+  rule: "kernel PCA separates concentric circles where linear PCA cannot"
+  prediction: "linear PCA + linear classifier at chance (<=0.60) AND RBF KernelPCA + same classifier >=0.95"
+  test: >-
+    LIVE-PENDING - kernel PCA separates concentric circles where linear PCA cannot. No test surface exists today because the capability is unimplemented: KernelPCA + Nystroem + RBFSampler (aprender#3158, CRUX-N-12). PROMOTE by authoring a test named unfolds_concentric_circles in module `decomposition/kernel_pca/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'kernel PCA separates concentric circles where linear PCA cannot' is violated — the linfa parity claim for CRUX-N-12 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-12-002
+  rule: "Nystroem error decreases monotonically in n_components"
+  prediction: "relative Frobenius reconstruction error is non-increasing over >=5 values of n_components"
+  test: >-
+    LIVE-PENDING - Nystroem error decreases monotonically in n_components. No test surface exists today because the capability is unimplemented: KernelPCA + Nystroem + RBFSampler (aprender#3158, CRUX-N-12). PROMOTE by authoring a test named nystroem_error_monotone in module `kernel_approximation/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'Nystroem error decreases monotonically in n_components' is violated — the linfa parity claim for CRUX-N-12 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-12-003
+  rule: "the Kernel trait is genuinely shared with the SVM"
+  prediction: "SVCRbf and KernelPCA produce identical kernel matrix values for the same gamma"
+  test: >-
+    LIVE-PENDING - the Kernel trait is genuinely shared with the SVM. No test surface exists today because the capability is unimplemented: KernelPCA + Nystroem + RBFSampler (aprender#3158, CRUX-N-12). PROMOTE by authoring a test named shared_between_svm_and_kernel_pca in module `kernel/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the Kernel trait is genuinely shared with the SVM' is violated — the linfa parity claim for CRUX-N-12 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "kernel PCA separates concentric circles where linear PCA cannot"
+- type: monotonicity
+  property: "Nystroem error decreases monotonically in n_components"
+- type: invariant
+  property: "the Kernel trait is genuinely shared with the SVM"
+
+kani_harnesses:
+- id: KH-CRUX-N-12-001
+  obligation: kernel_pca_unfolds_what_linear_pca_cannot
+  property: kernel_pca_unfolds_what_linear_pca_cannot_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-12-002
+  obligation: nystroem_approximation_converges
+  property: nystroem_approximation_converges_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-13-v1.yaml
+++ b/contracts/crux-N-13-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-13 — Gaussian + Sparse random projection (JL bound)
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3159, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-13
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 2  # 1..5, low priority in pmat work
+  intake_status: missing
+  github_issue: 3159
+  description: >
+    Distance-preserving random projection. linfa-reduction ships random projections, marked Tested. aprender has none. It is the only reduction method with a DATA-INDEPENDENT guarantee: Johnson-Lindenstrauss preserves all pairwise distances within (1±ε) at O(log n / ε²) dimensions with no fit pass. Directly useful here -- the CRUX-N-03 index degrades in high dimension, and crates/aprender-core/src/citl/pattern/mod.rs:25 already notes a "simplified linear scan for now".
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3159'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  johnson_lindenstrauss_tail_bound:
+    formula: |
+      k = jl_min_dim(n, ε);  P = project(X ∈ R^{n×d} -> R^{n×k})
+        |{ (i,j) : | ‖Px_i − Px_j‖ / ‖x_i − x_j‖ − 1 | > ε }| / C(n,2)  ≤  δ
+    domain: "n = 1000, d = 5000, ε = 0.1"
+    codomain: "fraction of pairs exceeding the distortion bound"
+    invariants:
+    - "the TAIL is checked, not the mean -- a mean distortion does not test the lemma"
+    - "distortion tightens monotonically as ε tightens, over >=3 values"
+
+  sparse_variant_is_actually_sparse:
+    formula: |
+      density(P_sparse) < 1/3  AND  P_sparse is never materialized densely
+    domain: "sparse random projection matrix"
+    codomain: "(density, allocation count)"
+    invariants:
+    - "sparse-that-allocates-dense is the defect this excludes"
+    - "identical seed => identical projection matrix"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-13-001
+  rule: "the JL tail bound holds"
+  prediction: "for 1000 points in 5000 dims projected to jl_min_dim(1000, 0.1), the FRACTION of pairs distorted beyond 10% is below the documented failure probability"
+  test: >-
+    LIVE-PENDING - the JL tail bound holds. No test surface exists today because the capability is unimplemented: Gaussian + Sparse random projection (JL bound) (aprender#3159, CRUX-N-13). PROMOTE by authoring a test named jl_tail_bound_holds in module `random_projection/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the JL tail bound holds' is violated — the linfa parity claim for CRUX-N-13 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-13-002
+  rule: "the sparse matrix is never densely materialized"
+  prediction: "an allocation-count check asserts the sparse variant's density below 1/3 and no dense allocation"
+  test: >-
+    LIVE-PENDING - the sparse matrix is never densely materialized. No test surface exists today because the capability is unimplemented: Gaussian + Sparse random projection (JL bound) (aprender#3159, CRUX-N-13). PROMOTE by authoring a test named sparse_never_materialized_dense in module `random_projection/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the sparse matrix is never densely materialized' is violated — the linfa parity claim for CRUX-N-13 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-13-003
+  rule: "jl_min_dim matches the sklearn oracle exactly"
+  prediction: "johnson_lindenstrauss_min_dim agrees with sklearn as an exact integer"
+  test: >-
+    LIVE-PENDING - jl_min_dim matches the sklearn oracle exactly. No test surface exists today because the capability is unimplemented: Gaussian + Sparse random projection (JL bound) (aprender#3159, CRUX-N-13). PROMOTE by authoring a test named jl_min_dim_oracle_parity in module `random_projection/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'jl_min_dim matches the sklearn oracle exactly' is violated — the linfa parity claim for CRUX-N-13 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "the JL tail bound holds"
+- type: invariant
+  property: "the sparse matrix is never densely materialized"
+- type: invariant
+  property: "jl_min_dim matches the sklearn oracle exactly"
+
+kani_harnesses:
+- id: KH-CRUX-N-13-001
+  obligation: johnson_lindenstrauss_tail_bound
+  property: johnson_lindenstrauss_tail_bound_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-13-002
+  obligation: sparse_variant_is_actually_sparse
+  property: sparse_variant_is_actually_sparse_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-14-v1.yaml
+++ b/contracts/crux-N-14-v1.yaml
@@ -1,0 +1,98 @@
+# CRUX-N-14 — Graph intermediate representation (IR)
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3165, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-14
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 4  # 1..5, high priority in pmat work
+  intake_status: missing
+  github_issue: 3165
+  description: >
+    A typed graph IR between model front-ends and execution backends. burn ships burn-ir ("Intermediate representation for the Burn framework"). aprender has NO IR: verified 2026-09-12, no ir/ module in any of the 79 workspace crates. Without one, ONNX import (CRUX-N-06) is a one-off translator rather than a front-end, kernel fusion has nothing to fuse over, and multi-backend routing must be hand-written per path.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3165'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  lowering_preserves_semantics:
+    formula: |
+      ∀ graph G:  execute(lower(G))  ≡  execute_direct(G)   BYTE-IDENTICAL
+    domain: "pinned fixture graphs"
+    codomain: "output tensors"
+    invariants:
+    - "the IR is a refactor, not a rewrite -- a changed result is a regression"
+
+  layout_is_carried_and_checked:
+    formula: |
+      ∀ edge e ∈ G:  e.layout ∈ {RowMajor, ColMajor} is REQUIRED
+        mixing layouts without an explicit transpose node => validate(G) = Err
+    domain: "graph with mixed-layout edges"
+    codomain: "validation result"
+    invariants:
+    - "this is where LAYOUT-001 becomes checkable at graph level, not per call site"
+    - "wired to contracts/tensor-layout-v1.yaml"
+
+  passes_are_effective:
+    formula: |
+      nodes(constant_fold(G)) < nodes(G) for a G with a foldable subtree
+      AND dead_node_elim removes an unreachable node AND retains every reachable one
+    domain: "graphs with foldable / unreachable subtrees"
+    codomain: "node counts"
+    invariants:
+    - "both halves of DCE are asserted -- removing everything also shrinks the count"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-14-001
+  rule: "lowering is byte-identical to the direct path"
+  prediction: "graphs lowered through the IR produce byte-identical output to the current direct execution path on pinned fixtures"
+  test: >-
+    LIVE-PENDING - lowering is byte-identical to the direct path. No test surface exists today because the capability is unimplemented: Graph intermediate representation (IR) (aprender#3165, CRUX-N-14). PROMOTE by authoring a test named lowering_byte_identical in module `ir/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'lowering is byte-identical to the direct path' is violated — the burn parity claim for CRUX-N-14 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-14-002
+  rule: "mixed-layout graphs are rejected"
+  prediction: "a graph mixing row-major and column-major edges without an explicit transpose node fails validation"
+  test: >-
+    LIVE-PENDING - mixed-layout graphs are rejected. No test surface exists today because the capability is unimplemented: Graph intermediate representation (IR) (aprender#3165, CRUX-N-14). PROMOTE by authoring a test named mixed_layout_rejected in module `ir/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'mixed-layout graphs are rejected' is violated — the burn parity claim for CRUX-N-14 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-14-003
+  rule: "constant folding and DCE both fire and are bounded"
+  prediction: "constant folding strictly reduces node count on a foldable graph; DCE removes an unreachable node and retains every reachable one"
+  test: >-
+    LIVE-PENDING - constant folding and DCE both fire and are bounded. No test surface exists today because the capability is unimplemented: Graph intermediate representation (IR) (aprender#3165, CRUX-N-14). PROMOTE by authoring a test named passes_effective_and_bounded in module `ir/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'constant folding and DCE both fire and are bounded' is violated — the burn parity claim for CRUX-N-14 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: idempotency
+  property: "lowering is byte-identical to the direct path"
+- type: invariant
+  property: "mixed-layout graphs are rejected"
+- type: invariant
+  property: "constant folding and DCE both fire and are bounded"
+
+kani_harnesses:
+- id: KH-CRUX-N-14-001
+  obligation: lowering_preserves_semantics
+  property: lowering_preserves_semantics_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-14-002
+  obligation: layout_is_carried_and_checked
+  property: layout_is_carried_and_checked_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-14-003
+  obligation: passes_are_effective
+  property: passes_are_effective_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-15-v1.yaml
+++ b/contracts/crux-N-15-v1.yaml
@@ -1,0 +1,84 @@
+# CRUX-N-15 — General RL algorithms (PPO / DQN / A2C)
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3166, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-15
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 2  # 1..5, low priority in pmat work
+  intake_status: partial
+  github_issue: 3166
+  description: >
+    General reinforcement learning. burn ships burn-rl. aprender has RL only in its RLHF sense: crates/aprender-core/src/online/dpo.rs and online/rlvr.rs. Verified 2026-09-12 -- PPO, DQN, A2C, SAC and Q-learning are absent; the single apparent PPO hit is a comment at online/dpo.rs:7 that names PPO to say it is NOT doing PPO. Demand 2: general RL is not on the four-pillar mission and nothing else in this epic depends on it.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3166'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  agent_learns_above_random:
+    formula: |
+      return(PPO, episodes ≤ B) > τ   AND   return(random policy) < τ
+    domain: "CartPole-equivalent environment"
+    codomain: "episode return, both policies"
+    invariants:
+    - "both halves asserted -- a threshold only the agent is measured against proves nothing"
+    - "deterministic under a fixed seed"
+
+  ppo_clipping_engages:
+    formula: |
+      for ratio r ∉ [1−ε, 1+ε]:  L_surrogate = clipped_branch(r)
+    domain: "constructed ratio outside the trust region"
+    codomain: "which branch of the surrogate objective is taken"
+    invariants:
+    - "DQN's target network is asserted to LAG: differs between syncs, matches right after"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-15-001
+  rule: "PPO learns where a random policy does not"
+  prediction: "on CartPole-equivalent, PPO exceeds a return threshold within a bounded episode budget and a random policy is asserted below it"
+  test: >-
+    LIVE-PENDING - PPO learns where a random policy does not. No test surface exists today because the capability is unimplemented: General RL algorithms (PPO / DQN / A2C) (aprender#3166, CRUX-N-15). PROMOTE by authoring a test named learns_above_random_policy in module `rl/ppo/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'PPO learns where a random policy does not' is violated — the burn parity claim for CRUX-N-15 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-15-002
+  rule: "the clipped surrogate branch is taken outside the trust region"
+  prediction: "a constructed ratio outside [1-eps, 1+eps] selects the clipped branch"
+  test: >-
+    LIVE-PENDING - the clipped surrogate branch is taken outside the trust region. No test surface exists today because the capability is unimplemented: General RL algorithms (PPO / DQN / A2C) (aprender#3166, CRUX-N-15). PROMOTE by authoring a test named clipping_engages in module `rl/ppo/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the clipped surrogate branch is taken outside the trust region' is violated — the burn parity claim for CRUX-N-15 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-15-003
+  rule: "the DQN target network lags the online network"
+  prediction: "target and online parameters differ between syncs and match immediately after a sync"
+  test: >-
+    LIVE-PENDING - the DQN target network lags the online network. No test surface exists today because the capability is unimplemented: General RL algorithms (PPO / DQN / A2C) (aprender#3166, CRUX-N-15). PROMOTE by authoring a test named target_network_lags in module `rl/dqn/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the DQN target network lags the online network' is violated — the burn parity claim for CRUX-N-15 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "PPO learns where a random policy does not"
+- type: invariant
+  property: "the clipped surrogate branch is taken outside the trust region"
+- type: invariant
+  property: "the DQN target network lags the online network"
+
+kani_harnesses:
+- id: KH-CRUX-N-15-001
+  obligation: agent_learns_above_random
+  property: agent_learns_above_random_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-15-002
+  obligation: ppo_clipping_engages
+  property: ppo_clipping_engages_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-16-v1.yaml
+++ b/contracts/crux-N-16-v1.yaml
@@ -1,0 +1,86 @@
+# CRUX-N-16 — Barnes-Hut t-SNE (O(n log n))
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3167, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-16
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: linfa
+  demand_score: 3  # 1..5, medium priority in pmat work
+  intake_status: partial
+  github_issue: 3167
+  description: >
+    Barnes-Hut approximation for t-SNE. linfa-tsne describes itself as "Barnes-Hut t-distributed stochastic neighbor embedding". aprender has TSNE at crates/aprender-core/src/preprocessing/tsne.rs but a scan for barnes, quadtree and octree found nothing -- it is the naive O(n^2) formulation. Same defect class as CRUX-N-03: an algorithm that is PRESENT but asymptotically worse than the comparator's. Presence is not parity.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3167'
+  - 'competitor: https://github.com/rust-ml/linfa'
+
+equations:
+  theta_zero_degenerates_to_exact:
+    formula: |
+      BarnesHut(X, θ = 0.0)  ≡  Naive(X)   within 1e-9
+    domain: "any X"
+    codomain: "embedding deviation"
+    invariants:
+    - "at θ=0 the approximation MUST reduce to the exact computation -- this is what proves the quadtree correct"
+    - "at θ=0.5 the KL divergence is within a documented tolerance of exact"
+
+  n_log_n_force_computation:
+    formula: |
+      visits(n) counted as quadtree node expansions:
+        visits(n) = O(n log n)  where naive = O(n²) on the same inputs
+    domain: "n ∈ {1e3, 1e4, 1e5}"
+    codomain: "node-visit counts"
+    invariants:
+    - "counted, never timed -- the repo forbids wall-clock in required checks"
+    - "the O(n²) P-matrix is NOT materialized on the Barnes-Hut path"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-16-001
+  rule: "theta=0 reproduces the exact embedding"
+  prediction: "Barnes-Hut with theta=0.0 matches the naive path within 1e-9"
+  test: >-
+    LIVE-PENDING - theta=0 reproduces the exact embedding. No test surface exists today because the capability is unimplemented: Barnes-Hut t-SNE (O(n log n)) (aprender#3167, CRUX-N-16). PROMOTE by authoring a test named theta_zero_equals_exact in module `preprocessing/tsne/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'theta=0 reproduces the exact embedding' is violated — the linfa parity claim for CRUX-N-16 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-16-002
+  rule: "force computation grows as n log n, not n squared"
+  prediction: "quadtree node-visit counts across n=1e3,1e4,1e5 grow as O(n log n) where the naive path is asserted O(n^2)"
+  test: >-
+    LIVE-PENDING - force computation grows as n log n, not n squared. No test surface exists today because the capability is unimplemented: Barnes-Hut t-SNE (O(n log n)) (aprender#3167, CRUX-N-16). PROMOTE by authoring a test named visits_n_log_n in module `preprocessing/tsne/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'force computation grows as n log n, not n squared' is violated — the linfa parity claim for CRUX-N-16 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-16-003
+  rule: "the O(n^2) P-matrix is not materialized"
+  prediction: "an allocation or peak-RSS check asserts the dense P-matrix is absent on the Barnes-Hut path"
+  test: >-
+    LIVE-PENDING - the O(n^2) P-matrix is not materialized. No test surface exists today because the capability is unimplemented: Barnes-Hut t-SNE (O(n log n)) (aprender#3167, CRUX-N-16). PROMOTE by authoring a test named no_dense_p_matrix in module `preprocessing/tsne/tests` of crate `aprender-core`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the O(n^2) P-matrix is not materialized' is violated — the linfa parity claim for CRUX-N-16 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "theta=0 reproduces the exact embedding"
+- type: invariant
+  property: "force computation grows as n log n, not n squared"
+- type: invariant
+  property: "the O(n^2) P-matrix is not materialized"
+
+kani_harnesses:
+- id: KH-CRUX-N-16-001
+  obligation: theta_zero_degenerates_to_exact
+  property: theta_zero_degenerates_to_exact_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-16-002
+  obligation: n_log_n_force_computation
+  property: n_log_n_force_computation_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-N-17-v1.yaml
+++ b/contracts/crux-N-17-v1.yaml
@@ -1,0 +1,84 @@
+# CRUX-N-17 — Vision ops: NMS, GPU connected components, tensor integration
+# CRUX category N: Rust ML Framework Parity (linfa + burn).
+# Filed from the 2026-09-12 competitive sweep. Tracks GitHub #3168, epic #3146.
+# registry: false — this contract carries real falsification gates and claims no
+# exemption (operator ruling 2026-08-21, "no contract exemptions").
+
+metadata:
+  id: CRUX-N-17
+  version: "1.0.0"
+  created: "2026-09-12"
+  updated: "2026-09-12"
+  author: PAIML Engineering
+  registry: false
+  status: draft
+  parent_contracts:
+  - crux-competitive-research-ux-v1
+  category: "N — Rust ML Framework Parity"
+  competitor: burn
+  demand_score: 2  # 1..5, low priority in pmat work
+  intake_status: partial
+  github_issue: 3168
+  description: >
+    Tensor-integrated vision operations. burn-vision ships NMS, GPU-accelerated connected components (Spaghetti/Spaghetti4C plus a cube backend with prefix sum), VGG19 gram-matrix perceptual loss and 2D transforms, all operating on burn tensors. aprender-image has real coverage burn does not emphasise (canny, morphology, histogram equalization, gradient magnitude) but is CPU-only, has no NMS, and operates on its own buf.rs type rather than on aprender-tensor -- so vision ops cannot join an autodiff graph or a GPU pipeline. Demand 2: vision is not one of the four pillars.
+  references:
+  - 'master: contracts/crux-competitive-research-ux-v1.yaml — §5 + §12'
+  - 'epic: https://github.com/paiml/aprender/issues/3146'
+  - 'story: https://github.com/paiml/aprender/issues/3168'
+  - 'competitor: https://github.com/tracel-ai/burn'
+
+equations:
+  nms_matches_the_torchvision_oracle:
+    formula: |
+      nms(boxes, scores, iou_thr)  ≡  torchvision.ops.nms(...)   as KEPT-INDEX SETS
+    domain: "pinned box/score fixtures"
+    codomain: "kept index set"
+    invariants:
+    - "degenerate cases asserted: identical boxes, zero boxes, all-below-threshold, IoU exactly at the boundary"
+
+  gpu_path_labels_identically:
+    formula: |
+      connected_components_gpu(I)  ≡  connected_components_cpu(I)   as LABELINGS
+    domain: "pinned binary images"
+    codomain: "label image (up to label permutation)"
+    invariants:
+    - "a faster path that labels differently is a defect, not an optimization"
+    - "GPU ops fail loudly when the backend is unavailable rather than silently using CPU while reporting a GPU device"
+
+falsification_tests:
+- id: FALSIFY-CRUX-N-17-001
+  rule: "NMS matches torchvision exactly"
+  prediction: "kept-index sets are identical to a pinned torchvision.ops.nms fixture, including the IoU-at-boundary case"
+  test: >-
+    LIVE-PENDING - NMS matches torchvision exactly. No test surface exists today because the capability is unimplemented: Vision ops: NMS, GPU connected components, tensor integration (aprender#3168, CRUX-N-17). PROMOTE by authoring a test named oracle_parity_torchvision in module `nms/tests` of crate `aprender-image`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'NMS matches torchvision exactly' is violated — the burn parity claim for CRUX-N-17 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-17-002
+  rule: "the GPU connected-components path labels identically to CPU"
+  prediction: "GPU and CPU produce the same labeling up to permutation on pinned fixtures"
+  test: >-
+    LIVE-PENDING - the GPU connected-components path labels identically to CPU. No test surface exists today because the capability is unimplemented: Vision ops: NMS, GPU connected components, tensor integration (aprender#3168, CRUX-N-17). PROMOTE by authoring a test named gpu_matches_cpu in module `connected_components/tests` of crate `aprender-image`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'the GPU connected-components path labels identically to CPU' is violated — the burn parity claim for CRUX-N-17 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+- id: FALSIFY-CRUX-N-17-003
+  rule: "tensor migration is output-preserving"
+  prediction: "ops migrated onto aprender-tensor produce byte-identical output to the buf.rs path"
+  test: >-
+    LIVE-PENDING - tensor migration is output-preserving. No test surface exists today because the capability is unimplemented: Vision ops: NMS, GPU connected components, tensor integration (aprender#3168, CRUX-N-17). PROMOTE by authoring a test named byte_identical_after_migration in module `tensor_integration/tests` of crate `aprender-image`; this gate then binds to it and the contract moves from draft to active. Until then the obligation is RECORDED and unfalsifiable-by-absence, NOT satisfied.
+  if_fails: rule 'tensor migration is output-preserving' is violated — the burn parity claim for CRUX-N-17 is FALSE and the contract MUST be re-verified against the competitor's canonical implementation
+
+proof_obligations:
+- type: invariant
+  property: "NMS matches torchvision exactly"
+- type: invariant
+  property: "the GPU connected-components path labels identically to CPU"
+- type: invariant
+  property: "tensor migration is output-preserving"
+
+kani_harnesses:
+- id: KH-CRUX-N-17-001
+  obligation: nms_matches_the_torchvision_oracle
+  property: nms_matches_the_torchvision_oracle_holds_on_bounded_input
+  bound: 4
+- id: KH-CRUX-N-17-002
+  obligation: gpu_path_labels_identically
+  property: gpu_path_labels_identically_holds_on_bounded_input
+  bound: 4

--- a/contracts/crux-competitive-research-ux-v1.yaml
+++ b/contracts/crux-competitive-research-ux-v1.yaml
@@ -435,19 +435,48 @@ stories:
   - { id: CRUX-K-20, title: "TensorRT-LLM export",                 competitor: ecosystem,   demand_score: 3, status: missing,   contract: crux-K-20-v1.yaml }
   - { id: CRUX-K-21, title: "MLX backend (Apple Silicon native)",  competitor: ecosystem,   demand_score: 3, status: missing,   contract: crux-K-21-v1.yaml }
 
+  # -- N: Rust ML Framework Parity (aprender#3146, added 2026-09-12) ----------
+  # The two Rust-native ML frameworks. Derived by enumerating BOTH sides, not
+  # recalled: linfa 0.8.1 (18 algorithm sub-crates) and burn 0.21.0 (35 crates)
+  # against aprender's ~55 fittable types and 21 transformer-path autodiff ops.
+  # Neither is a BEAT pillar - aprender claims no pinned-benchmark win over
+  # either; they are capability/UX sources. The registry edit that admits them
+  # is CRUX_COMPETITORS in crates/aprender-contracts/src/schema/validator.rs.
+  - { id: CRUX-N-01, title: "SVD substrate (Golub-Reinsch + randomized)",        competitor: burn,    demand_score: 5, status: missing,  contract: crux-N-01-v1.yaml }
+  - { id: CRUX-N-02, title: "PCA on SVD + TruncatedSVD",                         competitor: linfa,   demand_score: 5, status: partial,  contract: crux-N-02-v1.yaml }
+  - { id: CRUX-N-03, title: "Spatial neighbour index (kd-tree + ball-tree)",     competitor: linfa,   demand_score: 5, status: missing,  contract: crux-N-03-v1.yaml }
+  - { id: CRUX-N-04, title: "Const-generic rank-checked tensor",                 competitor: burn,    demand_score: 5, status: missing,  contract: crux-N-04-v1.yaml }
+  - { id: CRUX-N-05, title: "Autodiff ops: conv, pooling, embedding, gather",    competitor: burn,    demand_score: 4, status: partial,  contract: crux-N-05-v1.yaml }
+  - { id: CRUX-N-06, title: "ONNX import",                                       competitor: burn,    demand_score: 4, status: missing,  contract: crux-N-06-v1.yaml }
+  - { id: CRUX-N-07, title: "AdaBoost + generic Bagging/Voting",                 competitor: linfa,   demand_score: 4, status: missing,  contract: crux-N-07-v1.yaml }
+  - { id: CRUX-N-08, title: "FTRL-Proximal + SGDClassifier/SGDRegressor",        competitor: linfa,   demand_score: 4, status: missing,  contract: crux-N-08-v1.yaml }
+  - { id: CRUX-N-09, title: "OPTICS clustering",                                 competitor: linfa,   demand_score: 3, status: missing,  contract: crux-N-09-v1.yaml }
+  - { id: CRUX-N-10, title: "PLSRegression / PLSCanonical",                      competitor: linfa,   demand_score: 3, status: missing,  contract: crux-N-10-v1.yaml }
+  - { id: CRUX-N-11, title: "LARS / LassoLars / lars_path",                      competitor: linfa,   demand_score: 3, status: missing,  contract: crux-N-11-v1.yaml }
+  - { id: CRUX-N-12, title: "KernelPCA + Nystroem + RBFSampler",                 competitor: linfa,   demand_score: 3, status: missing,  contract: crux-N-12-v1.yaml }
+  - { id: CRUX-N-13, title: "Gaussian + Sparse random projection (JL bound)",    competitor: linfa,   demand_score: 2, status: missing,  contract: crux-N-13-v1.yaml }
+  - { id: CRUX-N-14, title: "Graph intermediate representation (IR)",            competitor: burn,    demand_score: 4, status: missing,  contract: crux-N-14-v1.yaml }
+  - { id: CRUX-N-15, title: "General RL algorithms (PPO / DQN / A2C)",           competitor: burn,    demand_score: 2, status: partial,  contract: crux-N-15-v1.yaml }
+  - { id: CRUX-N-16, title: "Barnes-Hut t-SNE (O(n log n))",                     competitor: linfa,   demand_score: 3, status: partial,  contract: crux-N-16-v1.yaml }
+  - { id: CRUX-N-17, title: "Vision ops: NMS, GPU connected components",         competitor: burn,    demand_score: 2, status: partial,  contract: crux-N-17-v1.yaml }
+
 # ─────────────────────────────────────────────────────────────
 # Coverage — intake v2.0.0 (verified by awk over §5 of subspec)
 # ─────────────────────────────────────────────────────────────
 coverage_intake:
   supported: 43
-  partial:   67
-  missing:   140
+  partial:   72
+  missing:   152
   unclear:    0
-  total:    250
+  total:    267
   notes: |
     ID gaps at C-14, F-10, H-04, I-05, K-06 are intentional — those
     five stories were dropped pre-v1.0.0 as duplicative (see inline
     comments in stories[]).
+    Category N (17 rows, aprender#3146) was added 2026-09-12: 12 missing,
+    5 partial. It is the first category whose competitors are Rust-native
+    frameworks rather than Python/C++ incumbents, which is why it required
+    a CRUX_COMPETITORS registry edit rather than reuse of an existing source.
 
 # ─────────────────────────────────────────────────────────────
 # Falsification conditions

--- a/crates/aprender-contracts/src/schema/crux_intake_tests.rs
+++ b/crates/aprender-contracts/src/schema/crux_intake_tests.rs
@@ -212,6 +212,10 @@ fn competitor_registry_covers_the_corpus_vocabulary() {
         "apr-qa-playbook",
         "openclip",
         "none",
+        // Category N — Rust ML Framework Parity (aprender#3146, 2026-09-12).
+        // 17 contracts: burn ×7, linfa ×10.
+        "burn",
+        "linfa",
     ] {
         assert!(
             CRUX_COMPETITORS.contains(&required),
@@ -250,6 +254,10 @@ fn beat_incumbents_cannot_name_the_crux_corpus() {
         "apr-qa-playbook",
         "openclip",
         "none",
+        // The two Rust-native frameworks: BEAT_INCUMBENTS names neither, which
+        // is why category N required a registry edit rather than a reuse.
+        "burn",
+        "linfa",
     ] {
         assert!(!beat_accepts(c), "BEAT_INCUMBENTS unexpectedly accepts {c}");
     }

--- a/crates/aprender-contracts/src/schema/validator.rs
+++ b/crates/aprender-contracts/src/schema/validator.rs
@@ -82,15 +82,34 @@ pub fn validate_contract(contract: &Contract) -> Vec<Violation> {
 /// - `ecosystem` (30), `openclaw` (20), `hf-kernels-community` (15),
 ///   `apr-qa-playbook` (9), `openclip` (2), `none` (1).
 ///
+/// Extended 2026-09-12 (aprender#3146): category N adds `burn` (7 stories) and
+/// `linfa` (10), the two Rust-native ML frameworks. Neither is substring-matched
+/// by `BEAT_INCUMBENTS`, so neither could be named by reusing that list.
+///
 /// So this registry is the corpus vocabulary, exactly. Every member is
 /// exercised by at least one contract in `contracts/`; adding a competitor is a
 /// deliberate one-line edit here plus a test, which is the point — an open
 /// domain is what let `THIS-COMPETITOR-DOES-NOT-EXIST` validate.
-pub(crate) const CRUX_COMPETITORS: [&str; 12] = [
+pub(crate) const CRUX_COMPETITORS: [&str; 14] = [
     "apr-qa-playbook",
+    // Burn (tracel-ai/burn) — the Rust deep-learning framework, 0.21.0 / 15.9k
+    // stars / 312 reverse-dependencies at admission. Added 2026-09-12 with 7
+    // category-N stories extracted from its crate surface: burn-linalg (SVD),
+    // burn-tensor (const-generic rank), burn-autodiff (op coverage), ONNX
+    // import, burn-ir, burn-rl, burn-vision. NOT a BEAT pillar — aprender makes
+    // no claim to beat Burn on a pinned benchmark; this is a capability/UX
+    // source, which is exactly the distinction this registry exists to keep.
+    "burn",
     "ecosystem",
     "hf-kernels-community",
     "huggingface",
+    // linfa (rust-ml/linfa) — the Rust classical-ML toolkit, 0.8.1 / 18
+    // algorithm sub-crates at admission. Added 2026-09-12 with 10 category-N
+    // stories: linfa-nn (spatial index), linfa-pls, linfa-lars, linfa-kernel,
+    // linfa-ftrl, linfa-ensemble (AdaBoost/bagging), OPTICS, Barnes-Hut t-SNE,
+    // random projection, PCA-on-SVD. `scikit-learn` is the BEAT pillar on this
+    // axis and is deliberately NOT here; linfa is the Rust-native UX source.
+    "linfa",
     "llama_cpp",
     "none",
     "ollama",

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -17099,3 +17099,87 @@ roadmap:
   labels:
   - kind:triage
   notes: null
+- id: PMAT-3165
+  github_issue: 3165
+  item_type: task
+  title: 'P1: graph intermediate representation (IR) — CRUX-N-14'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-12T12:16:04Z
+  updated: 2026-09-12T12:16:04Z
+  spec: null
+  acceptance_criteria:
+  - 'CRUX-N-14, competitor burn, demand 4. burn ships burn-ir; aprender has NO ir/ module in any of 79 crates (verified 2026-09-12). Substrate under ONNX import (#3152), kernel fusion (CUT on the epic largely BECAUSE there is no IR), and multi-backend routing. FALSIFIABLE (contracts/crux-N-14-v1.yaml): lowering an IR graph is BYTE-IDENTICAL to the direct execution path on pinned fixtures (the IR is a refactor, not a rewrite); a graph mixing row-major and column-major edges without an explicit transpose node is REJECTED at validation — this is where LAYOUT-001 becomes checkable at graph level rather than per call site; constant folding strictly reduces node count on a foldable graph AND dead-node elimination removes an unreachable node while retaining every reachable one (both halves, since removing everything also shrinks the count). Milestone 0.69.0.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - P1
+  - enhancement
+  - crux
+  - pareto-linfa-burn
+  notes: null
+- id: PMAT-3166
+  github_issue: 3166
+  item_type: task
+  title: 'P2: general RL algorithms (PPO/DQN/A2C) — CRUX-N-15'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-12T12:16:04Z
+  updated: 2026-09-12T12:16:04Z
+  spec: null
+  acceptance_criteria:
+  - 'CRUX-N-15, competitor burn, demand 2. burn ships burn-rl. aprender has RL only in the RLHF sense (online/dpo.rs, online/rlvr.rs); PPO, DQN, A2C, SAC and Q-learning are absent — the single apparent PPO hit is a comment at online/dpo.rs:7 naming PPO to say it is NOT doing PPO. Demand 2 is honest: general RL is not on the four-pillar mission and nothing else in the epic depends on it. FALSIFIABLE (contracts/crux-N-15-v1.yaml): PPO exceeds a return threshold on CartPole-equivalent within a bounded episode budget AND a random policy is asserted below it (both halves — a threshold only the agent is measured against proves nothing); a ratio outside [1-eps,1+eps] selects the CLIPPED branch of the surrogate; the DQN target network is asserted to LAG (differs between syncs, matches right after). Milestone 0.70.0.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - P2
+  - enhancement
+  - crux
+  - pareto-linfa-burn
+  notes: null
+- id: PMAT-3167
+  github_issue: 3167
+  item_type: task
+  title: 'P2: Barnes-Hut t-SNE (O(n log n)) — CRUX-N-16'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-12T12:16:04Z
+  updated: 2026-09-12T12:16:04Z
+  spec: null
+  acceptance_criteria:
+  - 'CRUX-N-16, competitor linfa, demand 3. linfa-tsne is explicitly Barnes-Hut; aprender''s preprocessing/tsne.rs has no barnes/quadtree/octree markers — naive O(n^2). SAME DEFECT CLASS as the neighbour index (#3149): an algorithm that is PRESENT but asymptotically worse than the comparator''s. Presence is not parity — the first sweep marked t-SNE present and never examined it. FALSIFIABLE (contracts/crux-N-16-v1.yaml): at theta=0.0 Barnes-Hut must DEGENERATE to the naive path within 1e-9 (this is what proves the quadtree correct); quadtree node-visit counts across n=1e3,1e4,1e5 grow O(n log n) where naive is asserted O(n^2) — COUNTED, not timed, per the repo rule against wall-clock in required checks; the dense O(n^2) P-matrix is asserted NOT materialized on the Barnes-Hut path. Milestone 0.70.0.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - P2
+  - enhancement
+  - crux
+  - pareto-linfa-burn
+  notes: null
+- id: PMAT-3168
+  github_issue: 3168
+  item_type: task
+  title: 'P2: vision ops — NMS, GPU connected components, tensor integration — CRUX-N-17'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-12T12:16:04Z
+  updated: 2026-09-12T12:16:04Z
+  spec: null
+  acceptance_criteria:
+  - 'CRUX-N-17, competitor burn, demand 2. burn-vision ships NMS, GPU connected components (Spaghetti/Spaghetti4C plus a cube backend with prefix sum), VGG19 gram-matrix perceptual loss and 2D transforms, all on burn tensors. aprender-image has real coverage burn does not emphasise (canny, morphology, histogram equalization, gradient magnitude) but is CPU-only, has no NMS, and operates on its own buf.rs type rather than aprender-tensor — so vision ops cannot join an autodiff graph or a GPU pipeline. The tensor integration is the piece with cross-cutting value. Demand 2: vision is not a pillar. FALSIFIABLE (contracts/crux-N-17-v1.yaml): NMS kept-index sets identical to a pinned torchvision.ops.nms fixture including the IoU-at-boundary case; the GPU connected-components path labels IDENTICALLY to CPU (a faster path that labels differently is a defect); migrated ops are byte-identical to the buf.rs path. Milestone 0.70.0.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - P2
+  - enhancement
+  - crux
+  - pareto-linfa-burn
+  notes: null

--- a/scripts/crux_scaffold_contracts.py
+++ b/scripts/crux_scaffold_contracts.py
@@ -29,6 +29,12 @@ CATEGORY_NAMES = {
     "I": "Observability & Metrics",
     "J": "Vision-Language (OpenCLIP/OpenCLAW)",
     "K": "Ecosystem & Integration",
+    # L, M and N were absent until 2026-09-12 (aprender#3146): contracts for
+    # these categories already existed, so the scaffolder would have emitted a
+    # bare letter as the category name had anyone re-run it over them.
+    "L": "HF kernels-community integration",
+    "M": "APR-QA Playbook Canonicalization",
+    "N": "Rust ML Framework Parity",
 }
 
 STATUS_BADGE = {


### PR DESCRIPTION
Admits **linfa** and **burn** to the CRUX competitor registry and lands **category N — Rust ML Framework Parity** as 17 contracts + 17 master stories. Closes the gap identified when the earlier linfa/burn tickets turned out not to be CRUX tickets at all.

## Why they weren't CRUX tickets

Not clerical — structural. `CRUX_COMPETITORS` is a closed registry of 12, and neither framework was in it, so `pv validate` rejected the entire category with **CRUX-002**. This is the registry edit the validator's own doc comment asks for:

> *"adding a competitor is a deliberate one-line edit here plus a test, which is the point — an open domain is what let `THIS-COMPETITOR-DOES-NOT-EXIST` validate."*

```
CRUX_COMPETITORS: [&str; 12] -> [&str; 14]    + burn, + linfa
```

Neither is a BEAT pillar. `BEAT_INCUMBENTS` is `["scikit-learn", "pytorch", "unsloth", "ollama", "llama.cpp"]` and its substring matcher accepts neither `"burn"` nor `"linfa"` — reusing that list could not have named them. scikit-learn is the BEAT pillar on linfa's axis; linfa is the Rust-native *UX source*. Both tests that pin that distinction are extended, not worked around.

## What's in category N

17 contracts, each with real equations and falsification gates (not the scaffold placeholder body), each registered as a master story. `coverage_intake` 250 → **267** (partial 67→72, missing 140→152), asserted against the actual status histogram rather than hand-edited.

| | burn | linfa |
|---|---|---|
| stories | 7 | 10 |

**Four are new findings** the first sweep missed — it enumerated *algorithms*, so it never looked for anything that wasn't one:

- **N-14 `burn-ir`** — no graph IR in any of the 79 crates. Substrate under ONNX import (#3152) and under the fusion framework the epic CUT largely *because* there's no IR.
- **N-16 Barnes-Hut t-SNE** — aprender's t-SNE is present but naive O(n²). Same defect class as the neighbour index: **presence is not parity**, and the first sweep marked t-SNE "present" and stopped looking.
- **N-15 `burn-rl`** — general RL absent; the one apparent PPO hit is a comment in `dpo.rs` naming PPO to say it is *not* doing PPO.
- **N-17 `burn-vision`** — NMS, GPU connected components, tensor integration.

`burn-cpu`'s MLIR backend was assessed and **CUT** — it would compete with trueno, aprender's own differentiator.

## Three gates satisfied honestly rather than dodged

1. **`registry: false`, not `true`.** `registry: true` is the exemption-from-proving flag the 2026-08-21 operator ruling retired. Setting it false opted these contracts *into* PROVABILITY-001 — which is where they belong — and they then needed real `proof_obligations`, one per gate.
2. **Falsification bodies are `LIVE-PENDING`, not `cargo test` citations.** The features are unimplemented, so citing a test path that doesn't exist is a dangling reference. strict-test-binding refused 51 of them: *"Fix the citation (or add the test); do NOT raise the baseline."* LIVE-PENDING is the repo's sanctioned state for a gate that can't bind yet, and it records the obligation as **unfalsifiable-by-absence, not satisfied**.
3. **The LIVE-PENDING prose then had to stop containing `::`.** The verify gate reads the tail after the last `::` and treats a leading `test_`/`prop_` as a citation — so two bodies that *described* a test to be written were read as *citing* one that exists. Module paths now use `/`.

## Verification — mechanism proved, not asserted

- **1501** `aprender-contracts` lib tests pass, 0 failed.
- **18/18** contracts validate (17 new + modified master) under a `pv` built from this tree. The stale `~/.cargo/bin/pv` rejects all 17 with CRUX-002 and the fresh one accepts them — *that behavioural delta* is the proof the registry edit engaged, not the fact that it compiled.
- **Mutation-verified**: deleting `"burn"` from `CRUX_COMPETITORS` turns `competitor_registry_covers_the_corpus_vocabulary` RED with `burn is used by contracts/ and must stay in CRUX_COMPETITORS`. Restored → 20/20 green.
- `coverage_intake` counts asserted equal to the stories histogram, so the registry can't silently drift.
- `cargo fmt --all -- --check` clean.

## Also fixed in passing

The scaffolder's `CATEGORY_NAMES` stopped at **K** — so categories L and M, which have had 24 contracts between them for months, would have scaffolded with a bare letter as their category name had anyone re-run it over them. L, M and N are all present now.

## Known drift NOT fixed here

The master registry had **250 stories against 275 contract files**. Categories L (15) and M (9) exist as contracts with **no story rows at all**. Category N doesn't repeat that — all 17 are registered — but those 24 pre-existing orphans want their own ticket.

Issues: #3146 (epic) · #3147–#3159 · #3165–#3168 — all 18 now carry the `crux` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
